### PR TITLE
Add websocket subscription ready-cycle helpers

### DIFF
--- a/docs/websocket-channels.md
+++ b/docs/websocket-channels.md
@@ -98,8 +98,10 @@ Subscription handle exposes:
 - `subscriptionId: string`
 - `lastEventId?: string`
 - `ready: Promise<void>` — resolves on `channel-subscribed`, rejects on `channel-error`
+- `waitForReady({timeoutMs?: number})` — waits for the current ready cycle with a timeout
 - `close()`
 - `isClosed()`
+- `isReady()`
 - User-supplied `onMessage(body)` / `onClose(reason)`
 
 Client behavior:
@@ -112,5 +114,6 @@ Client behavior:
 
 - `canSubscribe()` → `subscribed()` is the order on the server. `channel-subscribed` is sent AFTER `subscribed()` resolves.
 - Client's `subscription.ready` resolves after `channel-subscribed` arrives.
+- `subscription.waitForReady()` is the higher-level helper for app code. It resolves after the initial subscribe, then resets on disconnect and resolves again after `session-resumed`.
 - `unsubscribed()` fires exactly once: on client-initiated `channel-unsubscribe` OR on session teardown (socket drop, Phase 2 covers grace-period resumption).
 - No persistent event log, no replay, no cross-reconnect survival in Phase 1B. Publish-and-forget; subscribers who missed events while disconnected don't see them.

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -170,6 +170,26 @@ describe("WebsocketChannelV2 ()", () => {
     })
   })
 
