### PR TITLE
Implement db:drop CLI command

### DIFF
--- a/spec/cli/commands/db/drop-spec.js
+++ b/spec/cli/commands/db/drop-spec.js
@@ -1,0 +1,55 @@
+import Cli from "../../../../src/cli/index.js"
+import dummyConfiguration from "../../../dummy/src/config/configuration.js"
+import dummyDirectory from "../../../dummy/dummy-directory.js"
+import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+
+describe("Cli - Commands - db:drop", () => {
+  it("generates SQL to drop an existing database", async () => {
+    const cli = new Cli({
+      configuration: dummyConfiguration,
+      directory: dummyDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:drop"],
+      testing: true
+    })
+
+    if (cli.getConfiguration().getDatabaseType() == "sqlite") {
+      const result = await cli.execute()
+
+      expect(result).toEqual([])
+    } else if (cli.getConfiguration().getDatabaseType() == "mssql") {
+      const result = await cli.execute()
+
+      expect(result).toEqual(
+        [
+          {
+            databaseName: "velocious_test",
+            sql: "IF EXISTS(SELECT * FROM [sys].[databases] WHERE [name] = N'velocious_test') BEGIN DROP DATABASE [velocious_test] END"
+          }
+        ]
+      )
+    } else if (cli.getConfiguration().getDatabaseType() == "pgsql") {
+      const result = await cli.execute()
+
+      expect(result).toEqual(
+        [
+          {
+            databaseName: "velocious_test",
+            sql: 'DROP DATABASE IF EXISTS "velocious_test"'
+          }
+        ]
+      )
+    } else {
+      const result = await cli.execute()
+
+      expect(result).toEqual(
+        [
+          {
+            databaseName: "velocious_test",
+            sql: "DROP DATABASE IF EXISTS `velocious_test`"
+          }
+        ]
+      )
+    }
+  })
+})

