### PR TITLE
Add dependent: "restrict" for hasMany relationships

### DIFF
--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -34,10 +34,27 @@ Comment.belongsTo("acceptedTask", (scope) => scope.where({state: "accepted"}), {
 | Option | Description |
 |---|---|
 | `className` | Target model class name (inferred from relationship name by default) |
+| `dependent` | Action on parent destroy: `"destroy"` or `"restrict"` (hasMany/hasOne only) |
 | `foreignKey` | Explicit foreign key column (inferred by default) |
 | `primaryKey` | Primary key on the parent model (defaults to `"id"`) |
 | `polymorphic` | Enable polymorphic lookup via type+id columns |
 | `through` | Name of an intermediate `hasMany` relationship for many-to-many |
+
+## Dependent option
+
+The `dependent` option controls what happens to associated records when the parent is destroyed:
+
+```js
+User.hasMany("authenticationTokens", {dependent: "destroy"})
+Project.hasMany("tasks", {dependent: "restrict"})
+```
+
+| Value | Behavior |
+|---|---|
+| `"destroy"` | Loads and destroys all dependent records before destroying the parent |
+| `"restrict"` | Blocks destroy with an error when any dependent records exist (uses a COUNT query, does not load records) |
+
+The restrict error message follows the pattern `"Cannot delete record because dependent <relationship> exist"`.
 
 ## Through relationships (many-to-many)
 

--- a/spec/database/record/destroy.browser-spec.js
+++ b/spec/database/record/destroy.browser-spec.js
@@ -46,6 +46,27 @@ describe("Record - destroy", {tags: ["dummy"]}, () => {
     expect(translationsAfter.length).toEqual(0)
   })
 
+  it("blocks destroy when dependent restrict records exist", async () => {
+    const project = await Project.create()
+    await Task.create({name: "Blocking task", project})
+
+    await expect(async () => project.destroy()).toThrowError("Cannot delete record because dependent tasks exist")
+
+    const foundProject = await Project.where({id: project.id()}).first()
+
+    expect(foundProject).toBeDefined()
+  })
+
+  it("allows destroy when no dependent restrict records exist", async () => {
+    const project = await Project.create()
+
+    await project.destroy()
+
+    const foundProject = await Project.where({id: project.id()}).first()
+
+    expect(foundProject).toEqual(undefined)
+  })
+
   it("runs lifecycle callbacks around destroy", async () => {
     const previousLifecycleCallbacks = Task._lifecycleCallbacks
     /** @type {string[]} */

--- a/spec/dummy/src/models/project.js
+++ b/spec/dummy/src/models/project.js
@@ -4,7 +4,7 @@ class Project extends ProjectBase {
 }
 
 Project.belongsTo("creatingUser", {className: "User", foreignKey: "creating_user_reference", primaryKey: "reference"})
-Project.hasMany("tasks")
+Project.hasMany("tasks", {dependent: "restrict"})
 Project.hasMany("doneTasks", (scope) => scope.where({isDone: true}), {className: "Task"})
 Project.hasOne("projectDetail")
 Project.hasOne("activeProjectDetail", function() { return this.where({isActive: true}) }, {className: "ProjectDetail"})

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2305,15 +2305,11 @@ class VelociousDatabaseRecord {
 
     for (const relationship of this.getModelClass().getRelationships()) {
       if (relationship.getDependent() == "restrict") {
-        const TargetClass = relationship.getTargetModelClass()
+        const instanceRelationship = /** @type {any} */ (this.getRelationshipByName(relationship.getRelationshipName()))
+        const count = await instanceRelationship.query().count()
 
-        if (TargetClass) {
-          const fk = relationship.getForeignKey()
-          const count = await TargetClass.where({[fk]: this.id()}).count()
-
-          if (count > 0) {
-            throw new Error(`Cannot delete record because dependent ${relationship.getRelationshipName()} exist`)
-          }
+        if (count > 0) {
+          throw new Error(`Cannot delete record because dependent ${relationship.getRelationshipName()} exist`)
         }
 
         continue

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2304,6 +2304,21 @@ class VelociousDatabaseRecord {
     await this._runLifecycleCallbacks("beforeDestroy")
 
     for (const relationship of this.getModelClass().getRelationships()) {
+      if (relationship.getDependent() == "restrict") {
+        const TargetClass = relationship.getTargetModelClass()
+
+        if (TargetClass) {
+          const fk = relationship.getForeignKey()
+          const count = await TargetClass.where({[fk]: this.id()}).count()
+
+          if (count > 0) {
+            throw new Error(`Cannot delete record because dependent ${relationship.getRelationshipName()} exist`)
+          }
+        }
+
+        continue
+      }
+
       if (relationship.getDependent() != "destroy") {
         continue
       }


### PR DESCRIPTION
## Summary

- Adds `dependent: "restrict"` option for `hasMany` relationships, matching Rails' `dependent: :restrict_with_error`
- Checks for existing dependent records via COUNT query before destroy — raises an error when any exist
- Does not load all dependent records into memory

## Test plan

- [x] New spec: blocks destroy when dependent restrict records exist
- [x] New spec: allows destroy when no dependent restrict records exist
- [x] Existing destroy specs still pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)