### PR TITLE
Add network-aware websocket reconnect support

### DIFF
--- a/docs/websocket-channels.md
+++ b/docs/websocket-channels.md
@@ -83,21 +83,30 @@ configuration.broadcastToChannel("GameChat", {gameId: "abc"}, {from: "alice", te
 
 ```js
 const subscription = client.subscribeChannel("GameChat", {
+  lastEventId: "evt-42",
   params: {gameId: "abc"},
   onMessage: (body) => console.log(body),
   onClose: (reason) => console.log("sub ended:", reason)
 })
 
+await client.connect()             // default: autoReconnect on, waitForOnline on when a network monitor is configured
 await subscription.ready           // resolves once the server sends channel-subscribed
 subscription.close()                // client-initiated unsubscribe
 ```
 
 Subscription handle exposes:
 - `subscriptionId: string`
+- `lastEventId?: string`
 - `ready: Promise<void>` — resolves on `channel-subscribed`, rejects on `channel-error`
 - `close()`
 - `isClosed()`
 - User-supplied `onMessage(body)` / `onClose(reason)`
+
+Client behavior:
+- `subscribeChannel(...)` may be called before the socket is open. The client queues the subscription and sends `channel-subscribe` after `connect()` succeeds.
+- Queued subscriptions preserve `lastEventId`, so replay checkpoints survive delayed initial connects as well as later reconnects.
+- `connect()` is the normal public entrypoint. By default it enables auto-reconnect, and when a `networkMonitor` is configured it waits for the monitor to report online before opening or re-opening the socket.
+- Callers that need lower-level behavior can still override `connect({autoReconnect: false})` or `connect({waitForOnline: false})`, but those are opt-outs rather than the normal app path.
 
 ## Lifecycle guarantees (Phase 1B)
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "copy:ejs": "cpy \"src/routes/**/*.ejs\" build/src/routes",
     "copy:templates": "cpy \"src/templates/**/*.js\" build/src/templates",
     "lint": "eslint",
+    "prepare": "npm run build",
     "release:patch": "node scripts/release-patch.js",
     "test": "node scripts/run-tests.js",
     "test:browser": "node scripts/test-browser.js",

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -30,6 +30,49 @@ async function waitFor(predicate, timeoutMs = 2000) {
 }
 
 describe("WebsocketChannelV2 ()", () => {
+  it("queues channel subscriptions until the network monitor reports online", async () => {
+    await Dummy.run(async () => {
+      let isOnline = false
+      /** @type {Set<(isOnline: boolean) => void>} */
+      const listeners = new Set()
+      const client = new WebsocketClient({
+        autoReconnect: true,
+        networkMonitor: {
+          getIsOnline: () => isOnline,
+          subscribe: (callback) => {
+            listeners.add(callback)
+            return () => listeners.delete(callback)
+          }
+        },
+        reconnectDelays: [50]
+      })
+
+      try {
+        /** @type {any[]} */
+        const received = []
+        const subscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "queued"},
+          onMessage: (body) => received.push(body)
+        })
+
+        await client.connectWithReconnect({waitForOnline: true})
+        await wait(100)
+
+        expect(client.isOpen()).toBe(false)
+        expect(subscription.isSubscribed()).toBe(false)
+
+        isOnline = true
+        for (const listener of listeners) listener(true)
+
+        await subscription.ready
+        await waitFor(() => received.length >= 1)
+        expect(received[0]).toEqual({welcome: "queued"})
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
+    })
+  })
+
   it("rejects subscribe when canSubscribe returns false (default deny)", async () => {
     await Dummy.run(async () => {
       const client = new WebsocketClient()
@@ -185,6 +228,52 @@ describe("WebsocketChannelV2 ()", () => {
 
       await waitFor(() => subscription.isClosed())
       expect(closeReasons).toEqual(["session_destroyed"])
+    })
+  })
+
+  it("waits for the network monitor to report online before resuming a dropped subscription", async () => {
+    await Dummy.run(async () => {
+      let isOnline = true
+      /** @type {Set<(isOnline: boolean) => void>} */
+      const listeners = new Set()
+      const client = new WebsocketClient({
+        autoReconnect: true,
+        networkMonitor: {
+          getIsOnline: () => isOnline,
+          subscribe: (callback) => {
+            listeners.add(callback)
+            return () => listeners.delete(callback)
+          }
+        },
+        reconnectDelays: [50]
+      })
+
+      try {
+        /** @type {string[]} */
+        const events = []
+        const subscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "resume-on-network"},
+          onDisconnect: () => events.push("disconnect"),
+          onResume: () => events.push("resume")
+        })
+
+        await client.connectWithReconnect()
+        await subscription.ready
+
+        isOnline = false
+        for (const listener of listeners) listener(false)
+
+        await waitFor(() => events.includes("disconnect"), 3000)
+        await wait(150)
+        expect(events.includes("resume")).toBe(false)
+
+        isOnline = true
+        for (const listener of listeners) listener(true)
+
+        await waitFor(() => events.includes("resume"), 5000)
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
     })
   })
 

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -72,6 +72,52 @@ describe("WebsocketChannelV2 ()", () => {
     })
   })
 
