### PR TITLE
Fix generated frontend model resource config JSDoc

### DIFF
--- a/changelog.d/20260414-generated-resource-config-jsdoc.md
+++ b/changelog.d/20260414-generated-resource-config-jsdoc.md
@@ -1,0 +1,1 @@
+Fixed generated frontend-model `resourceConfig()` JSDoc output to include optional `modelName` and `path` keys so generated model files typecheck correctly in downstream apps.

--- a/changelog.d/20260414-remove-frontend-model-path-config.md
+++ b/changelog.d/20260414-remove-frontend-model-path-config.md
@@ -1,0 +1,1 @@
+Frontend models now derive their resource path from `modelName` only and reject `resourceConfig().path` on both backend resources and generated frontend models. Shared frontend-model commands continue to use the single `/frontend-models` endpoint, while attachment/member helper URLs keep using the derived model path.

--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -126,6 +126,8 @@ describe("Cli - generate - frontend-models", () => {
     expect(taskContents).toContain("builtInMemberCommands?: Record<string, string>")
     expect(taskContents).toContain("collectionCommands?: Record<string, string>")
     expect(taskContents).toContain("memberCommands?: Record<string, string>")
+    expect(taskContents).toContain("modelName?: string")
+    expect(taskContents).toContain("path?: string")
     expect(taskContents.includes("path:")).toEqual(false)
     expect(taskContents).toContain("attributes: [\n")
     expect(taskContents).toContain("      \"id\",\n")

--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -23,8 +23,7 @@ class CallFrontendResource extends FrontendModelBaseResource {
         metadata: {sqlType: "json", null: true},
         active: {type: "boolean"},
         endedAt: {type: "timestamp without time zone", null: true}
-      },
-      path: "/calls"
+      }
     }
   }
 }
@@ -33,8 +32,7 @@ class MissingAbilitiesTaskFrontendResource extends FrontendModelBaseResource {
   /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
   static resourceConfig() {
     return {
-      attributes: ["id", "name"],
-      path: "/tasks"
+      attributes: ["id", "name"]
     }
   }
 }
@@ -49,7 +47,6 @@ class MissingRelationshipTargetTaskFrontendResource extends FrontendModelBaseRes
   static resourceConfig() {
     return {
       attributes: ["id", "name"],
-      path: "/tasks",
       relationships: ["project"]
     }
   }
@@ -59,8 +56,7 @@ class NullableIdCallFrontendResource extends FrontendModelBaseResource {
   /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
   static resourceConfig() {
     return {
-      attributes: {id: {type: "uuid", null: true}},
-      path: "/calls"
+      attributes: {id: {type: "uuid", null: true}}
     }
   }
 }
@@ -69,8 +65,7 @@ class ReferenceUserFrontendResource extends FrontendModelBaseResource {
   /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
   static resourceConfig() {
     return {
-      attributes: ["reference", "email"],
-      path: "/users"
+      attributes: ["reference", "email"]
     }
   }
 }
