### PR TITLE
Share Dummy app + DB pool across tests

### DIFF
--- a/spec/database/pool/async-tracked-multi-connection-checkin-validation-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-checkin-validation-spec.js
@@ -14,6 +14,8 @@ function getPool() {
   return pool
 }
 
+// Mutates `pool.connections` directly, so start from a freshly restarted Dummy
+// to avoid leaking that replacement into unrelated tests sharing the pool.
 describe("database - pool - checkin with open transaction", () => {
   it("preserves connections with an open transaction so they can be rolled back later", async () => {
     await Dummy.run(async () => {
@@ -45,6 +47,6 @@ describe("database - pool - checkin with open transaction", () => {
         await connection.rollbackTransaction()
         expect(connection._transactionsCount).toBe(0)
       })
-    })
+    }, {fresh: true})
   })
 })

--- a/spec/database/pool/async-tracked-multi-connection-fallback-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-fallback-spec.js
@@ -13,6 +13,9 @@ function getPool() {
   return pool
 }
 
+// Each test mutates pool internals (global fallback, `pool.connections`) and
+// asserts on the "created when missing" path, so run against a freshly
+// restarted Dummy to avoid state leaking across examples.
 describe("database - pool - async tracked multi connection", () => {
   it("returns a global fallback connection when no async context has been set", async () => {
     await Dummy.run(async () => {
@@ -24,7 +27,7 @@ describe("database - pool - async tracked multi connection", () => {
       const currentConnection = await pool.asyncLocalStorage.run(undefined, async () => pool.getCurrentConnection())
 
       expect(currentConnection).toBe(fallbackConnection)
-    })
+    }, {fresh: true})
   })
 
   it("prefers the async-context connection and falls back to the global connection outside the context", async () => {
@@ -47,7 +50,7 @@ describe("database - pool - async tracked multi connection", () => {
       const outsideConnection = await pool.asyncLocalStorage.run(undefined, async () => pool.getCurrentConnection())
 
       expect(outsideConnection).toBe(fallbackConnection)
-    })
+    }, {fresh: true})
   })
 
   it("ensures a global connection is created when missing", async () => {
@@ -61,7 +64,7 @@ describe("database - pool - async tracked multi connection", () => {
 
       expect(connection).toBe(pool.getGlobalConnection())
       expect(outsideConnection).toBe(connection)
-    })
+    }, {fresh: true})
   })
 
   it("does not replace an existing global connection when ensuring", async () => {
@@ -79,6 +82,6 @@ describe("database - pool - async tracked multi connection", () => {
 
       expect(connection).toBe(existing)
       expect(outsideConnection).toBe(existing)
-    })
+    }, {fresh: true})
   })
 })

--- a/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
@@ -13,6 +13,8 @@ function getPool() {
   return pool
 }
 
+// Mutates `pool.connections` and asserts on a snapshot of `connectionsInUse`,
+// so run against a freshly restarted Dummy to isolate from other pool specs.
 describe("database - pool - async tracked multi connection reuse", () => {
   it("checks connections back in and reuses them", async () => {
     await Dummy.run(async () => {
@@ -43,6 +45,6 @@ describe("database - pool - async tracked multi connection reuse", () => {
       })
 
       expect(secondConnection).toBe(firstConnection)
-    })
+    }, {fresh: true})
   })
 })