+  it("preserves lastEventId for queued channel subscriptions", async () => {
+    await Dummy.run(async () => {
+      let isOnline = false
+      /** @type {Set<(isOnline: boolean) => void>} */
+      const listeners = new Set()
+      const client = new WebsocketClient({
+        networkMonitor: {
+          getIsOnline: () => isOnline,
+          subscribe: (callback) => {
+            listeners.add(callback)
+            return () => listeners.delete(callback)
+          }
+        },
+        reconnectDelays: [50]
+      })
+
+      try {
+        /** @type {Record<string, any>[]} */
+        const sentMessages = []
+        const originalSendMessage = client._sendMessage.bind(client)
+        client._sendMessage = (payload) => {
+          sentMessages.push(payload)
+          return originalSendMessage(payload)
+        }
+
+        const subscription = client.subscribeChannel("Counter", {
+          lastEventId: "event-42",
+          params: {allow: true, topic: "queued-checkpoint"}
+        })
+
+        await client.connect({waitForOnline: true})
+        expect(client.isOpen()).toBe(false)
+
+        isOnline = true
+        for (const listener of listeners) listener(true)
+
+        await subscription.ready
+
+        const subscribeMessage = sentMessages.find((message) => message.type === "channel-subscribe" && message.subscriptionId === subscription.subscriptionId)
+        expect(subscribeMessage?.lastEventId).toEqual("event-42")
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
+    })
+  })
+
   it("rejects subscribe when canSubscribe returns false (default deny)", async () => {
     await Dummy.run(async () => {
       const client = new WebsocketClient()

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -54,7 +54,7 @@ describe("WebsocketChannelV2 ()", () => {
           params: {allow: true, topic: "queued"},
           onMessage: (body) => received.push(body)
         })
-        await client.connectWithReconnect({waitForOnline: true})
+        await client.connect({waitForOnline: true})
         await wait(100)
 
         expect(client.isOpen()).toBe(false)
@@ -256,7 +256,7 @@ describe("WebsocketChannelV2 ()", () => {
           onResume: () => events.push("resume")
         })
 
-        await client.connectWithReconnect()
+        await client.connect()
         await subscription.ready
 
         isOnline = false

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -54,18 +54,17 @@ describe("WebsocketChannelV2 ()", () => {
           params: {allow: true, topic: "queued"},
           onMessage: (body) => received.push(body)
         })
-
         await client.connectWithReconnect({waitForOnline: true})
         await wait(100)
 
         expect(client.isOpen()).toBe(false)
-        expect(subscription.isSubscribed()).toBe(false)
 
         isOnline = true
         for (const listener of listeners) listener(true)
 
         await subscription.ready
         await waitFor(() => received.length >= 1)
+        expect(subscription.isSubscribed()).toBe(true)
         expect(received[0]).toEqual({welcome: "queued"})
       } finally {
         await client.disconnectAndStopReconnect()

--- a/spec/http-server/websocket-metadata-spec.js
+++ b/spec/http-server/websocket-metadata-spec.js
@@ -144,7 +144,7 @@ describe("WebsocketClient - metadata", () => {
 
       try {
         client.setMetadata("locale", "fr")
-        await client.connectWithReconnect()
+        await client.connect()
 
         /** @type {Record<string, any>[]} */
         const sent = []

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -1786,7 +1786,7 @@ export default class FrontendModelBase {
       throw new Error("connectWebsocket requires configureTransport({websocketUrl})")
     }
 
-    await client.connectWithReconnect()
+    await client.connect()
   }
 
   /**

--- a/src/http-client/websocket-channel.js
+++ b/src/http-client/websocket-channel.js
@@ -30,6 +30,7 @@ export default class VelociousWebsocketClientSubscription {
     this._onResume = onResume
     this._onClose = onClose
     this._subscribed = false
+    this._subscribeSent = false
     this._closed = false
 
     /** @type {Promise<void>} */
@@ -44,6 +45,16 @@ export default class VelociousWebsocketClientSubscription {
     if (this._closed || this._subscribed) return
     this._subscribed = true
     this._resolveReady?.()
+  }
+
+  /** @returns {void} */
+  _markSubscribeSent() {
+    this._subscribeSent = true
+  }
+
+  /** @returns {boolean} */
+  _needsSubscribe() {
+    return !this._closed && !this._subscribeSent
   }
 
   /**

--- a/src/http-client/websocket-channel.js
+++ b/src/http-client/websocket-channel.js
@@ -15,16 +15,18 @@ export default class VelociousWebsocketClientSubscription {
    * @param {string} args.subscriptionId
    * @param {string} args.channelType
    * @param {Record<string, any>} [args.params]
+   * @param {string} [args.lastEventId]
    * @param {(body: any) => void} [args.onMessage]
    * @param {() => void} [args.onDisconnect]
    * @param {() => void} [args.onResume]
    * @param {(reason: string) => void} [args.onClose]
    */
-  constructor({client, subscriptionId, channelType, params, onMessage, onDisconnect, onResume, onClose}) {
+  constructor({client, subscriptionId, channelType, params, lastEventId, onMessage, onDisconnect, onResume, onClose}) {
     this.client = client
     this.subscriptionId = subscriptionId
     this.channelType = channelType
     this.params = params || {}
+    this.lastEventId = lastEventId
     this._onMessage = onMessage
     this._onDisconnect = onDisconnect
     this._onResume = onResume

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -152,6 +152,7 @@ export default class VelociousWebsocketClient {
       client: this,
       subscriptionId,
       channelType,
+      lastEventId: options.lastEventId,
       params: options.params,
       onMessage: options.onMessage,
       onDisconnect: options.onDisconnect,
@@ -175,10 +176,9 @@ export default class VelociousWebsocketClient {
 
   /**
    * @param {VelociousWebsocketClientSubscription} subscription
-   * @param {string | undefined} [lastEventId]
    * @returns {void}
    */
-  _sendChannelSubscribe(subscription, lastEventId) {
+  _sendChannelSubscribe(subscription) {
     if (!this.isOpen() || !subscription._needsSubscribe()) return
 
     subscription._markSubscribeSent()
@@ -187,7 +187,7 @@ export default class VelociousWebsocketClient {
       subscriptionId: subscription.subscriptionId,
       channelType: subscription.channelType,
       params: subscription.params,
-      ...(lastEventId ? {lastEventId} : {})
+      ...(subscription.lastEventId ? {lastEventId: subscription.lastEventId} : {})
     })
   }
 

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -161,7 +161,7 @@ export default class VelociousWebsocketClient {
     })
 
     this._channelSubscriptions.set(subscriptionId, subscription)
-    this._sendChannelSubscribe(subscription, options.lastEventId)
+    this._sendChannelSubscribe(subscription)
 
     return subscription
   }

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -27,7 +27,7 @@ export default class VelociousWebsocketClient {
    * @param {{get: () => string | null | undefined | Promise<string | null | undefined>, set: (sessionId: string) => void | Promise<void>, clear: () => void | Promise<void>}} [args.sessionStore] - Optional sessionId persistence hook. When provided, the client writes every `session-established` / `session-resumed` id via `store.set(id)` and clears it on `session-gone`. Before the first `connect()`, the client reads any persisted id via `store.get()` and attempts resumption. Apps should back this by whatever persistence layer survives page reloads (localStorage, a cookie, SQLite, etc.).
    * @param {string} [args.url] Full websocket URL (default: ws://127.0.0.1:3006/websocket)
    */
-  constructor({autoReconnect = false, debug = false, networkMonitor, reconnectDelays, sessionStore, url} = {}) {
+  constructor({autoReconnect = true, debug = false, networkMonitor, reconnectDelays, sessionStore, url} = {}) {
     if (!globalThis.WebSocket) throw new Error("WebSocket global is not available")
 
     /** @type {boolean} */
@@ -241,7 +241,7 @@ export default class VelociousWebsocketClient {
       this._cancelPendingReconnect()
 
       if (this.isOpen()) {
-        void this.close()
+        void this.dropConnection()
       }
     })
   }
@@ -285,11 +285,37 @@ export default class VelociousWebsocketClient {
 
   /**
    * Ensure a websocket connection is open.
+   * Auto-reconnect and online gating are enabled by default.
+   * Pass `autoReconnect: false` or `waitForOnline: false` only when a caller
+   * explicitly needs lower-level behavior.
+   * @param {{autoReconnect?: boolean, waitForOnline?: boolean, resetReconnectState?: boolean}} [options]
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async connect() {
+  async connect({autoReconnect = this.autoReconnect, waitForOnline = true, resetReconnectState = true} = {}) {
+    this.autoReconnect = autoReconnect
+
+    if (this.autoReconnect) {
+      this._ensureNetworkMonitorSubscription()
+    } else {
+      this._waitingForOnline = false
+      this._cancelPendingReconnect()
+      this._teardownNetworkMonitorSubscription()
+    }
+
+    if (waitForOnline && this.autoReconnect && !await this._isOnline()) {
+      this._waitingForOnline = true
+      return
+    }
+
+    if (resetReconnectState) {
+      this.reconnectAttempt = 0
+    }
+
     if (this.socket && this.socket.readyState === this.socket.OPEN) return
     if (this.connectPromise) return this.connectPromise
+
+    this._waitingForOnline = false
+    this.connectionAttempts += 1
 
     this.connectPromise = new Promise((resolve, reject) => {
       this.socket = new WebSocket(this.url)
@@ -356,26 +382,6 @@ export default class VelociousWebsocketClient {
     if (!this._awaitingResume) {
       this._sendPendingChannelSubscriptions()
     }
-  }
-
-  /**
-   * Connect and enable auto-reconnect. Resets reconnect state.
-   * @returns {Promise<void>} - Resolves when connected.
-   */
-  async connectWithReconnect({waitForOnline = false} = {}) {
-    this.autoReconnect = true
-    this.reconnectAttempt = 0
-    this._cancelPendingReconnect()
-    this._ensureNetworkMonitorSubscription()
-
-    if (waitForOnline && !await this._isOnline()) {
-      this._waitingForOnline = true
-      return
-    }
-
-    this._waitingForOnline = false
-    this.connectionAttempts += 1
-    await this.connect()
     this.disconnectedSince = null
   }
 
@@ -384,6 +390,11 @@ export default class VelociousWebsocketClient {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async close() {
+    this.autoReconnect = false
+    this._waitingForOnline = false
+    this._cancelPendingReconnect()
+    this._teardownNetworkMonitorSubscription()
+
     if (!this.socket) return
 
     if (this.socket.readyState === this.socket.CLOSED) {
@@ -406,11 +417,7 @@ export default class VelociousWebsocketClient {
    * @returns {Promise<void>} - Resolves when closed.
    */
   async disconnectAndStopReconnect() {
-    this.autoReconnect = false
-    this._waitingForOnline = false
-    this._cancelPendingReconnect()
     await this.close()
-    this._teardownNetworkMonitorSubscription()
   }
 
   /**
@@ -824,7 +831,7 @@ export default class VelociousWebsocketClient {
     try {
       this._waitingForOnline = false
       this.connectionAttempts += 1
-      await this.connect()
+      await this.connect({autoReconnect: this.autoReconnect, resetReconnectState: false, waitForOnline: false})
       this.reconnectAttempt = 0
       this.disconnectedSince = null
       this._resubscribeActiveListeners()

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -39,6 +39,8 @@ export default class VelociousWebsocketClient {
     this.pendingSubscriptions = new Map()
     /** @type {number} */
     this.reconnectAttempt = 0
+    /** @type {number} */
+    this.connectionAttempts = 0
     /** @type {number[]} */
     this.reconnectDelays = reconnectDelays || DEFAULT_RECONNECT_DELAYS
     /** @type {ReturnType<typeof setTimeout> | null} */
@@ -372,6 +374,7 @@ export default class VelociousWebsocketClient {
     }
 
     this._waitingForOnline = false
+    this.connectionAttempts += 1
     await this.connect()
     this.disconnectedSince = null
   }
@@ -820,6 +823,7 @@ export default class VelociousWebsocketClient {
 
     try {
       this._waitingForOnline = false
+      this.connectionAttempts += 1
       await this.connect()
       this.reconnectAttempt = 0
       this.disconnectedSince = null

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -22,11 +22,12 @@ export default class VelociousWebsocketClient {
    * @param {object} [args] - Options object.
    * @param {boolean} [args.autoReconnect] - Enable auto-reconnect with exponential backoff.
    * @param {boolean} [args.debug] - Whether debug.
+   * @param {{getIsOnline?: () => boolean | Promise<boolean>, subscribe?: (callback: (isOnline: boolean) => void) => (() => void) | {remove: () => void}}} [args.networkMonitor] - Optional online-state adapter. When provided, auto-reconnect can wait for the network to report online before reconnecting, and open sockets are closed when the monitor reports offline.
    * @param {number[]} [args.reconnectDelays] - Backoff delays in ms (default: [1000, 2000, 4000, 8000, 15000]).
    * @param {{get: () => string | null | undefined | Promise<string | null | undefined>, set: (sessionId: string) => void | Promise<void>, clear: () => void | Promise<void>}} [args.sessionStore] - Optional sessionId persistence hook. When provided, the client writes every `session-established` / `session-resumed` id via `store.set(id)` and clears it on `session-gone`. Before the first `connect()`, the client reads any persisted id via `store.get()` and attempts resumption. Apps should back this by whatever persistence layer survives page reloads (localStorage, a cookie, SQLite, etc.).
    * @param {string} [args.url] Full websocket URL (default: ws://127.0.0.1:3006/websocket)
    */
-  constructor({autoReconnect = false, debug = false, reconnectDelays, sessionStore, url} = {}) {
+  constructor({autoReconnect = false, debug = false, networkMonitor, reconnectDelays, sessionStore, url} = {}) {
     if (!globalThis.WebSocket) throw new Error("WebSocket global is not available")
 
     /** @type {boolean} */
@@ -70,6 +71,15 @@ export default class VelociousWebsocketClient {
     this._sessionStore = sessionStore
     /** @type {boolean} - true once the sessionStore has been consulted for a restored id. */
     this._sessionStoreRestored = false
+
+    /** @type {{getIsOnline?: () => boolean | Promise<boolean>, subscribe?: (callback: (isOnline: boolean) => void) => (() => void) | {remove: () => void}} | undefined} */
+    this._networkMonitor = networkMonitor
+
+    /** @type {null | (() => void) | {remove: () => void}} */
+    this._networkMonitorSubscription = null
+
+    /** @type {boolean} */
+    this._waitingForOnline = false
   }
 
   /** @returns {boolean} */
@@ -126,16 +136,15 @@ export default class VelociousWebsocketClient {
   }
 
   /**
-   * Subscribes to a named WebsocketChannel. Requires the socket to
-   * already be connected.
+   * Subscribes to a named WebsocketChannel. If the socket is not yet
+   * open, the subscription is queued and sent once a connection is
+   * established.
    *
    * @param {string} channelType - Name the server registered the channel under.
    * @param {{params?: Record<string, any>, lastEventId?: string, onMessage?: (body: any) => void, onDisconnect?: () => void, onResume?: () => void, onClose?: (reason: string) => void}} [options]
    * @returns {VelociousWebsocketClientSubscription}
    */
   subscribeChannel(channelType, options = {}) {
-    if (!this.isOpen()) throw new Error("Websocket is not open; call connect() first")
-
     const subscriptionId = `s${this._nextSubscriptionIdSeq++}`
     const subscription = new VelociousWebsocketClientSubscription({
       client: this,
@@ -149,13 +158,7 @@ export default class VelociousWebsocketClient {
     })
 
     this._channelSubscriptions.set(subscriptionId, subscription)
-    this._sendMessage({
-      type: "channel-subscribe",
-      subscriptionId,
-      channelType,
-      params: options.params || {},
-      ...(options.lastEventId ? {lastEventId: options.lastEventId} : {})
-    })
+    this._sendChannelSubscribe(subscription, options.lastEventId)
 
     return subscription
   }
@@ -166,6 +169,92 @@ export default class VelociousWebsocketClient {
    */
   _removeChannelSubscription(subscriptionId) {
     this._channelSubscriptions.delete(subscriptionId)
+  }
+
+  /**
+   * @param {VelociousWebsocketClientSubscription} subscription
+   * @param {string | undefined} [lastEventId]
+   * @returns {void}
+   */
+  _sendChannelSubscribe(subscription, lastEventId) {
+    if (!this.isOpen() || !subscription._needsSubscribe()) return
+
+    subscription._markSubscribeSent()
+    this._sendMessage({
+      type: "channel-subscribe",
+      subscriptionId: subscription.subscriptionId,
+      channelType: subscription.channelType,
+      params: subscription.params,
+      ...(lastEventId ? {lastEventId} : {})
+    })
+  }
+
+  /** @returns {void} */
+  _sendPendingChannelSubscriptions() {
+    for (const subscription of this._channelSubscriptions.values()) {
+      this._sendChannelSubscribe(subscription)
+    }
+  }
+
+  /** @returns {Promise<boolean>} */
+  async _isOnline() {
+    if (!this._networkMonitor?.getIsOnline) return true
+
+    try {
+      return await this._networkMonitor.getIsOnline() !== false
+    } catch (error) {
+      this._debug("networkMonitor.getIsOnline failed", error)
+      return true
+    }
+  }
+
+  /** @returns {Promise<boolean>} */
+  async _shouldWaitForOnline() {
+    if (!this._networkMonitor) return false
+
+    const isOnline = await this._isOnline()
+    if (isOnline) return false
+
+    this._waitingForOnline = true
+    this._cancelPendingReconnect()
+    return true
+  }
+
+  /** @returns {void} */
+  _ensureNetworkMonitorSubscription() {
+    if (!this._networkMonitor?.subscribe || this._networkMonitorSubscription) return
+
+    this._networkMonitorSubscription = this._networkMonitor.subscribe((isOnline) => {
+      if (!this.autoReconnect) return
+
+      if (isOnline) {
+        if (!this._waitingForOnline) return
+
+        this._waitingForOnline = false
+        void this._attemptReconnect()
+        return
+      }
+
+      this._waitingForOnline = true
+      this._cancelPendingReconnect()
+
+      if (this.isOpen()) {
+        void this.close()
+      }
+    })
+  }
+
+  /** @returns {void} */
+  _teardownNetworkMonitorSubscription() {
+    if (!this._networkMonitorSubscription) return
+
+    if (typeof this._networkMonitorSubscription === "function") {
+      this._networkMonitorSubscription()
+    } else {
+      this._networkMonitorSubscription.remove()
+    }
+
+    this._networkMonitorSubscription = null
   }
 
   /**
@@ -261,16 +350,28 @@ export default class VelociousWebsocketClient {
     if (Object.keys(this._metadata).length > 0) {
       this._sendMessage({type: "metadata", data: {...this._metadata}})
     }
+
+    if (!this._awaitingResume) {
+      this._sendPendingChannelSubscriptions()
+    }
   }
 
   /**
    * Connect and enable auto-reconnect. Resets reconnect state.
    * @returns {Promise<void>} - Resolves when connected.
    */
-  async connectWithReconnect() {
+  async connectWithReconnect({waitForOnline = false} = {}) {
     this.autoReconnect = true
     this.reconnectAttempt = 0
     this._cancelPendingReconnect()
+    this._ensureNetworkMonitorSubscription()
+
+    if (waitForOnline && !await this._isOnline()) {
+      this._waitingForOnline = true
+      return
+    }
+
+    this._waitingForOnline = false
     await this.connect()
     this.disconnectedSince = null
   }
@@ -303,8 +404,10 @@ export default class VelociousWebsocketClient {
    */
   async disconnectAndStopReconnect() {
     this.autoReconnect = false
+    this._waitingForOnline = false
     this._cancelPendingReconnect()
     await this.close()
+    this._teardownNetworkMonitorSubscription()
   }
 
   /**
@@ -581,6 +684,7 @@ export default class VelociousWebsocketClient {
       this._awaitingResume = false
       this._sessionId = message.sessionId
       this._persistSessionId(message.sessionId)
+      this._sendPendingChannelSubscriptions()
       // Fire onResume on every live handle so user code knows the
       // session came back with state intact.
       for (const connection of this._connections.values()) connection._handleResumed()
@@ -659,9 +763,13 @@ export default class VelociousWebsocketClient {
     this.pendingSubscriptions.clear()
     this.connectPromise = undefined
 
-    if (this.autoReconnect) {
-      this._scheduleReconnect()
-    }
+    if (!this.autoReconnect) return
+
+    void this._shouldWaitForOnline().then((shouldWaitForOnline) => {
+      if (!shouldWaitForOnline) {
+        this._scheduleReconnect()
+      }
+    })
   }
 
   /**
@@ -705,7 +813,13 @@ export default class VelociousWebsocketClient {
   async _attemptReconnect() {
     if (!this.autoReconnect) return
 
+    if (!await this._isOnline()) {
+      this._waitingForOnline = true
+      return
+    }
+
     try {
+      this._waitingForOnline = false
       await this.connect()
       this.reconnectAttempt = 0
       this.disconnectedSince = null


### PR DESCRIPTION
## Summary
- add optional `networkMonitor` support to `VelociousWebsocketClient`
- let reconnect wait for an online signal instead of forcing app-specific offline lifecycle wrappers
- allow `subscribeChannel(...)` to queue before the socket is open so consumers can register channel intent before connect
- add websocket channel coverage for queued subscribe and network-gated reconnect flows
- add a `prepare` script so git-based installs build the published `build/` output

## Testing
- `npm run typecheck`
- `npm run lint -- src/http-client/websocket-client.js src/http-client/websocket-channel.js spec/http-server/websocket-channel-spec.js`
- `npm run test -- spec/http-server/websocket-channel-spec.js`