### PR TITLE
Add scope option to uniqueness validator

### DIFF
--- a/spec/database/record/validations.browser-spec.js
+++ b/spec/database/record/validations.browser-spec.js
@@ -32,4 +32,28 @@ describe("Record - validations", {tags: ["dummy"]}, () => {
       expect(error.message).toEqual("Name has already been taken")
     }
   })
+
+  it("allows the same name on different projects when uniqueness is scoped to projectId", async () => {
+    const projectA = await Project.create()
+    const projectB = await Project.create()
+
+    await Task.create({name: "Shared Name", project: projectA})
+    const taskOnB = await Task.create({name: "Shared Name", project: projectB})
+
+    expect(taskOnB.id()).toBeDefined()
+  })
+
+  it("rejects the same name on the same project when uniqueness is scoped to projectId", async () => {
+    const project = await Project.create()
+    await Task.create({name: "Duplicate", project})
+
+    try {
+      await Task.create({name: "Duplicate", project})
+
+      throw new Error("Duplicate task on same project didn't fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError)
+      expect(error.message).toEqual("Name has already been taken")
+    }
+  })
 })

--- a/spec/dummy/src/models/task.js
+++ b/spec/dummy/src/models/task.js
@@ -27,6 +27,6 @@ Task.hasOne("primaryInteraction", {className: "Interaction", foreignKey: "subjec
 Task.hasMany("comments")
 Task.hasManyAttachments("files")
 Task.hasOneAttachment("descriptionFile")
-Task.validates("name", {presence: true, uniqueness: true})
+Task.validates("name", {presence: true, uniqueness: {scope: "projectId"}})
 
 export default Task

--- a/src/database/record/validators/uniqueness.js
+++ b/src/database/record/validators/uniqueness.js
@@ -30,9 +30,17 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
 
     for (const scopeColumn of scopeColumns) {
       const scopeUnderscore = inflection.underscore(scopeColumn)
-      const scopeValue = /** @type {string | number} */ (model.readAttribute(scopeColumn))
+      const scopeValue = model.readAttribute(scopeColumn)
 
-      whereArgs[scopeUnderscore] = scopeValue
+      // When the scope value is not yet available (e.g. a belongsTo FK
+      // that hasn't been flushed from the relationship object onto the
+      // attribute store), the uniqueness check cannot be evaluated — the
+      // DB would receive `column = N'undefined'` and reject it. Bail
+      // out and let the DB-level unique constraint catch it at INSERT
+      // time instead.
+      if (scopeValue == null || scopeValue === undefined) return
+
+      whereArgs[scopeUnderscore] = /** @type {string | number} */ (scopeValue)
     }
 
     let existingRecordQuery = modelClass

--- a/src/database/record/validators/uniqueness.js
+++ b/src/database/record/validators/uniqueness.js
@@ -23,6 +23,18 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
 
     whereArgs[attributeNameUnderscore] = attributeValue
 
+    // Rails parity: `validates :attr, uniqueness: {scope: :other}` adds
+    // the scoped column(s) to the WHERE clause so uniqueness is checked
+    // within the given scope (e.g. `role` unique per `userId`).
+    const scopeColumns = this._normalizeScopeColumns()
+
+    for (const scopeColumn of scopeColumns) {
+      const scopeUnderscore = inflection.underscore(scopeColumn)
+      const scopeValue = /** @type {string | number} */ (model.readAttribute(scopeColumn))
+
+      whereArgs[scopeUnderscore] = scopeValue
+    }
+
     let existingRecordQuery = modelClass
       .select(modelClass.primaryKey())
       .where(whereArgs)
@@ -38,5 +50,21 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
 
       model._validationErrors[attributeName].push({type: "uniqueness", message: "has already been taken"})
     }
+  }
+
+  /**
+   * Normalize the `scope` option into an array of attribute names.
+   * Supports string (`"userId"`), array of strings (`["userId", "projectId"]`),
+   * or absent (empty array — no scope, original single-column behavior).
+   *
+   * @returns {string[]}
+   */
+  _normalizeScopeColumns() {
+    const scope = this.args?.scope
+
+    if (!scope) return []
+    if (Array.isArray(scope)) return scope
+
+    return [String(scope)]
   }
 }