+  it("waitForReady resolves the initial subscribe and reports ready state", async () => {
+    await Dummy.run(async () => {
+      const client = new WebsocketClient()
+
+      try {
+        await client.connect()
+
+        const subscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "wait-for-ready"}
+        })
+
+        expect(subscription.isReady()).toBe(false)
+        await subscription.waitForReady({timeoutMs: 3000})
+        expect(subscription.isReady()).toBe(true)
+      } finally {
+        await client.close()
+      }
+    })
+  })
+
   it("routes broadcasts to matching subscribers only", async () => {
     await Dummy.run(async () => {
       const clientA = new WebsocketClient()
@@ -316,6 +336,51 @@ describe("WebsocketChannelV2 ()", () => {
         for (const listener of listeners) listener(true)
 
         await waitFor(() => events.includes("resume"), 5000)
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
+    })
+  })
+
+  it("waitForReady waits for the next ready cycle after disconnect", async () => {
+    await Dummy.run(async () => {
+      let isOnline = true
+      /** @type {Set<(isOnline: boolean) => void>} */
+      const listeners = new Set()
+      const client = new WebsocketClient({
+        autoReconnect: true,
+        networkMonitor: {
+          getIsOnline: () => isOnline,
+          subscribe: (callback) => {
+            listeners.add(callback)
+            return () => listeners.delete(callback)
+          }
+        },
+        reconnectDelays: [50]
+      })
+
+      try {
+        const subscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "ready-cycle-resume"}
+        })
+
+        await client.connect()
+        await subscription.waitForReady({timeoutMs: 3000})
+        expect(subscription.isReady()).toBe(true)
+
+        isOnline = false
+        for (const listener of listeners) listener(false)
+
+        await waitFor(() => subscription.isReady() === false, 3000)
+
+        const waitForResume = subscription.waitForReady({timeoutMs: 5000})
+        await wait(100)
+
+        isOnline = true
+        for (const listener of listeners) listener(true)
+
+        await waitForResume
+        expect(subscription.isReady()).toBe(true)
       } finally {
         await client.disconnectAndStopReconnect()
       }

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -387,6 +387,56 @@ describe("WebsocketChannelV2 ()", () => {
     })
   })
 
+  it("does not mark queued subscriptions ready on session resume before channel acknowledgement", async () => {
+    await Dummy.run(async () => {
+      let isOnline = true
+      /** @type {Set<(isOnline: boolean) => void>} */
+      const listeners = new Set()
+      const client = new WebsocketClient({
+        autoReconnect: true,
+        networkMonitor: {
+          getIsOnline: () => isOnline,
+          subscribe: (callback) => {
+            listeners.add(callback)
+            return () => listeners.delete(callback)
+          }
+        },
+        reconnectDelays: [50]
+      })
+
+      try {
+        const existingSubscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "existing-before-resume"}
+        })
+
+        await client.connect()
+        await existingSubscription.waitForReady({timeoutMs: 3000})
+
+        isOnline = false
+        for (const listener of listeners) listener(false)
+
+        await waitFor(() => existingSubscription.isReady() === false, 3000)
+
+        const queuedSubscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "queued-during-disconnect"}
+        })
+
+        expect(queuedSubscription.isReady()).toBe(false)
+
+        isOnline = true
+        for (const listener of listeners) listener(true)
+
+        await waitFor(() => existingSubscription.isReady() === true, 5000)
+        expect(queuedSubscription.isReady()).toBe(false)
+
+        await queuedSubscription.waitForReady({timeoutMs: 5000})
+        expect(queuedSubscription.isReady()).toBe(true)
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
+    })
+  })
+
   it("returns connection-error for unknown channel type", async () => {
     await Dummy.run(async () => {
       const client = new WebsocketClient()

--- a/src/http-client/websocket-channel.js
+++ b/src/http-client/websocket-channel.js
@@ -32,6 +32,7 @@ export default class VelociousWebsocketClientSubscription {
     this._onResume = onResume
     this._onClose = onClose
     this._ready = false
+    this._resumeReadyOnResume = false
     this._subscribed = false
     this._subscribeSent = false
     this._closed = false
@@ -63,7 +64,6 @@ export default class VelociousWebsocketClientSubscription {
   /** @returns {void} */
   _markNotReady() {
     this._ready = false
-    this._ensureReadyPromise()
   }
 
   /** @returns {void} */
@@ -95,6 +95,7 @@ export default class VelociousWebsocketClientSubscription {
   /** @returns {void} */
   _handleDisconnected() {
     if (this._closed) return
+    this._resumeReadyOnResume ||= this._subscribed
     this._subscribed = false
     this._markNotReady()
     this._onDisconnect?.()
@@ -103,8 +104,11 @@ export default class VelociousWebsocketClientSubscription {
   /** @returns {void} */
   _handleResumed() {
     if (this._closed) return
-    this._subscribed = true
-    this._resolveReadyState()
+    if (this._resumeReadyOnResume) {
+      this._subscribed = true
+      this._resolveReadyState()
+    }
+    this._resumeReadyOnResume = false
     this._onResume?.()
   }
 
@@ -119,6 +123,7 @@ export default class VelociousWebsocketClientSubscription {
     try {
       this._onClose?.(reason)
     } finally {
+      this._resumeReadyOnResume = false
       if (!this._ready) {
         this._rejectReady?.(new Error(`Subscription closed before acknowledgement: ${reason}`))
       }

--- a/src/http-client/websocket-channel.js
+++ b/src/http-client/websocket-channel.js
@@ -31,22 +31,46 @@ export default class VelociousWebsocketClientSubscription {
     this._onDisconnect = onDisconnect
     this._onResume = onResume
     this._onClose = onClose
+    this._ready = false
     this._subscribed = false
     this._subscribeSent = false
     this._closed = false
 
-    /** @type {Promise<void>} */
-    this.ready = new Promise((resolve, reject) => {
-      this._resolveReady = resolve
-      this._rejectReady = reject
-    })
+    this._ensureReadyPromise()
+  }
+
+  /** @returns {Promise<void>} */
+  _ensureReadyPromise() {
+    if (!this.ready || !this._resolveReady || !this._rejectReady) {
+      /** @type {Promise<void>} */
+      this.ready = new Promise((resolve, reject) => {
+        this._resolveReady = resolve
+        this._rejectReady = reject
+      })
+    }
+
+    return this.ready
+  }
+
+  /** @returns {void} */
+  _resolveReadyState() {
+    this._ready = true
+    this._resolveReady?.()
+    this._resolveReady = null
+    this._rejectReady = null
+  }
+
+  /** @returns {void} */
+  _markNotReady() {
+    this._ready = false
+    this._ensureReadyPromise()
   }
 
   /** @returns {void} */
   _handleSubscribed() {
     if (this._closed || this._subscribed) return
     this._subscribed = true
-    this._resolveReady?.()
+    this._resolveReadyState()
   }
 
   /** @returns {void} */
@@ -71,12 +95,16 @@ export default class VelociousWebsocketClientSubscription {
   /** @returns {void} */
   _handleDisconnected() {
     if (this._closed) return
+    this._subscribed = false
+    this._markNotReady()
     this._onDisconnect?.()
   }
 
   /** @returns {void} */
   _handleResumed() {
     if (this._closed) return
+    this._subscribed = true
+    this._resolveReadyState()
     this._onResume?.()
   }
 
@@ -91,10 +119,28 @@ export default class VelociousWebsocketClientSubscription {
     try {
       this._onClose?.(reason)
     } finally {
-      if (!this._subscribed) {
+      if (!this._ready) {
         this._rejectReady?.(new Error(`Subscription closed before acknowledgement: ${reason}`))
       }
+
+      this._resolveReady = null
+      this._rejectReady = null
     }
+  }
+
+  /**
+   * @param {{timeoutMs?: number}} [params]
+   * @returns {Promise<void>}
+   */
+  async waitForReady({timeoutMs = 5000} = {}) {
+    if (this._ready) return
+
+    const readyPromise = this._ensureReadyPromise()
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error(`Subscription not ready after ${timeoutMs}ms`)), timeoutMs)
+    })
+
+    await Promise.race([readyPromise, timeoutPromise])
   }
 
   /** @returns {void} */
@@ -115,6 +161,9 @@ export default class VelociousWebsocketClientSubscription {
 
   /** @returns {boolean} */
   isClosed() { return this._closed }
+
+  /** @returns {boolean} */
+  isReady() { return this._ready }
 
   /** @returns {boolean} */
   isSubscribed() { return this._subscribed && !this._closed }


### PR DESCRIPTION
## Summary
- add ready-cycle helpers to websocket subscriptions with isReady() and waitForReady(timeoutMs)
- reset subscription readiness on disconnect and resolve it again after resume
- document the new subscription API and lifecycle behavior

## Testing
- npm run typecheck
- npm run test -- spec/http-server/websocket-channel-spec.js