### PR TITLE
Cohort auto-batch-preload for frontend-model relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,30 @@ new Configuration({
 
 Both flags default to `true`. When disabled, lazy access falls back to a per-record load.
 
+The same cohort auto-batch-preload applies to **frontend models**. When a batch is loaded from the backend (`Task.where(...).toArray()` or similar), the first async relationship access on any cohort sibling triggers one combined HTTP request that preloads that relationship for every sibling at once:
+
+```js
+const tasks = await Task.toArray()
+
+// First call issues ONE request to preload the project for every task in the batch.
+const firstProject = await tasks[0].projectOrLoad()
+
+// Sibling has been populated from the same response — no extra request.
+const secondProject = tasks[1].project()
+```
+
+The generator threads the per-relationship `autoload: false` flag through automatically, so `Task.belongsTo("project", {autoload: false})` on the backend also disables cohort batching on the generated frontend model.
+
+Disable auto-batch-preload globally on the frontend:
+
+```js
+import FrontendModelBase from "velocious/frontend-models"
+
+FrontendModelBase.setAutoload(false)
+```
+
+Scoped frontend queries (e.g. `Task.where(...).preload([name]).toArray()` from user code) bypass cohort batching by design, same as the backend. Siblings with locally set state from `.setRelationship()` / `.build()` are preserved across cohort batches.
+
 ## Through relationships
 
 Use the `through` option on `hasMany` to define a relationship that traverses an intermediate (join) table:

--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -133,7 +133,7 @@ describe("Cli - generate - frontend-models", () => {
     expect(taskContents).toContain("identifier() { return this.readAttribute(\"identifier\") }")
     expect(taskContents).toContain("setIdentifier(newValue) { return this.setAttribute(\"identifier\", newValue) }")
     expect(taskContents.includes("import Project from")).toEqual(false)
-    expect(taskContents).toContain("/** @returns {Record<string, {type: \"belongsTo\" | \"hasOne\" | \"hasMany\"}>} - Relationship definitions. */")
+    expect(taskContents).toContain("/** @returns {Record<string, {type: \"belongsTo\" | \"hasOne\" | \"hasMany\", autoload?: boolean}>} - Relationship definitions. */")
     expect(taskContents).toContain("static relationshipDefinitions()")
     expect(taskContents).toContain("project: \"Project\",")
     expect(taskContents).toContain("FrontendModelBase.registerModel(Task)")

--- a/spec/frontend-models/autoload-spec.js
+++ b/spec/frontend-models/autoload-spec.js
@@ -1,0 +1,390 @@
+import FrontendModelBase from "../../src/frontend-models/base.js"
+
+/**
+ * @typedef {{body: Record<string, any>, url: string}} FetchCall
+ */
+
+/**
+ * @returns {{Comment: typeof FrontendModelBase, Project: typeof FrontendModelBase, Task: typeof FrontendModelBase}} - Test classes with relationships.
+ */
+function buildAutoloadTestModelClasses() {
+  /** Frontend model comment test class. */
+  class Comment extends FrontendModelBase {
+    /**
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
+     */
+    static resourceConfig() {
+      return {
+        attributes: ["id", "body"],
+        commands: {index: "index"},
+        primaryKey: "id"
+      }
+    }
+  }
+
+  /** Frontend model task test class. */
+  class Task extends FrontendModelBase {
+    /**
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
+     */
+    static resourceConfig() {
+      return {
+        attributes: ["id", "name"],
+        commands: {index: "index"},
+        primaryKey: "id"
+      }
+    }
+
+    /**
+     * @returns {Record<string, typeof FrontendModelBase>}
+     */
+    static relationshipModelClasses() {
+      return {
+        comments: Comment,
+        project: Project
+      }
+    }
+
+    /**
+     * @returns {Record<string, {type: "hasMany" | "belongsTo", autoload?: boolean}>}
+     */
+    static relationshipDefinitions() {
+      return {
+        comments: {type: "hasMany"},
+        project: {type: "belongsTo"}
+      }
+    }
+  }
+
+  /** Frontend model project test class. */
+  class Project extends FrontendModelBase {
+    /**
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}}
+     */
+    static resourceConfig() {
+      return {
+        attributes: ["id", "name"],
+        commands: {index: "index"},
+        primaryKey: "id"
+      }
+    }
+
+    /**
+     * @returns {Record<string, typeof FrontendModelBase>}
+     */
+    static relationshipModelClasses() {
+      return {
+        tasks: Task
+      }
+    }
+
+    /**
+     * @returns {Record<string, {type: "hasMany", autoload?: boolean}>}
+     */
+    static relationshipDefinitions() {
+      return {
+        tasks: {type: "hasMany"}
+      }
+    }
+  }
+
+  return {Comment, Project, Task}
+}
+
+/**
+ * Fetch stub that selects response per request URL + body. Each entry is tried
+ * in order; the first predicate that returns truthy wins. When no predicate
+ * matches, throws so the test fails loudly instead of hanging on a bad stub.
+ * @param {Array<{match: (body: Record<string, any>, url: string) => boolean, response: Record<string, any>}>} responders
+ * @returns {{calls: FetchCall[], restore: () => void}} - Stub handle.
+ */
+function stubFetchWith(responders) {
+  const originalFetch = globalThis.fetch
+  /** @type {FetchCall[]} */
+  const calls = []
+
+  globalThis.fetch = /** @type {typeof fetch} */ (async (url, options) => {
+    const bodyString = typeof options?.body === "string" ? options.body : "{}"
+    const parsedBody = JSON.parse(bodyString)
+    const batchRequests = Array.isArray(parsedBody.requests) ? parsedBody.requests : null
+    const normalizedBody = batchRequests && batchRequests.length === 1 && typeof batchRequests[0] === "object"
+      ? batchRequests[0].payload
+      : parsedBody
+    const stringUrl = `${url}`
+
+    calls.push({body: normalizedBody, url: stringUrl})
+
+    let matchedResponse = null
+
+    for (const responder of responders) {
+      if (responder.match(normalizedBody, stringUrl)) {
+        matchedResponse = responder.response
+        break
+      }
+    }
+
+    if (!matchedResponse) {
+      throw new Error(`No stub responder matched request: ${JSON.stringify(normalizedBody)}`)
+    }
+
+    const responsePayload = batchRequests
+      ? {responses: batchRequests.map((req) => ({requestId: req.requestId, response: matchedResponse}))}
+      : matchedResponse
+
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(responsePayload),
+      json: async () => responsePayload
+    }
+  })
+
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = originalFetch
+    }
+  }
+}
+
+/** @returns {void} */
+function resetFrontendModelTransport() {
+  FrontendModelBase.configureTransport({
+    shared: undefined,
+    url: undefined,
+    websocketClient: undefined
+  })
+}
+
+describe("Frontend models - autoload", () => {
+  it("batch-loads a belongsTo relationship for every cohort sibling in one request", async () => {
+    const {Task} = buildAutoloadTestModelClasses()
+
+    const fetchStub = stubFetchWith([
+      {
+        // Initial list without preload.
+        match: (body) => !body.preload && !body.where,
+        response: {
+          models: [
+            {id: "1", name: "Task one"},
+            {id: "2", name: "Task two"}
+          ]
+        }
+      },
+      {
+        // Cohort preload request for projects.
+        match: (body) => Boolean(body.preload?.project) && Array.isArray(body.where?.id) && body.where.id.length === 2,
+        response: {
+          models: [
+            {id: "1", name: "Task one", __preloadedRelationships: {project: {id: "101", name: "P1"}}},
+            {id: "2", name: "Task two", __preloadedRelationships: {project: {id: "102", name: "P2"}}}
+          ]
+        }
+      }
+    ])
+
+    try {
+      const tasks = await Task.toArray()
+
+      expect(tasks.length).toEqual(2)
+      expect(fetchStub.calls.length).toEqual(1)
+
+      // First lazy access triggers ONE cohort request for both tasks.
+      const firstProject = await tasks[0].relationshipOrLoad("project")
+
+      expect(firstProject.readAttribute("id")).toEqual("101")
+      expect(fetchStub.calls.length).toEqual(2)
+
+      // Sibling must now be preloaded — no additional request.
+      const secondRelationship = tasks[1].getRelationshipByName("project")
+
+      expect(secondRelationship.getPreloaded()).toEqual(true)
+
+      const secondProject = await tasks[1].relationshipOrLoad("project")
+
+      expect(secondProject.readAttribute("id")).toEqual("102")
+      expect(fetchStub.calls.length).toEqual(2)
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("batch-loads a hasMany relationship across cohort siblings via toArray()", async () => {
+    const {Project} = buildAutoloadTestModelClasses()
+
+    const fetchStub = stubFetchWith([
+      {
+        match: (body) => !body.preload && !body.where,
+        response: {
+          models: [
+            {id: "1", name: "P1"},
+            {id: "2", name: "P2"}
+          ]
+        }
+      },
+      {
+        match: (body) => Boolean(body.preload?.tasks) && Array.isArray(body.where?.id),
+        response: {
+          models: [
+            {id: "1", name: "P1", __preloadedRelationships: {tasks: [{id: "11", name: "T1"}]}},
+            {id: "2", name: "P2", __preloadedRelationships: {tasks: [{id: "22", name: "T2"}]}}
+          ]
+        }
+      }
+    ])
+
+    try {
+      const projects = await Project.toArray()
+
+      expect(projects.length).toEqual(2)
+      expect(fetchStub.calls.length).toEqual(1)
+
+      const firstTasks = await projects[0].getRelationshipByName("tasks").toArray()
+
+      expect(firstTasks.length).toEqual(1)
+      expect(firstTasks[0].readAttribute("id")).toEqual("11")
+      expect(fetchStub.calls.length).toEqual(2)
+
+      // Sibling is preloaded from the cohort batch — no additional request.
+      const secondRelationship = projects[1].getRelationshipByName("tasks")
+
+      expect(secondRelationship.getPreloaded()).toEqual(true)
+      expect(secondRelationship.loaded().map((task) => task.readAttribute("id"))).toEqual(["22"])
+      expect(fetchStub.calls.length).toEqual(2)
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("falls back to per-record load when autoload: false is set on the relationship", async () => {
+    const {Task} = buildAutoloadTestModelClasses()
+
+    // Patch definition to disable autoload for this test.
+    const originalDefinitions = Task.relationshipDefinitions
+    Task.relationshipDefinitions = () => ({
+      comments: {type: "hasMany"},
+      project: {type: "belongsTo", autoload: false}
+    })
+
+    const fetchStub = stubFetchWith([
+      {
+        match: (body) => !body.preload && !body.where,
+        response: {
+          models: [
+            {id: "1", name: "Task one"},
+            {id: "2", name: "Task two"}
+          ]
+        }
+      },
+      {
+        // Per-record preload via .find() — where is a single id, not an array.
+        match: (body) => Boolean(body.preload?.project) && (typeof body.where?.id === "string" || typeof body.where?.id === "number"),
+        response: {
+          models: [{id: "1", name: "Task one", __preloadedRelationships: {project: {id: "101", name: "P1"}}}]
+        }
+      }
+    ])
+
+    try {
+      const tasks = await Task.toArray()
+
+      await tasks[0].relationshipOrLoad("project")
+
+      // Sibling remains NOT preloaded — autoload disabled for this relationship.
+      const secondRelationship = tasks[1].getRelationshipByName("project")
+
+      expect(secondRelationship.getPreloaded()).toEqual(false)
+    } finally {
+      Task.relationshipDefinitions = originalDefinitions
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("falls back to per-record load when FrontendModelBase.setAutoload(false) is set globally", async () => {
+    const {Task} = buildAutoloadTestModelClasses()
+    const originalAutoload = FrontendModelBase.getAutoload()
+
+    FrontendModelBase.setAutoload(false)
+
+    const fetchStub = stubFetchWith([
+      {
+        match: (body) => !body.preload && !body.where,
+        response: {
+          models: [
+            {id: "1", name: "Task one"},
+            {id: "2", name: "Task two"}
+          ]
+        }
+      },
+      {
+        match: (body) => Boolean(body.preload?.project) && (typeof body.where?.id === "string" || typeof body.where?.id === "number"),
+        response: {
+          models: [{id: "1", name: "Task one", __preloadedRelationships: {project: {id: "101", name: "P1"}}}]
+        }
+      }
+    ])
+
+    try {
+      const tasks = await Task.toArray()
+
+      await tasks[0].relationshipOrLoad("project")
+
+      const secondRelationship = tasks[1].getRelationshipByName("project")
+
+      expect(secondRelationship.getPreloaded()).toEqual(false)
+    } finally {
+      FrontendModelBase.setAutoload(originalAutoload)
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("preserves locally set singular relationship state on siblings during cohort preload", async () => {
+    const {Project, Task} = buildAutoloadTestModelClasses()
+
+    const fetchStub = stubFetchWith([
+      {
+        match: (body) => !body.preload && !body.where,
+        response: {
+          models: [
+            {id: "1", name: "Task one"},
+            {id: "2", name: "Task two"}
+          ]
+        }
+      },
+      {
+        match: (body) => Boolean(body.preload?.project) && Array.isArray(body.where?.id),
+        response: {
+          models: [
+            {id: "1", name: "Task one", __preloadedRelationships: {project: {id: "101", name: "P1"}}}
+            // Intentionally omit task 2 — cohort code must skip it because it's locally touched.
+          ]
+        }
+      }
+    ])
+
+    try {
+      const tasks = await Task.toArray()
+      const overrideProject = new Project({id: "999", name: "Local override"})
+
+      tasks[1].setRelationship("project", overrideProject)
+
+      await tasks[0].relationshipOrLoad("project")
+
+      const secondRelationship = tasks[1].getRelationshipByName("project")
+
+      expect(secondRelationship.loaded()).toEqual(overrideProject)
+
+      // Cohort preload request must have excluded the locally touched sibling.
+      const cohortRequest = fetchStub.calls.find((call) => call.body.preload?.project)
+
+      expect(cohortRequest?.body.where.id).toEqual(["1"])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+})

--- a/spec/frontend-models/autoload-spec.js
+++ b/spec/frontend-models/autoload-spec.js
@@ -342,6 +342,62 @@ describe("Frontend models - autoload", () => {
     }
   })
 
+  it("falls back to per-record load when the caller record is missing from the cohort preload response", async () => {
+    const {Task} = buildAutoloadTestModelClasses()
+
+    const fetchStub = stubFetchWith([
+      {
+        match: (body) => !body.preload && !body.where,
+        response: {
+          models: [
+            {id: "1", name: "Task one"},
+            {id: "2", name: "Task two"}
+          ]
+        }
+      },
+      {
+        // Cohort preload request — server only returns the other sibling, not the caller.
+        match: (body) => Boolean(body.preload?.project) && Array.isArray(body.where?.id),
+        response: {
+          models: [
+            {id: "2", name: "Task two", __preloadedRelationships: {project: {id: "102", name: "P2"}}}
+          ]
+        }
+      },
+      {
+        // Per-record fallback — the record was deleted so the backend returns an empty list.
+        match: (body) => Boolean(body.preload?.project) && (typeof body.where?.id === "string" || typeof body.where?.id === "number"),
+        response: {models: []}
+      }
+    ])
+
+    try {
+      const tasks = await Task.toArray()
+      let thrown = null
+
+      try {
+        await tasks[0].relationshipOrLoad("project")
+      } catch (error) {
+        thrown = error
+      }
+
+      // The caller must fall through to per-record load rather than throw
+      // "hasn't been preloaded". The per-record path will throw a real
+      // not-found error instead, which is the desired outcome.
+      expect(thrown).toBeTruthy()
+      expect(String(thrown?.message || "")).not.toContain("hasn't been preloaded")
+
+      // The populated sibling still benefited from the batch attempt.
+      const siblingRelationship = tasks[1].getRelationshipByName("project")
+
+      expect(siblingRelationship.getPreloaded()).toEqual(true)
+      expect(siblingRelationship.loaded().readAttribute("id")).toEqual("102")
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
   it("preserves locally set singular relationship state on siblings during cohort preload", async () => {
     const {Project, Task} = buildAutoloadTestModelClasses()
 

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -309,11 +309,15 @@ export default class DbGenerateFrontendModels extends BaseCommand {
 
     if (relationships.length > 0) {
       fileContent += "\n"
-      fileContent += "  /** @returns {Record<string, {type: \"belongsTo\" | \"hasOne\" | \"hasMany\"}>} - Relationship definitions. */\n"
+      fileContent += "  /** @returns {Record<string, {type: \"belongsTo\" | \"hasOne\" | \"hasMany\", autoload?: boolean}>} - Relationship definitions. */\n"
       fileContent += "  static relationshipDefinitions() {\n"
       fileContent += "    return {\n"
       for (const relationship of relationships) {
-        fileContent += `      ${relationship.relationshipName}: {type: ${JSON.stringify(relationship.type)}},\n`
+        const parts = [`type: ${JSON.stringify(relationship.type)}`]
+
+        if (relationship.autoload === false) parts.push("autoload: false")
+
+        fileContent += `      ${relationship.relationshipName}: {${parts.join(", ")}},\n`
       }
       fileContent += "    }\n"
       fileContent += "  }\n"
@@ -730,7 +734,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    * @param {string} args.className - Model class name.
    * @param {Record<string, any>} args.modelConfig - Model configuration.
    * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} [args.resourceClass]
-   * @returns {Array<{relationshipName: string, targetClassName: string, targetFileName: string, type: "belongsTo" | "hasOne" | "hasMany"}>} - Relationships.
+   * @returns {Array<{autoload: boolean, relationshipName: string, targetClassName: string, targetFileName: string, type: "belongsTo" | "hasOne" | "hasMany"}>} - Relationships.
    */
   relationshipsForModel({className, modelConfig, resourceClass}) {
     const relationships = modelConfig.relationships
@@ -751,7 +755,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    * @param {string} args.className - Model class name.
    * @param {string} args.relationshipName - Relationship name.
    * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} [args.resourceClass]
-   * @returns {{relationshipName: string, targetClassName: string, targetFileName: string, type: "belongsTo" | "hasOne" | "hasMany"}} Inferred relationship definition.
+   * @returns {{autoload: boolean, relationshipName: string, targetClassName: string, targetFileName: string, type: "belongsTo" | "hasOne" | "hasMany"}} Inferred relationship definition.
    */
   inferredRelationshipDefinition({className, relationshipName, resourceClass}) {
     const modelClass = resourceClass?.ModelClass || this.getConfiguration().getModelClass(className)
@@ -786,6 +790,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     }
 
     return {
+      autoload: relationship.getAutoload(),
       relationshipName,
       targetClassName,
       targetFileName: inflection.dasherize(inflection.underscore(targetClassName)),

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -1513,6 +1513,12 @@ export default class FrontendModelBase {
       sibling.getRelationshipByName(relationshipName).setLoaded(reloadedValue)
     }
 
+    // If the caller itself was not populated (record deleted/filtered between
+    // the list fetch and this preload request), fall back to per-record load
+    // so the caller gets a real not-found error instead of a misleading
+    // "hasn't been preloaded" throw from loaded().
+    if (!this.getRelationshipByName(relationshipName).getPreloaded()) return false
+
     return true
   }
 

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -263,9 +263,22 @@ export class FrontendModelHasManyRelationship {
   }
 
   /**
+   * Force-reload the relationship. When the parent record was loaded as part
+   * of a batch, siblings that have not preloaded this relationship get
+   * batched into one request via the cohort preloader. The scoped query path
+   * (`Model.where(...).preload([name]).toArray()` directly from user code)
+   * bypasses cohort batching by design.
    * @returns {Promise<Array<InstanceType<T>>>} - Loaded relationship models.
    */
   async load() {
+    // Reset so the cohort preloader (or single-record fallback) repopulates.
+    this._preloaded = false
+    this._loadedValue = []
+
+    const batched = await /** @type {any} */ (this.model)._tryCohortPreload(this.relationshipName)
+
+    if (batched) return this._loadedValue
+
     return /** @type {Promise<Array<InstanceType<T>>>} */ (this.model.loadRelationship(this.relationshipName))
   }
 
@@ -273,7 +286,7 @@ export class FrontendModelHasManyRelationship {
    * @returns {Promise<Array<InstanceType<T>>>} - Loaded relationship models.
    */
   async toArray() {
-    if (this._loadedValue.length > 0 || this.getPreloaded()) {
+    if (this.getPreloaded() || this._loadedValue.length > 0) {
       return this._loadedValue
     }
 
@@ -1127,6 +1140,18 @@ export default class FrontendModelBase {
   /** @type {string | undefined} */
   static modelName
 
+  /** @type {boolean} - Global auto-batch-preload toggle. Apps can opt out via FrontendModelBase.setAutoload(false). */
+  static _autoload = true
+
+  /** @returns {boolean} Whether auto-batch-preload of relationships on lazy access is enabled globally. */
+  static getAutoload() { return FrontendModelBase._autoload }
+
+  /**
+   * @param {boolean} newValue - Whether auto-batch-preload of relationships is enabled.
+   * @returns {void}
+   */
+  static setAutoload(newValue) { FrontendModelBase._autoload = newValue }
+
   /** @type {Record<string, any>} */
   _attributes
   /** @type {Record<string, FrontendModelHasManyRelationship<any, any> | FrontendModelSingularRelationship<any, any>>} */
@@ -1141,6 +1166,8 @@ export default class FrontendModelBase {
   _markedForDestruction
   /** @type {Record<string, any>} */
   _persistedAttributes
+  /** @type {Array<FrontendModelBase> | undefined} - Shared reference to sibling records loaded in the same batch. Used by auto-batch-preload. */
+  _loadCohort
 
   /**
    * @param {Record<string, any>} [attributes] - Initial attributes.
@@ -1217,7 +1244,7 @@ export default class FrontendModelBase {
 
   /**
    * @this {typeof FrontendModelBase}
-   * @returns {Record<string, {type: "belongsTo" | "hasOne" | "hasMany"}>} - Relationship definitions keyed by relationship name.
+   * @returns {Record<string, {type: "belongsTo" | "hasOne" | "hasMany", autoload?: boolean}>} - Relationship definitions keyed by relationship name.
    */
   static relationshipDefinitions() {
     return {}
@@ -1243,7 +1270,7 @@ export default class FrontendModelBase {
   /**
    * @this {typeof FrontendModelBase}
    * @param {string} relationshipName - Relationship name.
-   * @returns {{type: "belongsTo" | "hasOne" | "hasMany"} | null} - Relationship definition.
+   * @returns {{type: "belongsTo" | "hasOne" | "hasMany", autoload?: boolean} | null} - Relationship definition.
    */
   static relationshipDefinition(relationshipName) {
     const definitions = this.relationshipDefinitions()
@@ -1406,11 +1433,87 @@ export default class FrontendModelBase {
   async relationshipOrLoad(relationshipName) {
     const relationship = this.getRelationshipByName(relationshipName)
 
-    if ("_loadedValue" in relationship && (relationship.getPreloaded() || relationship._loadedValue !== null)) {
-      return relationship._loadedValue
+    if (relationship.getPreloaded()) {
+      return relationship.loaded()
     }
 
+    const batched = await this._tryCohortPreload(relationshipName)
+
+    if (batched) return relationship.loaded()
+
     return await this.loadRelationship(relationshipName)
+  }
+
+  /**
+   * Attempts to batch-load `relationshipName` across cohort siblings via a
+   * single `preload([name]).where({pk: [ids]}).toArray()` request, then copies
+   * the preloaded relationship state onto each sibling. Returns true when a
+   * batch ran, false when autoload is off, there is no cohort, or no batch
+   * candidates remain. Siblings whose relationship state is already set
+   * (preloaded or locally manipulated via `build` / `setRelationship`) are
+   * skipped so their cached/edited value is preserved.
+   * @param {string} relationshipName - Relationship name.
+   * @returns {Promise<boolean>} - Whether a cohort batch preload ran.
+   */
+  async _tryCohortPreload(relationshipName) {
+    if (!FrontendModelBase.getAutoload()) return false
+
+    const ModelClass = /** @type {typeof FrontendModelBase} */ (this.constructor)
+    const cohort = this._loadCohort
+
+    if (!cohort || cohort.length <= 1) return false
+
+    const definition = ModelClass.relationshipDefinition(relationshipName)
+
+    if (!definition) return false
+    if (definition.autoload === false) return false
+
+    /** @type {Array<FrontendModelBase>} */
+    const batch = []
+
+    // Exact same class, persisted, no existing in-memory relationship state.
+    // `setLoaded` sets `_preloaded = true` on every mutation path (preload,
+    // setRelationship, build, addToLoaded), so `getPreloaded()` alone is a
+    // reliable "already touched" signal on the frontend.
+    for (const sibling of cohort) {
+      if (sibling.constructor !== ModelClass) continue
+      if (sibling.isNewRecord()) continue
+
+      const siblingRelationship = sibling.getRelationshipByName(relationshipName)
+
+      if (siblingRelationship.getPreloaded()) continue
+
+      batch.push(sibling)
+    }
+
+    if (batch.length === 0) return false
+
+    const primaryKey = ModelClass.primaryKey()
+    const batchIds = batch.map((sibling) => sibling.primaryKeyValue())
+    const reloadedBatch = await ModelClass
+      .preload([relationshipName])
+      .where({[primaryKey]: batchIds})
+      .toArray()
+
+    /** @type {Map<string, FrontendModelBase>} */
+    const reloadedById = new Map()
+
+    for (const reloaded of reloadedBatch) {
+      reloadedById.set(String(reloaded.primaryKeyValue()), reloaded)
+    }
+
+    for (const sibling of batch) {
+      const key = String(sibling.primaryKeyValue())
+      const reloaded = reloadedById.get(key)
+
+      if (!reloaded) continue
+
+      const reloadedValue = reloaded.getRelationshipByName(relationshipName).loaded()
+
+      sibling.getRelationshipByName(relationshipName).setLoaded(reloadedValue)
+    }
+
+    return true
   }
 
   /**

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -1309,9 +1309,18 @@ export default class FrontendModelQuery {
       throw new Error(`Expected object response but got: ${response}`)
     }
 
-    const models = Array.isArray(response.models) ? response.models : []
+    const modelsData = Array.isArray(response.models) ? response.models : []
+    /** @type {InstanceType<T>[]} */
+    const models = modelsData.map((model) => this.modelClass.instantiateFromResponse(model))
 
-    return /** @type {InstanceType<T>[]} */ (models.map((model) => this.modelClass.instantiateFromResponse(model)))
+    // Share a single cohort reference across every sibling so auto-batch-preload
+    // can batch lazy relationship access later. Single-record lookups still flow
+    // through here (with a cohort of one) and degrade cleanly to per-record load.
+    for (const model of models) {
+      /** @type {any} */ (model)._loadCohort = models
+    }
+
+    return models
   }
 
   /**


### PR DESCRIPTION
## Summary

Mirrors the backend cohort preload (#589) on the frontend-model side: the first async relationship access on any sibling in a loaded batch fires one combined HTTP request that preloads that relationship for every cohort sibling at once, instead of N separate round-trips.

- `FrontendModelQuery.load()` tags every instance it produces with a shared `_loadCohort` array reference.
- `FrontendModelBase._tryCohortPreload(name)` filters the cohort (same class, persisted, relationship not already preloaded / locally manipulated), issues one `preload([name]).where({pk: [ids]}).toArray()` request, and copies the preloaded state onto each sibling.
- `relationshipOrLoad(name)` and the hasMany state object's `load()` / `toArray()` route through the cohort preloader first and fall back to the existing per-record load when no cohort is present. Locally set state via `setRelationship` / `build` is preserved because those paths set `_preloaded = true`.
- Per-relationship `autoload: false` is threaded from the backend `belongsTo/hasMany/hasOne` declaration through the frontend-model generator into `relationshipDefinitions()` so one flag disables cohort batching on both ends.
- `FrontendModelBase.setAutoload(false)` disables cohort batching globally.

## Design notes

- `getPreloaded()` alone is a reliable "already touched" signal on the frontend: every mutation path (preload, `setRelationship`, `build`, `addToLoaded`) routes through `setLoaded()` which sets `_preloaded = true`. No secondary filter like the backend's `_loaded !== undefined` is needed here.
- `findBy` / `find` paths still return a single record without a cohort; single-record paths degrade cleanly to the existing per-record load path (cohort size of 1 short-circuits).
- Generator emits `autoload: false` only when the backend relationship explicitly disables it — the default (`true`) keeps generated output clean.

## Test plan

- [x] `npm run lint` — 0 errors on changed files
- [x] `npm run typecheck` — passes
- [x] New `spec/frontend-models/autoload-spec.js` covers:
  - belongsTo cohort batching via `relationshipOrLoad`
  - hasMany cohort batching via `toArray()`
  - per-relationship `autoload: false` falls back to per-record load
  - global `FrontendModelBase.setAutoload(false)` opts out everywhere
  - locally set singular state on a sibling survives cohort preload
- [x] `spec/frontend-models/` full suite (165 specs) — green, no regressions
- [x] `spec/cli/commands/generate/` (11 specs) — green (one existing assertion updated for the new JSDoc signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)