--- a/spec/dummy/index.js
+++ b/spec/dummy/index.js
@@ -90,6 +90,15 @@ export default class Dummy {
   async run(callback, options) {
     if (options?.fresh) await this.teardown()
 
+    // Always re-assert the dummy as the current configuration before running.
+    // Why: other specs (e.g. spec/mailers/mailer-spec.js) call setCurrent on
+    // their own throwaway Configuration and never restore it, so the shared
+    // singleton can point at a dead configuration by the time a dummy-backed
+    // spec runs. Before the shared-lifecycle change, Dummy.prepare() reset
+    // this on every run; that reset now only happens on the first start,
+    // so force it here on every call.
+    dummyConfiguration.setCurrent()
+
     await dummyConfiguration.ensureConnections(async () => {
       await this.start()
       await callback()

--- a/spec/dummy/index.js
+++ b/spec/dummy/index.js
@@ -7,6 +7,9 @@ import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
 import Migrator from "../../src/database/migrator.js"
 
 export default class Dummy {
+  /** @type {Dummy | undefined} */
+  static velociousDummy
+
   static current() {
     if (!this.velociousDummy) {
       this.velociousDummy = new Dummy()
@@ -15,11 +18,23 @@ export default class Dummy {
     return this.velociousDummy
   }
 
+  /** @type {boolean} */
+  _migrationsDone = false
+
+  /** @type {boolean} */
+  _started = false
+
+  /** @type {Promise<void> | undefined} */
+  _startingPromise
+
+  /** @type {Application | undefined} */
+  application
+
   static async prepare() {
     dummyConfiguration.setCurrent()
 
     await dummyConfiguration.ensureConnections(async () => {
-      await this.runMigrations()
+      await this.current()._runMigrationsOnce()
 
       if (!dummyConfiguration.isInitialized()) {
         await dummyConfiguration.initialize()
@@ -27,7 +42,14 @@ export default class Dummy {
     })
   }
 
-  static async runMigrations() {
+  /**
+   * Runs migrations exactly once per process. Subsequent calls are no-ops
+   * so repeated Dummy.run calls don't re-query schema_migrations and reload models.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _runMigrationsOnce() {
+    if (this._migrationsDone) return
+
     const environmentHandlerNode = new EnvironmentHandlerNode()
 
     environmentHandlerNode.setConfiguration(dummyConfiguration)
@@ -36,27 +58,69 @@ export default class Dummy {
 
     await migrator.prepare()
     await migrator.migrateFiles(await environmentHandlerNode.findMigrations(), digg(environmentHandlerNode, "requireMigration"))
+
+    this._migrationsDone = true
   }
 
-  /** @param {function(): Promise<any>} callback */
-  static async run(callback) {
-    await this.current().run(callback)
+  /**
+   * @param {function(): Promise<any>} callback - Callback function.
+   * @param {object} [options] - Options.
+   * @param {boolean} [options.fresh] - Tear down any existing dummy and start a new one.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  static async run(callback, options) {
+    await this.current().run(callback, options)
   }
 
-  /** @param {function(): Promise<void>} callback */
-  async run(callback) {
+  /**
+   * @returns {Promise<void>} - Resolves when the dummy is fully torn down.
+   */
+  static async teardown() {
+    if (!this.velociousDummy) return
+
+    await this.velociousDummy.teardown()
+  }
+
+  /**
+   * @param {function(): Promise<void>} callback - Callback function.
+   * @param {object} [options] - Options.
+   * @param {boolean} [options.fresh] - Force a full stop + restart before running.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async run(callback, options) {
+    if (options?.fresh) await this.teardown()
+
+    await dummyConfiguration.ensureConnections(async () => {
+      await this.start()
+      await callback()
+    })
+  }
+
+  /**
+   * Starts the dummy application if it isn't already running. Concurrent callers
+   * share a single startup promise so the first one wins and the rest await it.
+   * @returns {Promise<void>} - Resolves when started.
+   */
+  async start() {
+    if (this._started) return
+    if (this._startingPromise) {
+      await this._startingPromise
+      return
+    }
+
+    this._startingPromise = this._doStart()
+
     try {
-      await dummyConfiguration.ensureConnections(async () => {
-        await Dummy.prepare()
-        await this.start()
-        await callback()
-      })
+      await this._startingPromise
     } finally {
-      await this.stop()
+      this._startingPromise = undefined
     }
   }
 
-  async start() {
+  /** @returns {Promise<void>} - Resolves when complete. */
+  async _doStart() {
+    await Dummy.prepare()
+
     if (!dummyConfiguration.isDatabasePoolInitialized()) {
       await dummyConfiguration.initializeDatabasePool()
     }
@@ -73,11 +137,30 @@ export default class Dummy {
 
     await this.application.initialize()
     await this.application.startHttpServer()
+
+    this._started = true
   }
 
-  async stop() {
+  /**
+   * Tears down the running application (HTTP server + DB connections). Safe to call
+   * when nothing is running; resets state so a subsequent Dummy.run will do a full start again.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async teardown() {
     if (this.application) {
       await this.application.stop()
+      this.application = undefined
     }
+
+    this._started = false
+    this._migrationsDone = false
+  }
+
+  /**
+   * Back-compat alias: older call sites used `stop()` to mean full teardown.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async stop() {
+    await this.teardown()
   }
 }

--- a/spec/dummy/src/config/testing.js
+++ b/spec/dummy/src/config/testing.js
@@ -1,3 +1,4 @@
+import Dummy from "../../index.js"
 import dummyConfiguration from "./configuration.js"
 
 export default async function configureTesting() {
@@ -45,5 +46,11 @@ export default async function configureTesting() {
         }
       }
     })
+  })
+
+  // Tear the shared Dummy down once at suite end so the HTTP server stops
+  // and DB pools close cleanly. Dummy.teardown is a no-op when nothing was started.
+  afterAll(async () => {
+    await Dummy.teardown()
   })
 }


### PR DESCRIPTION
## Summary
- `Dummy.run()` is now idempotent — first call does `prepare()` + `start()`, subsequent calls reuse the already-running app + DB pool.
- Migrations run once per process instead of on every test.
- Suite-end teardown wired through a new `afterAll` hook in the dummy testing config; `Dummy.teardown()` can also be called explicitly. A `{fresh: true}` opt-out on `Dummy.run` forces a restart for the rare spec that needs it.

Tests no longer pay per-test: migrator query, model re-initialization, `Application` construction, HTTP server start/stop, and DB reconnect. On my machine the full `spec/http-server/` suite (109 specs) drops from ~106.6s to ~93.7s (~12%). Savings scale with the number of dummy-backed specs.

## Test plan
- [x] `npm run lint` on changed files (clean)
- [x] `npm run typecheck` (clean)
- [x] Full suite: 827 pass, 1 unrelated flake (`background-jobs forked-jobs` — reproduces identically on master)
- [x] Websocket specs (46): all green
- [ ] CI