### PR TITLE
Add specs for changed-attributes-only save() on update path

### DIFF
--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -2330,6 +2330,150 @@ describe("Frontend models - base", () => {
     }
   })
 
+  it("save() on the update path sends only changed attributes, never framework-managed fields", async () => {
+    const User = buildTestModelClass()
+    const fetchStub = stubFetch({model: {email: "john@example.com", id: 5, name: "John Changed"}})
+    const user = User.instantiateFromResponse({createdAt: "2026-01-01T00:00:00.000Z", email: "john@example.com", id: 5, name: "John", updatedAt: "2026-01-02T00:00:00.000Z"})
+
+    try {
+      user.setName("John Changed")
+
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            attributes: {name: "John Changed"},
+            id: 5
+          },
+          url: "/frontend-models"
+        }
+      ])
+      expect(user.isChanged()).toEqual(false)
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("save() on the update path with no changes sends an empty attributes hash", async () => {
+    const User = buildTestModelClass()
+    const fetchStub = stubFetch({model: {email: "john@example.com", id: 5, name: "John"}})
+    const user = User.instantiateFromResponse({createdAt: "2026-01-01T00:00:00.000Z", email: "john@example.com", id: 5, name: "John", updatedAt: "2026-01-02T00:00:00.000Z"})
+
+    try {
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            attributes: {},
+            id: 5
+          },
+          url: "/frontend-models"
+        }
+      ])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("save() on the update path sends only the subset of attributes touched by setters", async () => {
+    const User = buildTestModelClass()
+    const fetchStub = stubFetch({model: {email: "renamed@example.com", id: 5, name: "Renamed"}})
+    const user = User.instantiateFromResponse({email: "john@example.com", id: 5, name: "John"})
+
+    try {
+      user.setName("Renamed")
+      user.setAttribute("email", "renamed@example.com")
+
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            attributes: {email: "renamed@example.com", name: "Renamed"},
+            id: 5
+          },
+          url: "/frontend-models"
+        }
+      ])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("save() on the create path still sends every assigned attribute", async () => {
+    const User = buildTestModelClass()
+    const fetchStub = stubFetch({model: {email: "draft@example.com", id: 9, name: "Draft"}})
+    const user = new User({email: "draft@example.com", name: "Draft"})
+
+    try {
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            attributes: {email: "draft@example.com", name: "Draft"}
+          },
+          url: "/frontend-models"
+        }
+      ])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("save() resets dirty tracking after a successful update so the next save sends nothing extra", async () => {
+    const User = buildTestModelClass()
+    const fetchStub = stubFetch({model: {email: "john@example.com", id: 5, name: "Renamed"}})
+    const user = User.instantiateFromResponse({email: "john@example.com", id: 5, name: "John"})
+
+    try {
+      user.setName("Renamed")
+      await user.save()
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            attributes: {name: "Renamed"},
+            id: 5
+          },
+          url: "/frontend-models"
+        },
+        {
+          body: {
+            attributes: {},
+            id: 5
+          },
+          url: "/frontend-models"
+        }
+      ])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("_changedAttributesForSave returns the dirty subset only", () => {
+    const User = buildTestModelClass()
+    const user = User.instantiateFromResponse({email: "john@example.com", id: 5, name: "John"})
+
+    expect(user._changedAttributesForSave()).toEqual({})
+
+    user.setName("Renamed")
+
+    expect(user._changedAttributesForSave()).toEqual({name: "Renamed"})
+
+    user.setAttribute("email", "renamed@example.com")
+
+    expect(user._changedAttributesForSave()).toEqual({email: "renamed@example.com", name: "Renamed"})
+  })
+
   it("tracks changes and supports findOrInitializeBy/findOrCreateBy", async () => {
     const User = buildTestModelClass()
     const fetchStub = stubFetch({


### PR DESCRIPTION
## Summary

Backfills spec coverage for #568 (`Send only changed attributes from FrontendModelBase.save() on update`). The fix shipped without dedicated specs hitting `save()` directly, so this PR locks down the contract:

- `save()` on the update path sends **only** changed attributes.
- Framework-managed fields like `id`, `createdAt`, `updatedAt` that were hydrated from the server response are never re-sent — which is exactly what the strict-by-default `permittedParams()` (since 1.0.321) rejects.
- `save()` on the create path still sends every assigned attribute.
- Second `save()` right after a successful update sends an empty `attributes` hash (dirty tracking is reset).

The pre-existing tests at `base-spec.js:2010,2035` exercised this through `update(attrs)` rather than `save()` directly, so they didn't catch the regression that broke every auraline edit screen against strict permits.

## Test plan

- [x] `npm test -- spec/frontend-models/base-spec.js` — 82 successful tests (6 new)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean

## New specs

1. `save() on the update path sends only changed attributes, never framework-managed fields`
2. `save() on the update path with no changes sends an empty attributes hash`
3. `save() on the update path sends only the subset of attributes touched by setters`
4. `save() on the create path still sends every assigned attribute`
5. `save() resets dirty tracking after a successful update so the next save sends nothing extra`
6. `_changedAttributesForSave returns the dirty subset only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)