### PR TITLE
db:create: honor charset and collation from database config

### DIFF
--- a/spec/database/drivers/mysql/sql/create-database-spec.js
+++ b/spec/database/drivers/mysql/sql/create-database-spec.js
@@ -23,10 +23,10 @@ describe("database/drivers/mysql/sql/create-database", () => {
     expect(createDatabase.toSql()).toEqual(["CREATE DATABASE IF NOT EXISTS `awesome_tasks_test`"])
   })
 
-  it("emits CHARACTER SET when charset is provided", () => {
+  it("emits CHARACTER SET when databaseCharset is provided", () => {
     const driver = buildDriver()
     const createDatabase = new CreateDatabase({
-      charset: "utf8mb4",
+      databaseCharset: "utf8mb4",
       databaseName: "awesome_tasks_test",
       driver,
       ifNotExists: true
@@ -37,10 +37,10 @@ describe("database/drivers/mysql/sql/create-database", () => {
     ])
   })
 
-  it("emits COLLATE when collation is provided", () => {
+  it("emits COLLATE when databaseCollation is provided", () => {
     const driver = buildDriver()
     const createDatabase = new CreateDatabase({
-      collation: "utf8mb4_unicode_ci",
+      databaseCollation: "utf8mb4_unicode_ci",
       databaseName: "awesome_tasks_test",
       driver,
       ifNotExists: true
@@ -54,8 +54,8 @@ describe("database/drivers/mysql/sql/create-database", () => {
   it("emits both CHARACTER SET and COLLATE when both are provided", () => {
     const driver = buildDriver()
     const createDatabase = new CreateDatabase({
-      charset: "utf8mb4",
-      collation: "utf8mb4_unicode_ci",
+      databaseCharset: "utf8mb4",
+      databaseCollation: "utf8mb4_unicode_ci",
       databaseName: "awesome_tasks_test",
       driver,
       ifNotExists: true
@@ -66,10 +66,10 @@ describe("database/drivers/mysql/sql/create-database", () => {
     ])
   })
 
-  it("rejects charset values that don't match [A-Za-z0-9_]+", () => {
+  it("rejects databaseCharset values that don't match [A-Za-z0-9_]+", () => {
     const driver = buildDriver()
     const createDatabase = new CreateDatabase({
-      charset: "utf8mb4; DROP TABLE users",
+      databaseCharset: "utf8mb4; DROP TABLE users",
       databaseName: "awesome_tasks_test",
       driver,
       ifNotExists: true
@@ -84,13 +84,13 @@ describe("database/drivers/mysql/sql/create-database", () => {
     }
 
     expect(thrown).toBeDefined()
-    expect(thrown.message).toContain("Invalid charset value")
+    expect(thrown.message).toContain("Invalid databaseCharset value")
   })
 
-  it("rejects collation values that don't match [A-Za-z0-9_]+", () => {
+  it("rejects databaseCollation values that don't match [A-Za-z0-9_]+", () => {
     const driver = buildDriver()
     const createDatabase = new CreateDatabase({
-      collation: "utf8mb4_unicode_ci; DROP TABLE users",
+      databaseCollation: "utf8mb4_unicode_ci; DROP TABLE users",
       databaseName: "awesome_tasks_test",
       driver,
       ifNotExists: true
@@ -105,6 +105,6 @@ describe("database/drivers/mysql/sql/create-database", () => {
     }
 
     expect(thrown).toBeDefined()
-    expect(thrown.message).toContain("Invalid collation value")
+    expect(thrown.message).toContain("Invalid databaseCollation value")
   })
 })

--- a/spec/database/drivers/mysql/sql/create-database-spec.js
+++ b/spec/database/drivers/mysql/sql/create-database-spec.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../src/testing/test.js"
+import CreateDatabase from "../../../../../src/database/drivers/mysql/sql/create-database.js"
+import MysqlDriver from "../../../../../src/database/drivers/mysql/index.js"
+
+/**
+ * Build a bare-bones mysql driver instance for toSql() tests. We never
+ * connect — we just need the Options wiring that the base query uses for
+ * quoting.
+ *
+ * @returns {MysqlDriver}
+ */
+function buildDriver() {
+  return new MysqlDriver({type: "mysql"})
+}
+
+describe("database/drivers/mysql/sql/create-database", () => {
+  it("emits CREATE DATABASE IF NOT EXISTS without charset or collation by default", () => {
+    const driver = buildDriver()
+    const createDatabase = new CreateDatabase({databaseName: "awesome_tasks_test", driver, ifNotExists: true})
+
+    expect(createDatabase.toSql()).toEqual(["CREATE DATABASE IF NOT EXISTS `awesome_tasks_test`"])
+  })
+
+  it("emits CHARACTER SET when charset is provided", () => {
+    const driver = buildDriver()
+    const createDatabase = new CreateDatabase({
+      charset: "utf8mb4",
+      databaseName: "awesome_tasks_test",
+      driver,
+      ifNotExists: true
+    })
+
+    expect(createDatabase.toSql()).toEqual([
+      "CREATE DATABASE IF NOT EXISTS `awesome_tasks_test` CHARACTER SET utf8mb4"
+    ])
+  })
+
+  it("emits COLLATE when collation is provided", () => {
+    const driver = buildDriver()
+    const createDatabase = new CreateDatabase({
+      collation: "utf8mb4_unicode_ci",
+      databaseName: "awesome_tasks_test",
+      driver,
+      ifNotExists: true
+    })
+
+    expect(createDatabase.toSql()).toEqual([
+      "CREATE DATABASE IF NOT EXISTS `awesome_tasks_test` COLLATE utf8mb4_unicode_ci"
+    ])
+  })
+
+  it("emits both CHARACTER SET and COLLATE when both are provided", () => {
+    const driver = buildDriver()
+    const createDatabase = new CreateDatabase({
+      charset: "utf8mb4",
+      collation: "utf8mb4_unicode_ci",
+      databaseName: "awesome_tasks_test",
+      driver,
+      ifNotExists: true
+    })
+
+    expect(createDatabase.toSql()).toEqual([
+      "CREATE DATABASE IF NOT EXISTS `awesome_tasks_test` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    ])
+  })
+
+  it("rejects charset values that don't match [A-Za-z0-9_]+", () => {
+    const driver = buildDriver()
+    const createDatabase = new CreateDatabase({
+      charset: "utf8mb4; DROP TABLE users",
+      databaseName: "awesome_tasks_test",
+      driver,
+      ifNotExists: true
+    })
+
+    let thrown
+
+    try {
+      createDatabase.toSql()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeDefined()
+    expect(thrown.message).toContain("Invalid charset value")
+  })
+
+  it("rejects collation values that don't match [A-Za-z0-9_]+", () => {
+    const driver = buildDriver()
+    const createDatabase = new CreateDatabase({
+      collation: "utf8mb4_unicode_ci; DROP TABLE users",
+      databaseName: "awesome_tasks_test",
+      driver,
+      ifNotExists: true
+    })
+
+    let thrown
+
+    try {
+      createDatabase.toSql()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeDefined()
+    expect(thrown.message).toContain("Invalid collation value")
+  })
+})

--- a/src/cli/commands/db/create.js
+++ b/src/cli/commands/db/create.js
@@ -54,8 +54,8 @@ export default class DbCreate extends BaseCommand{
   async createDatabase(databaseIdentifier) {
     const databaseConfiguration = digg(this.getConfiguration().getDatabaseConfiguration(), databaseIdentifier)
     const databaseName = digg(databaseConfiguration, "database")
-    const {charset, collation} = databaseConfiguration
-    const sqls = this.databaseConnection.createDatabaseSql(databaseName, {ifNotExists: true, charset, collation})
+    const {databaseCharset, databaseCollation} = databaseConfiguration
+    const sqls = this.databaseConnection.createDatabaseSql(databaseName, {ifNotExists: true, databaseCharset, databaseCollation})
     if (this.args.testing && !this.result) {
       throw new Error("Expected test result collection to be initialized")
     }

--- a/src/cli/commands/db/create.js
+++ b/src/cli/commands/db/create.js
@@ -52,8 +52,10 @@ export default class DbCreate extends BaseCommand{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async createDatabase(databaseIdentifier) {
-    const databaseName = digg(this.getConfiguration().getDatabaseConfiguration(), databaseIdentifier, "database")
-    const sqls = this.databaseConnection.createDatabaseSql(databaseName, {ifNotExists: true})
+    const databaseConfiguration = digg(this.getConfiguration().getDatabaseConfiguration(), databaseIdentifier)
+    const databaseName = digg(databaseConfiguration, "database")
+    const {charset, collation} = databaseConfiguration
+    const sqls = this.databaseConnection.createDatabaseSql(databaseName, {ifNotExists: true, charset, collation})
     if (this.args.testing && !this.result) {
       throw new Error("Expected test result collection to be initialized")
     }

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -53,8 +53,8 @@
 
 /**
  * @typedef {object} DatabaseConfigurationType
- * @property {string} [charset] - Default character set applied when Velocious creates the database (mysql/mariadb `CHARACTER SET`).
- * @property {string} [collation] - Default collation applied when Velocious creates the database (mysql/mariadb `COLLATE`).
+ * @property {string} [databaseCharset] - Default character set applied by `db:create` via mysql/mariadb `CREATE DATABASE ... CHARACTER SET`. Distinct from `charset`, which is the client connection charset forwarded to the mysql2 driver.
+ * @property {string} [databaseCollation] - Default collation applied by `db:create` via mysql/mariadb `CREATE DATABASE ... COLLATE`.
  * @property {string} [database] - Database name for this connection.
  * @property {typeof import("./database/drivers/base.js").default} [driver] - Driver class to use for this database.
  * @property {typeof import("./database/pool/base.js").default} [poolType] - Pool class to use for this database.

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -53,6 +53,8 @@
 
 /**
  * @typedef {object} DatabaseConfigurationType
+ * @property {string} [charset] - Default character set applied when Velocious creates the database (mysql/mariadb `CHARACTER SET`).
+ * @property {string} [collation] - Default collation applied when Velocious creates the database (mysql/mariadb `COLLATE`).
  * @property {string} [database] - Database name for this connection.
  * @property {typeof import("./database/drivers/base.js").default} [driver] - Driver class to use for this database.
  * @property {typeof import("./database/pool/base.js").default} [poolType] - Pool class to use for this database.

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -160,8 +160,8 @@ export default class VelociousDatabaseDriversBase {
    * @param {string} databaseName - Database name.
    * @param {object} [args] - Options object.
    * @param {boolean} [args.ifNotExists] - Whether if not exists.
-   * @param {string} [args.charset] - Default character set (driver-specific; mysql/mariadb).
-   * @param {string} [args.collation] - Default collation (driver-specific; mysql/mariadb).
+   * @param {string} [args.databaseCharset] - Database-default character set (driver-specific; mysql/mariadb).
+   * @param {string} [args.databaseCollation] - Database-default collation (driver-specific; mysql/mariadb).
    * @returns {string[]} - SQL statements.
    */
   createDatabaseSql(databaseName, args) { throw new Error("'createDatabaseSql' not implemented") } // eslint-disable-line no-unused-vars

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -160,6 +160,8 @@ export default class VelociousDatabaseDriversBase {
    * @param {string} databaseName - Database name.
    * @param {object} [args] - Options object.
    * @param {boolean} [args.ifNotExists] - Whether if not exists.
+   * @param {string} [args.charset] - Default character set (driver-specific; mysql/mariadb).
+   * @param {string} [args.collation] - Default collation (driver-specific; mysql/mariadb).
    * @returns {string[]} - SQL statements.
    */
   createDatabaseSql(databaseName, args) { throw new Error("'createDatabaseSql' not implemented") } // eslint-disable-line no-unused-vars

--- a/src/database/drivers/mysql/sql/create-database.js
+++ b/src/database/drivers/mysql/sql/create-database.js
@@ -2,5 +2,36 @@
 
 import CreateDatabaseBase from "../../../query/create-database-base.js"
 
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9_]+$/
+
+/**
+ * @param {string} field - Field name (for error messages).
+ * @param {string} value - Identifier value.
+ * @returns {string} - Same value, validated.
+ */
+function validateCharsetOrCollation(field, value) {
+  if (!IDENTIFIER_PATTERN.test(value)) {
+    throw new Error(`Invalid ${field} value: ${JSON.stringify(value)} — expected [A-Za-z0-9_]+`)
+  }
+
+  return value
+}
+
 export default class VelociousDatabaseConnectionDriversMysqlSqlCreateDatabase extends CreateDatabaseBase {
+  /**
+   * @returns {string[]} - SQL statements.
+   */
+  toSql() {
+    const options = this.getOptions()
+    let sql = "CREATE DATABASE"
+
+    if (this.ifNotExists) sql += " IF NOT EXISTS"
+
+    sql += ` ${options.quoteDatabaseName(this.databaseName)}`
+
+    if (this.charset) sql += ` CHARACTER SET ${validateCharsetOrCollation("charset", this.charset)}`
+    if (this.collation) sql += ` COLLATE ${validateCharsetOrCollation("collation", this.collation)}`
+
+    return [sql]
+  }
 }

--- a/src/database/drivers/mysql/sql/create-database.js
+++ b/src/database/drivers/mysql/sql/create-database.js
@@ -29,8 +29,8 @@ export default class VelociousDatabaseConnectionDriversMysqlSqlCreateDatabase ex
 
     sql += ` ${options.quoteDatabaseName(this.databaseName)}`
 
-    if (this.charset) sql += ` CHARACTER SET ${validateCharsetOrCollation("charset", this.charset)}`
-    if (this.collation) sql += ` COLLATE ${validateCharsetOrCollation("collation", this.collation)}`
+    if (this.databaseCharset) sql += ` CHARACTER SET ${validateCharsetOrCollation("databaseCharset", this.databaseCharset)}`
+    if (this.databaseCollation) sql += ` COLLATE ${validateCharsetOrCollation("databaseCollation", this.databaseCollation)}`
 
     return [sql]
   }

--- a/src/database/query/create-database-base.js
+++ b/src/database/query/create-database-base.js
@@ -5,8 +5,8 @@
  * @property {import("../drivers/base.js").default} driver - Database driver used to generate SQL.
  * @property {string} databaseName - Name of the database to create.
  * @property {boolean} [ifNotExists] - Skip creation if the database already exists.
- * @property {string} [charset] - Default character set (driver-specific; currently used by mysql).
- * @property {string} [collation] - Default collation (driver-specific; currently used by mysql).
+ * @property {string} [databaseCharset] - Database-default character set (driver-specific; currently used by mysql).
+ * @property {string} [databaseCollation] - Database-default collation (driver-specific; currently used by mysql).
  */
 
 import QueryBase from "./base.js"
@@ -15,12 +15,12 @@ export default class VelociousDatabaseQueryCreateDatabaseBase extends QueryBase 
   /**
    * @param {CreateDatabaseArgsType} args - Options object.
    */
-  constructor({driver, databaseName, ifNotExists, charset, collation}) {
+  constructor({driver, databaseName, ifNotExists, databaseCharset, databaseCollation}) {
     super({driver})
     this.databaseName = databaseName
     this.ifNotExists = ifNotExists
-    this.charset = charset
-    this.collation = collation
+    this.databaseCharset = databaseCharset
+    this.databaseCollation = databaseCollation
   }
 
   /**

--- a/src/database/query/create-database-base.js
+++ b/src/database/query/create-database-base.js
@@ -5,6 +5,8 @@
  * @property {import("../drivers/base.js").default} driver - Database driver used to generate SQL.
  * @property {string} databaseName - Name of the database to create.
  * @property {boolean} [ifNotExists] - Skip creation if the database already exists.
+ * @property {string} [charset] - Default character set (driver-specific; currently used by mysql).
+ * @property {string} [collation] - Default collation (driver-specific; currently used by mysql).
  */
 
 import QueryBase from "./base.js"
@@ -13,10 +15,12 @@ export default class VelociousDatabaseQueryCreateDatabaseBase extends QueryBase 
   /**
    * @param {CreateDatabaseArgsType} args - Options object.
    */
-  constructor({driver, databaseName, ifNotExists}) {
+  constructor({driver, databaseName, ifNotExists, charset, collation}) {
     super({driver})
     this.databaseName = databaseName
     this.ifNotExists = ifNotExists
+    this.charset = charset
+    this.collation = collation
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds optional \`charset\` and \`collation\` fields to \`DatabaseConfigurationType\`.
- Extends \`CreateDatabaseBase\` to carry the two options; the mysql driver's \`CreateDatabase\` subclass emits them as \`CHARACTER SET\` / \`COLLATE\` clauses.
- \`db:create\` reads them from the per-identifier database configuration and passes them through to the driver, so the created database matches the explicit collation the app expects.
- Values are validated against \`[A-Za-z0-9_]+\` to prevent SQL injection via config.

## Context
Downstream app (\`awesome_tasks\`) was running \`mysql -u root -e 'CREATE DATABASE ... CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'\` before bootstrapping tests. When the inline shell step was replaced with \`npx velocious db:drop db:create db:schema:load\`, the created database inherited MariaDB 11 server defaults (\`utf8mb4_general_ci\`) instead of the configured collation. Per-table \`CHARSET\`/\`COLLATE\` from the structure SQL keeps table-level behavior intact, but the DB-level default still mattered and a code reviewer flagged the divergence.

## Test plan
- [x] \`npm run typecheck\`
- [x] New unit specs in \`spec/database/drivers/mysql/sql/create-database-spec.js\` (default, charset-only, collation-only, both, injection guards for each).
- [x] \`spec/cli/commands/db/create-spec.js\` and \`db/drop-spec.js\` still pass.