### PR TITLE
Skip automatic structure sql writes in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,16 +973,19 @@ Evaluate inline JavaScript (Rails-style runner) with initialized app/database co
 npx velocious runner "const users = await db.query('SELECT COUNT(*) AS count FROM users'); console.log(users[0].count)"
 ```
 
-By default, migrations write `db/structure-<identifier>.sql` files for each database. Disable writing for specific environments in your configuration:
+By default, migrations write `db/structure-<identifier>.sql` files for each database in non-test environments. Test skips these automatic writes unless you explicitly opt in. Configure allow/deny lists in your configuration:
 
 ```js
 export default new Configuration({
   // ...
   structureSql: {
+    enabledEnvironments: ["development"],
     disabledEnvironments: ["test"]
   }
 })
 ```
+
+If you only want automatic writes in one or two environments, prefer `enabledEnvironments`. `db:schema:dump` is an explicit schema-generation command and still writes missing structure files regardless of the current environment.
 
 If you need to regenerate missing structure files without rerunning migrations, use:
 

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -254,8 +254,21 @@ describe("Cli - Commands - db:migrate", () => {
 
   it("writes structure sql for sqlite", {databaseCleaning: {transaction: false}}, async () => {
     const directory = dummyDirectory()
+    const configuration = new Configuration({
+      database: dummyConfiguration.database,
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      locale: dummyConfiguration.locale,
+      localeFallbacks: dummyConfiguration.localeFallbacks,
+      locales: dummyConfiguration.locales,
+      structureSql: {
+        enabledEnvironments: ["test"]
+      },
+      testing: dummyConfiguration.getTesting()
+    })
     const cli = new Cli({
-      configuration: dummyConfiguration,
+      configuration,
       directory,
       environmentHandler: new EnvironmentHandlerNode(),
       processArgs: ["db:migrate"],
@@ -307,7 +320,7 @@ describe("Cli - Commands - db:migrate", () => {
     })
   })
 
-  it("skips writing structure sql when disabled for the environment", {databaseCleaning: {transaction: false}}, async () => {
+  it("skips writing structure sql by default in test", {databaseCleaning: {transaction: false}}, async () => {
     const directory = dummyDirectory()
     const configuration = new Configuration({
       database: dummyConfiguration.database,
@@ -317,9 +330,6 @@ describe("Cli - Commands - db:migrate", () => {
       locale: dummyConfiguration.locale,
       localeFallbacks: dummyConfiguration.localeFallbacks,
       locales: dummyConfiguration.locales,
-      structureSql: {
-        disabledEnvironments: ["test"]
-      },
       testing: dummyConfiguration.getTesting()
     })
     const cli = new Cli({

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -118,6 +118,7 @@
 
 /**
  * @typedef {object} StructureSqlConfiguration
+ * @property {string[]} [enabledEnvironments] - Environments allowed to write structure sql files during automatic migration dumps.
  * @property {string[]} [disabledEnvironments] - Environments that should skip writing structure sql files.
  */
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -513,13 +513,28 @@ export default class VelociousConfiguration {
   getStructureSqlConfig() { return this._structureSql }
 
   /**
+   * @param {{reason?: "migration" | "schemaDump"}} [args] - Call context for the structure sql write decision.
    * @returns {boolean} - Whether structure SQL files should be generated for the current environment.
    */
-  shouldWriteStructureSql() {
+  shouldWriteStructureSql(args = {}) {
+    const {reason = "migration"} = args
     const config = this.getStructureSqlConfig()
+    const enabledEnvironments = config?.enabledEnvironments
     const disabledEnvironments = config?.disabledEnvironments
 
+    if (reason === "schemaDump") {
+      return true
+    }
+
+    if (Array.isArray(enabledEnvironments)) {
+      return enabledEnvironments.includes(this.getEnvironment())
+    }
+
     if (Array.isArray(disabledEnvironments) && disabledEnvironments.includes(this.getEnvironment())) {
+      return false
+    }
+
+    if (this.getEnvironment() === "test") {
       return false
     }
 

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -326,6 +326,7 @@ export default class VelociousEnvironmentHandlerBase {
   /**
    * @param {object} args - Options object.
    * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs.
+   * @param {"migration" | "schemaDump"} [args.reason] - Why the structure write hook is being invoked.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async afterMigrations(args) { // eslint-disable-line no-unused-vars

--- a/src/environment-handlers/browser.js
+++ b/src/environment-handlers/browser.js
@@ -266,6 +266,7 @@ export default class VelociousEnvironmentsHandlerBrowser extends Base {
   /**
    * @param {object} args - Options object.
    * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs.
+   * @param {"migration" | "schemaDump"} [args.reason] - Why the structure hook is running.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async afterMigrations({dbs}) {

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -673,12 +673,13 @@ export default class VelociousEnvironmentHandlerNode extends Base{
   /**
    * @param {object} args - Options object.
    * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs.
+   * @param {"migration" | "schemaDump"} [args.reason] - Why the structure write is being triggered.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async afterMigrations({dbs}) {
+  async afterMigrations({dbs, reason = "migration"}) {
     const configuration = this.getConfiguration()
 
-    if (!configuration.shouldWriteStructureSql()) return
+    if (!configuration.shouldWriteStructureSql({reason})) return
 
     const dbDir = path.join(configuration.getDirectory(), "db")
     const structureSqlByIdentifier = await this._structureSqlByIdentifier({dbs})

--- a/src/environment-handlers/node/cli/commands/db/schema/dump.js
+++ b/src/environment-handlers/node/cli/commands/db/schema/dump.js
@@ -11,7 +11,7 @@ export default class DbSchemaDump extends BaseCommand {
 
       if (!shouldGenerate) return
 
-      await this.getEnvironmentHandler().afterMigrations({dbs})
+      await this.getEnvironmentHandler().afterMigrations({dbs, reason: "schemaDump"})
     })
   }
 
@@ -21,7 +21,7 @@ export default class DbSchemaDump extends BaseCommand {
    * @returns {Promise<boolean>} - Whether structure SQL should be generated.
    */
   async shouldGenerateStructureSql({dbs}) {
-    if (!this.getConfiguration().shouldWriteStructureSql()) return false
+    if (!this.getConfiguration().shouldWriteStructureSql({reason: "schemaDump"})) return false
 
     const dbDir = path.join(this.directory(), "db")
 


### PR DESCRIPTION
## Summary
- skip automatic `db/structure-<identifier>.sql` writes during `db:migrate` in `test` by default
- add `structureSql.enabledEnvironments` so apps can explicitly opt in to automatic writes outside the default
- keep `db:schema:dump` as an explicit schema-generation command that still writes missing structure files in any environment

## Verification
- `node scripts/run-tests.js spec/cli/commands/db/migrate-spec.js spec/cli/commands/db/schema/dump-spec.js`
- `npm run typecheck`