### PR TITLE
Wrap background job perform in DB connection context

### DIFF
--- a/changelog.d/20260422-fix-background-jobs-db-connection-context.md
+++ b/changelog.d/20260422-fix-background-jobs-db-connection-context.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- Background jobs now run inside an active database connection context. The inline worker (`forked: false`) and forked job runner both wrap `perform` in `Configuration#withConnections`, so DB calls from a job no longer fail with `Error: ID hasn't been set for this async context`.

--- a/spec/background-jobs/db-context-spec.js
+++ b/spec/background-jobs/db-context-spec.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+import fs from "fs/promises"
+import path from "path"
+import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import DbQueryJob from "../dummy/src/jobs/db-query-job.js"
+
+describe("Background jobs - DB context", {tags: ["dummy"]}, () => {
+  it("wraps inline job perform calls in a database connection context", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    await store.clearAll()
+
+    const main = new BackgroundJobsMain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+    await main.start()
+
+    dummyConfiguration.setBackgroundJobsConfig({
+      host: "127.0.0.1",
+      port: main.getPort()
+    })
+
+    const worker = new BackgroundJobsWorker({configuration: dummyConfiguration})
+    await worker.start()
+
+    const tmpDir = path.join(dummyConfiguration.getDirectory(), "tmp")
+    await fs.mkdir(tmpDir, {recursive: true})
+    const outputPath = path.join(tmpDir, `db-query-job-${Date.now()}.json`)
+
+    const originalWithConnections = dummyConfiguration.withConnections.bind(dummyConfiguration)
+    let withConnectionsCallsAfterStart = 0
+    dummyConfiguration.withConnections = async (callback) => {
+      withConnectionsCallsAfterStart++
+
+      return await originalWithConnections(callback)
+    }
+
+    let jobId
+
+    try {
+      jobId = await DbQueryJob.performLaterWithOptions({
+        args: [outputPath],
+        options: {forked: false}
+      })
+
+      await timeout({timeout: 5000}, async () => {
+        while (true) {
+          const job = await store.getJob(jobId)
+
+          if (job?.status === "completed") break
+          if (job?.status === "failed") throw new Error(`Job failed: ${job.lastError}`)
+
+          await wait(0.05)
+        }
+      })
+    } finally {
+      dummyConfiguration.withConnections = originalWithConnections
+    }
+
+    expect(withConnectionsCallsAfterStart).toBeGreaterThan(0)
+
+    const result = JSON.parse(await fs.readFile(outputPath, "utf8"))
+
+    expect(typeof result.count).toEqual("number")
+
+    await worker.stop()
+    await main.stop()
+  })
+})

--- a/spec/dummy/src/jobs/db-query-job.js
+++ b/spec/dummy/src/jobs/db-query-job.js
@@ -1,0 +1,11 @@
+import VelociousJob from "../../../../src/background-jobs/job.js"
+import fs from "fs/promises"
+import User from "../models/user.js"
+
+export default class DbQueryJob extends VelociousJob {
+  async perform(outputPath) {
+    const users = await User.all().toArray()
+
+    await fs.writeFile(outputPath, JSON.stringify({count: users.length}))
+  }
+}

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -22,7 +22,9 @@ export default async function runJobPayload(payload) {
   const perform = jobInstance.perform
 
   try {
-    await perform.apply(jobInstance, payload.args || [])
+    await configuration.withConnections(async () => {
+      await perform.apply(jobInstance, payload.args || [])
+    })
 
     if (payload.id) {
       await reporter.reportWithRetry({

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -137,7 +137,9 @@ export default class BackgroundJobsWorker {
     /** @type {(...args: any[]) => Promise<void>} */
     const perform = jobInstance.perform
 
-    await perform.apply(jobInstance, payload.args || [])
+    await configuration.withConnections(async () => {
+      await perform.apply(jobInstance, payload.args || [])
+    })
   }
 
   /**


### PR DESCRIPTION
## Summary

Background jobs were silently crashing on their first database call with:

```
Error: ID hasn't been set for this async context
    at VelociousDatabasePoolAsyncTrackedMultiConnection.getCurrentConnection
    at Build.connection
    at <Job's first DB call>
```

The inline worker (`BackgroundJobsWorker._runJobInline`, `forked: false`) and the forked job runner (`runJobPayload`) both called `perform.apply(jobInstance, args)` directly. Without an enclosing `Configuration#withConnections(...)` frame and without a registered global fallback connection in the worker process, any model query in the job throws on the async-context lookup.

This wraps `perform` in `configuration.withConnections(...)` in both code paths, matching the connection-setup pattern that HTTP request handlers and websocket sessions already use (`websocket-session.js#_withConnections` -> `ensureConnections` -> `withConnections`).

Diagnosed by inspecting a downstream consumer (Peakflow tensorbuzz) where every `RunQueuedBuildsJob`, `BuildTimeoutsJob`, and `RunDuePingChecksJob` was failing with this exact error on every attempt — no jobs in the system could touch the DB.

## Test plan

- [x] New `spec/background-jobs/db-context-spec.js` enqueues an inline DB-touching job (`DbQueryJob`) and asserts both that the job completes and that `configuration.withConnections` was invoked from the worker frame.
- [x] Verified the new test fails on `master` (without the fix) and passes with the fix.
- [x] All existing `spec/background-jobs/` tests still pass (one pre-existing failure on `queue-spec.js:65` is unrelated and reproduces on plain `master`).
- [x] `npm run build`, `npx eslint`, and `npx tsc --noEmit` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)