### PR TITLE
Support crontab expressions for scheduled background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1630,6 +1630,37 @@ Supported schedule syntax:
 - `every: ["1h", {first_in: "30s"}]`
 - `every: ["1 day", {firstIn: "5 minutes"}]`
 
+Or a 5-field POSIX crontab expression via `cron`:
+
+```js
+scheduledBackgroundJobs: {
+  jobs: {
+    nightlyDigest: {
+      class: NightlyDigestJob,
+      cron: "0 3 * * *" // every day at 03:00 server-local time
+    },
+    weekdayMornings: {
+      class: WeekdayMorningJob,
+      cron: "0 9 * * 1-5" // 09:00 Mon–Fri
+    },
+    everyHour: {
+      class: HourlyCleanupJob,
+      cron: "@hourly"
+    }
+  }
+}
+```
+
+Cron fields are: `minute hour day-of-month month day-of-week`. Supported syntax:
+
+- `*` (any), single values (`5`), ranges (`1-5`), lists (`1,3,5`).
+- Step expressions: `*/15` (every 15 minutes), `0-30/5` (every 5 between 0 and 30).
+- Month and weekday names: `jan`-`dec`, `sun`-`sat` (case-insensitive). Both `0` and `7` mean Sunday.
+- POSIX shortcuts: `@hourly`, `@daily` / `@midnight`, `@weekly`, `@monthly`, `@yearly` / `@annually`.
+- Day-of-month and day-of-week interaction follows POSIX/Vixie cron: when both are restricted (neither `*`), the job fires when **either** matches.
+
+Each job must define exactly one of `every` or `cron`. Cron times are evaluated in the **server's local timezone**, at minute granularity.
+
 `background-jobs-main` owns the schedule and enqueues the configured jobs into the normal Velocious background-jobs queue. The HTTP server does not run scheduled jobs itself.
 
 ## Persistence and retries

--- a/spec/background-jobs/cron-expression-spec.js
+++ b/spec/background-jobs/cron-expression-spec.js
@@ -58,6 +58,17 @@ describe("Background jobs - cron expression", () => {
     expect(parseCronExpression("0 0 * * 0").dayOfWeek.has(0)).toBeTrue()
   })
 
+  it("supports day-of-week ranges that span Sunday-as-7 (Fri-Sun)", () => {
+    const parsed = parseCronExpression("0 0 * * 5-7")
+
+    // 5=Fri, 6=Sat, 7→Sun normalizes to 0.
+    expect(parsed.dayOfWeek.has(5)).toBeTrue()
+    expect(parsed.dayOfWeek.has(6)).toBeTrue()
+    expect(parsed.dayOfWeek.has(0)).toBeTrue()
+    expect(parsed.dayOfWeek.has(7)).toBeFalse()
+    expect(parsed.dayOfWeek.size).toEqual(3)
+  })
+
   it("rejects expressions with the wrong field count", () => {
     expect(() => parseCronExpression("* * * *")).toThrow(/expected 5 fields/)
     expect(() => parseCronExpression("* * * * * *")).toThrow(/expected 5 fields/)
@@ -112,5 +123,17 @@ describe("Background jobs - cron expression", () => {
     const parsed = parseCronExpression("0 0 31 2 *")
 
     expect(() => nextCronFireDate(parsed, new Date(2026, 0, 1))).toThrow(/never matches/)
+  })
+
+  it("finds the next leap-year-only fire (Feb 29) even from a non-leap year", () => {
+    const parsed = parseCronExpression("0 0 29 2 *")
+    // 2026 is not a leap year; the next Feb 29 is 2028-02-29.
+    const next = nextCronFireDate(parsed, new Date(2026, 2, 1, 0, 0, 0))
+
+    expect(next.getFullYear()).toEqual(2028)
+    expect(next.getMonth()).toEqual(1)
+    expect(next.getDate()).toEqual(29)
+    expect(next.getHours()).toEqual(0)
+    expect(next.getMinutes()).toEqual(0)
   })
 })

