### PR TITLE
WebSocket: flow session metadata into request headers as x-<key>

### DIFF
--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -279,9 +279,24 @@ export default class VelociousHttpServerClientWebsocketSession {
     if (!method) throw new Error("method is required")
     if (!path) throw new Error("path is required")
 
+    // Merge session metadata into request headers under the `x-` prefix
+    // so downstream controllers/resources can read `locale`, tenant
+    // identifiers, etc. from the standard request.header(name) API
+    // without plumbing a separate metadata channel through every
+    // request-scoped code path. Session values take precedence over
+    // matching keys the client already sent as headers — metadata is
+    // explicitly a session-wide override.
+    const mergedHeaders = Object.assign({}, headers || {})
+
+    for (const [key, value] of Object.entries(this._metadata || {})) {
+      if (value === null || value === undefined) continue
+
+      mergedHeaders[`x-${key.toLowerCase()}`] = typeof value === "string" ? value : JSON.stringify(value)
+    }
+
     const request = new WebsocketRequest({
       body,
-      headers,
+      headers: mergedHeaders,
       method,
       path,
       remoteAddress: this.client.remoteAddress


### PR DESCRIPTION
## Summary
- When a client calls `setMetadata("locale", "da")` on a WebSocket connection today, the value is stored per-session and surfaces only to `onMetadataChanged` subscription callbacks. Individual request handlers have no way to read it.
- Merge the session's `_metadata` into every WebSocket-request's `headers` under an `x-<metadata-key>` prefix so downstream apps can use the normal `request.header("x-locale")` API. Session values win over client-sent headers on collision — metadata is explicitly a session-wide override.

## Use case
Needed by laser-warriors' backend gettext-universal integration so resources can translate error messages per-request using the locale the app set via `FrontendModelBase.setWebsocketMetadata("locale", …)`.

## Test plan
- [ ] Existing WebSocket session tests still pass (no breaking changes to the metadata channel, just an additional header enrichment downstream).
- [ ] Manual: laser-warriors backend reads `request.header("x-locale")` and returns translated Danish error strings when the client has set locale metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
