### PR TITLE
Add frontend model ability request helper

### DIFF
--- a/changelog.d/20260414-frontend-model-ability-request-helper.md
+++ b/changelog.d/20260414-frontend-model-ability-request-helper.md
@@ -1,0 +1,1 @@
+Dummy Peakflow configs now detect shared and direct frontend-model requests through a shared helper so ability resolution stays aligned across generated and custom frontend-model routes.

--- a/spec/dummy/db/structure-mssql.sql
+++ b/spec/dummy/db/structure-mssql.sql
@@ -1,3 +1,37 @@
-CREATE TABLE [accounts] ([id] bigint NOT NULL, [name] varchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+CREATE TABLE [accounts] ([id] bigint NOT NULL, [name] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
 
-CREATE TABLE [schema_migrations] ([version] varchar(255) NOT NULL, PRIMARY KEY ([version]));
+CREATE TABLE [authentication_tokens] ([id] bigint NOT NULL, [user_token] nvarchar(255) DEFAULT (newid()), [user_id] bigint, [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [background_jobs] ([id] nvarchar(255) NOT NULL, [job_name] nvarchar(255) NOT NULL, [args_json] nvarchar(max) NOT NULL, [forked] bit NOT NULL, [max_retries] int NOT NULL, [attempts] int NOT NULL, [status] nvarchar(255) NOT NULL, [scheduled_at_ms] bigint NOT NULL, [created_at_ms] bigint NOT NULL, [handed_off_at_ms] bigint, [completed_at_ms] bigint, [failed_at_ms] bigint, [orphaned_at_ms] bigint, [worker_id] nvarchar(255), [last_error] nvarchar(max), PRIMARY KEY ([id]));
+
+CREATE TABLE [comments] ([id] bigint NOT NULL, [task_id] bigint NOT NULL, [body] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [interactions] ([id] bigint NOT NULL, [subject_id] bigint NOT NULL, [subject_type] nvarchar(255), [kind] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [project_details] ([id] bigint NOT NULL, [project_id] bigint NOT NULL, [note] nvarchar(max), [created_at] datetime, [updated_at] datetime, [is_active] bit, PRIMARY KEY ([id]));
+
+CREATE TABLE [project_translations] ([id] bigint NOT NULL, [project_id] bigint NOT NULL, [locale] nvarchar(255) NOT NULL, [name] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [projects] ([id] bigint NOT NULL, [creating_user_reference] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [schema_migrations] ([version] nvarchar(255) NOT NULL, PRIMARY KEY ([version]));
+
+CREATE TABLE [string_subject_interactions] ([id] bigint NOT NULL, [subject_id] nvarchar(255) NOT NULL, [subject_type] nvarchar(255), [kind] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [string_subjects] ([id] nvarchar(255) NOT NULL, [name] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [tasks] ([id] bigint NOT NULL, [project_id] bigint NOT NULL, [name] nvarchar(255), [description] nvarchar(max), [created_at] datetime, [updated_at] datetime, [is_done] bit, PRIMARY KEY ([id]));
+
+CREATE TABLE [users] ([id] bigint NOT NULL, [email] nvarchar(255) NOT NULL, [encrypted_password] nvarchar(255) NOT NULL, [reference] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [uuid_interactions] ([id] bigint NOT NULL, [subject_id] varchar(36) NOT NULL, [subject_type] nvarchar(255), [kind] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [uuid_items] ([id] varchar(36) DEFAULT (newid()) NOT NULL, [title] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
+
+CREATE TABLE [velocious_attachments] ([id] nvarchar(255) NOT NULL, [record_type] nvarchar(255) NOT NULL, [record_id] nvarchar(255) NOT NULL, [name] nvarchar(255) NOT NULL, [position] int NOT NULL, [filename] nvarchar(255) NOT NULL, [content_type] nvarchar(255), [byte_size] bigint NOT NULL, [driver] nvarchar(255), [storage_key] nvarchar(255), [content_base64] nvarchar(max), [created_at_ms] bigint NOT NULL, [updated_at_ms] bigint NOT NULL, PRIMARY KEY ([id]));
+
+CREATE TABLE [velocious_internal_migrations] ([key] nvarchar(255) NOT NULL, [scope] nvarchar(255) NOT NULL, [version] nvarchar(255) NOT NULL, [applied_at_ms] bigint NOT NULL, PRIMARY KEY ([key]));
+
+CREATE TABLE [websocket_channel_events] ([sequence] int NOT NULL, [id] nvarchar(255) NOT NULL, [channel] nvarchar(255) NOT NULL, [payload_json] nvarchar(max) NOT NULL, [created_at] datetime NOT NULL, PRIMARY KEY ([sequence]));
+
+CREATE TABLE [websocket_replay_channels] ([channel] nvarchar(255) NOT NULL, [interested_until] datetime NOT NULL, PRIMARY KEY ([channel]));

--- a/spec/dummy/src/config/configuration.js
+++ b/spec/dummy/src/config/configuration.js
@@ -2,21 +2,22 @@ import "../../../../src/utils/with-tracked-stack-async-hooks.js"
 import Ability from "../../../../src/authorization/ability.js"
 import AsyncTrackedMultiConnection from "../../../../src/database/pool/async-tracked-multi-connection.js"
 import backendProjects from "./backend-projects.js"
-import CommentFrontendModelAbilityResource from "../resources/comment-frontend-model-ability-resource.js"
 import Configuration from "../../../../src/configuration.js"
 import FilesystemAttachmentStorageDriver from "../../../../src/database/record/attachments/storage-drivers/filesystem.js"
 import dummyDirectory from "../../dummy-directory.js"
 import fs from "fs/promises"
+import isFrontendModelAbilityRequest from "./frontend-model-ability-request.js"
 import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
 import NodeEnvironmentHandler from "../../../../src/environment-handlers/node.js"
-import ProjectFrontendModelAbilityResource from "../resources/project-frontend-model-ability-resource.js"
 import installSqlJsWasmRoute from "../../../../src/plugins/sqljs-wasm-route.js"
 import SqliteDriver from "../../../../src/database/drivers/sqlite/index.js"
-import TaskFrontendModelAbilityResource from "../resources/task-frontend-model-ability-resource.js"
-import UserFrontendModelAbilityResource from "../resources/user-frontend-model-ability-resource.js"
 import path from "path"
 import requireContext from "require-context"
 import SingleMultiUsePool from "../../../../src/database/pool/single-multi-use.js"
+import CommentFrontendModelAbilityResource from "../resources/comment-frontend-model-ability-resource.js"
+import ProjectFrontendModelAbilityResource from "../resources/project-frontend-model-ability-resource.js"
+import TaskFrontendModelAbilityResource from "../resources/task-frontend-model-ability-resource.js"
+import UserFrontendModelAbilityResource from "../resources/user-frontend-model-ability-resource.js"
 import TestWebsocketChannel from "../channels/test-websocket-channel.js"
 
 const queryParam = (request, key) => {
@@ -58,7 +59,6 @@ async function websocketMessageHandlerResolver({request}) {
   }
 }
 
-
 /**
  * @param {object} args - Ability resolver args.
  * @param {Record<string, any>} args.params - Request params.
@@ -68,36 +68,11 @@ async function websocketMessageHandlerResolver({request}) {
  * @returns {Ability | undefined}
  */
 function resolveTaskFrontendModelAbility({configuration, params, request, response}) {
-  const requestPath = request.path().split("?")[0]
-  const isTaskFrontendModelCommand = requestPath.startsWith("/api/frontend-models/tasks/") || requestPath.startsWith("/tasks/")
-  const isSharedFrontendModelApi = requestPath === "/frontend-models"
-  const frontendModelRequests = Array.isArray(params.requests) ? params.requests : [params]
-  const requestedModelNames = frontendModelRequests
-    .map((requestEntry) => requestEntry?.model)
-    .filter((modelName) => typeof modelName === "string")
-  const includesTaskSharedRequest = requestedModelNames.includes("Task")
-
-  /** @type {Array<typeof BaseResource>} */
-  const resources = []
-
-  if (isTaskFrontendModelCommand || includesTaskSharedRequest) {
-    resources.push(TaskFrontendModelAbilityResource)
-  }
-
-  if (isSharedFrontendModelApi) {
-    resources.push(
-      TaskFrontendModelAbilityResource,
-      UserFrontendModelAbilityResource,
-      ProjectFrontendModelAbilityResource,
-      CommentFrontendModelAbilityResource
-    )
-  }
-
-  if (resources.length === 0) return
+  if (!isFrontendModelAbilityRequest({backendProjects, params, request})) return
 
   return new Ability({
     context: {configuration, params, request, response},
-    resources
+    resources: [TaskFrontendModelAbilityResource, UserFrontendModelAbilityResource, ProjectFrontendModelAbilityResource, CommentFrontendModelAbilityResource]
   })
 }
 
@@ -154,19 +129,27 @@ const configuration = new Configuration({
     await configuration.ensureConnections(async (dbs) => {
       const db = dbs.default
 
-      for (const key of requireContextModels.keys()) {
-        const importedModel = requireContextModels(key)
-        const modelClass = importedModel?.default
+      for (const fileName of requireContextModels.keys()) {
+        const modelClassImport = requireContextModels(fileName)
+        const modelClass = modelClassImport?.default
 
-        if (!modelClass?.initializeRecord || typeof modelClass.tableName !== "function") continue
-        if (!db || !await db.tableExists(modelClass.tableName())) continue
+        if (!modelClass?.initializeRecord) continue
+
+        if (typeof modelClass.getDatabaseIdentifier === "function" && modelClass.getDatabaseIdentifier() !== "default") {
+          continue
+        }
+
+        const tableName = modelClass.tableName()
+
+        if (!db || !await db.tableExists(tableName)) continue
 
         await modelClass.initializeRecord({configuration})
 
-        if (typeof modelClass.hasTranslationsTable === "function" && await modelClass.hasTranslationsTable()) {
-          const translationClass = modelClass.getTranslationClass?.()
+        if (await modelClass.hasTranslationsTable()) {
+          const translationClass = modelClass.getTranslationClass()
+          const translationTableName = translationClass.tableName()
 
-          if (translationClass && await db.tableExists(translationClass.tableName())) {
+          if (db && await db.tableExists(translationTableName)) {
             await translationClass.initializeRecord({configuration})
           }
         }

--- a/spec/dummy/src/config/configuration.peakflow.mariadb.js
+++ b/spec/dummy/src/config/configuration.peakflow.mariadb.js
@@ -6,6 +6,7 @@ import Configuration from "../../../../src/configuration.js"
 import FilesystemAttachmentStorageDriver from "../../../../src/database/record/attachments/storage-drivers/filesystem.js"
 import dummyDirectory from "../../dummy-directory.js"
 import fs from "fs/promises"
+import isFrontendModelAbilityRequest from "./frontend-model-ability-request.js"
 import InitializerFromRequireContext from "../../../../src/database/initializer-from-require-context.js"
 import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
 import MysqlDriver from "../../../../src/database/drivers/mysql/index.js"
@@ -67,13 +68,7 @@ async function websocketMessageHandlerResolver({request}) {
  * @returns {Ability | undefined}
  */
 function resolveTaskFrontendModelAbility({configuration, params, request, response}) {
-  const requestPath = request.path().split("?")[0]
-  const isFrontendModelCommand = requestPath.startsWith("/api/frontend-models/")
-  const isSharedFrontendModelApi = requestPath === "/velocious/api" || requestPath === "/frontend-models" || requestPath === "/frontend-models/request"
-  const frontendModelRequests = Array.isArray(params.requests) ? params.requests : [params]
-  const includesFrontendModelRequest = frontendModelRequests.some((requestEntry) => typeof requestEntry?.model === "string")
-
-  if (!isFrontendModelCommand && !(isSharedFrontendModelApi && includesFrontendModelRequest)) return
+  if (!isFrontendModelAbilityRequest({backendProjects, params, request})) return
 
   return new Ability({
     context: {configuration, params, request, response},

--- a/spec/dummy/src/config/configuration.peakflow.mssql.js
+++ b/spec/dummy/src/config/configuration.peakflow.mssql.js
@@ -6,6 +6,7 @@ import Configuration from "../../../../src/configuration.js"
 import FilesystemAttachmentStorageDriver from "../../../../src/database/record/attachments/storage-drivers/filesystem.js"
 import dummyDirectory from "../../dummy-directory.js"
 import fs from "fs/promises"
+import isFrontendModelAbilityRequest from "./frontend-model-ability-request.js"
 import InitializerFromRequireContext from "../../../../src/database/initializer-from-require-context.js"
 import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
 import NodeEnvironmentHandler from "../../../../src/environment-handlers/node.js"
@@ -66,13 +67,7 @@ async function websocketMessageHandlerResolver({request}) {
  * @returns {Ability | undefined}
  */
 function resolveTaskFrontendModelAbility({configuration, params, request, response}) {
-  const requestPath = request.path().split("?")[0]
-  const isFrontendModelCommand = requestPath.startsWith("/api/frontend-models/")
-  const isSharedFrontendModelApi = requestPath === "/velocious/api" || requestPath === "/frontend-models" || requestPath === "/frontend-models/request"
-  const frontendModelRequests = Array.isArray(params.requests) ? params.requests : [params]
-  const includesFrontendModelRequest = frontendModelRequests.some((requestEntry) => typeof requestEntry?.model === "string")
-
-  if (!isFrontendModelCommand && !(isSharedFrontendModelApi && includesFrontendModelRequest)) return
+  if (!isFrontendModelAbilityRequest({backendProjects, params, request})) return
 
   return new Ability({
     context: {configuration, params, request, response},

--- a/spec/dummy/src/config/configuration.peakflow.pgsql.js
+++ b/spec/dummy/src/config/configuration.peakflow.pgsql.js
@@ -6,6 +6,7 @@ import Configuration from "../../../../src/configuration.js"
 import FilesystemAttachmentStorageDriver from "../../../../src/database/record/attachments/storage-drivers/filesystem.js"
 import dummyDirectory from "../../dummy-directory.js"
 import fs from "fs/promises"
+import isFrontendModelAbilityRequest from "./frontend-model-ability-request.js"
 import InitializerFromRequireContext from "../../../../src/database/initializer-from-require-context.js"
 import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
 import NodeEnvironmentHandler from "../../../../src/environment-handlers/node.js"
@@ -67,13 +68,7 @@ async function websocketMessageHandlerResolver({request}) {
  * @returns {Ability | undefined}
  */
 function resolveTaskFrontendModelAbility({configuration, params, request, response}) {
-  const requestPath = request.path().split("?")[0]
-  const isFrontendModelCommand = requestPath.startsWith("/api/frontend-models/")
-  const isSharedFrontendModelApi = requestPath === "/velocious/api" || requestPath === "/frontend-models" || requestPath === "/frontend-models/request"
-  const frontendModelRequests = Array.isArray(params.requests) ? params.requests : [params]
-  const includesFrontendModelRequest = frontendModelRequests.some((requestEntry) => typeof requestEntry?.model === "string")
-
-  if (!isFrontendModelCommand && !(isSharedFrontendModelApi && includesFrontendModelRequest)) return
+  if (!isFrontendModelAbilityRequest({backendProjects, params, request})) return
 
   return new Ability({
     context: {configuration, params, request, response},

--- a/spec/dummy/src/config/configuration.peakflow.sqlite.js
+++ b/spec/dummy/src/config/configuration.peakflow.sqlite.js
@@ -6,6 +6,7 @@ import Configuration from "../../../../src/configuration.js"
 import FilesystemAttachmentStorageDriver from "../../../../src/database/record/attachments/storage-drivers/filesystem.js"
 import dummyDirectory from "../../dummy-directory.js"
 import fs from "fs/promises"
+import isFrontendModelAbilityRequest from "./frontend-model-ability-request.js"
 import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
 import NodeEnvironmentHandler from "../../../../src/environment-handlers/node.js"
 import installSqlJsWasmRoute from "../../../../src/plugins/sqljs-wasm-route.js"
@@ -67,13 +68,7 @@ async function websocketMessageHandlerResolver({request}) {
  * @returns {Ability | undefined}
  */
 function resolveTaskFrontendModelAbility({configuration, params, request, response}) {
-  const requestPath = request.path().split("?")[0]
-  const isFrontendModelCommand = requestPath.startsWith("/api/frontend-models/")
-  const isSharedFrontendModelApi = requestPath === "/velocious/api" || requestPath === "/frontend-models" || requestPath === "/frontend-models/request"
-  const frontendModelRequests = Array.isArray(params.requests) ? params.requests : [params]
-  const includesFrontendModelRequest = frontendModelRequests.some((requestEntry) => typeof requestEntry?.model === "string")
-
-  if (!isFrontendModelCommand && !(isSharedFrontendModelApi && includesFrontendModelRequest)) return
+  if (!isFrontendModelAbilityRequest({backendProjects, params, request})) return
 
   return new Ability({
     context: {configuration, params, request, response},

--- a/spec/dummy/src/config/frontend-model-ability-request-spec.js
+++ b/spec/dummy/src/config/frontend-model-ability-request-spec.js
@@ -41,16 +41,6 @@ describe("Dummy frontend model ability request helper", () => {
     expect(result).toEqual(true)
   })
 
-  it("matches legacy api frontend-model command routes", () => {
-    const result = isFrontendModelAbilityRequest({
-      backendProjects,
-      params: {},
-      request: requestStub("/api/frontend-models/tasks/list")
-    })
-
-    expect(result).toEqual(true)
-  })
-
   it("matches direct custom frontend-model member command routes", () => {
     const result = isFrontendModelAbilityRequest({
       backendProjects,

--- a/spec/dummy/src/config/frontend-model-ability-request-spec.js
+++ b/spec/dummy/src/config/frontend-model-ability-request-spec.js
@@ -1,0 +1,63 @@
+import backendProjects from "./backend-projects.js"
+import {describe, expect, it} from "../../../../src/testing/test.js"
+import isFrontendModelAbilityRequest from "./frontend-model-ability-request.js"
+
+/**
+ * @param {string} path - Request path.
+ * @returns {{path: () => string}} - Request stub.
+ */
+function requestStub(path) {
+  return {
+    path() {
+      return path
+    }
+  }
+}
+
+describe("Dummy frontend model ability request helper", () => {
+  it("matches shared frontend-model API requests with model payloads", () => {
+    const result = isFrontendModelAbilityRequest({
+      backendProjects,
+      params: {
+        requests: [{
+          commandType: "index",
+          model: "Task",
+          payload: {}
+        }]
+      },
+      request: requestStub("/frontend-models")
+    })
+
+    expect(result).toEqual(true)
+  })
+
+  it("matches direct built-in frontend-model command routes", () => {
+    const result = isFrontendModelAbilityRequest({
+      backendProjects,
+      params: {},
+      request: requestStub("/tasks/list")
+    })
+
+    expect(result).toEqual(true)
+  })
+
+  it("matches direct custom frontend-model member command routes", () => {
+    const result = isFrontendModelAbilityRequest({
+      backendProjects,
+      params: {},
+      request: requestStub("/users/user-1/refresh-profile")
+    })
+
+    expect(result).toEqual(true)
+  })
+
+  it("ignores unrelated routes", () => {
+    const result = isFrontendModelAbilityRequest({
+      backendProjects,
+      params: {},
+      request: requestStub("/raw-socket")
+    })
+
+    expect(result).toEqual(false)
+  })
+})

--- a/spec/dummy/src/config/frontend-model-ability-request-spec.js
+++ b/spec/dummy/src/config/frontend-model-ability-request-spec.js
@@ -41,6 +41,16 @@ describe("Dummy frontend model ability request helper", () => {
     expect(result).toEqual(true)
   })
 
+  it("matches legacy api frontend-model command routes", () => {
+    const result = isFrontendModelAbilityRequest({
+      backendProjects,
+      params: {},
+      request: requestStub("/api/frontend-models/tasks/list")
+    })
+
+    expect(result).toEqual(true)
+  })
+
   it("matches direct custom frontend-model member command routes", () => {
     const result = isFrontendModelAbilityRequest({
       backendProjects,

--- a/spec/dummy/src/config/frontend-model-ability-request.js
+++ b/spec/dummy/src/config/frontend-model-ability-request.js
@@ -13,25 +13,31 @@ import {
  */
 function isDirectFrontendModelCommandPath({backendProjects, currentPath}) {
   const normalizedCurrentPath = currentPath.startsWith("/") ? currentPath : `/${currentPath}`
+  const legacyApiPath = normalizedCurrentPath.startsWith("/api/frontend-models/")
+    ? normalizedCurrentPath.replace("/api/frontend-models", "")
+    : null
+  const candidatePaths = legacyApiPath ? [normalizedCurrentPath, legacyApiPath] : [normalizedCurrentPath]
 
-  if (frontendModelCustomCommandForPath({backendProjects, currentPath: normalizedCurrentPath})) {
-    return true
-  }
+  for (const candidatePath of candidatePaths) {
+    if (frontendModelCustomCommandForPath({backendProjects, currentPath: candidatePath})) {
+      return true
+    }
 
-  for (const backendProject of backendProjects) {
-    const resources = frontendModelResourcesForBackendProject(backendProject)
+    for (const backendProject of backendProjects) {
+      const resources = frontendModelResourcesForBackendProject(backendProject)
 
-    for (const modelName in resources) {
-      const resourceDefinition = resources[modelName]
-      const resourcePath = frontendModelResourcePath(modelName, resourceDefinition)
-      const expectedPrefix = `${resourcePath}/`
+      for (const modelName in resources) {
+        const resourceDefinition = resources[modelName]
+        const resourcePath = frontendModelResourcePath(modelName, resourceDefinition)
+        const expectedPrefix = `${resourcePath}/`
 
-      if (!normalizedCurrentPath.startsWith(expectedPrefix)) continue
+        if (!candidatePath.startsWith(expectedPrefix)) continue
 
-      const commandName = normalizedCurrentPath.slice(expectedPrefix.length)
+        const commandName = candidatePath.slice(expectedPrefix.length)
 
-      if (!commandName.includes("/") && frontendModelActionForCommand({commandName, modelName, resourceDefinition})) {
-        return true
+        if (!commandName.includes("/") && frontendModelActionForCommand({commandName, modelName, resourceDefinition})) {
+          return true
+        }
       }
     }
   }

--- a/spec/dummy/src/config/frontend-model-ability-request.js
+++ b/spec/dummy/src/config/frontend-model-ability-request.js
@@ -1,0 +1,60 @@
+import {
+  frontendModelActionForCommand,
+  frontendModelCustomCommandForPath,
+  frontendModelResourcePath,
+  frontendModelResourcesForBackendProject
+} from "../../../../src/frontend-models/resource-definition.js"
+
+/**
+ * @param {object} args - Arguments.
+ * @param {import("../../../../src/configuration-types.js").BackendProjectConfiguration[]} args.backendProjects - Backend projects.
+ * @param {string} args.currentPath - Current request path.
+ * @returns {boolean} - Whether the path targets a direct frontend-model route.
+ */
+function isDirectFrontendModelCommandPath({backendProjects, currentPath}) {
+  const normalizedCurrentPath = currentPath.startsWith("/") ? currentPath : `/${currentPath}`
+
+  if (frontendModelCustomCommandForPath({backendProjects, currentPath: normalizedCurrentPath})) {
+    return true
+  }
+
+  for (const backendProject of backendProjects) {
+    const resources = frontendModelResourcesForBackendProject(backendProject)
+
+    for (const modelName in resources) {
+      const resourceDefinition = resources[modelName]
+      const resourcePath = frontendModelResourcePath(modelName, resourceDefinition)
+      const expectedPrefix = `${resourcePath}/`
+
+      if (!normalizedCurrentPath.startsWith(expectedPrefix)) continue
+
+      const commandName = normalizedCurrentPath.slice(expectedPrefix.length)
+
+      if (!commandName.includes("/") && frontendModelActionForCommand({commandName, modelName, resourceDefinition})) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * @param {object} args - Arguments.
+ * @param {import("../../../../src/configuration-types.js").BackendProjectConfiguration[]} args.backendProjects - Backend projects.
+ * @param {Record<string, any>} args.params - Request params.
+ * @param {import("../../../../src/http-server/client/request.js").default | import("../../../../src/http-server/client/websocket-request.js").default} args.request - Request object.
+ * @returns {boolean} - Whether this request should resolve frontend-model ability resources.
+ */
+export default function isFrontendModelAbilityRequest({backendProjects, params, request}) {
+  const requestPath = request.path().split("?")[0]
+  const frontendModelRequests = Array.isArray(params.requests) ? params.requests : [params]
+  const includesFrontendModelRequest = frontendModelRequests.some((requestEntry) => typeof requestEntry?.model === "string")
+  const isSharedFrontendModelApi = requestPath === "/velocious/api" || requestPath === "/frontend-models" || requestPath === "/frontend-models/request"
+
+  if (isSharedFrontendModelApi && includesFrontendModelRequest) {
+    return true
+  }
+
+  return isDirectFrontendModelCommandPath({backendProjects, currentPath: requestPath})
+}

--- a/spec/dummy/src/config/frontend-model-ability-request.js
+++ b/spec/dummy/src/config/frontend-model-ability-request.js
@@ -13,31 +13,25 @@ import {
  */
 function isDirectFrontendModelCommandPath({backendProjects, currentPath}) {
   const normalizedCurrentPath = currentPath.startsWith("/") ? currentPath : `/${currentPath}`
-  const legacyApiPath = normalizedCurrentPath.startsWith("/api/frontend-models/")
-    ? normalizedCurrentPath.replace("/api/frontend-models", "")
-    : null
-  const candidatePaths = legacyApiPath ? [normalizedCurrentPath, legacyApiPath] : [normalizedCurrentPath]
+  
+  if (frontendModelCustomCommandForPath({backendProjects, currentPath: normalizedCurrentPath})) {
+    return true
+  }
 
-  for (const candidatePath of candidatePaths) {
-    if (frontendModelCustomCommandForPath({backendProjects, currentPath: candidatePath})) {
-      return true
-    }
+  for (const backendProject of backendProjects) {
+    const resources = frontendModelResourcesForBackendProject(backendProject)
 
-    for (const backendProject of backendProjects) {
-      const resources = frontendModelResourcesForBackendProject(backendProject)
+    for (const modelName in resources) {
+      const resourceDefinition = resources[modelName]
+      const resourcePath = frontendModelResourcePath(modelName, resourceDefinition)
+      const expectedPrefix = `${resourcePath}/`
 
-      for (const modelName in resources) {
-        const resourceDefinition = resources[modelName]
-        const resourcePath = frontendModelResourcePath(modelName, resourceDefinition)
-        const expectedPrefix = `${resourcePath}/`
+      if (!normalizedCurrentPath.startsWith(expectedPrefix)) continue
 
-        if (!candidatePath.startsWith(expectedPrefix)) continue
+      const commandName = normalizedCurrentPath.slice(expectedPrefix.length)
 
-        const commandName = candidatePath.slice(expectedPrefix.length)
-
-        if (!commandName.includes("/") && frontendModelActionForCommand({commandName, modelName, resourceDefinition})) {
-          return true
-        }
+      if (!commandName.includes("/") && frontendModelActionForCommand({commandName, modelName, resourceDefinition})) {
+        return true
       }
     }
   }

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -1010,6 +1010,8 @@ export default class FrontendModelController extends Controller {
   _frontendModelParams = undefined
   /** @type {Record<string, any> | undefined} */
   _frontendModelParamsOverride = undefined
+  /** @type {import("./authorization/ability.js").default | undefined} */
+  _frontendModelAbilityOverride = undefined
 
   /**
    * @returns {Record<string, any>} - Decoded request params.
@@ -1067,12 +1069,25 @@ export default class FrontendModelController extends Controller {
           request: this.request(),
           response
         })
+        /** @type {import("./authorization/ability.js").default | undefined} */
+        const previousAbilityOverride = this._frontendModelAbilityOverride
 
-        return await configuration.runWithAbility(ability, async () => {
-          return await callback()
-        })
+        this._frontendModelAbilityOverride = ability
+
+        try {
+          return await configuration.runWithAbility(ability, async () => {
+            return await callback()
+          })
+        } finally {
+          this._frontendModelAbilityOverride = previousAbilityOverride
+        }
       })
     })
+  }
+
+  /** @returns {import("./authorization/ability.js").default | undefined} - Current ability for frontend-model request scope. */
+  currentAbility() {
+    return this._frontendModelAbilityOverride || super.currentAbility()
   }
 
   /**
@@ -1313,7 +1328,7 @@ export default class FrontendModelController extends Controller {
   frontendModelAuthorizedQuery(action) {
     const abilityAction = this.frontendModelAbilityAction(action)
 
-    return this.frontendModelClass().accessibleFor(abilityAction)
+    return this.frontendModelClass().accessibleFor(abilityAction, this.currentAbility())
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a shared dummy frontend-model ability-request helper and cover it with a focused spec
- wire the Peakflow dummy configs through that helper and keep the controller ability override available during frontend-model request handling
- include the remaining local structure sql snapshot and changelog fragment from the leftover worktree changes

## Validation
- VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/dummy/src/config/frontend-model-ability-request-spec.js spec/frontend-models/authorization.http-integration-spec.js:128
- npm run typecheck
- npm run lint