--- a/spec/background-jobs/cron-expression-spec.js
+++ b/spec/background-jobs/cron-expression-spec.js
@@ -1,0 +1,116 @@
+// @ts-check
+
+import {nextCronFireDate, parseCronExpression} from "../../src/background-jobs/cron-expression.js"
+
+describe("Background jobs - cron expression", () => {
+  it("parses a basic 5-field expression", () => {
+    const parsed = parseCronExpression("0 9 * * 1-5")
+
+    expect(parsed.minute.has(0)).toBeTrue()
+    expect(parsed.minute.size).toEqual(1)
+    expect(parsed.hour.has(9)).toBeTrue()
+    expect(parsed.dayOfWeek.has(1)).toBeTrue()
+    expect(parsed.dayOfWeek.has(5)).toBeTrue()
+    expect(parsed.dayOfWeek.size).toEqual(5)
+    expect(parsed.dayOfMonthRestricted).toBeFalse()
+    expect(parsed.dayOfWeekRestricted).toBeTrue()
+  })
+
+  it("expands @hourly to 0 * * * *", () => {
+    const parsed = parseCronExpression("@hourly")
+
+    expect(parsed.minute.size).toEqual(1)
+    expect(parsed.hour.size).toEqual(24)
+    expect(parsed.dayOfMonthRestricted).toBeFalse()
+    expect(parsed.dayOfWeekRestricted).toBeFalse()
+  })
+
+  it("expands @daily, @midnight, @weekly, @monthly, @yearly, @annually", () => {
+    expect(parseCronExpression("@daily").hour.size).toEqual(1)
+    expect(parseCronExpression("@midnight").hour.has(0)).toBeTrue()
+    expect(parseCronExpression("@weekly").dayOfWeek.has(0)).toBeTrue()
+    expect(parseCronExpression("@monthly").dayOfMonth.has(1)).toBeTrue()
+    expect(parseCronExpression("@yearly").month.has(1)).toBeTrue()
+    expect(parseCronExpression("@annually").month.has(1)).toBeTrue()
+  })
+
+  it("supports steps, ranges, and lists", () => {
+    const parsed = parseCronExpression("*/15 0,12 1-7 * *")
+
+    expect([...parsed.minute].sort((leftMinute, rightMinute) => leftMinute - rightMinute)).toEqual([0, 15, 30, 45])
+    expect([...parsed.hour].sort((leftHour, rightHour) => leftHour - rightHour)).toEqual([0, 12])
+    expect([...parsed.dayOfMonth].sort((leftDay, rightDay) => leftDay - rightDay)).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it("supports month and weekday names case-insensitively", () => {
+    const parsed = parseCronExpression("0 12 * JAN-MAR mon,wed,FRI")
+
+    expect(parsed.month.size).toEqual(3)
+    expect(parsed.month.has(1)).toBeTrue()
+    expect(parsed.month.has(3)).toBeTrue()
+    expect(parsed.dayOfWeek.has(1)).toBeTrue()
+    expect(parsed.dayOfWeek.has(3)).toBeTrue()
+    expect(parsed.dayOfWeek.has(5)).toBeTrue()
+  })
+
+  it("treats Sunday as both 0 and 7", () => {
+    expect(parseCronExpression("0 0 * * 7").dayOfWeek.has(0)).toBeTrue()
+    expect(parseCronExpression("0 0 * * 0").dayOfWeek.has(0)).toBeTrue()
+  })
+
+  it("rejects expressions with the wrong field count", () => {
+    expect(() => parseCronExpression("* * * *")).toThrow(/expected 5 fields/)
+    expect(() => parseCronExpression("* * * * * *")).toThrow(/expected 5 fields/)
+  })
+
+  it("rejects out-of-range values", () => {
+    expect(() => parseCronExpression("60 * * * *")).toThrow(/out of range/)
+    expect(() => parseCronExpression("* 24 * * *")).toThrow(/out of range/)
+  })
+
+  it("computes the next fire after a given reference Date for hourly", () => {
+    const parsed = parseCronExpression("0 * * * *")
+    const reference = new Date(2026, 0, 1, 9, 30, 12)
+    const next = nextCronFireDate(parsed, reference)
+
+    expect(next.getFullYear()).toEqual(2026)
+    expect(next.getMonth()).toEqual(0)
+    expect(next.getDate()).toEqual(1)
+    expect(next.getHours()).toEqual(10)
+    expect(next.getMinutes()).toEqual(0)
+  })
+
+  it("rolls forward across day/month boundaries for daily", () => {
+    const parsed = parseCronExpression("0 9 * * *")
+    const reference = new Date(2026, 0, 1, 23, 59, 30)
+    const next = nextCronFireDate(parsed, reference)
+
+    expect(next.getDate()).toEqual(2)
+    expect(next.getHours()).toEqual(9)
+    expect(next.getMinutes()).toEqual(0)
+  })
+
+  it("OR-combines day-of-month and day-of-week when both are restricted (POSIX semantics)", () => {
+    // Fires on the 1st OR on Sunday.
+    const parsed = parseCronExpression("0 0 1 * 0")
+    // 2026-01-04 is a Sunday.
+    const sundayMatch = nextCronFireDate(parsed, new Date(2026, 0, 3, 12, 0, 0))
+
+    expect(sundayMatch.getDate()).toEqual(4)
+    expect(sundayMatch.getDay()).toEqual(0)
+
+    // From 2026-01-05 (Monday), the next match is the 11th (Sunday)
+    // — neither 1st of month nor Sunday until then.
+    const nextSundayMatch = nextCronFireDate(parsed, new Date(2026, 0, 5, 0, 0, 0))
+
+    expect(nextSundayMatch.getDate()).toEqual(11)
+    expect(nextSundayMatch.getDay()).toEqual(0)
+  })
+
+  it("throws for expressions that can never match", () => {
+    // Feb 31st never exists.
+    const parsed = parseCronExpression("0 0 31 2 *")
+
+    expect(() => nextCronFireDate(parsed, new Date(2026, 0, 1))).toThrow(/never matches/)
+  })
+})

--- a/spec/background-jobs/scheduler-spec.js
+++ b/spec/background-jobs/scheduler-spec.js
@@ -194,6 +194,99 @@ describe("Background jobs - scheduler", () => {
     }
   })
 
+  it("rejects schedules that define both every and cron", async () => {
+    const scheduler = new BackgroundJobsScheduler({
+      configuration: {
+        async getScheduledBackgroundJobsConfig() {
+          return {
+            jobs: {
+              bothScheduleJob: {
+                class: TestJob,
+                cron: "0 * * * *",
+                every: "1h"
+              }
+            }
+          }
+        }
+      },
+      enqueueJob: async () => {}
+    })
+
+    let error = null
+
+    try {
+      await scheduler.start()
+    } catch (newError) {
+      error = newError
+    }
+
+    expect(error).toBeTruthy()
+    expect(error?.message).toEqual('Scheduled background job bothScheduleJob must define either "every" or "cron", not both.')
+  })
+
+  it("does not re-arm a cron schedule when stop() runs during an in-flight enqueue", async () => {
+    const originalSetTimeout = globalThis.setTimeout
+    const originalSetInterval = globalThis.setInterval
+    const originalClearTimeout = globalThis.clearTimeout
+    const originalClearInterval = globalThis.clearInterval
+    const enqueuedJobs = []
+    const timeoutCallbacks = []
+
+    globalThis.setTimeout = (callback) => {
+      timeoutCallbacks.push(callback)
+      return /** @type {NodeJS.Timeout} */ ({})
+    }
+    globalThis.setInterval = () => /** @type {NodeJS.Timeout} */ ({})
+    globalThis.clearTimeout = () => {}
+    globalThis.clearInterval = () => {}
+
+    try {
+      let resolveEnqueue
+      const enqueueGate = new Promise((resolve) => { resolveEnqueue = resolve })
+      const scheduler = new BackgroundJobsScheduler({
+        configuration: {
+          async getScheduledBackgroundJobsConfig() {
+            return {
+              jobs: {
+                stopRaceJob: {
+                  class: TestJob,
+                  cron: "* * * * *"
+                }
+              }
+            }
+          }
+        },
+        enqueueJob: async (job) => {
+          enqueuedJobs.push(job)
+          await enqueueGate
+        }
+      })
+
+      await scheduler.start()
+
+      const initialCallbackCount = timeoutCallbacks.length
+      // Fire the cron timeout — its callback is async and awaits the
+      // enqueue gate, so it pauses inside the await.
+      const firePromise = timeoutCallbacks[timeoutCallbacks.length - 1]?.()
+
+      // While the enqueue is pending, stop the scheduler.
+      scheduler.stop()
+      // Now release the enqueue. The post-await branch must NOT
+      // schedule another setTimeout because we're stopped.
+      resolveEnqueue?.()
+      await firePromise
+
+      expect(enqueuedJobs.length).toEqual(1)
+      // No new setTimeout queued after the stop+release sequence.
+      expect(timeoutCallbacks.length).toEqual(initialCallbackCount)
+    } finally {
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.setInterval = originalSetInterval
+      globalThis.clearTimeout = originalClearTimeout
+      globalThis.clearInterval = originalClearInterval
+    }
+  })
+
   it("rejects schedules that have neither every nor cron", async () => {
     const scheduler = new BackgroundJobsScheduler({
       configuration: {

--- a/spec/background-jobs/scheduler-spec.js
+++ b/spec/background-jobs/scheduler-spec.js
@@ -108,4 +108,117 @@ describe("Background jobs - scheduler", () => {
       globalThis.clearInterval = originalClearInterval
     }
   })
+
+  it("schedules cron jobs and self-reschedules after each fire", async () => {
+    const originalSetTimeout = globalThis.setTimeout
+    const originalSetInterval = globalThis.setInterval
+    const originalClearTimeout = globalThis.clearTimeout
+    const originalClearInterval = globalThis.clearInterval
+    const enqueuedJobs = []
+    const timeoutCallbacks = []
+    const timeoutDelays = []
+    const intervalDelays = []
+
+    globalThis.setTimeout = (callback, delay) => {
+      timeoutCallbacks.push(callback)
+      timeoutDelays.push(delay)
+      return /** @type {NodeJS.Timeout} */ ({})
+    }
+    globalThis.setInterval = (callback, delay) => {
+      intervalDelays.push(delay)
+      return /** @type {NodeJS.Timeout} */ ({})
+    }
+    globalThis.clearTimeout = () => {}
+    globalThis.clearInterval = () => {}
+
+    try {
+      const scheduler = new BackgroundJobsScheduler({
+        configuration: {
+          async getScheduledBackgroundJobsConfig() {
+            return {
+              jobs: {
+                cronTestJob: {
+                  args: ["cron"],
+                  class: TestJob,
+                  // Every minute — shortest cadence so we don't have
+                  // to wait long for the test.
+                  cron: "* * * * *",
+                  options: {forked: false}
+                }
+              }
+            }
+          }
+        },
+        enqueueJob: async (job) => {
+          enqueuedJobs.push(job)
+        }
+      })
+
+      await scheduler.start()
+
+      // The cron path schedules a setTimeout with a delay between 1ms
+      // and 60_000ms (the gap to the next minute boundary for
+      // `* * * * *`). The test runner internals can also call
+      // setTimeout during the `await` boundary, so we look at the
+      // most recent timeout instead of asserting an exact count.
+      const lastTimeoutDelay = timeoutDelays[timeoutDelays.length - 1]
+
+      expect(lastTimeoutDelay).toBeGreaterThan(0)
+      expect(lastTimeoutDelay).toBeLessThanOrEqual(60_000)
+
+      const beforeFireTimeoutCount = timeoutDelays.length
+
+      await timeoutCallbacks[timeoutCallbacks.length - 1]?.()
+
+      expect(enqueuedJobs).toEqual([{
+        args: ["cron"],
+        jobClass: TestJob,
+        jobKey: "cronTestJob",
+        options: {forked: false}
+      }])
+
+      // After firing, the cron path uses setTimeout again (NOT
+      // setInterval) so each subsequent run is recomputed against
+      // wall-clock time.
+      expect(intervalDelays).toEqual([])
+      expect(timeoutDelays.length).toBeGreaterThan(beforeFireTimeoutCount)
+
+      await timeoutCallbacks[timeoutCallbacks.length - 1]?.()
+
+      expect(enqueuedJobs.length).toEqual(2)
+    } finally {
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.setInterval = originalSetInterval
+      globalThis.clearTimeout = originalClearTimeout
+      globalThis.clearInterval = originalClearInterval
+    }
+  })
+
+  it("rejects schedules that have neither every nor cron", async () => {
+    const scheduler = new BackgroundJobsScheduler({
+      configuration: {
+        async getScheduledBackgroundJobsConfig() {
+          return {
+            jobs: {
+              missingScheduleJob: {
+                class: TestJob
+              }
+            }
+          }
+        }
+      },
+      enqueueJob: async () => {}
+    })
+
+    let error = null
+
+    try {
+      await scheduler.start()
+    } catch (newError) {
+      error = newError
+    }
+
+    expect(error).toBeTruthy()
+    expect(error?.message).toEqual('Scheduled background job missingScheduleJob must define either "every" or "cron".')
+  })
 })

--- a/src/background-jobs/cron-expression.js
+++ b/src/background-jobs/cron-expression.js
@@ -31,7 +31,9 @@ const FIELDS = [
   {name: "hour", min: 0, max: 23},
   {name: "dayOfMonth", min: 1, max: 31},
   {name: "month", min: 1, max: 12, names: MONTH_NAMES},
-  {name: "dayOfWeek", min: 0, max: 6, names: DAY_NAMES}
+  // Accept 0-7 so ranges like `5-7` (Fri-Sun) work; we normalize 7
+  // down to 0 after parsing in `normalizeDayOfWeek` below.
+  {name: "dayOfWeek", min: 0, max: 7, names: DAY_NAMES}
 ]
 
 /**
@@ -69,9 +71,10 @@ export function parseCronExpression(expression) {
     hour: parseField(hourField, FIELDS[1], expression),
     dayOfMonth: parseField(dayOfMonthField, FIELDS[2], expression),
     month: parseField(monthField, FIELDS[3], expression),
-    // Cron treats both 0 and 7 as Sunday — normalize 7 down so the
-    // rest of the matcher can use 0-6 exclusively.
-    dayOfWeek: normalizeDayOfWeek(parseField(dayOfWeekField, FIELDS[4], expression, {extraNames: {"7": "0"}})),
+    // Cron treats both 0 and 7 as Sunday. We accept 7 throughout the
+    // parse pass (so `5-7` for Fri-Sun works) and then normalize any
+    // 7s down to 0 so the matcher only deals with 0-6.
+    dayOfWeek: normalizeDayOfWeek(parseField(dayOfWeekField, FIELDS[4], expression)),
     dayOfMonthRestricted: dayOfMonthField !== "*",
     dayOfWeekRestricted: dayOfWeekField !== "*",
     expression
@@ -97,14 +100,13 @@ function normalizeDayOfWeek(dayOfWeek) {
  * @param {string} field - Field expression.
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Whole cron expression for error messages.
- * @param {{extraNames?: Record<string, string>}} [options] - Extra name -> numeric aliases.
  * @returns {Set<number>}
  */
-function parseField(field, fieldSpec, expression, options = {}) {
+function parseField(field, fieldSpec, expression) {
   const result = new Set()
 
   for (const part of field.split(",")) {
-    addPartValues(part, fieldSpec, expression, result, options.extraNames)
+    addPartValues(part, fieldSpec, expression, result)
   }
 
   return result
@@ -115,17 +117,16 @@ function parseField(field, fieldSpec, expression, options = {}) {
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Original expression for errors.
  * @param {Set<number>} result - Accumulator.
- * @param {Record<string, string>} [extraNames] - Extra raw aliases.
  * @returns {void}
  */
-function addPartValues(part, fieldSpec, expression, result, extraNames) {
+function addPartValues(part, fieldSpec, expression, result) {
   if (!part) {
     throw new Error(`Invalid ${fieldSpec.name} field in cron expression "${expression}"`)
   }
 
   const [rangePart, stepPart] = part.split("/")
   const step = stepPart === undefined ? 1 : parseStep(stepPart, fieldSpec, expression)
-  const [start, end] = parseRange(rangePart, fieldSpec, expression, stepPart !== undefined, extraNames)
+  const [start, end] = parseRange(rangePart, fieldSpec, expression, stepPart !== undefined)
 
   for (let value = start; value <= end; value += step) {
     if (value < fieldSpec.min || value > fieldSpec.max) {
@@ -157,10 +158,9 @@ function parseStep(value, fieldSpec, expression) {
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Original expression for errors.
  * @param {boolean} hasStep - Whether the part had a `/step` suffix.
- * @param {Record<string, string>} [extraNames] - Extra raw aliases (e.g. `{"7": "0"}`).
  * @returns {[number, number]}
  */
-function parseRange(rangePart, fieldSpec, expression, hasStep, extraNames) {
+function parseRange(rangePart, fieldSpec, expression, hasStep) {
   if (rangePart === "*") {
     return [fieldSpec.min, fieldSpec.max]
   }
@@ -168,14 +168,14 @@ function parseRange(rangePart, fieldSpec, expression, hasStep, extraNames) {
   const dashIndex = rangePart.indexOf("-")
 
   if (dashIndex === -1) {
-    const value = parseValue(rangePart, fieldSpec, expression, extraNames)
+    const value = parseValue(rangePart, fieldSpec, expression)
 
     // `N/step` is shorthand for `N-max/step` (Vixie cron).
     return [value, hasStep ? fieldSpec.max : value]
   }
 
-  const start = parseValue(rangePart.slice(0, dashIndex), fieldSpec, expression, extraNames)
-  const end = parseValue(rangePart.slice(dashIndex + 1), fieldSpec, expression, extraNames)
+  const start = parseValue(rangePart.slice(0, dashIndex), fieldSpec, expression)
+  const end = parseValue(rangePart.slice(dashIndex + 1), fieldSpec, expression)
 
   if (start > end) {
     throw new Error(`Range start ${start} > end ${end} for ${fieldSpec.name} in cron expression "${expression}"`)
@@ -188,22 +188,20 @@ function parseRange(rangePart, fieldSpec, expression, hasStep, extraNames) {
  * @param {string} rawValue - Raw value (may be a name).
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Original expression for errors.
- * @param {Record<string, string>} [extraNames] - Extra raw aliases.
  * @returns {number}
  */
-function parseValue(rawValue, fieldSpec, expression, extraNames) {
+function parseValue(rawValue, fieldSpec, expression) {
   if (!rawValue) {
     throw new Error(`Invalid ${fieldSpec.name} value in cron expression "${expression}"`)
   }
 
-  const aliased = extraNames?.[rawValue] ?? rawValue
-  const namedIndex = fieldSpec.names?.indexOf(aliased)
+  const namedIndex = fieldSpec.names?.indexOf(rawValue)
 
   if (typeof namedIndex === "number" && namedIndex !== -1) {
     return namedIndex + fieldSpec.min
   }
 
-  const value = Number(aliased)
+  const value = Number(rawValue)
 
   if (!Number.isInteger(value)) {
     throw new Error(`Invalid ${fieldSpec.name} value "${rawValue}" in cron expression "${expression}"`)
@@ -212,13 +210,16 @@ function parseValue(rawValue, fieldSpec, expression, extraNames) {
   return value
 }
 
-const MAX_NEXT_FIRE_ITERATIONS = 366 * 24 * 60
+// 5 years of minutes — covers the worst-case legitimate gap, the
+// `0 0 29 2 *` (Feb 29) leap-year-only schedule, with a one-year
+// buffer so we never report a real cron pattern as "never matches".
+const MAX_NEXT_FIRE_ITERATIONS = 5 * 366 * 24 * 60
 
 /**
  * Returns the next Date strictly after `from` that satisfies `parsed`.
- * Operates at minute granularity. Bails out with an error after a year
- * of search, which only happens if the expression matches no real time
- * (e.g., `0 0 31 2 *` — Feb 31st).
+ * Operates at minute granularity. Bails out with an error after five
+ * years of search, which only happens if the expression matches no
+ * real time (e.g., `0 0 31 2 *` — Feb 31st).
  *
  * @param {ParsedCron} parsed - Parsed cron expression.
  * @param {Date} from - Reference Date — the next match is strictly after this.

--- a/src/background-jobs/cron-expression.js
+++ b/src/background-jobs/cron-expression.js
@@ -1,0 +1,266 @@
+// @ts-check
+
+/**
+ * Minimal POSIX-style 5-field cron parser used by the background-job
+ * scheduler. Supports `*`, single values, ranges (`N-M`), steps
+ * (`*\/N` or `N-M/N`), comma-separated lists, and the common
+ * `@hourly`/`@daily`/`@weekly`/`@monthly`/`@yearly`/`@midnight`
+ * shortcuts. Month and day-of-week names (`jan`-`dec`, `sun`-`sat`,
+ * case-insensitive) are also accepted.
+ *
+ * For day-of-month + day-of-week interaction, follows POSIX/Vixie
+ * cron semantics: when both fields are restricted (neither `*`), the
+ * job fires when EITHER matches. When one is `*` it has no effect.
+ */
+
+const MONTH_NAMES = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+const DAY_NAMES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+
+const SHORTCUTS = {
+  "@hourly": "0 * * * *",
+  "@daily": "0 0 * * *",
+  "@midnight": "0 0 * * *",
+  "@weekly": "0 0 * * 0",
+  "@monthly": "0 0 1 * *",
+  "@yearly": "0 0 1 1 *",
+  "@annually": "0 0 1 1 *"
+}
+
+const FIELDS = [
+  {name: "minute", min: 0, max: 59},
+  {name: "hour", min: 0, max: 23},
+  {name: "dayOfMonth", min: 1, max: 31},
+  {name: "month", min: 1, max: 12, names: MONTH_NAMES},
+  {name: "dayOfWeek", min: 0, max: 6, names: DAY_NAMES}
+]
+
+/**
+ * @typedef {object} ParsedCron
+ * @property {Set<number>} minute - Allowed minute values (0-59).
+ * @property {Set<number>} hour - Allowed hour values (0-23).
+ * @property {Set<number>} dayOfMonth - Allowed day-of-month values (1-31).
+ * @property {Set<number>} month - Allowed month values (1-12).
+ * @property {Set<number>} dayOfWeek - Allowed day-of-week values (0-6, 0=Sun).
+ * @property {boolean} dayOfMonthRestricted - True when the dayOfMonth field is not `*`.
+ * @property {boolean} dayOfWeekRestricted - True when the dayOfWeek field is not `*`.
+ * @property {string} expression - Original expression for diagnostics.
+ */
+
+/**
+ * @param {string} expression - Cron expression or shortcut.
+ * @returns {ParsedCron}
+ */
+export function parseCronExpression(expression) {
+  if (typeof expression !== "string" || !expression.trim()) {
+    throw new Error(`Invalid cron expression: ${expression}`)
+  }
+
+  const trimmed = expression.trim().toLowerCase()
+  const expanded = SHORTCUTS[/** @type {keyof typeof SHORTCUTS} */ (trimmed)] || trimmed
+  const fields = expanded.split(/\s+/)
+
+  if (fields.length !== 5) {
+    throw new Error(`Invalid cron expression "${expression}": expected 5 fields, got ${fields.length}`)
+  }
+
+  const [minuteField, hourField, dayOfMonthField, monthField, dayOfWeekField] = fields
+  const parsed = {
+    minute: parseField(minuteField, FIELDS[0], expression),
+    hour: parseField(hourField, FIELDS[1], expression),
+    dayOfMonth: parseField(dayOfMonthField, FIELDS[2], expression),
+    month: parseField(monthField, FIELDS[3], expression),
+    // Cron treats both 0 and 7 as Sunday — normalize 7 down so the
+    // rest of the matcher can use 0-6 exclusively.
+    dayOfWeek: normalizeDayOfWeek(parseField(dayOfWeekField, FIELDS[4], expression, {extraNames: {"7": "0"}})),
+    dayOfMonthRestricted: dayOfMonthField !== "*",
+    dayOfWeekRestricted: dayOfWeekField !== "*",
+    expression
+  }
+
+  return parsed
+}
+
+/**
+ * @param {Set<number>} dayOfWeek
+ * @returns {Set<number>}
+ */
+function normalizeDayOfWeek(dayOfWeek) {
+  if (dayOfWeek.has(7)) {
+    dayOfWeek.delete(7)
+    dayOfWeek.add(0)
+  }
+
+  return dayOfWeek
+}
+
+/**
+ * @param {string} field - Field expression.
+ * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
+ * @param {string} expression - Whole cron expression for error messages.
+ * @param {{extraNames?: Record<string, string>}} [options] - Extra name -> numeric aliases.
+ * @returns {Set<number>}
+ */
+function parseField(field, fieldSpec, expression, options = {}) {
+  const result = new Set()
+
+  for (const part of field.split(",")) {
+    addPartValues(part, fieldSpec, expression, result, options.extraNames)
+  }
+
+  return result
+}
+
+/**
+ * @param {string} part - Single comma-separated chunk.
+ * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
+ * @param {string} expression - Original expression for errors.
+ * @param {Set<number>} result - Accumulator.
+ * @param {Record<string, string>} [extraNames] - Extra raw aliases.
+ * @returns {void}
+ */
+function addPartValues(part, fieldSpec, expression, result, extraNames) {
+  if (!part) {
+    throw new Error(`Invalid ${fieldSpec.name} field in cron expression "${expression}"`)
+  }
+
+  const [rangePart, stepPart] = part.split("/")
+  const step = stepPart === undefined ? 1 : parseStep(stepPart, fieldSpec, expression)
+  const [start, end] = parseRange(rangePart, fieldSpec, expression, stepPart !== undefined, extraNames)
+
+  for (let value = start; value <= end; value += step) {
+    if (value < fieldSpec.min || value > fieldSpec.max) {
+      throw new Error(`Value ${value} out of range for ${fieldSpec.name} in cron expression "${expression}"`)
+    }
+
+    result.add(value)
+  }
+}
+
+/**
+ * @param {string} value - Step value.
+ * @param {{name: string, min: number, max: number}} fieldSpec - Field spec.
+ * @param {string} expression - Original expression for errors.
+ * @returns {number}
+ */
+function parseStep(value, fieldSpec, expression) {
+  const step = Number(value)
+
+  if (!Number.isInteger(step) || step <= 0) {
+    throw new Error(`Invalid step "${value}" for ${fieldSpec.name} in cron expression "${expression}"`)
+  }
+
+  return step
+}
+
+/**
+ * @param {string} rangePart - Range portion (before any `/`).
+ * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
+ * @param {string} expression - Original expression for errors.
+ * @param {boolean} hasStep - Whether the part had a `/step` suffix.
+ * @param {Record<string, string>} [extraNames] - Extra raw aliases (e.g. `{"7": "0"}`).
+ * @returns {[number, number]}
+ */
+function parseRange(rangePart, fieldSpec, expression, hasStep, extraNames) {
+  if (rangePart === "*") {
+    return [fieldSpec.min, fieldSpec.max]
+  }
+
+  const dashIndex = rangePart.indexOf("-")
+
+  if (dashIndex === -1) {
+    const value = parseValue(rangePart, fieldSpec, expression, extraNames)
+
+    // `N/step` is shorthand for `N-max/step` (Vixie cron).
+    return [value, hasStep ? fieldSpec.max : value]
+  }
+
+  const start = parseValue(rangePart.slice(0, dashIndex), fieldSpec, expression, extraNames)
+  const end = parseValue(rangePart.slice(dashIndex + 1), fieldSpec, expression, extraNames)
+
+  if (start > end) {
+    throw new Error(`Range start ${start} > end ${end} for ${fieldSpec.name} in cron expression "${expression}"`)
+  }
+
+  return [start, end]
+}
+
+/**
+ * @param {string} rawValue - Raw value (may be a name).
+ * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
+ * @param {string} expression - Original expression for errors.
+ * @param {Record<string, string>} [extraNames] - Extra raw aliases.
+ * @returns {number}
+ */
+function parseValue(rawValue, fieldSpec, expression, extraNames) {
+  if (!rawValue) {
+    throw new Error(`Invalid ${fieldSpec.name} value in cron expression "${expression}"`)
+  }
+
+  const aliased = extraNames?.[rawValue] ?? rawValue
+  const namedIndex = fieldSpec.names?.indexOf(aliased)
+
+  if (typeof namedIndex === "number" && namedIndex !== -1) {
+    return namedIndex + fieldSpec.min
+  }
+
+  const value = Number(aliased)
+
+  if (!Number.isInteger(value)) {
+    throw new Error(`Invalid ${fieldSpec.name} value "${rawValue}" in cron expression "${expression}"`)
+  }
+
+  return value
+}
+
+const MAX_NEXT_FIRE_ITERATIONS = 366 * 24 * 60
+
+/**
+ * Returns the next Date strictly after `from` that satisfies `parsed`.
+ * Operates at minute granularity. Bails out with an error after a year
+ * of search, which only happens if the expression matches no real time
+ * (e.g., `0 0 31 2 *` — Feb 31st).
+ *
+ * @param {ParsedCron} parsed - Parsed cron expression.
+ * @param {Date} from - Reference Date — the next match is strictly after this.
+ * @returns {Date}
+ */
+export function nextCronFireDate(parsed, from) {
+  const candidate = new Date(from.getTime())
+
+  candidate.setSeconds(0, 0)
+  candidate.setMinutes(candidate.getMinutes() + 1)
+
+  for (let iterations = 0; iterations < MAX_NEXT_FIRE_ITERATIONS; iterations += 1) {
+    if (candidateMatches(candidate, parsed)) return candidate
+
+    candidate.setMinutes(candidate.getMinutes() + 1)
+  }
+
+  throw new Error(`Cron expression "${parsed.expression}" never matches`)
+}
+
+/**
+ * @param {Date} candidate - Candidate Date (in local time).
+ * @param {ParsedCron} parsed - Parsed expression.
+ * @returns {boolean}
+ */
+function candidateMatches(candidate, parsed) {
+  if (!parsed.minute.has(candidate.getMinutes())) return false
+  if (!parsed.hour.has(candidate.getHours())) return false
+  if (!parsed.month.has(candidate.getMonth() + 1)) return false
+
+  const dayOfMonthMatch = parsed.dayOfMonth.has(candidate.getDate())
+  const dayOfWeekMatch = parsed.dayOfWeek.has(candidate.getDay())
+
+  // POSIX/Vixie cron OR semantics: when both day fields are
+  // restricted, fire when EITHER matches. When only one is
+  // restricted, only that one applies.
+  if (parsed.dayOfMonthRestricted && parsed.dayOfWeekRestricted) {
+    return dayOfMonthMatch || dayOfWeekMatch
+  }
+
+  if (parsed.dayOfMonthRestricted) return dayOfMonthMatch
+  if (parsed.dayOfWeekRestricted) return dayOfWeekMatch
+
+  return true
+}

--- a/src/background-jobs/scheduler.js
+++ b/src/background-jobs/scheduler.js
@@ -73,10 +73,14 @@ export default class BackgroundJobsScheduler {
     this.intervalIds = []
     /** @type {Array<ReturnType<typeof setTimeout>>} */
     this.timeoutIds = []
+    /** @type {boolean} - True between stop() and the next start(); cron self-rescheduler checks this so a stop() during an in-flight enqueue doesn't immediately re-arm. */
+    this.stopped = false
   }
 
   /** @returns {Promise<void>} */
   async start() {
+    this.stopped = false
+
     const scheduledBackgroundJobsConfig = await this.configuration.getScheduledBackgroundJobsConfig()
 
     if (!scheduledBackgroundJobsConfig?.jobs) {
@@ -96,6 +100,8 @@ export default class BackgroundJobsScheduler {
 
   /** @returns {void} */
   stop() {
+    this.stopped = true
+
     for (const intervalId of this.intervalIds) {
       clearInterval(intervalId)
     }
@@ -117,6 +123,10 @@ export default class BackgroundJobsScheduler {
   scheduleJob({jobConfiguration, jobKey}) {
     if (!jobConfiguration.class || typeof jobConfiguration.class.performLaterWithOptions !== "function") {
       throw new Error(`Scheduled background job ${jobKey} must define a job class.`)
+    }
+
+    if (jobConfiguration.cron !== undefined && jobConfiguration.every !== undefined) {
+      throw new Error(`Scheduled background job ${jobKey} must define either "every" or "cron", not both.`)
     }
 
     if (jobConfiguration.cron !== undefined) {
@@ -181,10 +191,19 @@ export default class BackgroundJobsScheduler {
 
     const parsed = parseCronExpression(cronExpression)
     const scheduleNext = () => {
+      if (this.stopped) return
+
       const nextDate = nextCronFireDate(parsed, new Date())
       const delayMs = Math.max(1, nextDate.getTime() - Date.now())
       const timeoutId = setTimeout(async () => {
+        if (this.stopped) return
+
         await this.enqueueScheduledJob({jobConfiguration, jobKey})
+
+        // The await above can yield to a stop() call. Re-check before
+        // re-arming so we don't keep firing after shutdown.
+        if (this.stopped) return
+
         scheduleNext()
       }, delayMs)
 

--- a/src/background-jobs/scheduler.js
+++ b/src/background-jobs/scheduler.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import Logger from "../logger.js"
+import {nextCronFireDate, parseCronExpression} from "./cron-expression.js"
 
 const DURATION_MULTIPLIERS = {
   d: 24 * 60 * 60 * 1000,
@@ -114,16 +115,37 @@ export default class BackgroundJobsScheduler {
    * @returns {void}
    */
   scheduleJob({jobConfiguration, jobKey}) {
-    const {everyValue, firstInValue} = this.normalizeEvery(jobConfiguration.every)
+    if (!jobConfiguration.class || typeof jobConfiguration.class.performLaterWithOptions !== "function") {
+      throw new Error(`Scheduled background job ${jobKey} must define a job class.`)
+    }
+
+    if (jobConfiguration.cron !== undefined) {
+      this.scheduleCronJob({jobConfiguration, jobKey})
+
+      return
+    }
+
+    if (jobConfiguration.every === undefined) {
+      throw new Error(`Scheduled background job ${jobKey} must define either "every" or "cron".`)
+    }
+
+    this.scheduleEveryJob({jobConfiguration, jobKey})
+  }
+
+  /**
+   * @param {object} args - Options.
+   * @param {import("../configuration-types.js").ScheduledBackgroundJobConfiguration} args.jobConfiguration - Job configuration.
+   * @param {string} args.jobKey - Job key.
+   * @returns {void}
+   */
+  scheduleEveryJob({jobConfiguration, jobKey}) {
+    const everyConfig = /** @type {NonNullable<typeof jobConfiguration.every>} */ (jobConfiguration.every)
+    const {everyValue, firstInValue} = this.normalizeEvery(everyConfig)
     const intervalMs = parseScheduledDuration(everyValue, `${jobKey}.every`)
     const firstInMs = firstInValue !== undefined ? parseScheduledDuration(firstInValue, `${jobKey}.first_in`) : intervalMs
 
     if (intervalMs < 1) {
       throw new Error(`Scheduled background job ${jobKey}.every must be at least 1 millisecond.`)
-    }
-
-    if (!jobConfiguration.class || typeof jobConfiguration.class.performLaterWithOptions !== "function") {
-      throw new Error(`Scheduled background job ${jobKey} must define a job class.`)
     }
 
     const timeoutId = setTimeout(() => {
@@ -137,6 +159,39 @@ export default class BackgroundJobsScheduler {
     }, firstInMs)
 
     this.timeoutIds.push(timeoutId)
+  }
+
+  /**
+   * Crontab schedules don't have a constant interval (`0 9 * * 1-5`
+   * fires once per weekday at 9 AM, with gaps of varying length), so
+   * we self-reschedule with `setTimeout` after every fire instead of
+   * using `setInterval`.
+   *
+   * @param {object} args - Options.
+   * @param {import("../configuration-types.js").ScheduledBackgroundJobConfiguration} args.jobConfiguration - Job configuration.
+   * @param {string} args.jobKey - Job key.
+   * @returns {void}
+   */
+  scheduleCronJob({jobConfiguration, jobKey}) {
+    const cronExpression = jobConfiguration.cron
+
+    if (typeof cronExpression !== "string") {
+      throw new Error(`Scheduled background job ${jobKey}.cron must be a string.`)
+    }
+
+    const parsed = parseCronExpression(cronExpression)
+    const scheduleNext = () => {
+      const nextDate = nextCronFireDate(parsed, new Date())
+      const delayMs = Math.max(1, nextDate.getTime() - Date.now())
+      const timeoutId = setTimeout(async () => {
+        await this.enqueueScheduledJob({jobConfiguration, jobKey})
+        scheduleNext()
+      }, delayMs)
+
+      this.timeoutIds.push(timeoutId)
+    }
+
+    scheduleNext()
   }
 
   /**
@@ -159,7 +214,7 @@ export default class BackgroundJobsScheduler {
   }
 
   /**
-   * @param {import("../configuration-types.js").ScheduledBackgroundJobConfiguration["every"]} every - Every config.
+   * @param {NonNullable<import("../configuration-types.js").ScheduledBackgroundJobConfiguration["every"]>} every - Every config (caller must guarantee not undefined).
    * @returns {{everyValue: number | string, firstInValue?: number | string}} - Normalized interval and first-run delay values.
    */
   normalizeEvery(every) {

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -136,8 +136,9 @@
  * @typedef {object} ScheduledBackgroundJobConfiguration
  * @property {any[]} [args] - Arguments passed to the job when enqueued.
  * @property {typeof import("./background-jobs/job.js").default} class - Job class to enqueue.
+ * @property {string} [cron] - Crontab expression (5-field POSIX, plus `@hourly`/`@daily`/`@weekly`/`@monthly`/`@yearly`/`@midnight`). Mutually exclusive with `every`.
  * @property {boolean} [enabled] - Whether the schedule is enabled.
- * @property {number | string | [number | string, ScheduledBackgroundJobEveryOptions]} every - Repeat interval.
+ * @property {number | string | [number | string, ScheduledBackgroundJobEveryOptions]} [every] - Repeat interval. Either `every` or `cron` must be set.
  * @property {import("./background-jobs/types.js").BackgroundJobOptions} [options] - Job options.
  */
 


### PR DESCRIPTION
## Summary
Adds a `cron` field on `ScheduledBackgroundJobConfiguration` as an alternative to `every`. Lets consumers schedule jobs at fixed wall-clock times (`0 9 * * 1-5`) instead of constant intervals only.

- `src/background-jobs/cron-expression.js`: minimal POSIX 5-field parser + `nextCronFireDate(parsed, from)`. Supports `*`, single values, ranges (`N-M`), steps (`*/N`, `N-M/N`), comma lists, month/weekday names (case-insensitive), `0`/`7` for Sunday, and `@hourly`/`@daily`/`@midnight`/`@weekly`/`@monthly`/`@yearly`/`@annually`. Day-of-month + day-of-week follow POSIX/Vixie cron OR semantics when both are restricted.
- `src/background-jobs/scheduler.js`: split into `scheduleEveryJob` (existing `setTimeout` + `setInterval` cadence) and `scheduleCronJob` (self-rescheduling `setTimeout` because cron intervals are not constant). Each schedule must now define exactly one of `every` or `cron`; the scheduler raises a clear error otherwise.
- `src/configuration-types.js`: new optional `cron` field; `every` is now optional.
- README: documents `cron` syntax and OR semantics for the day fields.
- Specs: new `cron-expression-spec.js` for the parser; new scheduler tests for the cron path and the "must define every or cron" guard. Existing `every` tests untouched.

## Test plan
- [x] `npm test -- spec/background-jobs/cron-expression-spec.js spec/background-jobs/scheduler-spec.js` — 17 specs, all green.
- [x] `npm run build` clean.