### PR TITLE
Wait for websocket session readiness before subscribing

### DIFF
--- a/spec/http-server/websocket-session-resume-spec.js
+++ b/spec/http-server/websocket-session-resume-spec.js
@@ -272,6 +272,50 @@ describe("WebsocketSession resumption (Phase 2)", () => {
     }
   })
 
+  it("rejects connect when the socket closes before session readiness is established", async () => {
+    await Dummy.run(async () => {
+      const client = new WebsocketClient({autoReconnect: false})
+      const originalOnMessage = client.onMessage
+
+      client.onMessage = (event) => {
+        const raw = typeof event.data === "string" ? event.data : event.data?.toString?.()
+
+        if (raw) {
+          const message = JSON.parse(raw)
+
+          if (message.type === "session-established") return
+        }
+
+        originalOnMessage(event)
+      }
+
+      try {
+        const connectPromise = client.connect()
+
+        await waitFor(() => client.isOpen(), 3000)
+        client.socket?.close()
+
+        /** @type {unknown} */
+        let caughtError = null
+
+        try {
+          await connectPromise
+        } catch (error) {
+          caughtError = error
+        }
+
+        expect(caughtError instanceof Error).toBe(true)
+        expect(/** @type {Error} */ (caughtError).message).toContain("session readiness")
+      } finally {
+        try {
+          await client.close()
+        } catch {
+          // Socket may already be gone from the test-induced early close.
+        }
+      }
+    })
+  })
+
   it("tears down live handles with grace_expired when no resume arrives in time", async () => {
     // Override grace window to 100ms for the test.
     const originalGrace = dummyConfiguration.getWebsocketSessionGraceSeconds()

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -69,6 +69,18 @@ export default class VelociousWebsocketClient {
     /** @type {boolean} - true between a reconnect and the session-resumed / session-gone reply. */
     this._awaitingResume = false
 
+    /** @type {boolean} - true once the current socket has an active session ready for app messages. */
+    this._sessionReady = false
+
+    /** @type {string | null} - provisional session id announced before a resume attempt finishes. */
+    this._pendingSessionId = null
+
+    /** @type {Promise<void> | null} */
+    this._sessionReadyPromise = null
+
+    /** @type {(() => void) | null} */
+    this._resolveSessionReady = null
+
     /** @type {{get: () => string | null | undefined | Promise<string | null | undefined>, set: (sessionId: string) => void | Promise<void>, clear: () => void | Promise<void>} | undefined} */
     this._sessionStore = sessionStore
     /** @type {boolean} - true once the sessionStore has been consulted for a restored id. */
@@ -87,6 +99,11 @@ export default class VelociousWebsocketClient {
   /** @returns {boolean} */
   isOpen() {
     return Boolean(this.socket && this.socket.readyState === this.socket.OPEN)
+  }
+
+  /** @returns {boolean} */
+  isSessionReady() {
+    return this._sessionReady
   }
 
   /**
@@ -179,7 +196,7 @@ export default class VelociousWebsocketClient {
    * @returns {void}
    */
   _sendChannelSubscribe(subscription) {
-    if (!this.isOpen() || !subscription._needsSubscribe()) return
+    if (!this.isOpen() || !this.isSessionReady() || !subscription._needsSubscribe()) return
 
     subscription._markSubscribeSent()
     this._sendMessage({
@@ -314,6 +331,7 @@ export default class VelociousWebsocketClient {
     if (this.socket && this.socket.readyState === this.socket.OPEN) return
     if (this.connectPromise) return this.connectPromise
 
+    this._resetSessionReadyState()
     this._waitingForOnline = false
     this.connectionAttempts += 1
 
@@ -379,9 +397,7 @@ export default class VelociousWebsocketClient {
       this._sendMessage({type: "metadata", data: {...this._metadata}})
     }
 
-    if (!this._awaitingResume) {
-      this._sendPendingChannelSubscriptions()
-    }
+    await this._waitForSessionReady()
     this.disconnectedSince = null
   }
 
@@ -400,6 +416,7 @@ export default class VelociousWebsocketClient {
     if (this.socket.readyState === this.socket.CLOSED) {
       this.socket = undefined
       this.connectPromise = undefined
+      this._resetSessionReadyState()
       return
     }
 
@@ -410,6 +427,7 @@ export default class VelociousWebsocketClient {
 
     this.socket = undefined
     this.connectPromise = undefined
+    this._resetSessionReadyState()
   }
 
   /**
@@ -434,6 +452,7 @@ export default class VelociousWebsocketClient {
     })
 
     this.connectPromise = undefined
+    this._resetSessionReadyState()
   }
 
   /**
@@ -685,15 +704,24 @@ export default class VelociousWebsocketClient {
         sub._handleClosed(`error: ${message.message || "channel-error"}`)
       }
     } else if (type === "session-established") {
+      this._pendingSessionId = typeof message.sessionId === "string" ? message.sessionId : null
+
       // First connect: cache sessionId for future resume attempts.
       if (!this._awaitingResume) {
-        this._sessionId = message.sessionId
-        this._persistSessionId(message.sessionId)
+        this._sessionId = this._pendingSessionId
+        if (this._sessionId) {
+          this._persistSessionId(this._sessionId)
+        }
+
+        this._markSessionReady()
+        this._sendPendingChannelSubscriptions()
       }
     } else if (type === "session-resumed") {
       this._awaitingResume = false
+      this._pendingSessionId = null
       this._sessionId = message.sessionId
       this._persistSessionId(message.sessionId)
+      this._markSessionReady()
       this._sendPendingChannelSubscriptions()
       // Fire onResume on every live handle so user code knows the
       // session came back with state intact.
@@ -702,7 +730,9 @@ export default class VelociousWebsocketClient {
     } else if (type === "session-gone") {
       this._awaitingResume = false
       this._sessionId = null
+      this._pendingSessionId = null
       this._clearPersistedSessionId()
+
       // Tear down every live handle — their server-side counterparts
       // are gone and nothing can bring them back.
       const connections = [...this._connections.values()]
@@ -712,6 +742,8 @@ export default class VelociousWebsocketClient {
       const subs = [...this._channelSubscriptions.values()]
       this._channelSubscriptions.clear()
       for (const subscription of subs) subscription._handleClosed("session_gone")
+
+      this._markSessionReady()
     } else if (type === "error" && message.id) {
       const pending = this.pendingRequests.get(message.id)
 
@@ -738,6 +770,7 @@ export default class VelociousWebsocketClient {
    */
   onClose = () => {
     this.disconnectedSince ||= Date.now()
+    this._resetSessionReadyState()
 
     for (const [id, {reject}] of this.pendingRequests.entries()) {
       reject(new Error(`Websocket closed before response for ${id}`))
@@ -912,6 +945,37 @@ export default class VelociousWebsocketClient {
     } catch (error) {
       this._debug("sessionStore.clear failed", error)
     }
+  }
+
+  /** @returns {Promise<void>} */
+  _waitForSessionReady() {
+    if (this._sessionReady) return Promise.resolve()
+
+    if (!this._sessionReadyPromise || !this._resolveSessionReady) {
+      this._sessionReadyPromise = new Promise((resolve) => {
+        this._resolveSessionReady = resolve
+      })
+    }
+
+    return this._sessionReadyPromise
+  }
+
+  /** @returns {void} */
+  _markSessionReady() {
+    if (this._sessionReady) return
+
+    this._sessionReady = true
+    this._resolveSessionReady?.()
+    this._resolveSessionReady = null
+    this._sessionReadyPromise = null
+  }
+
+  /** @returns {void} */
+  _resetSessionReadyState() {
+    this._sessionReady = false
+    this._pendingSessionId = null
+    this._sessionReadyPromise = null
+    this._resolveSessionReady = null
   }
 }
 

--- a/src/http-client/websocket-client.js
+++ b/src/http-client/websocket-client.js
@@ -81,6 +81,9 @@ export default class VelociousWebsocketClient {
     /** @type {(() => void) | null} */
     this._resolveSessionReady = null
 
+    /** @type {unknown | null} */
+    this._sessionReadyError = null
+
     /** @type {{get: () => string | null | undefined | Promise<string | null | undefined>, set: (sessionId: string) => void | Promise<void>, clear: () => void | Promise<void>} | undefined} */
     this._sessionStore = sessionStore
     /** @type {boolean} - true once the sessionStore has been consulted for a restored id. */
@@ -957,7 +960,13 @@ export default class VelociousWebsocketClient {
       })
     }
 
-    return this._sessionReadyPromise
+    return this._sessionReadyPromise.then(() => {
+      if (this._sessionReadyError) {
+        const error = this._sessionReadyError
+        this._sessionReadyError = null
+        throw error
+      }
+    })
   }
 
   /** @returns {void} */
@@ -965,15 +974,21 @@ export default class VelociousWebsocketClient {
     if (this._sessionReady) return
 
     this._sessionReady = true
+    this._sessionReadyError = null
     this._resolveSessionReady?.()
     this._resolveSessionReady = null
     this._sessionReadyPromise = null
   }
 
-  /** @returns {void} */
-  _resetSessionReadyState() {
+  /**
+   * @param {unknown} [error]
+   * @returns {void}
+   */
+  _resetSessionReadyState(error = new Error("Websocket session readiness was reset")) {
     this._sessionReady = false
     this._pendingSessionId = null
+    this._sessionReadyError = error
+    this._resolveSessionReady?.()
     this._sessionReadyPromise = null
     this._resolveSessionReady = null
   }


### PR DESCRIPTION
## Summary
- wait for websocket session readiness before sending channel subscriptions
- delay reconnect resubscribe flows until the websocket session handshake is ready
- preserve existing session-resume semantics while fixing the subscription race seen in scanner-app CI

## Validation
- npm run typecheck
- npm run lint -- src/http-client/websocket-client.js spec/http-server/websocket-channel-spec.js
- node scripts/run-tests.js spec/http-server/websocket-channel-spec.js spec/http-server/websocket-session-resume-spec.js