### PR TITLE
[codex] Add model scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,36 @@ Project.hasMany("acceptedTasks", function() {
 }, {className: "Task"})
 ```
 
+## Model scopes
+
+Backend records and frontend models can define reusable named scopes with `defineScope(...)`.
+
+```js
+class Task extends TaskBase {
+  static withAccepted = this.defineScope(({query}, accepted) => query.where({accepted}))
+}
+
+await Task.withAccepted(true).toArray()
+await Task.where({projectId: 1}).scope(Task.withAccepted.scope(true)).toArray()
+await Task.joins({project: {tasks: true}}).scope(["project", "tasks"], Task.withAccepted.scope(true)).toArray()
+```
+
+`Model.scopeName(args...)` starts a fresh query for that model. `Model.scopeName.scope(args...)` returns a reusable scope descriptor for `.scope(...)` on an existing query. Backend record queries also support `.scope(path, descriptor)` to apply a scope to a joined relationship path.
+
+Backend record scopes receive alias-aware SQL context:
+
+```js
+class Task extends TaskBase {
+  static nameLike = this.defineScope(({driver, query, table}, value) => query.where(
+    `${driver.quoteTable(table)}.${driver.quoteColumn("name")} LIKE ${driver.quote(`%${value}%`)}`
+  ))
+}
+```
+
+The `table` value is the active table reference for the current query and may be an alias from `FROM ... AS ...`, not just `Task.tableName()`.
+
+Joined-path scopes receive the joined path in `context.path` and may only add `where(...)` and `joins(...)` clauses.
+
 ### Finding records
 
 `find()` and `findByOrFail()` throw an error when no record is found. `findBy()` returns `null`. These apply to records.

--- a/changelog.d/20260419-model-scopes.md
+++ b/changelog.d/20260419-model-scopes.md
@@ -1,0 +1,1 @@
+- Added `defineScope(...)` support for backend records and frontend models, including reusable query descriptors via `.scope(...)`, backend joined-path scope application via `.scope(path, descriptor)`, and alias-aware backend SQL scope context.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -37,6 +37,8 @@
 - `order(...)` is available as alias parity with backend `order(...)` (and forwards to frontend sort payloads).
 - `first()` and `last()` are available on frontend query/model classes.
 - `search(path, column, operator, value)` supports both named operators (`gt`, `lt`, `gteq`, `lteq`) and symbolic aliases (`>`, `<`, `>=`, `<=`).
+- `defineScope(...)` creates reusable named query scopes. Call `Model.scopeName(args...)` to start a new query, or `query.scope(Model.scopeName.scope(args...))` to apply the same scope to an existing frontend query.
+- Frontend scope callbacks receive `{query, modelClass}` plus `table: null` and `driver: null`; frontend scopes should stay descriptor-based (`where`, `joins`, `sort`, etc.) rather than building raw SQL.
 
 ## Nested attributes on `save()`
 - Parents can save dirty `hasMany` children in the same request via Rails-style nested-attribute writes. See [nested-attributes.md](nested-attributes.md) for the full feature doc.

--- a/spec/database/query/model-class-query.browser-spec.js
+++ b/spec/database/query/model-class-query.browser-spec.js
@@ -1,3 +1,4 @@
+import Comment from "../../dummy/src/models/comment.js"
 import Project from "../../dummy/src/models/project.js"
 import ProjectDetail from "../../dummy/src/models/project-detail.js"
 import Task from "../../dummy/src/models/task.js"
@@ -120,6 +121,32 @@ describe("Database - query - model class query", {databaseCleaning: {transaction
       .sort()
 
     expect(names).toEqual(["Needle child task", "Root task match"])
+  })
+
+  it("keeps joined-path context when a joined scope adds nested joins", async () => {
+    Task.withCommentBody = Task.defineScope(({driver, query}, body) => query
+      .joins({comments: true})
+      .where(`${query.getTableForJoin("comments")}.${driver.quoteColumn("body")} = ${driver.quote(body)}`))
+
+    const matchingUser = await User.create({email: "joined-scope-match@example.com", encryptedPassword: "secret", reference: "joined-scope-match"})
+    const missingUser = await User.create({email: "joined-scope-miss@example.com", encryptedPassword: "secret", reference: "joined-scope-miss"})
+    const matchingProject = await Project.create({creatingUserReference: matchingUser.reference(), nameEn: "Join scope match", nameDe: "Join bereich treffer"})
+    const missingProject = await Project.create({creatingUserReference: missingUser.reference(), nameEn: "Join scope miss", nameDe: "Join bereich fehlt"})
+    const childTaskMatch = await Task.create({name: "Child task match", project: matchingProject})
+    const childTaskMiss = await Task.create({name: "Child task miss", project: missingProject})
+
+    await Comment.create({body: "needle", task: childTaskMatch})
+    await Comment.create({body: "haystack", task: childTaskMiss})
+
+    const emails = (await User
+      .joins({createdProjects: {tasks: true}})
+      .scope(["createdProjects", "tasks"], Task.withCommentBody.scope("needle"))
+      .distinct()
+      .toArray())
+      .map((user) => user.email())
+      .sort()
+
+    expect(emails).toEqual(["joined-scope-match@example.com"])
   })
 
   it("raises when applying the wrong model scope to a joined path", () => {

--- a/spec/database/query/model-class-query.browser-spec.js
+++ b/spec/database/query/model-class-query.browser-spec.js
@@ -53,6 +53,84 @@ describe("Database - query - model class query", {databaseCleaning: {transaction
     expect(falseNames).toEqual(["Task False 1", "Task False 2"])
   })
 
+  it("defines root scopes on record classes", async () => {
+    Task.withDoneState = Task.defineScope(({query}, isDone) => query.where({isDone}))
+
+    const project = await Project.create({nameEn: "Scoped Tasks", nameDe: "Bereichte Aufgaben"})
+
+    await Task.create({isDone: true, name: "Done scoped task", project})
+    await Task.create({isDone: false, name: "Open scoped task", project})
+
+    const names = (await Task.withDoneState(true).toArray()).map((task) => task.name())
+
+    expect(names).toEqual(["Done scoped task"])
+  })
+
+  it("applies reusable record scopes to existing queries", async () => {
+    Task.withDoneState = Task.defineScope(({query}, isDone) => query.where({isDone}))
+
+    const project = await Project.create({nameEn: "Scoped Query Project", nameDe: "Bereichte Abfrageprojekt"})
+
+    await Task.create({isDone: true, name: "Scoped done task", project})
+    await Task.create({isDone: false, name: "Scoped open task", project})
+
+    const names = (await Task
+      .joins({project: true})
+      .where({projects: {id: project.id()}})
+      .scope(Task.withDoneState.scope(true))
+      .toArray())
+      .map((task) => task.name())
+
+    expect(names).toEqual(["Scoped done task"])
+  })
+
+  it("passes the active table alias into raw SQL record scopes", () => {
+    Task.nameLike = Task.defineScope(({driver, query, table}, value) => query.where(
+      `${driver.quoteTable(table)}.${driver.quoteColumn("name")} LIKE ${driver.quote(`%${value}%`)}`
+    ))
+
+    const query = Task
+      .all()
+      .from("tasks AS scoped_tasks")
+      .scope(Task.nameLike.scope("needle"))
+    const sql = query.toSql()
+
+    expect(sql).toContain(`${query.driver.quoteTable("scoped_tasks")}.${query.driver.quoteColumn("name")} LIKE ${query.driver.quote("%needle%")}`)
+  })
+
+  it("applies record scopes on joined paths using the joined table alias", async () => {
+    Task.nameLike = Task.defineScope(({driver, query, table}, value) => query.where(
+      `${driver.quoteTable(table)}.${driver.quoteColumn("name")} LIKE ${driver.quote(`%${value}%`)}`
+    ))
+
+    const matchingProject = await Project.create({nameEn: "Match root", nameDe: "Treffer wurzel"})
+    const missingProject = await Project.create({nameEn: "Miss root", nameDe: "Fehlt wurzel"})
+
+    await Task.create({name: "Root task match", project: matchingProject})
+    await Task.create({name: "Needle child task", project: matchingProject})
+    await Task.create({name: "Root task miss", project: missingProject})
+    await Task.create({name: "Haystack child task", project: missingProject})
+
+    const names = (await Task
+      .joins({project: {tasks: true}})
+      .scope(["project", "tasks"], Task.nameLike.scope("Needle"))
+      .distinct()
+      .toArray())
+      .map((task) => task.name())
+      .sort()
+
+    expect(names).toEqual(["Needle child task", "Root task match"])
+  })
+
+  it("raises when applying the wrong model scope to a joined path", () => {
+    Task.withDoneState = Task.defineScope(({query}, isDone) => query.where({isDone}))
+    Project.activeNamed = Project.defineScope(({query}, value) => query.where({nameEn: value}))
+    const query = Task.joins({project: true})
+
+    expect(() => query.scope("project", Task.withDoneState.scope(true))).toThrow(/Cannot apply Task scope to join path project/)
+    expect(() => query.scope("project", Project.activeNamed.scope("Match"))).not.toThrow()
+  })
+
   it("filters on nested relationship attributes", async () => {
     const projectMatch = await Project.create({
       creatingUserReference: "creator-1",

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -70,6 +70,27 @@ function buildCreatedAtTestModelClass() {
 }
 
 /**
+ * @returns {typeof FrontendModelBase} - Test frontend model class with scope support.
+ */
+function buildScopedTestModelClass() {
+  /** Test model implementation with query scope support. */
+  class Task extends FrontendModelBase {
+    /**
+     * @returns {{attributes: string[], commands: {index: string}, primaryKey: string}} - Resource configuration.
+     */
+    static resourceConfig() {
+      return {
+        attributes: ["id", "isDone", "name"],
+        commands: {index: "index"},
+        primaryKey: "id"
+      }
+    }
+  }
+
+  return Task
+}
+
+/**
  * @returns {typeof FrontendModelBase} - Test frontend model class with attachments.
  */
 function buildAttachmentTestModelClass() {
@@ -275,6 +296,26 @@ function resetFrontendModelTransport() {
 }
 
 describe("Frontend models - base", () => {
+  it("defines root scopes on frontend model classes", () => {
+    const Task = buildScopedTestModelClass()
+
+    Task.withDoneState = Task.defineScope(({query}, isDone) => query.where({isDone}))
+
+    expect(Task.withDoneState(true).wherePayload()).toEqual({where: {isDone: true}})
+  })
+
+  it("applies reusable frontend model scopes to existing queries", () => {
+    const Task = buildScopedTestModelClass()
+
+    Task.withDoneState = Task.defineScope(({query}, isDone) => query.where({isDone}))
+
+    const query = Task
+      .where({name: "Keep me"})
+      .scope(Task.withDoneState.scope(false))
+
+    expect(query.wherePayload()).toEqual({where: {isDone: false, name: "Keep me"}})
+  })
+
   it("uses the shared frontend-model API and batches requests by default", async () => {
     const originalFetch = globalThis.fetch
     /** @type {FetchCall[]} */

--- a/src/database/query/join-object.js
+++ b/src/database/query/join-object.js
@@ -12,10 +12,12 @@ import WhereNot from "./where-not.js"
 export default class VelociousDatabaseQueryJoinObject extends JoinBase {
   /**
    * @param {JoinObject} object - Object.
+   * @param {string[]} [basePath] - Join base path relative to the root query.
    */
-  constructor(object) {
+  constructor(object, basePath = []) {
     super()
     this.object = object
+    this.basePath = basePath
   }
 
   toSql() {
@@ -25,12 +27,12 @@ export default class VelociousDatabaseQueryJoinObject extends JoinBase {
       throw new Error(`Query has to be a ModelClassQuery but was a ${query.constructor.name}`)
     }
 
-    // @ts-expect-error
-    const ModelClass = /** @type {typeof import("../record/index.js").default} */ (query.modelClass)
-
     const modelQuery = /** @type {import("./model-class-query.js").default} */ (query)
+    const ModelClass = /** @type {typeof import("../record/index.js").default} */ (
+      this.basePath.length > 0 ? modelQuery._resolveModelClassForJoinPath(this.basePath) : modelQuery.modelClass
+    )
 
-    return this.joinObject(this.object, ModelClass, "", 0, modelQuery.getJoinBasePath())
+    return this.joinObject(this.object, ModelClass, "", 0, modelQuery.getJoinBasePath().concat(this.basePath))
   }
 
   /**

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -9,6 +9,7 @@ import DatabaseQuery from "./index.js"
 import JoinTracker from "./join-tracker.js"
 import RecordNotFoundError from "../record/record-not-found-error.js"
 import {normalizeRansackParams, parseRansackSort} from "../../utils/ransack.js"
+import {isModelScopeDescriptor} from "../../utils/model-scope.js"
 import WhereModelClassHash from "./where-model-class-hash.js"
 import WhereNot from "./where-not.js"
 import JoinsParser from "../query-parser/joins-parser.js"
@@ -46,6 +47,30 @@ function parseFromPlainTableReference(fromPlain) {
   if (!aliasMatch || !aliasMatch[1]) return null
 
   return unquoteSqlIdentifier(aliasMatch[1])
+}
+
+/**
+ * @param {string | string[]} path - Scope path input.
+ * @returns {string[]} - Normalized path.
+ */
+function normalizeScopePath(path) {
+  if (typeof path === "string") {
+    if (path.length < 1) throw new Error("Scope path strings must be non-empty")
+
+    return [path]
+  }
+
+  if (!Array.isArray(path)) {
+    throw new Error(`Invalid scope path type: ${typeof path}`)
+  }
+
+  for (const entry of path) {
+    if (typeof entry !== "string" || entry.length < 1) {
+      throw new Error("Scope path entries must be non-empty strings")
+    }
+  }
+
+  return [...path]
 }
 
 /**
@@ -301,9 +326,15 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
    * @returns {string} - Table name for path.
    */
   _resolveTableNameForJoinPath(path) {
-    let modelClass = this._joinTracker.getRootModelClass()
+    return this._resolveModelClassForJoinPath(path).tableName()
+  }
 
-    if (path.length === 0) return modelClass.tableName()
+  /**
+   * @param {string[]} path - Join path.
+   * @returns {typeof import("../record/index.js").default} - Target model class.
+   */
+  _resolveModelClassForJoinPath(path) {
+    let modelClass = this._joinTracker.getRootModelClass()
 
     for (const relationshipName of path) {
       const relationship = modelClass.getRelationshipByName(relationshipName)
@@ -316,7 +347,7 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       modelClass = targetModelClass
     }
 
-    return modelClass.tableName()
+    return modelClass
   }
 
   /**
@@ -355,6 +386,102 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
    */
   getTableForJoin(...path) {
     return this.driver.quoteTable(this.getTableReferenceForJoin(...path))
+  }
+
+  /**
+   * @param {import("../../utils/model-scope.js").ModelScopeDescriptor | string | string[]} pathOrScopeDescriptor - Scope descriptor or join path.
+   * @param {import("../../utils/model-scope.js").ModelScopeDescriptor} [maybeScopeDescriptor] - Scope descriptor when path is given.
+   * @returns {this} - Scoped query.
+   */
+  scope(pathOrScopeDescriptor, maybeScopeDescriptor) {
+    if (isModelScopeDescriptor(pathOrScopeDescriptor) && !maybeScopeDescriptor) {
+      return this._applyRootScope(pathOrScopeDescriptor)
+    }
+
+    if (!maybeScopeDescriptor) {
+      throw new Error("scope(path, descriptor) requires a scope descriptor")
+    }
+
+    return this._applyJoinPathScope({
+      joinPath: normalizeScopePath(/** @type {string | string[]} */ (pathOrScopeDescriptor)),
+      scopeDescriptor: maybeScopeDescriptor
+    })
+  }
+
+  /**
+   * @param {import("../../utils/model-scope.js").ModelScopeDescriptor} scopeDescriptor - Scope descriptor.
+   * @returns {this} - Scoped query.
+   */
+  _applyRootScope(scopeDescriptor) {
+    if (!isModelScopeDescriptor(scopeDescriptor)) {
+      throw new Error("scope() expects a descriptor returned by defineScope(...).scope(...)")
+    }
+
+    if (scopeDescriptor.modelClass !== this.getModelClass()) {
+      throw new Error(`Cannot apply ${scopeDescriptor.modelClass.name} scope to ${this.getModelClass().name} query`)
+    }
+
+    const scopedQuery = /** @type {this | void} */ (scopeDescriptor.callback({
+      driver: this.driver,
+      modelClass: this.getModelClass(),
+      query: this,
+      table: this.rootTableReference()
+    }, ...scopeDescriptor.scopeArgs))
+
+    return scopedQuery || this
+  }
+
+  /**
+   * @param {object} args - Join-path scope options.
+   * @param {string[]} args.joinPath - Join path relative to the current query.
+   * @param {import("../../utils/model-scope.js").ModelScopeDescriptor} args.scopeDescriptor - Scope descriptor.
+   * @returns {this} - Scoped query.
+   */
+  _applyJoinPathScope({joinPath, scopeDescriptor}) {
+    if (!isModelScopeDescriptor(scopeDescriptor)) {
+      throw new Error("scope() expects a descriptor returned by defineScope(...).scope(...)")
+    }
+
+    const fullJoinPath = this.getJoinBasePath().concat(joinPath)
+    const targetModelClass = this._resolveModelClassForJoinPath(fullJoinPath)
+
+    if (scopeDescriptor.modelClass !== targetModelClass) {
+      throw new Error(`Cannot apply ${scopeDescriptor.modelClass.name} scope to join path ${fullJoinPath.join(".")} (${targetModelClass.name})`)
+    }
+
+    const scopedQuery = this.buildJoinScopeQuery(targetModelClass, fullJoinPath)
+    const originalJoinCount = scopedQuery._joins.length
+    const originalWhereCount = scopedQuery._wheres.length
+    const appliedQuery = /** @type {typeof scopedQuery | void} */ (scopeDescriptor.callback({
+      driver: scopedQuery.driver,
+      modelClass: targetModelClass,
+      path: [...fullJoinPath],
+      query: scopedQuery,
+      table: scopedQuery.getTableReferenceForJoin()
+    }, ...scopeDescriptor.scopeArgs)) || scopedQuery
+
+    if (appliedQuery.getFroms().length !== scopedQuery.getFroms().length ||
+      appliedQuery.getGroups().length !== scopedQuery.getGroups().length ||
+      appliedQuery.getSelects().length !== scopedQuery.getSelects().length ||
+      appliedQuery._orders.length !== scopedQuery._orders.length ||
+      appliedQuery._limit !== scopedQuery._limit ||
+      appliedQuery._offset !== scopedQuery._offset ||
+      appliedQuery._page !== scopedQuery._page ||
+      appliedQuery._perPage !== scopedQuery._perPage ||
+      appliedQuery._distinct !== scopedQuery._distinct ||
+      Object.keys(appliedQuery._preload).length !== Object.keys(scopedQuery._preload).length) {
+      throw new Error("Joined-path scopes may only add where(...) and joins(...) clauses")
+    }
+
+    if (appliedQuery._joins.length > originalJoinCount) {
+      this._joins.push(...appliedQuery._joins.slice(originalJoinCount))
+    }
+
+    if (appliedQuery._wheres.length > originalWhereCount) {
+      this._wheres.push(...appliedQuery._wheres.slice(originalWhereCount))
+    }
+
+    return this
   }
 
   /**

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -6,6 +6,8 @@ import {isPlainObject} from "is-plain-object"
 import Logger from "../../logger.js"
 import Preloader from "./preloader.js"
 import DatabaseQuery from "./index.js"
+import JoinObject from "./join-object.js"
+import JoinPlain from "./join-plain.js"
 import JoinTracker from "./join-tracker.js"
 import RecordNotFoundError from "../record/record-not-found-error.js"
 import {normalizeRansackParams, parseRansackSort} from "../../utils/ransack.js"
@@ -474,7 +476,15 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
     }
 
     if (appliedQuery._joins.length > originalJoinCount) {
-      this._joins.push(...appliedQuery._joins.slice(originalJoinCount))
+      for (const join of appliedQuery._joins.slice(originalJoinCount)) {
+        if (join instanceof JoinObject) {
+          this._joins.push(new JoinObject(join.object, fullJoinPath))
+        } else if (join instanceof JoinPlain) {
+          this._joins.push(join)
+        } else {
+          this._joins.push(join)
+        }
+      }
     }
 
     if (appliedQuery._wheres.length > originalWhereCount) {

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -512,9 +512,8 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
    * Executes a bulk UPDATE on all rows matching the query's WHERE
    * clause. Bypasses model lifecycle callbacks — use this for
    * efficient batch updates where per-row hooks aren't needed.
-   *
    * @param {Record<string, any>} data - camelCase attribute names → values.
-   * @returns {Promise<void>}
+   * @returns {Promise<void>} - Resolves when the update completes.
    */
   async updateAll(data) {
     const driver = this.driver

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -23,6 +23,7 @@ import * as inflection from "inflection"
 import ModelClassQuery from "../query/model-class-query.js"
 import restArgsError from "../../utils/rest-args-error.js"
 import singularizeModelName from "../../utils/singularize-model-name.js"
+import {defineModelScope} from "../../utils/model-scope.js"
 import ValidatorsFormat from "./validators/format.js"
 import ValidatorsPresence from "./validators/presence.js"
 import ValidatorsUniqueness from "./validators/uniqueness.js"
@@ -118,6 +119,18 @@ class VelociousDatabaseRecord {
     }
 
     return this._attributeNameToColumnName
+  }
+
+  /**
+   * @param {(...args: any[]) => any} callback - Scope callback.
+   * @returns {((...args: any[]) => import("../query/model-class-query.js").default<any>) & {scope: (...args: any[]) => import("../../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
+   */
+  static defineScope(callback) {
+    return defineModelScope({
+      callback,
+      modelClass: this,
+      startQuery: () => this._newQuery()
+    })
   }
 
   static getColumnNameToAttributeNameMap() {

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -496,7 +496,6 @@ class VelociousDatabaseRecord {
    * Registers afterCreate, afterSave, and afterDestroy callbacks to sync
    * a counter cache column on the parent model. The column name follows
    * the convention `<childModelPluralCamelCase>Count`.
-   *
    * @param {string} relationshipName - The belongsTo relationship name.
    */
   static _registerCounterCacheCallbacks(relationshipName) {
@@ -506,9 +505,8 @@ class VelociousDatabaseRecord {
      * Atomically recomputes the counter cache column on the parent via a
      * single UPDATE ... SET col = (SELECT COUNT(*)) so concurrent
      * creates/destroys cannot race into a stale count.
-     *
-     * @param {number | string | null} parentId
-     * @returns {Promise<void>}
+     * @param {number | string | null} parentId - Parent primary-key value.
+     * @returns {Promise<void>} - Resolves when the counter cache has been synced.
      */
     async function syncCounter(parentId) {
       if (!parentId) return
@@ -533,7 +531,10 @@ class VelociousDatabaseRecord {
       await connection.query(sql)
     }
 
-    /** @param {any} record @returns {any} */
+    /**
+     * @param {any} record - Child record instance.
+     * @returns {any} - Current foreign-key attribute value.
+     */
     function readFkAttribute(record) {
       const relationship = ChildModel.getRelationshipByName(relationshipName)
       const fkAttribute = inflection.camelize(relationship.getForeignKey().replace(/_id$/, "Id"), true)
@@ -598,7 +599,7 @@ class VelociousDatabaseRecord {
     return Object.values(this.getRelationshipsMap())
   }
 
-  /** @returns {Record<string, import("./relationships/base.js").default>} */
+  /** @returns {Record<string, import("./relationships/base.js").default>} - Relationship definitions keyed by name. */
   static getRelationshipsMap() {
     if (!Object.hasOwn(this, "_relationships")) {
       /** @type {Record<string, import("./relationships/base.js").default>} */
@@ -1796,7 +1797,6 @@ class VelociousDatabaseRecord {
    * The lock is acquired before the callback runs and released in a
    * `finally` block afterwards, so the callback's return value is
    * propagated and thrown errors still release the lock.
-   *
    * @template T
    * @param {string} name - Lock name.
    * @param {() => Promise<T>} callback - Callback to invoke while the lock is held.
@@ -1823,10 +1823,8 @@ class VelociousDatabaseRecord {
    * Runs the callback only if the named advisory lock can be acquired
    * immediately. If the lock is already held by any session, throws
    * `AdvisoryLockBusyError` without waiting.
-   *
    * Use this when contention is a signal that somebody else is already
    * doing the work and you want to bail out rather than queue up.
-   *
    * @template T
    * @param {string} name - Lock name.
    * @param {() => Promise<T>} callback - Callback to invoke while the lock is held.
@@ -1853,9 +1851,8 @@ class VelociousDatabaseRecord {
    * session. Primarily useful as a diagnostic; callers that want to act
    * on the result should prefer `withAdvisoryLockOrFail` to avoid a
    * TOCTOU window between the check and the action.
-   *
    * @param {string} name - Lock name.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory lock is currently held.
    */
   static async hasAdvisoryLock(name) {
     return await this.connection().isAdvisoryLockHeld(name)

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -658,7 +658,7 @@ const FRONTEND_MODELS_CHANNEL_NAME = "frontend-models"
  * callers can read fresh values from the same instance handle.
  */
 class FrontendModelEventSubscription {
-  /** @param {typeof FrontendModelBase} ModelClass */
+  /** @param {typeof FrontendModelBase} ModelClass - Frontend model class for this subscription bucket. */
   constructor(ModelClass) {
     this.ModelClass = ModelClass
     /** @type {Set<(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void>} */
@@ -722,7 +722,7 @@ class FrontendModelEventSubscription {
     await this.readyPromise
   }
 
-  /** @param {any} body */
+  /** @param {any} body - WebSocket event payload. */
   _dispatchEvent(body) {
     if (!body || typeof body !== "object") return
 
@@ -1336,8 +1336,7 @@ export default class FrontendModelBase {
    * Marks this record for destruction when its parent is next saved through
    * nested-attribute support. The record is not removed from the parent's
    * relationship collection until the server confirms the delete.
-   *
-   * @returns {void}
+   * @returns {void} - No return value.
    */
   markForDestruction() {
     this._markedForDestruction = true
@@ -1802,7 +1801,7 @@ export default class FrontendModelBase {
 
   /**
    * Returns the current WebSocket connection state.
-   * @returns {{disconnectedSince: number | null, hasClient: boolean, isOpen: boolean, listenerCount: number}}
+   * @returns {{disconnectedSince: number | null, hasClient: boolean, isOpen: boolean, listenerCount: number}} - Snapshot of the managed websocket connection state.
    */
   static websocketState() {
     if (!internalWebsocketClient) {
@@ -1847,10 +1846,9 @@ export default class FrontendModelBase {
    * Call `handle.sync()` whenever the inputs that drive those
    * functions change (e.g. current-user sign-in/out). The handle
    * retries when the WS client isn't ready and reopens on close.
-   *
-   * @param {string} connectionType
-   * @param {{shouldConnect: () => boolean, params: () => Record<string, any>, onMessage?: (body: any) => void}} options
-   * @returns {{sync: () => void, close: () => void}}
+   * @param {string} connectionType - Connection class name registered on the server.
+   * @param {{shouldConnect: () => boolean, params: () => Record<string, any>, onMessage?: (body: any) => void}} options - Connection lifecycle and payload callbacks.
+   * @returns {{sync: () => void, close: () => void}} - Handle used to resync or close the managed connection.
    */
   static openManagedConnection(connectionType, options) {
     /** @type {any} */
@@ -1936,9 +1934,8 @@ export default class FrontendModelBase {
    * convenience wrapper around the internal WS client's
    * `openConnection`. Apps use this for per-session state/messaging
    * that doesn't fit the pub/sub Channel model (locale, presence).
-   *
    * @param {string} connectionType - Name the server registered the class under.
-   * @param {{params?: Record<string, any>, onConnect?: () => void, onMessage?: (body: any) => void, onDisconnect?: () => void, onResume?: () => void, onClose?: (reason: string) => void}} [options]
+   * @param {{params?: Record<string, any>, onConnect?: () => void, onMessage?: (body: any) => void, onDisconnect?: () => void, onResume?: () => void, onClose?: (reason: string) => void}} [options] - Connection options and event handlers.
    * @returns {any} - VelociousWebsocketClientConnection handle (typed loosely to avoid a cross-module import cycle).
    */
   static openWebsocketConnection(connectionType, options) {
@@ -1954,10 +1951,9 @@ export default class FrontendModelBase {
   /**
    * Subscribes to a pub/sub `WebsocketChannel`. Thin wrapper around
    * the internal client's `subscribeChannel`.
-   *
-   * @param {string} channelType
-   * @param {{params?: Record<string, any>, onMessage?: (body: any) => void, onDisconnect?: () => void, onResume?: () => void, onClose?: (reason: string) => void}} [options]
-   * @returns {any}
+   * @param {string} channelType - Channel class name registered on the server.
+   * @param {{params?: Record<string, any>, onMessage?: (body: any) => void, onDisconnect?: () => void, onResume?: () => void, onClose?: (reason: string) => void}} [options] - Channel subscription options and event handlers.
+   * @returns {any} - Websocket channel handle from the configured client.
    */
   static subscribeWebsocketChannel(channelType, options) {
     const client = /** @type {any} */ (frontendModelTransportConfig.websocketClient || resolveInternalWebsocketClient())
@@ -2221,7 +2217,6 @@ export default class FrontendModelBase {
    * Subscribe-time authorization only — once a subscription is
    * accepted, every future `create` event for this model is delivered
    * without re-checking per-record visibility.
-   *
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
    * @returns {Promise<() => void>} - Unsubscribe callback.
@@ -2240,7 +2235,6 @@ export default class FrontendModelBase {
 
   /**
    * Class-level hook fired when any record of this model is updated.
-   *
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
    * @returns {Promise<() => void>} - Unsubscribe callback.
@@ -2259,7 +2253,6 @@ export default class FrontendModelBase {
 
   /**
    * Class-level hook fired when any record of this model is destroyed.
-   *
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string}) => void} callback - Event callback.
    * @returns {Promise<() => void>} - Unsubscribe callback.
@@ -2281,7 +2274,6 @@ export default class FrontendModelBase {
    * instance's attributes are auto-merged with the broadcast payload
    * before the callback runs, so callers can read fresh values via
    * `this.someAttr()` without re-fetching.
-   *
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
@@ -2317,7 +2309,6 @@ export default class FrontendModelBase {
 
   /**
    * Instance-level hook fired when THIS record is destroyed.
-   *
    * @param {(payload: {id: string}) => void} callback - Event callback.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -7,6 +7,7 @@ import {validateFrontendModelResourceCommandName, validateFrontendModelResourceP
 import {deserializeFrontendModelTransportValue, serializeFrontendModelTransportValue} from "./transport-serialization.js"
 import VelociousWebsocketClient from "../http-client/websocket-client.js"
 import {bufferOutgoingEvent, drainBufferedOutgoingEvents} from "./outgoing-event-buffer.js"
+import {defineModelScope} from "../utils/model-scope.js"
 
 /** @typedef {"create" | "find" | "index" | "update" | "destroy" | "attach" | "download" | "url"} FrontendModelCommandType */
 /** @typedef {FrontendModelCommandType | string} FrontendModelRequestCommandType */
@@ -1231,6 +1232,18 @@ export default class FrontendModelBase {
    */
   static registerModel(modelClass) {
     registerFrontendModel(modelClass)
+  }
+
+  /**
+   * @param {(...args: any[]) => any} callback - Scope callback.
+   * @returns {((...args: any[]) => import("./query.js").default<any>) & {scope: (...args: any[]) => import("../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
+   */
+  static defineScope(callback) {
+    return defineModelScope({
+      callback,
+      modelClass: this,
+      startQuery: () => this.query()
+    })
   }
 
   /**

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -2,6 +2,7 @@
 
 import {resolveFrontendModelClass} from "./model-registry.js"
 import {normalizeRansackParams, parseRansackSort} from "../utils/ransack.js"
+import {isModelScopeDescriptor} from "../utils/model-scope.js"
 
 /**
  * @typedef {object} FrontendModelSearch
@@ -935,6 +936,29 @@ export default class FrontendModelQuery {
   }
 
   /**
+   * @param {import("../utils/model-scope.js").ModelScopeDescriptor} scopeDescriptor - Scope descriptor.
+   * @returns {this} - Scoped query.
+   */
+  scope(scopeDescriptor) {
+    if (!isModelScopeDescriptor(scopeDescriptor)) {
+      throw new Error("scope() expects a descriptor returned by defineScope(...).scope(...)")
+    }
+
+    if (scopeDescriptor.modelClass !== this.modelClass) {
+      throw new Error(`Cannot apply ${scopeDescriptor.modelClass.name} scope to ${this.modelClass.name} query`)
+    }
+
+    const scopedQuery = /** @type {this | void} */ (scopeDescriptor.callback({
+      driver: null,
+      modelClass: this.modelClass,
+      query: this,
+      table: null
+    }, ...scopeDescriptor.scopeArgs))
+
+    return scopedQuery || this
+  }
+
+  /**
    * @param {Record<string, any>} params - Ransack-style params hash. Supports `s` key for sorting (e.g., `{s: "name asc"}`).
    * @returns {this} - Query with Ransack filters and sort applied.
    */
@@ -1173,6 +1197,11 @@ export default class FrontendModelQuery {
     newQuery._perPage = this._perPage
 
     return newQuery
+  }
+
+  /** @returns {T} - Root model class. */
+  getModelClass() {
+    return this.modelClass
   }
 
   /**

--- a/src/utils/model-scope.js
+++ b/src/utils/model-scope.js
@@ -1,0 +1,49 @@
+// @ts-check
+
+const MODEL_SCOPE_DESCRIPTOR_MARKER = "velociousModelScopeDescriptor"
+
+/**
+ * @typedef {object} ModelScopeDescriptor
+ * @property {true} [velociousModelScopeDescriptor] - Internal marker.
+ * @property {(...args: any[]) => any} callback - Scope callback.
+ * @property {typeof import("../database/record/index.js").default | typeof import("../frontend-models/base.js").default} modelClass - Owning model class.
+ * @property {any[]} scopeArgs - Scope arguments.
+ */
+
+/**
+ * @param {object} args - Definition arguments.
+ * @param {(...args: any[]) => any} args.callback - Scope callback.
+ * @param {typeof import("../database/record/index.js").default | typeof import("../frontend-models/base.js").default} args.modelClass - Owning model class.
+ * @param {() => any} args.startQuery - Factory that returns a fresh query for the owning model class.
+ * @returns {((...args: any[]) => any) & {scope: (...args: any[]) => ModelScopeDescriptor}} - Scope helper.
+ */
+export function defineModelScope({callback, modelClass, startQuery}) {
+  /**
+   * @param {...any} scopeArgs - Scope arguments.
+   * @returns {any} - Scoped root query.
+   */
+  function definedScope(...scopeArgs) {
+    return startQuery().scope(definedScope.scope(...scopeArgs))
+  }
+
+  /**
+   * @param {...any} scopeArgs - Scope arguments.
+   * @returns {ModelScopeDescriptor} - Reusable scope descriptor.
+   */
+  definedScope.scope = (...scopeArgs) => ({
+    [MODEL_SCOPE_DESCRIPTOR_MARKER]: true,
+    callback,
+    modelClass,
+    scopeArgs
+  })
+
+  return definedScope
+}
+
+/**
+ * @param {unknown} value - Candidate descriptor.
+ * @returns {value is ModelScopeDescriptor} - Whether the value is a scope descriptor.
+ */
+export function isModelScopeDescriptor(value) {
+  return Boolean(value && typeof value === "object" && /** @type {Record<string, any>} */ (value)[MODEL_SCOPE_DESCRIPTOR_MARKER] === true)
+}


### PR DESCRIPTION
## Summary
- add `defineScope(...)` for backend records and frontend models
- support reusable query descriptors via `.scope(...)` and backend joined-path scopes via `.scope(path, descriptor)`
- pass alias-aware backend scope context for raw SQL scopes and document the new API

## Validation
- `npm run test -- spec/database/query/model-class-query.browser-spec.js spec/frontend-models/base-spec.js`
- `npm run typecheck`
- `npm run lint -- src/utils/model-scope.js src/database/query/model-class-query.js src/database/record/index.js src/frontend-models/query.js src/frontend-models/base.js spec/database/query/model-class-query.browser-spec.js spec/frontend-models/base-spec.js`

## Notes
- lint still reports existing JSDoc warnings in touched files, but no new lint errors were introduced
- joined-path scope application is backend-only in this patch because frontend queries do not have alias/raw-SQL semantics