--- a/src/database/record/validators/uniqueness.js
+++ b/src/database/record/validators/uniqueness.js
@@ -89,7 +89,7 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
       const instanceRelationship = model.getRelationshipByName(relationshipName)
       const loaded = instanceRelationship.loaded()
 
-      if (loaded && typeof loaded.id === "function") {
+      if (loaded && !Array.isArray(loaded) && typeof loaded.id === "function") {
         return loaded.id()
       }
     }

--- a/src/database/record/validators/uniqueness.js
+++ b/src/database/record/validators/uniqueness.js
@@ -30,15 +30,17 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
 
     for (const scopeColumn of scopeColumns) {
       const scopeUnderscore = inflection.underscore(scopeColumn)
-      const scopeValue = model.readAttribute(scopeColumn)
+      let scopeValue = model.readAttribute(scopeColumn)
 
-      // When the scope value is not yet available (e.g. a belongsTo FK
-      // that hasn't been flushed from the relationship object onto the
-      // attribute store), the uniqueness check cannot be evaluated — the
-      // DB would receive `column = N'undefined'` and reject it. Bail
-      // out and let the DB-level unique constraint catch it at INSERT
-      // time instead.
-      if (scopeValue == null || scopeValue === undefined) return
+      // When the FK hasn't been flushed from the relationship object
+      // onto the attribute store yet (e.g. `new Task({project})` where
+      // `projectId` is still undefined), try resolving it from the
+      // loaded belongsTo relationship instead.
+      if (scopeValue == null) {
+        scopeValue = this._resolveScopeValueFromRelationship(model, scopeColumn)
+      }
+
+      if (scopeValue == null) return
 
       whereArgs[scopeUnderscore] = /** @type {string | number} */ (scopeValue)
     }
@@ -58,6 +60,41 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
 
       model._validationErrors[attributeName].push({type: "uniqueness", message: "has already been taken"})
     }
+  }
+
+  /**
+   * Try to resolve a scope column value from a loaded belongsTo
+   * relationship on the model. When a Task is created via
+   * `new Task({project})`, the FK (`projectId`) is only flushed onto
+   * the attribute store during save — but the relationship object is
+   * already loaded and carries the id we need for the WHERE clause.
+   *
+   * @param {import("../index.js").default} model
+   * @param {string} scopeColumn - camelCase attribute name (e.g. `"projectId"`).
+   * @returns {string | number | null}
+   */
+  _resolveScopeValueFromRelationship(model, scopeColumn) {
+    const modelClass = /** @type {typeof import("../index.js").default} */ (model.constructor)
+    const relationships = modelClass.getRelationshipsMap()
+
+    for (const relationshipName in relationships) {
+      const relationship = relationships[relationshipName]
+
+      if (relationship.getType?.() !== "belongsTo") continue
+
+      const foreignKey = inflection.camelize(relationship.getForeignKey(), true)
+
+      if (foreignKey !== scopeColumn) continue
+
+      const instanceRelationship = model.getRelationshipByName(relationshipName)
+      const loaded = instanceRelationship.loaded()
+
+      if (loaded && typeof loaded.id === "function") {
+        return loaded.id()
+      }
+    }
+
+    return null
   }
 
   /**


### PR DESCRIPTION
## Summary
Adds a `scope` option to the uniqueness validator so `validates("role", {uniqueness: {scope: "userId"}})` checks uniqueness of `role` **within** the given `userId` — matching the Rails `validates :role, uniqueness: {scope: :user}` behavior.

Accepts `scope` as a string, array of strings, or absent (preserves existing single-column behavior). Each scope column is added to the WHERE clause alongside the main attribute.

## Why
Downstream apps (awesome_tasks) need scoped uniqueness for join models like `UserRole(userId, role)`, `TaskAssignedUser(taskId, userId)`, etc. Without `scope`, the workaround is a manual `beforeValidation` hook that duplicates the query logic the validator already has.

## Test plan
- [x] `npm run lint` (clean, 2 warnings — pre-existing JSDoc style)
- Manual verification in awesome_tasks via `UserRole.validates("role", {uniqueness: {scope: "userId"}})`

🤖 Generated with [Claude Code](https://claude.com/claude-code)