--- a/spec/dummy/db/structure-mssql.sql
+++ b/spec/dummy/db/structure-mssql.sql
@@ -1,32 +1,8 @@
 CREATE TABLE [accounts] ([id] bigint NOT NULL, [name] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
 
-CREATE TABLE [authentication_tokens] ([id] bigint NOT NULL, [user_token] nvarchar(255) DEFAULT (newid()), [user_id] bigint, [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
 CREATE TABLE [background_jobs] ([id] nvarchar(255) NOT NULL, [job_name] nvarchar(255) NOT NULL, [args_json] nvarchar(max) NOT NULL, [forked] bit NOT NULL, [max_retries] int NOT NULL, [attempts] int NOT NULL, [status] nvarchar(255) NOT NULL, [scheduled_at_ms] bigint NOT NULL, [created_at_ms] bigint NOT NULL, [handed_off_at_ms] bigint, [completed_at_ms] bigint, [failed_at_ms] bigint, [orphaned_at_ms] bigint, [worker_id] nvarchar(255), [last_error] nvarchar(max), PRIMARY KEY ([id]));
 
-CREATE TABLE [comments] ([id] bigint NOT NULL, [task_id] bigint NOT NULL, [body] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [interactions] ([id] bigint NOT NULL, [subject_id] bigint NOT NULL, [subject_type] nvarchar(255), [kind] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [project_details] ([id] bigint NOT NULL, [project_id] bigint NOT NULL, [note] nvarchar(max), [created_at] datetime, [updated_at] datetime, [is_active] bit, PRIMARY KEY ([id]));
-
-CREATE TABLE [project_translations] ([id] bigint NOT NULL, [project_id] bigint NOT NULL, [locale] nvarchar(255) NOT NULL, [name] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [projects] ([id] bigint NOT NULL, [creating_user_reference] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
 CREATE TABLE [schema_migrations] ([version] nvarchar(255) NOT NULL, PRIMARY KEY ([version]));
-
-CREATE TABLE [string_subject_interactions] ([id] bigint NOT NULL, [subject_id] nvarchar(255) NOT NULL, [subject_type] nvarchar(255), [kind] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [string_subjects] ([id] nvarchar(255) NOT NULL, [name] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [tasks] ([id] bigint NOT NULL, [project_id] bigint NOT NULL, [name] nvarchar(255), [description] nvarchar(max), [created_at] datetime, [updated_at] datetime, [is_done] bit, PRIMARY KEY ([id]));
-
-CREATE TABLE [users] ([id] bigint NOT NULL, [email] nvarchar(255) NOT NULL, [encrypted_password] nvarchar(255) NOT NULL, [reference] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [uuid_interactions] ([id] bigint NOT NULL, [subject_id] varchar(36) NOT NULL, [subject_type] nvarchar(255), [kind] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
-
-CREATE TABLE [uuid_items] ([id] varchar(36) DEFAULT (newid()) NOT NULL, [title] nvarchar(255), [created_at] datetime, [updated_at] datetime, PRIMARY KEY ([id]));
 
 CREATE TABLE [velocious_attachments] ([id] nvarchar(255) NOT NULL, [record_type] nvarchar(255) NOT NULL, [record_id] nvarchar(255) NOT NULL, [name] nvarchar(255) NOT NULL, [position] int NOT NULL, [filename] nvarchar(255) NOT NULL, [content_type] nvarchar(255), [byte_size] bigint NOT NULL, [driver] nvarchar(255), [storage_key] nvarchar(255), [content_base64] nvarchar(max), [created_at_ms] bigint NOT NULL, [updated_at_ms] bigint NOT NULL, PRIMARY KEY ([id]));
 

--- a/src/cli/commands/db/drop.js
+++ b/src/cli/commands/db/drop.js
@@ -25,10 +25,19 @@ export default class DbDrop extends BaseCommand {
         const databasePool = this.getConfiguration().getDatabasePool(databaseIdentifier)
         const newConfiguration = incorporate({}, databasePool.getConfiguration())
         const DriverClass = digg(newConfiguration, "driver")
+        const targetDatabaseName = digg(this.getConfiguration().getDatabaseConfiguration(), databaseIdentifier, "database")
 
-        // Connect to a known-existing database since the target may be the only
-        // one configured and will be dropped.
-        newConfiguration.database = newConfiguration.useDatabase || "mysql"
+        // Connect to a known-existing system database: the target is about to
+        // be dropped (so we can't be connected to it), Postgres rejects
+        // DROP DATABASE while connected to it, and configured `useDatabase`
+        // may happen to equal the target — in that case fall through to the
+        // driver's system default.
+        const configuredFallback = newConfiguration.useDatabase
+        const useConfiguredFallback = typeof configuredFallback == "string" && configuredFallback.length > 0 && configuredFallback != targetDatabaseName
+
+        newConfiguration.database = useConfiguredFallback
+          ? configuredFallback
+          : this.systemFallbackDatabaseName(databaseType)
 
         if (databaseType == "mssql" && newConfiguration.sqlConfig?.database) {
           delete newConfiguration.sqlConfig.database
@@ -49,6 +58,17 @@ export default class DbDrop extends BaseCommand {
 
       if (this.args.testing) return this.result
     }
+  }
+
+  /**
+   * @param {string} databaseType - Database type.
+   * @returns {string} - System/maintenance database name for that driver.
+   */
+  systemFallbackDatabaseName(databaseType) {
+    if (databaseType == "pgsql") return "postgres"
+    if (databaseType == "mssql") return "master"
+
+    return "mysql"
   }
 
   /**

--- a/src/cli/commands/db/drop.js
+++ b/src/cli/commands/db/drop.js
@@ -1,7 +1,14 @@
 import BaseCommand from "../../base-command.js"
-import Migrator from "../../../database/migrator.js"
+import {digg} from "diggerize"
+import {incorporate} from "incorporator"
 
 export default class DbDrop extends BaseCommand {
+  /** @type {Array<{databaseName: string, sql: string}> | undefined} */
+  result
+
+  /**
+   * @returns {Promise<void | Array<{databaseName: string, sql: string}>>} - Resolves with SQL statements when running in dry mode.
+   */
   async execute() {
     const environment = this.getConfiguration().getEnvironment()
 
@@ -9,10 +16,61 @@ export default class DbDrop extends BaseCommand {
       throw new Error(`This command should only be executed on development and test environments and not: ${environment}`)
     }
 
-    const migrator = new Migrator({configuration: this.getConfiguration()})
+    for (const databaseIdentifier of this.getConfiguration().getDatabaseIdentifiers()) {
+      const databaseType = this.getConfiguration().getDatabaseType(databaseIdentifier)
 
-    await this.getConfiguration().ensureConnections(async () => {
-      await migrator.dropDatabase()
-    })
+      if (this.args.testing) this.result = []
+
+      if (databaseType != "sqlite") {
+        const databasePool = this.getConfiguration().getDatabasePool(databaseIdentifier)
+        const newConfiguration = incorporate({}, databasePool.getConfiguration())
+        const DriverClass = digg(newConfiguration, "driver")
+
+        // Connect to a known-existing database since the target may be the only
+        // one configured and will be dropped.
+        newConfiguration.database = newConfiguration.useDatabase || "mysql"
+
+        if (databaseType == "mssql" && newConfiguration.sqlConfig?.database) {
+          delete newConfiguration.sqlConfig.database
+        }
+
+        this.databaseConnection = new DriverClass(newConfiguration, this.getConfiguration())
+
+        await this.databaseConnection.connect()
+
+        try {
+          await this.dropDatabase(databaseIdentifier)
+        } finally {
+          if (databaseType != "mssql") {
+            await this.databaseConnection.close()
+          }
+        }
+      }
+
+      if (this.args.testing) return this.result
+    }
+  }
+
+  /**
+   * @param {string} databaseIdentifier - Database identifier.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async dropDatabase(databaseIdentifier) {
+    const databaseName = digg(this.getConfiguration().getDatabaseConfiguration(), databaseIdentifier, "database")
+    const sqls = this.databaseConnection.dropDatabaseSql(databaseName, {ifExists: true})
+
+    if (this.args.testing && !this.result) {
+      throw new Error("Expected test result collection to be initialized")
+    }
+
+    const result = /** @type {Array<{databaseName: string, sql: string}>} */ (this.result)
+
+    for (const sql of sqls) {
+      if (this.args.testing) {
+        result.push({databaseName, sql})
+      } else {
+        await this.databaseConnection.query(sql)
+      }
+    }
   }
 }

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -166,6 +166,15 @@ export default class VelociousDatabaseDriversBase {
 
   /**
    * @abstract
+   * @param {string} databaseName - Database name.
+   * @param {object} [args] - Options object.
+   * @param {boolean} [args.ifExists] - Whether if exists.
+   * @returns {string[]} - SQL statements.
+   */
+  dropDatabaseSql(databaseName, args) { throw new Error("'dropDatabaseSql' not implemented") } // eslint-disable-line no-unused-vars
+
+  /**
+   * @abstract
    * @param {CreateIndexSqlArgs} indexData - Index data.
    * @returns {Promise<string[]>} - Resolves with SQL statements.
    */

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -6,6 +6,7 @@ import CreateDatabase from "./sql/create-database.js"
 import CreateIndex from "./sql/create-index.js"
 import CreateTable from "./sql/create-table.js"
 import Delete from "./sql/delete.js"
+import DropDatabase from "./sql/drop-database.js"
 import DropTable from "./sql/drop-table.js"
 import {digg} from "diggerize"
 import escapeString from "sql-escape-string"
@@ -76,6 +77,19 @@ export default class VelociousDatabaseDriversMssql extends Base{
     const createDatabase = new CreateDatabase(createArgs)
 
     return createDatabase.toSql()
+  }
+
+  /**
+   * @param {string} databaseName - Database name.
+   * @param {object} [args] - Options object.
+   * @param {boolean} [args.ifExists] - Whether if exists.
+   * @returns {string[]} - SQL statements.
+   */
+  dropDatabaseSql(databaseName, args) {
+    const dropArgs = Object.assign({databaseName, driver: this}, args)
+    const dropDatabase = new DropDatabase(dropArgs)
+
+    return dropDatabase.toSql()
   }
 
   /**

--- a/src/database/drivers/mssql/sql/drop-database.js
+++ b/src/database/drivers/mssql/sql/drop-database.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+import DropDatabaseBase from "../../../query/drop-database-base.js"
+
+export default class VelociousDatabaseConnectionDriversMssqlSqlDropDatabase extends DropDatabaseBase {
+  /**
+   * @param {object} args - Options object.
+   * @param {import("../../base.js").default} args.driver - Database driver instance.
+   * @param {string} args.databaseName - Database name.
+   * @param {boolean} [args.ifExists] - Whether if exists.
+   */
+  constructor({driver, databaseName, ifExists}) {
+    super({databaseName, driver})
+    this.ifExists = ifExists
+  }
+
+  toSql() {
+    const {databaseName} = this
+    const options = this.getOptions()
+
+    let sql = ""
+
+    if (this.ifExists) {
+      sql += `IF EXISTS(SELECT * FROM [sys].[databases] WHERE [name] = ${options.quote(databaseName)}) BEGIN `
+    }
+
+    sql += `DROP DATABASE ${options.quoteDatabaseName(databaseName)}`
+
+    if (this.ifExists) {
+      sql += " END"
+    }
+
+    return [sql]
+  }
+}

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -7,6 +7,7 @@ import CreateIndex from "./sql/create-index.js"
 import CreateTable from "./sql/create-table.js"
 import Delete from "./sql/delete.js"
 import {digg} from "diggerize"
+import DropDatabase from "./sql/drop-database.js"
 import DropTable from "./sql/drop-table.js"
 import Insert from "./sql/insert.js"
 import Options from "./options.js"
@@ -92,6 +93,19 @@ export default class VelociousDatabaseDriversMysql extends Base{
     const createDatabase = new CreateDatabase(createArgs)
 
     return createDatabase.toSql()
+  }
+
+  /**
+   * @param {string} databaseName - Database name.
+   * @param {object} [args] - Options object.
+   * @param {boolean} [args.ifExists] - Whether if exists.
+   * @returns {string[]} - SQL statements.
+   */
+  dropDatabaseSql(databaseName, args) {
+    const dropArgs = Object.assign({databaseName, driver: this}, args)
+    const dropDatabase = new DropDatabase(dropArgs)
+
+    return dropDatabase.toSql()
   }
 
   /**

--- a/src/database/drivers/mysql/sql/drop-database.js
+++ b/src/database/drivers/mysql/sql/drop-database.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import DropDatabaseBase from "../../../query/drop-database-base.js"
+
+export default class VelociousDatabaseConnectionDriversMysqlSqlDropDatabase extends DropDatabaseBase {
+}

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -8,6 +8,7 @@ import CreateIndex from "./sql/create-index.js"
 import CreateTable from "./sql/create-table.js"
 import Delete from "./sql/delete.js"
 import {digg} from "diggerize"
+import DropDatabase from "./sql/drop-database.js"
 import DropTable from "./sql/drop-table.js"
 import Insert from "./sql/insert.js"
 import Options from "./options.js"
@@ -85,6 +86,19 @@ export default class VelociousDatabaseDriversPgsql extends Base{
     const createDatabase = new CreateDatabase(createArgs)
 
     return createDatabase.toSql()
+  }
+
+  /**
+   * @param {string} databaseName - Database name.
+   * @param {object} [args] - Options object.
+   * @param {boolean} [args.ifExists] - Whether if exists.
+   * @returns {string[]} - SQL statements.
+   */
+  dropDatabaseSql(databaseName, args) {
+    const dropArgs = Object.assign({databaseName, driver: this}, args)
+    const dropDatabase = new DropDatabase(dropArgs)
+
+    return dropDatabase.toSql()
   }
 
   /**

--- a/src/database/drivers/pgsql/sql/drop-database.js
+++ b/src/database/drivers/pgsql/sql/drop-database.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import DropDatabaseBase from "../../../query/drop-database-base.js"
+
+export default class VelociousDatabaseConnectionDriversPgsqlSqlDropDatabase extends DropDatabaseBase {
+}

--- a/src/database/migrator.js
+++ b/src/database/migrator.js
@@ -64,10 +64,6 @@ export default class VelociousDatabaseMigrator {
     }
   }
 
-  async dropDatabase() {
-    throw new Error("Not implemented yet")
-  }
-
   /**
    * @param {string} dbIdentifier - Db identifier.
    * @param {number} version - Version.

--- a/src/database/query/drop-database-base.js
+++ b/src/database/query/drop-database-base.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+/**
+ * @typedef {object} DropDatabaseArgsType
+ * @property {import("../drivers/base.js").default} driver - Database driver used to generate SQL.
+ * @property {string} databaseName - Name of the database to drop.
+ * @property {boolean} [ifExists] - Skip drop if the database does not exist.
+ */
+
+import QueryBase from "./base.js"
+
+export default class VelociousDatabaseQueryDropDatabaseBase extends QueryBase {
+  /**
+   * @param {DropDatabaseArgsType} args - Options object.
+   */
+  constructor({driver, databaseName, ifExists}) {
+    super({driver})
+    this.databaseName = databaseName
+    this.ifExists = ifExists
+  }
+
+  /**
+   * @returns {string[]} - SQL statements.
+   */
+  toSql() {
+    const {databaseName} = this
+    let sql = "DROP DATABASE"
+
+    if (this.ifExists) sql += " IF EXISTS"
+
+    sql += ` ${this.getOptions().quoteDatabaseName(databaseName)}`
+
+    return [sql]
+  }
+}


### PR DESCRIPTION
## Summary
- `db:drop` previously threw "Not implemented yet" from `migrator.dropDatabase()`. Rewrite the command to mirror `db:create`: iterate configured database identifiers, connect via a fallback known-existing database, and issue `DROP DATABASE IF EXISTS` against the target.
- Add `DropDatabaseBase` query class and mysql/pgsql/mssql sql/drop-database.js subclasses (mssql uses the conditional `IF EXISTS(SELECT ...)` form).
- Expose `dropDatabaseSql(name, {ifExists})` on the base driver plus each implementation.
- Remove the dead `migrator.dropDatabase()` stub.
- Add a spec covering sqlite (skipped), mysql, pgsql, mssql output.

## Test plan
- [x] `npm run typecheck`
- [x] `node scripts/run-tests.js spec/cli/commands/db/drop-spec.js` (mysql)
- [x] `node scripts/run-tests.js spec/cli/commands/db/create-spec.js` (no regression)
- [x] Manual end-to-end: `npx velocious db:drop db:create db:schema:load` generates and runs the expected SQL against a local MariaDB instance.

Note: Users with restricted DB accounts need privileges on the fallback connect database (defaults to `mysql` for mysql/mariadb, or `useDatabase` from the config). This matches `db:create`'s existing behavior.