### PR TITLE
Add format validator

### DIFF
--- a/spec/database/record/validations.browser-spec.js
+++ b/spec/database/record/validations.browser-spec.js
@@ -1,4 +1,5 @@
 import Task from "../../dummy/src/models/task.js"
+import User from "../../dummy/src/models/user.js"
 import {ValidationError} from "../../../src/database/record/index.js"
 import Project from "../../dummy/src/models/project.js"
 
@@ -55,5 +56,23 @@ describe("Record - validations", {tags: ["dummy"]}, () => {
       expect(error).toBeInstanceOf(ValidationError)
       expect(error.message).toEqual("Name has already been taken")
     }
+  })
+
+  it("rejects a malformed email with a format validation", async () => {
+    const user = new User({email: "not-an-email"})
+
+    await expect(async () => user.save()).toThrowError(new ValidationError("Email is invalid"))
+  })
+
+  it("allows a valid email with a format validation", async () => {
+    const user = await User.create({email: "valid@example.com"})
+
+    expect(user.email()).toEqual("valid@example.com")
+  })
+
+  it("allows a blank email when format validation has allowBlank", async () => {
+    const user = await User.create({email: ""})
+
+    expect(user.id()).toBeDefined()
   })
 })

--- a/spec/database/record/validations.browser-spec.js
+++ b/spec/database/record/validations.browser-spec.js
@@ -59,19 +59,19 @@ describe("Record - validations", {tags: ["dummy"]}, () => {
   })
 
   it("rejects a malformed email with a format validation", async () => {
-    const user = new User({email: "not-an-email"})
+    const user = new User({email: "not-an-email", encryptedPassword: "test"})
 
     await expect(async () => user.save()).toThrowError(new ValidationError("Email is invalid"))
   })
 
   it("allows a valid email with a format validation", async () => {
-    const user = await User.create({email: "valid@example.com"})
+    const user = await User.create({email: "valid@example.com", encryptedPassword: "test"})
 
     expect(user.email()).toEqual("valid@example.com")
   })
 
   it("allows a blank email when format validation has allowBlank", async () => {
-    const user = await User.create({email: ""})
+    const user = await User.create({email: "", encryptedPassword: "test"})
 
     expect(user.id()).toBeDefined()
   })

--- a/spec/dummy/src/models/user.js
+++ b/spec/dummy/src/models/user.js
@@ -9,6 +9,8 @@ User.hasOne("createdProject", {className: "Project", foreignKey: "creating_user_
 User.hasMany("authenticationTokens" , {dependent: "destroy"})
 User.hasMany("createdProjects", {className: "Project", foreignKey: "creating_user_reference", primaryKey: "reference"})
 
+User.validates("email", {format: {with: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, allowBlank: true}})
+
 const userModule = new UserModule({
   secretKey: "02e383b7-aad1-437c-b1e1-17c0240ad851"
 })

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -23,6 +23,7 @@ import * as inflection from "inflection"
 import ModelClassQuery from "../query/model-class-query.js"
 import restArgsError from "../../utils/rest-args-error.js"
 import singularizeModelName from "../../utils/singularize-model-name.js"
+import ValidatorsFormat from "./validators/format.js"
 import ValidatorsPresence from "./validators/presence.js"
 import ValidatorsUniqueness from "./validators/uniqueness.js"
 import UUID from "pure-uuid"
@@ -2807,6 +2808,7 @@ class TranslationBase extends VelociousDatabaseRecord {
   }
 }
 
+VelociousDatabaseRecord.registerValidatorType("format", ValidatorsFormat)
 VelociousDatabaseRecord.registerValidatorType("presence", ValidatorsPresence)
 VelociousDatabaseRecord.registerValidatorType("uniqueness", ValidatorsUniqueness)
 

--- a/src/database/record/validators/format.js
+++ b/src/database/record/validators/format.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+import Base from "./base.js"
+
+export default class VelociousDatabaseRecordValidatorsFormat extends Base {
+  /**
+   * @param {object} args - Options object.
+   * @param {import("../index.js").default} args.model - Model instance.
+   * @param {string} args.attributeName - Attribute name.
+   * @returns {Promise<void>}
+   */
+  async validate({model, attributeName}) {
+    const value = model.readAttribute(attributeName)
+
+    // Rails parity: `allow_blank: true` skips the format check for
+    // blank/null/undefined values. Default to false (same as Rails).
+    const allowBlank = this.args?.allowBlank === true
+
+    if (value == null || (typeof value === "string" && value.trim() === "")) {
+      if (allowBlank) return
+
+      if (!(attributeName in model._validationErrors)) model._validationErrors[attributeName] = []
+
+      model._validationErrors[attributeName].push({type: "format", message: "is invalid"})
+
+      return
+    }
+
+    const pattern = this.args?.with
+
+    if (!(pattern instanceof RegExp)) {
+      throw new Error(`validates format requires a 'with' option that is a RegExp, got: ${typeof pattern}`)
+    }
+
+    const stringValue = String(value)
+
+    if (!pattern.test(stringValue)) {
+      const message = typeof this.args?.message === "string" ? this.args.message : "is invalid"
+
+      if (!(attributeName in model._validationErrors)) model._validationErrors[attributeName] = []
+
+      model._validationErrors[attributeName].push({type: "format", message})
+    }
+  }
+}

--- a/src/database/record/validators/format.js
+++ b/src/database/record/validators/format.js
@@ -34,6 +34,10 @@ export default class VelociousDatabaseRecordValidatorsFormat extends Base {
 
     const stringValue = String(value)
 
+    // Reset lastIndex so stateful flags (g, y) on a shared RegExp
+    // instance don't cause nondeterministic pass/fail across calls.
+    pattern.lastIndex = 0
+
     if (!pattern.test(stringValue)) {
       const message = typeof this.args?.message === "string" ? this.args.message : "is invalid"
 


### PR DESCRIPTION
## Summary
Adds a `format` validator so `validates("email", {format: {with: /regex/, allowBlank: true}})` works like Rails.

Options: `with` (RegExp), `allowBlank` (boolean, default false), `message` (string, default "is invalid").

## Why
Downstream apps need email/phone/pattern validation on model attributes. Without this, the workaround is a manual `beforeValidation` hook.

## Test plan
- [x] `npm run lint` (clean on changed files)
- Three new spec examples: malformed rejected, valid accepted, blank allowed with allowBlank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)