@@ -122,12 +117,8 @@ describe("Cli - generate - frontend-models", () => {
     const userContents = await fs.readFile(userPath, "utf8")
 
     expect(taskContents).toContain("class Task extends FrontendModelBase")
-    expect(taskContents).toContain("builtInCollectionCommands?: Record<string, string>")
-    expect(taskContents).toContain("builtInMemberCommands?: Record<string, string>")
-    expect(taskContents).toContain("collectionCommands?: Record<string, string>")
-    expect(taskContents).toContain("memberCommands?: Record<string, string>")
-    expect(taskContents).toContain("modelName?: string")
-    expect(taskContents).toContain("path?: string")
+    expect(taskContents).toContain("@typedef {import(\"../../../../src/frontend-models/base.js\").FrontendModelResourceConfig} FrontendModelResourceConfig")
+    expect(taskContents).toContain("/** @returns {FrontendModelResourceConfig} - Resource config. */")
     expect(taskContents.includes("path:")).toEqual(false)
     expect(taskContents).toContain("attributes: [\n")
     expect(taskContents).toContain("      \"id\",\n")

--- a/spec/controller/json-render-frontend-models-spec.js
+++ b/spec/controller/json-render-frontend-models-spec.js
@@ -11,12 +11,11 @@ import {deserializeFrontendModelTransportValue} from "../../src/frontend-models/
 
 /** Test frontend model for controller render specs. */
 class RenderTask extends FrontendModelBase {
-  /** @returns {{attributes: string[], modelName: string, path: string, primaryKey: string}} - Resource config. */
+  /** @returns {{attributes: string[], modelName: string, primaryKey: string}} - Resource config. */
   static resourceConfig() {
     return {
       attributes: ["id", "name"],
       modelName: "RenderTask",
-      path: "/render-tasks",
       primaryKey: "id"
     }
   }

--- a/spec/dummy/src/frontend-models/user.js
+++ b/spec/dummy/src/frontend-models/user.js
@@ -7,7 +7,7 @@ import FrontendModelBase from "../../../../src/frontend-models/base.js"
  */
 /** Frontend model for User. */
 export default class User extends FrontendModelBase {
-  /** @returns {{attachments?: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, memberCommands?: Record<string, string>, primaryKey?: string}} - Resource config. */
+  /** @returns {{attachments?: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, memberCommands?: Record<string, string>, modelName?: string, path?: string, primaryKey?: string}} - Resource config. */
   static resourceConfig() {
     return {
       modelName: "User",

--- a/spec/dummy/src/frontend-models/user.js
+++ b/spec/dummy/src/frontend-models/user.js
@@ -1,5 +1,7 @@
 import FrontendModelBase from "../../../../src/frontend-models/base.js"
 
+/** @typedef {import("../../../../src/frontend-models/base.js").FrontendModelResourceConfig} FrontendModelResourceConfig */
+
 /**
  * @typedef {object} UserAttributes
  * @property {any} reference - Attribute value.
@@ -7,11 +9,10 @@ import FrontendModelBase from "../../../../src/frontend-models/base.js"
  */
 /** Frontend model for User. */
 export default class User extends FrontendModelBase {
-  /** @returns {{attachments?: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, memberCommands?: Record<string, string>, modelName?: string, path?: string, primaryKey?: string}} - Resource config. */
+  /** @returns {FrontendModelResourceConfig} - Resource config. */
   static resourceConfig() {
     return {
       modelName: "User",
-      path: "/users",
       attributes: [
         "reference",
         "email",

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -12,7 +12,7 @@ function buildTestModelClass() {
   /** Test model implementation for frontend model base specs. */
   class User extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {create: string, destroy: string, find: string, index: string, update: string}, path: string, primaryKey: string}} - Resource configuration.
+     * @returns {{attributes: string[], commands: {create: string, destroy: string, find: string, index: string, update: string}, primaryKey: string}} - Resource configuration.
      */
     static resourceConfig() {
       return {
@@ -24,7 +24,6 @@ function buildTestModelClass() {
           index: "index",
           update: "update"
         },
-        path: "/api/frontend-models/users",
         primaryKey: "id"
       }
     }
@@ -77,7 +76,7 @@ function buildAttachmentTestModelClass() {
   /** Test frontend model with attachment definitions. */
   class Task extends FrontendModelBase {
     /**
-     * @returns {{attachments: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], commands: {attach: string, download: string, update: string, url?: string}, path: string, primaryKey: string}}
+     * @returns {{attachments: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], commands: {attach: string, download: string, update: string, url?: string}, primaryKey: string}}
      */
     static resourceConfig() {
       return {
@@ -90,7 +89,6 @@ function buildAttachmentTestModelClass() {
           download: "download",
           update: "update"
         },
-        path: "/api/frontend-models/tasks",
         primaryKey: "id"
       }
     }
@@ -139,13 +137,12 @@ function buildPreloadTestModelClasses() {
   /** Frontend model comment test class. */
   class Comment extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {index: string}, path: string, primaryKey: string}}
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
      */
     static resourceConfig() {
       return {
         attributes: ["id", "body"],
         commands: {index: "index"},
-        path: "/api/frontend-models/comments",
         primaryKey: "id"
       }
     }
@@ -154,13 +151,12 @@ function buildPreloadTestModelClasses() {
   /** Frontend model task test class. */
   class Task extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {index: string}, path: string, primaryKey: string}}
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
      */
     static resourceConfig() {
       return {
         attributes: ["id", "name"],
         commands: {index: "index"},
-        path: "/api/frontend-models/tasks",
         primaryKey: "id"
       }
     }
@@ -194,13 +190,12 @@ function buildPreloadTestModelClasses() {
   /** Frontend model project test class. */
   class Project extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {index: string}, path: string, primaryKey: string}}
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
      */
     static resourceConfig() {
       return {
         attributes: ["id", "name"],
         commands: {index: "index"},
-        path: "/api/frontend-models/projects",
         primaryKey: "id"
       }
     }
@@ -280,12 +275,12 @@ function resetFrontendModelTransport() {
 }
 
 describe("Frontend models - base", () => {
-  it("uses the shared frontend-model API and batches requests when resource path is not configured", async () => {
+  it("uses the shared frontend-model API and batches requests by default", async () => {
     const originalFetch = globalThis.fetch
     /** @type {FetchCall[]} */
     const calls = []
 
-    /** Shared API user model without explicit resource path. */
+    /** Shared API user model. */
     class SharedApiUser extends FrontendModelBase {
       /**
        * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
@@ -711,34 +706,14 @@ describe("Frontend models - base", () => {
     }
   })
 
-  it("rejects unsafe resource path segments in resourceConfig", async () => {
-    /** Model with unsafe resource path. */
-    class UnsafePathUser extends FrontendModelBase {
-      /** @returns {{attributes: string[], commands: {index: string}, path: string, primaryKey: string}} */
-      static resourceConfig() {
-        return {
-          attributes: ["id"],
-          commands: {index: "index"},
-          path: "/api/frontend-models/users;drop",
-          primaryKey: "id"
-        }
-      }
-    }
-
-    await expect(async () => {
-      await UnsafePathUser.toArray()
-    }).toThrow(/Invalid frontend model resource path/)
-  })
-
   it("rejects unsafe command segments in resourceConfig", async () => {
     /** Model with unsafe command name. */
     class UnsafeCommandUser extends FrontendModelBase {
-      /** @returns {{attributes: string[], commands: {index: string}, path: string, primaryKey: string}} */
+      /** @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} */
       static resourceConfig() {
         return {
           attributes: ["id"],
           commands: {index: "index?raw=1"},
-          path: "/api/frontend-models/users",
           primaryKey: "id"
         }
       }
@@ -752,12 +727,11 @@ describe("Frontend models - base", () => {
   it("rejects empty command overrides in resourceConfig", async () => {
     /** Model with empty command override. */
     class EmptyCommandUser extends FrontendModelBase {
-      /** @returns {{attributes: string[], commands: {index: string}, path: string, primaryKey: string}} */
+      /** @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} */
       static resourceConfig() {
         return {
           attributes: ["id"],
           commands: {index: ""},
-          path: "/api/frontend-models/users",
           primaryKey: "id"
         }
       }
@@ -2033,7 +2007,7 @@ describe("Frontend models - base", () => {
             attachmentName: "descriptionFile",
             id: 10
           },
-          url: "/api/frontend-models/tasks/attach"
+          url: "/tasks/attach"
         }
       ])
     } finally {
@@ -2101,7 +2075,7 @@ describe("Frontend models - base", () => {
             attachmentName: "descriptionFile",
             id: 10
           },
-          url: "/api/frontend-models/tasks/attach"
+          url: "/tasks/attach"
         }
       ])
     } finally {
@@ -2246,7 +2220,7 @@ describe("Frontend models - base", () => {
             attachmentName: "descriptionFile",
             id: 10
           },
-          url: "/api/frontend-models/tasks/attach"
+          url: "/tasks/attach"
         }
       ])
     } finally {

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -342,6 +342,78 @@ describe("Frontend models - base", () => {
     }
   })
 
+  it("keeps built-in command aliases as built-in command types in shared requests", async () => {
+    const originalFetch = globalThis.fetch
+    /** @type {FetchCall[]} */
+    const calls = []
+
+    /** Shared API task model with aliased index command. */
+    class SharedApiTask extends FrontendModelBase {
+      /**
+       * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} - Resource configuration.
+       */
+      static resourceConfig() {
+        return {
+          attributes: ["id", "name"],
+          commands: {
+            index: "list"
+          },
+          primaryKey: "id"
+        }
+      }
+    }
+
+    globalThis.fetch = /** @type {typeof fetch} */ (async (url, options) => {
+      const bodyString = typeof options?.body === "string" ? options.body : "{}"
+      const body = JSON.parse(bodyString)
+
+      calls.push({
+        body,
+        url: `${url}`
+      })
+
+      return {
+        ok: true,
+        status: 200,
+        /** @returns {Promise<string>} */
+        text: async () => JSON.stringify({
+          responses: [{
+            requestId: body.requests[0].requestId,
+            response: {
+              models: [{id: "1", name: "One"}],
+              status: "success"
+            }
+          }],
+          status: "success"
+        }),
+        /** @returns {Promise<Record<string, any>>} */
+        json: async () => ({
+          responses: [{
+            requestId: body.requests[0].requestId,
+            response: {
+              models: [{id: "1", name: "One"}],
+              status: "success"
+            }
+          }],
+          status: "success"
+        })
+      }
+    })
+
+    try {
+      await SharedApiTask.toArray()
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].url).toEqual("/frontend-models")
+      expect(calls[0].body.requests[0].commandType).toEqual("index")
+      expect(calls[0].body.requests[0].customPath).toEqual(undefined)
+      expect(calls[0].body.requests[0].model).toEqual("SharedApiTask")
+    } finally {
+      resetFrontendModelTransport()
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it("batches custom commands through the shared frontend-model API", async () => {
     const User = buildTestModelClass()
     const originalFetch = globalThis.fetch

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -76,7 +76,7 @@ function buildAttachmentTestModelClass() {
   /** Test frontend model with attachment definitions. */
   class Task extends FrontendModelBase {
     /**
-     * @returns {{attachments: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], commands: {attach: string, download: string, update: string, url?: string}, primaryKey: string}}
+     * @returns {{attachments: Record<string, {type: "hasOne" | "hasMany"}>, attributes: string[], commands: {attach: string, download: string, update: string, url?: string}, primaryKey: string}} - Resource configuration.
      */
     static resourceConfig() {
       return {
@@ -137,7 +137,7 @@ function buildPreloadTestModelClasses() {
   /** Frontend model comment test class. */
   class Comment extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} - Resource configuration.
      */
     static resourceConfig() {
       return {
@@ -151,7 +151,7 @@ function buildPreloadTestModelClasses() {
   /** Frontend model task test class. */
   class Task extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} - Resource configuration.
      */
     static resourceConfig() {
       return {
@@ -190,7 +190,7 @@ function buildPreloadTestModelClasses() {
   /** Frontend model project test class. */
   class Project extends FrontendModelBase {
     /**
-     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} - Resource configuration.
      */
     static resourceConfig() {
       return {

--- a/spec/frontend-models/transport-serialization-spec.js
+++ b/spec/frontend-models/transport-serialization-spec.js
@@ -6,12 +6,11 @@ import {deserializeFrontendModelTransportValue, serializeFrontendModelTransportV
 
 /** Test frontend model for transport serialization specs. */
 class TransportTask extends FrontendModelBase {
-  /** @returns {{attributes: string[], modelName: string, path: string, primaryKey: string}} - Resource config. */
+  /** @returns {{attributes: string[], modelName: string, primaryKey: string}} - Resource config. */
   static resourceConfig() {
     return {
       attributes: ["id", "name"],
       modelName: "TransportTask",
-      path: "/transport-tasks",
       primaryKey: "id"
     }
   }

--- a/spec/routes/frontend-model-command-route-hook-spec.js
+++ b/spec/routes/frontend-model-command-route-hook-spec.js
@@ -208,6 +208,22 @@ describe("routes - frontend model command route hook", () => {
     }).toThrow("Unknown arguments: capabilities")
   })
 
+  it("throws when resourceConfig includes the removed path key", () => {
+    class PathUserFrontendResource extends FrontendModelBaseResource {
+      /** @returns {Record<string, any>} */
+      static resourceConfig() {
+        return {
+          attributes: ["id"],
+          path: "/users"
+        }
+      }
+    }
+
+    expect(() => {
+      frontendModelResourceConfigurationFromDefinition(PathUserFrontendResource)
+    }).toThrow("Unknown arguments: path")
+  })
+
   it("separates built-in and custom command normalization for opted-in resources", () => {
     const resourceConfiguration = frontendModelResourceConfigurationFromDefinition(UserFrontendResource)
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -210,7 +210,6 @@
  * @property {Record<string, string> | string[]} [builtInCollectionCommands] - Built-in collection command names keyed by action (`index`, `create`) or shorthand command list using default names.
  * @property {Record<string, string> | string[]} [builtInMemberCommands] - Built-in member command names keyed by action (`find`, `update`, `destroy`, `attach`, `download`, `url`) or shorthand command list using default names.
  * @property {string[]} [relationships] - Relationship names to expose in frontend models. Type and target model are inferred from the backend model's registered relationships.
- * @property {string} [path] - Resource path (e.g., "/users"). Generated into frontend model resourceConfig so minified class names don't break path derivation.
  * @property {string} [primaryKey] - Primary key attribute name.
  * @property {FrontendModelResourceServerConfiguration} [server] - Optional legacy backend behavior overrides for built-in frontend actions.
  */

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -225,6 +225,8 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     fileContent += `import FrontendModelBase from "${importPath}"\n`
 
     fileContent += "\n"
+    fileContent += `/** @typedef {import("${importPath}").FrontendModelResourceConfig} FrontendModelResourceConfig */\n`
+    fileContent += "\n"
     fileContent += "/**\n"
     fileContent += ` * @typedef {object} ${attributesTypeName}\n`
     for (const attribute of attributes) {
@@ -233,13 +235,10 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     fileContent += " */\n"
     fileContent += `/** Frontend model for ${className}. */\n`
     fileContent += `export default class ${className} extends FrontendModelBase {\n`
-    fileContent += "  /** @returns {{attachments?: Record<string, {type: \"hasOne\" | \"hasMany\"}>, attributes: string[], builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, memberCommands?: Record<string, string>, modelName?: string, path?: string, primaryKey?: string}} - Resource config. */\n"
+    fileContent += "  /** @returns {FrontendModelResourceConfig} - Resource config. */\n"
     fileContent += "  static resourceConfig() {\n"
     fileContent += "    return {\n"
     fileContent += `      modelName: ${JSON.stringify(className)},\n`
-    if (modelConfig.path) {
-      fileContent += `      path: ${JSON.stringify(modelConfig.path)},\n`
-    }
     if (Object.keys(attachments).length > 0) {
       fileContent += "      attachments: {\n"
       for (const [attachmentName, attachmentConfig] of Object.entries(attachments)) {

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -233,7 +233,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     fileContent += " */\n"
     fileContent += `/** Frontend model for ${className}. */\n`
     fileContent += `export default class ${className} extends FrontendModelBase {\n`
-    fileContent += "  /** @returns {{attachments?: Record<string, {type: \"hasOne\" | \"hasMany\"}>, attributes: string[], builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, memberCommands?: Record<string, string>, primaryKey?: string}} - Resource config. */\n"
+    fileContent += "  /** @returns {{attachments?: Record<string, {type: \"hasOne\" | \"hasMany\"}>, attributes: string[], builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, memberCommands?: Record<string, string>, modelName?: string, path?: string, primaryKey?: string}} - Resource config. */\n"
     fileContent += "  static resourceConfig() {\n"
     fileContent += "    return {\n"
     fileContent += `      modelName: ${JSON.stringify(className)},\n`

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -41,8 +41,6 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   static memberCommands = undefined
   /** @type {Record<string, string> | string[] | undefined} */
   static builtInMemberCommands = undefined
-  /** @type {string | undefined} */
-  static path = undefined
   /** @type {string[] | undefined} */
   static relationships = undefined
   /** @type {string[] | undefined} */
@@ -88,7 +86,6 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     }
 
     if (this.attachments) config.attachments = this.attachments
-    if (this.path) config.path = this.path
     if (this.builtInCollectionCommands) config.builtInCollectionCommands = this.builtInCollectionCommands
     if (this.builtInMemberCommands) config.builtInMemberCommands = this.builtInMemberCommands
     if (this.collectionCommands) config.collectionCommands = this.collectionCommands

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -14,12 +14,12 @@ import {bufferOutgoingEvent, drainBufferedOutgoingEvents} from "./outgoing-event
  * @typedef {{type: "hasOne" | "hasMany"}} FrontendModelAttachmentDefinition
  */
 /**
- * @typedef {{builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, commands?: Record<string, string>, memberCommands?: Record<string, string>, attachments?: Record<string, FrontendModelAttachmentDefinition>, modelName?: string, path?: string, primaryKey?: string}} FrontendModelResourceConfig
+ * @typedef {{builtInCollectionCommands?: Record<string, string>, builtInMemberCommands?: Record<string, string>, collectionCommands?: Record<string, string>, commands?: Record<string, string>, memberCommands?: Record<string, string>, attachments?: Record<string, FrontendModelAttachmentDefinition>, modelName?: string, primaryKey?: string}} FrontendModelResourceConfig
  */
 /**
  * @typedef {object} FrontendModelTransportConfig
- * @property {string | (() => string | undefined | null)} [url] - Optional frontend-model URL. For shared-endpoint models this should be the full shared endpoint (for example `"/frontend-models"` or `"https://example.com/frontend-models"`). For legacy direct-resource models this can be the backend origin/prefix.
- * @property {boolean} [shared] - When true, route built-in commands for path-based models through the shared frontend-model API envelope instead of direct per-command endpoints.
+ * @property {string | (() => string | undefined | null)} [url] - Optional frontend-model URL. This should be the shared endpoint (for example `"/frontend-models"` or `"https://example.com/frontend-models"`).
+ * @property {boolean} [shared] - Deprecated shared-endpoint flag retained for compatibility. Frontend-model CRUD/custom commands use the shared frontend-model API envelope by default.
  * @property {string | (() => string | undefined | null)} [websocketUrl] - Optional websocket URL. When set, Velocious creates and manages its own websocket client internally. Subscriptions use the websocket; CRUD uses HTTP and falls back gracefully. Example: `"ws://localhost:3006/websocket"`.
  * @property {{post: (path: string, body?: any, options?: {headers?: Record<string, string>}) => Promise<{json: () => any}>, subscribe: (channel: string, options: {params?: Record<string, any>}, callback: (payload: any) => void) => (() => void), subscribeAndWait?: (channel: string, options: {params?: Record<string, any>}, callback: (payload: any) => void) => Promise<(() => void)>}} [websocketClient] - Optional websocket client for shared frontend-model API requests and subscriptions.
  */
@@ -1324,14 +1324,12 @@ export default class FrontendModelBase {
 
   /**
    * @this {typeof FrontendModelBase}
-   * @returns {string} - Resource path.
+   * @returns {string} - Derived resource path.
    */
   static resourcePath() {
-    const path = this.resourceConfig().path || defaultFrontendModelResourcePath(this)
-
     return validateFrontendModelResourcePath({
       modelName: this.getModelName(),
-      resourcePath: path
+      resourcePath: defaultFrontendModelResourcePath(this)
     })
   }
 
@@ -2206,8 +2204,7 @@ export default class FrontendModelBase {
   static async executeCommand(commandType, payload) {
     const commandName = this.commandName(commandType)
     const serializedPayload = /** @type {Record<string, any>} */ (serializeFrontendModelTransportValue(payload))
-    const resourceConfig = /** @type {Record<string, any>} */ (this.resourceConfig())
-    const resourcePath = typeof resourceConfig.path === "string" && resourceConfig.path.length > 0 ? this.resourcePath() : null
+    const resourcePath = this.resourcePath()
     const containsAttachmentUpload = frontendModelPayloadContainsAttachmentUpload(serializedPayload)
     const useSharedTransport = !containsAttachmentUpload
     const url = useSharedTransport ? frontendModelApiUrl() : frontendModelCommandUrl(resourcePath || "", commandName)

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -724,14 +724,8 @@ async function flushPendingSharedFrontendModelRequests() {
         }
       }
 
-      const isCustomCommandRoute = request.commandName && request.commandName !== request.commandType && request.resourcePath
-      const customPath = isCustomCommandRoute
-        ? `${request.resourcePath}/${request.commandName}`
-        : undefined
-
       return {
-        commandType: isCustomCommandRoute ? request.commandName : request.commandType,
-        customPath,
+        commandType: request.commandType,
         model: request.modelClass.getModelName(),
         payload: request.payload,
         requestId: request.requestId

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -66,7 +66,6 @@ function normalizeFrontendModelResourceConfiguration(resourceConfiguration) {
     "commands",
     "memberCommands",
     "modelName",
-    "path",
     "primaryKey",
     "relationships",
     "server"
@@ -268,10 +267,6 @@ export function frontendModelResourcePath(modelName, resourceDefinition) {
 
   if (!resourceConfiguration) {
     throw new Error(`Invalid frontend model resource definition for ${modelName}`)
-  }
-
-  if (resourceConfiguration.path) {
-    return resourceConfiguration.path
   }
 
   return `/${inflection.dasherize(inflection.pluralize(inflection.underscore(modelName)))}`


### PR DESCRIPTION
## Summary
- fix generated frontend-model `resourceConfig()` JSDoc to include optional `modelName` and `path`
- keep the generator output aligned with Velocious' actual frontend-model resource config contract
- add generator coverage so downstream app typechecks do not regress on regenerated model files

## Validation
- `npm run lint`
- `npm run typecheck`
- `node scripts/run-tests.js spec/cli/commands/generate/frontend-models-spec.js`
