### PR TITLE
Websocket: route via default when messageHandler has no onMessage + reassemble fragmented frames

### DIFF
--- a/spec/dummy/src/config/configuration.example.js
+++ b/spec/dummy/src/config/configuration.example.js
@@ -38,6 +38,14 @@ async function websocketMessageHandlerResolver({request}) {
       }
     }
   }
+
+  if (pathValue === "/lifecycle-only-socket") {
+    return {
+      onOpen: ({session}) => {
+        session.sendJson({type: "welcome"})
+      }
+    }
+  }
 }
 
 export default new Configuration({

--- a/spec/dummy/src/config/configuration.js
+++ b/spec/dummy/src/config/configuration.js
@@ -50,6 +50,14 @@ async function websocketMessageHandlerResolver({request}) {
       }
     }
   }
+
+  if (pathValue === "/lifecycle-only-socket") {
+    return {
+      onOpen: ({session}) => {
+        session.sendJson({type: "welcome"})
+      }
+    }
+  }
 }
 
 /**

--- a/spec/http-server/websocket-fragmented-frames-spec.js
+++ b/spec/http-server/websocket-fragmented-frames-spec.js
@@ -134,6 +134,45 @@ describe("WebsocketSession fragmented frames", () => {
     expect(dispatched[0]).toMatchObject({type: "metadata", data: {locale: "en"}})
   })
 
+  it("closes the connection when a fragmented message exceeds the per-fragment count cap", async () => {
+    /** @type {Buffer[]} */
+    const emittedFrames = []
+    let handleCloseCalls = 0
+
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({
+        events: {
+          emit: (name, value) => {
+            if (name === "output" && value instanceof Buffer) emittedFrames.push(value)
+          }
+        },
+        remoteAddress: "127.0.0.1"
+      }),
+      configuration: dummyConfiguration
+    })
+
+    session._handleMessage = async () => { throw new Error("should not dispatch when caps are exceeded") }
+    session._handleClose = () => { handleCloseCalls += 1 }
+
+    const chunkBodies = Array.from({length: 3000}, () => Buffer.from("x"))
+    const framesIn = []
+
+    framesIn.push(buildClientFrame({fin: false, opcode: 0x1, payload: chunkBodies[0]}))
+    for (let i = 1; i < chunkBodies.length; i++) {
+      framesIn.push(buildClientFrame({fin: false, opcode: 0x0, payload: chunkBodies[i]}))
+    }
+
+    session.onData(Buffer.concat(framesIn))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(handleCloseCalls).toBe(1)
+    // Close frame emitted (opcode 0x8 with FIN=1).
+    expect(emittedFrames.length).toBeGreaterThan(0)
+    expect(emittedFrames.some((frame) => frame[0] === 0x88)).toBe(true)
+    expect(session._fragmentedPayloads).toBe(null)
+    expect(session._fragmentedBytes).toBe(0)
+  })
+
   it("still processes a single-frame message after a fragmented message", async () => {
     const session = new WebsocketSession({
       client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),

--- a/spec/http-server/websocket-fragmented-frames-spec.js
+++ b/spec/http-server/websocket-fragmented-frames-spec.js
@@ -1,0 +1,169 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import EventEmitter from "../../src/utils/event-emitter.js"
+import WebsocketSession from "../../src/http-server/client/websocket-session.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+/**
+ * Builds a single client→server websocket frame with mandatory masking,
+ * matching what a browser produces. Used to drive `_processBuffer` from
+ * unit tests without going through a real socket.
+ * @param {{fin: boolean, opcode: number, payload: Buffer}} params
+ * @returns {Buffer}
+ */
+function buildClientFrame({fin, opcode, payload}) {
+  const mask = Buffer.from([0x01, 0x02, 0x03, 0x04])
+  const maskedPayload = Buffer.alloc(payload.length)
+
+  for (let i = 0; i < payload.length; i++) {
+    maskedPayload[i] = payload[i] ^ mask[i % 4]
+  }
+
+  const firstByte = (fin ? 0x80 : 0x00) | (opcode & 0x0F)
+  /** @type {Buffer} */
+  let header
+
+  if (payload.length < 126) {
+    header = Buffer.from([firstByte, 0x80 | payload.length])
+  } else if (payload.length < 65536) {
+    header = Buffer.alloc(4)
+    header[0] = firstByte
+    header[1] = 0x80 | 126
+    header.writeUInt16BE(payload.length, 2)
+  } else {
+    header = Buffer.alloc(10)
+    header[0] = firstByte
+    header[1] = 0x80 | 127
+    header.writeBigUInt64BE(BigInt(payload.length), 2)
+  }
+
+  return Buffer.concat([header, mask, maskedPayload])
+}
+
+describe("WebsocketSession fragmented frames", () => {
+  it("reassembles a channel-subscribe split across continuation frames", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+
+    /** @type {any[]} */
+    const dispatched = []
+
+    session._handleMessage = async (message) => { dispatched.push(message) }
+
+    const body = JSON.stringify({
+      type: "channel-subscribe",
+      subscriptionId: "s1",
+      channelType: "ticket-scans",
+      params: {authenticationToken: "x".repeat(4096), eventID: "event-1"}
+    })
+    const payload = Buffer.from(body, "utf-8")
+    const mid = Math.floor(payload.length / 2)
+
+    const firstFrame = buildClientFrame({
+      fin: false,
+      opcode: 0x1,
+      payload: payload.slice(0, mid)
+    })
+    const continuationFrame = buildClientFrame({
+      fin: true,
+      opcode: 0x0,
+      payload: payload.slice(mid)
+    })
+
+    session.onData(Buffer.concat([firstFrame, continuationFrame]))
+
+    // Synchronous parse → _handleMessage() runs in the event loop.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(dispatched.length).toBe(1)
+    expect(dispatched[0]).toMatchObject({
+      type: "channel-subscribe",
+      subscriptionId: "s1",
+      channelType: "ticket-scans"
+    })
+    expect(dispatched[0].params.authenticationToken.length).toBe(4096)
+  })
+
+  it("handles a PING interleaved between fragments without losing the data message", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+
+    /** @type {any[]} */
+    const dispatched = []
+    /** @type {Array<{opcode: number, payload: Buffer}>} */
+    const sentControlFrames = []
+
+    session._handleMessage = async (message) => { dispatched.push(message) }
+    session._sendControlFrame = (opcode, payload) => {
+      sentControlFrames.push({opcode, payload: Buffer.from(payload)})
+    }
+
+    const body = JSON.stringify({type: "metadata", data: {locale: "en"}})
+    const payload = Buffer.from(body, "utf-8")
+    const mid = Math.floor(payload.length / 2)
+
+    const firstFrame = buildClientFrame({
+      fin: false,
+      opcode: 0x1,
+      payload: payload.slice(0, mid)
+    })
+    const pingFrame = buildClientFrame({
+      fin: true,
+      opcode: 0x9,
+      payload: Buffer.from("ping")
+    })
+    const continuationFrame = buildClientFrame({
+      fin: true,
+      opcode: 0x0,
+      payload: payload.slice(mid)
+    })
+
+    session.onData(Buffer.concat([firstFrame, pingFrame, continuationFrame]))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(sentControlFrames.length).toBe(1)
+    expect(sentControlFrames[0].opcode).toBe(0xA) // PONG
+    expect(sentControlFrames[0].payload.toString("utf-8")).toBe("ping")
+
+    expect(dispatched.length).toBe(1)
+    expect(dispatched[0]).toMatchObject({type: "metadata", data: {locale: "en"}})
+  })
+
+  it("still processes a single-frame message after a fragmented message", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+
+    /** @type {any[]} */
+    const dispatched = []
+
+    session._handleMessage = async (message) => { dispatched.push(message) }
+
+    const firstBody = JSON.stringify({type: "channel-subscribe", subscriptionId: "s1", channelType: "c"})
+    const firstPayload = Buffer.from(firstBody, "utf-8")
+    const half = Math.floor(firstPayload.length / 2)
+
+    const fragA = buildClientFrame({fin: false, opcode: 0x1, payload: firstPayload.slice(0, half)})
+    const fragB = buildClientFrame({fin: true, opcode: 0x0, payload: firstPayload.slice(half)})
+
+    const secondBody = JSON.stringify({type: "metadata", data: {theme: "dark"}})
+    const secondFrame = buildClientFrame({
+      fin: true,
+      opcode: 0x1,
+      payload: Buffer.from(secondBody, "utf-8")
+    })
+
+    session.onData(Buffer.concat([fragA, fragB, secondFrame]))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(dispatched.length).toBe(2)
+    expect(dispatched[0]).toMatchObject({type: "channel-subscribe", subscriptionId: "s1"})
+    expect(dispatched[1]).toMatchObject({type: "metadata", data: {theme: "dark"}})
+  })
+})

--- a/spec/http-server/websocket-lifecycle-handler-spec.js
+++ b/spec/http-server/websocket-lifecycle-handler-spec.js
@@ -59,6 +59,33 @@ describe("WebsocketSession lifecycle-only message handler", () => {
     expect(session.getMetadata()).toEqual({})
   })
 
+  it("finishes an async onOpen before replaying queued messages", async () => {
+    /** @type {string[]} */
+    const callOrder = []
+
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration,
+      messageHandlerPromise: Promise.resolve({
+        onOpen: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          callOrder.push("onOpen:done")
+        }
+      })
+    })
+
+    session._handleChannelSubscribe = async () => { callOrder.push("channel-subscribe:dispatched") }
+
+    // Queue a message while the handler is still pending so it
+    // lands in messageQueue and is flushed after the promise
+    // resolves.
+    await session._handleMessage({type: "channel-subscribe", subscriptionId: "s1", channelType: "Counter"})
+
+    await session._resolveMessageHandlerPromise()
+
+    expect(callOrder).toEqual(["onOpen:done", "channel-subscribe:dispatched"])
+  })
+
   it("subscribes via the lifecycle-only socket path when the server only tracks open/close", async () => {
     await Dummy.run(async () => {
       const client = new WebsocketClient({url: "ws://127.0.0.1:3006/lifecycle-only-socket"})

--- a/spec/http-server/websocket-lifecycle-handler-spec.js
+++ b/spec/http-server/websocket-lifecycle-handler-spec.js
@@ -1,0 +1,81 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Dummy from "../dummy/index.js"
+import EventEmitter from "../../src/utils/event-emitter.js"
+import WebsocketClient from "../../src/http-client/websocket-client.js"
+import WebsocketSession from "../../src/http-server/client/websocket-session.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+describe("WebsocketSession lifecycle-only message handler", () => {
+  it("falls through to default routing for channel-subscribe when handler has no onMessage", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration,
+      messageHandler: {
+        onOpen: () => {},
+        onClose: () => {}
+      }
+    })
+
+    /** @type {any[]} */
+    const handledChannelSubscribes = []
+
+    session._handleChannelSubscribe = async (message) => { handledChannelSubscribes.push(message) }
+
+    await session._handleMessage({
+      type: "channel-subscribe",
+      subscriptionId: "s1",
+      channelType: "Counter",
+      params: {allow: true}
+    })
+
+    expect(handledChannelSubscribes.length).toBe(1)
+    expect(handledChannelSubscribes[0]).toMatchObject({
+      type: "channel-subscribe",
+      subscriptionId: "s1",
+      channelType: "Counter"
+    })
+  })
+
+  it("still routes every message through onMessage when the handler defines one", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration,
+      messageHandler: {
+        onMessage: async ({message}) => { received.push(message) }
+      }
+    })
+
+    /** @type {any[]} */
+    const received = []
+
+    await session._handleMessage({type: "channel-subscribe", subscriptionId: "s1", channelType: "X"})
+    await session._handleMessage({type: "metadata", data: {locale: "en"}})
+
+    expect(received.length).toBe(2)
+    expect(received[0]).toMatchObject({type: "channel-subscribe", subscriptionId: "s1"})
+    expect(received[1]).toMatchObject({type: "metadata"})
+    expect(session.getMetadata()).toEqual({})
+  })
+
+  it("subscribes via the lifecycle-only socket path when the server only tracks open/close", async () => {
+    await Dummy.run(async () => {
+      const client = new WebsocketClient({url: "ws://127.0.0.1:3006/lifecycle-only-socket"})
+
+      try {
+        const subscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "lifecycle-handler"}
+        })
+
+        await client.connect()
+
+        await subscription.waitForReady({timeoutMs: 3000})
+        expect(subscription.isReady()).toBe(true)
+        expect(subscription.isSubscribed()).toBe(true)
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
+    })
+  })
+})

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -20,6 +20,12 @@ const WEBSOCKET_OPCODE_PONG = 0xA
 /** Cap on the paused outbound queue; oldest frames drop on overflow. */
 const WEBSOCKET_PAUSED_QUEUE_CAP = 1000
 
+/** Cap on total bytes buffered for a single fragmented message. */
+const WEBSOCKET_MAX_FRAGMENTED_MESSAGE_BYTES = 16 * 1024 * 1024
+
+/** Cap on fragment count for a single fragmented message. */
+const WEBSOCKET_MAX_FRAGMENTED_MESSAGE_FRAGMENTS = 1024
+
 /**
  * @typedef {{type: "subscribe", channel: string, lastEventId?: string, params?: Record<string, any>} | {type: "metadata", data?: Record<string, any>} | {type?: "request", body?: unknown, headers?: Record<string, any>, id?: string | number | null, method: string, path: string} | Record<string, any>} WebsocketSessionMessage
  */
@@ -164,6 +170,14 @@ export default class VelociousHttpServerClientWebsocketSession {
      * @type {number | null}
      */
     this._fragmentedOpcode = null
+
+    /**
+     * Running byte total for `_fragmentedPayloads`. Used to enforce
+     * `WEBSOCKET_MAX_FRAGMENTED_MESSAGE_BYTES` so a peer cannot
+     * exhaust memory by streaming non-final fragments indefinitely.
+     * @type {number}
+     */
+    this._fragmentedBytes = 0
   }
 
   /**
@@ -569,17 +583,22 @@ export default class VelociousHttpServerClientWebsocketSession {
           continue
         }
 
-        this._fragmentedPayloads.push(payload)
+        if (!this._appendFragment(payload)) return
 
         if (!isFinal) continue
       } else if (opcode === WEBSOCKET_OPCODE_TEXT || opcode === WEBSOCKET_OPCODE_BINARY) {
         if (this._fragmentedPayloads !== null) {
           this.logger.warn("Received new data frame while a fragmented message was in progress; discarding prior fragments")
+          this._resetFragmentBuffer()
         }
 
         if (!isFinal) {
           this._fragmentedPayloads = [payload]
           this._fragmentedOpcode = opcode
+          this._fragmentedBytes = payload.length
+
+          if (!this._enforceFragmentLimits()) return
+
           continue
         }
       } else {
@@ -600,8 +619,7 @@ export default class VelociousHttpServerClientWebsocketSession {
           finalPayload = payload
           finalOpcode = opcode
         }
-        this._fragmentedPayloads = null
-        this._fragmentedOpcode = null
+        this._resetFragmentBuffer()
       } else {
         finalPayload = payload
         finalOpcode = opcode
@@ -624,6 +642,66 @@ export default class VelociousHttpServerClientWebsocketSession {
         this.sendJson({error: "Invalid websocket message", type: "error"})
       }
     }
+  }
+
+  /**
+   * Appends a continuation-frame payload to the in-progress
+   * fragmented message. Returns true when the fragment was accepted
+   * and false when the per-message cap was hit and the socket has
+   * been closed.
+   * @param {Buffer} payload
+   * @returns {boolean}
+   */
+  _appendFragment(payload) {
+    // Guard pushing first so `_enforceFragmentLimits` sees the final
+    // state; on overflow the reset inside the enforcer drops the
+    // buffered fragments.
+    this._fragmentedPayloads?.push(payload)
+    this._fragmentedBytes += payload.length
+
+    return this._enforceFragmentLimits()
+  }
+
+  /**
+   * Verifies the fragmented message has not exceeded the byte or
+   * fragment-count caps. On overflow, clears the buffer, sends a
+   * close frame, and tears the session down. Returns true when the
+   * caller can continue processing, false when the session is being
+   * closed.
+   * @returns {boolean}
+   */
+  _enforceFragmentLimits() {
+    if (this._fragmentedPayloads === null) return true
+
+    const fragmentCount = this._fragmentedPayloads.length
+    const overBytes = this._fragmentedBytes > WEBSOCKET_MAX_FRAGMENTED_MESSAGE_BYTES
+    const overFragments = fragmentCount > WEBSOCKET_MAX_FRAGMENTED_MESSAGE_FRAGMENTS
+
+    if (!overBytes && !overFragments) return true
+
+    this.logger.warn(() => [
+      "Fragmented websocket message exceeded caps; closing connection",
+      {
+        fragmentBytes: this._fragmentedBytes,
+        fragmentCount,
+        maxBytes: WEBSOCKET_MAX_FRAGMENTED_MESSAGE_BYTES,
+        maxFragments: WEBSOCKET_MAX_FRAGMENTED_MESSAGE_FRAGMENTS
+      }
+    ])
+
+    this._resetFragmentBuffer()
+    this.buffer = Buffer.alloc(0)
+    this.sendGoodbye(this.client)
+    this._handleClose()
+
+    return false
+  }
+
+  /** @returns {void} */
+  _resetFragmentBuffer() {
+    this._fragmentedPayloads = null
+    this._fragmentedOpcode = null
+    this._fragmentedBytes = 0
   }
 
   /**

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -10,7 +10,9 @@ import WebsocketChannel from "../websocket-channel.js"
 import {websocketEventLogStoreForConfiguration} from "../websocket-event-log-store.js"
 
 const WEBSOCKET_FINAL_FRAME = 0x80
+const WEBSOCKET_OPCODE_CONTINUATION = 0x0
 const WEBSOCKET_OPCODE_TEXT = 0x1
+const WEBSOCKET_OPCODE_BINARY = 0x2
 const WEBSOCKET_OPCODE_CLOSE = 0x8
 const WEBSOCKET_OPCODE_PING = 0x9
 const WEBSOCKET_OPCODE_PONG = 0xA
@@ -146,6 +148,22 @@ export default class VelociousHttpServerClientWebsocketSession {
      * @type {Promise<any> | undefined}
      */
     this._resumeIdentityPromise = undefined
+
+    /**
+     * Accumulates payloads for a fragmented websocket message per
+     * RFC 6455. Non-null while mid-fragment; cleared when the frame
+     * with FIN=1 completes and the message is dispatched.
+     * @type {Buffer[] | null}
+     */
+    this._fragmentedPayloads = null
+
+    /**
+     * Opcode (TEXT/BINARY) captured from the first frame of a
+     * fragmented message. Continuation frames (opcode 0) inherit it
+     * at reassembly time.
+     * @type {number | null}
+     */
+    this._fragmentedOpcode = null
   }
 
   /**
@@ -518,11 +536,10 @@ export default class VelociousHttpServerClientWebsocketSession {
 
       this.buffer = this.buffer.slice(offset + maskLength + payloadLength)
 
-      if (!isFinal) {
-        this.logger.warn("Fragmented frames are not supported yet")
-        continue
-      }
-
+      // Control frames (opcode >= 0x8) must not be fragmented per
+      // RFC 6455 and can arrive interleaved with a fragmented data
+      // message. Handle them first without touching the fragment
+      // accumulator.
       if (opcode === WEBSOCKET_OPCODE_PING) {
         this._sendControlFrame(WEBSOCKET_OPCODE_PONG, payload)
         continue
@@ -534,13 +551,69 @@ export default class VelociousHttpServerClientWebsocketSession {
         continue
       }
 
-      if (opcode !== WEBSOCKET_OPCODE_TEXT) {
-        this.logger.warn(`Unsupported websocket opcode: ${opcode}`)
+      if (opcode >= 0x8) {
+        this.logger.warn(`Unsupported websocket control opcode: ${opcode}`)
+        continue
+      }
+
+      // Data frame (TEXT/BINARY/CONTINUATION). Reassemble fragments
+      // before dispatching. Browsers (Chrome) legitimately fragment
+      // longer client→server text frames; a prior version dropped
+      // every fragmented message silently, so any payload large
+      // enough to hit the browser's fragmentation threshold
+      // (e.g. a channel-subscribe with an auth token) never reached
+      // the handler.
+      if (opcode === WEBSOCKET_OPCODE_CONTINUATION) {
+        if (this._fragmentedPayloads === null) {
+          this.logger.warn("Received continuation frame with no fragmented message in progress")
+          continue
+        }
+
+        this._fragmentedPayloads.push(payload)
+
+        if (!isFinal) continue
+      } else if (opcode === WEBSOCKET_OPCODE_TEXT || opcode === WEBSOCKET_OPCODE_BINARY) {
+        if (this._fragmentedPayloads !== null) {
+          this.logger.warn("Received new data frame while a fragmented message was in progress; discarding prior fragments")
+        }
+
+        if (!isFinal) {
+          this._fragmentedPayloads = [payload]
+          this._fragmentedOpcode = opcode
+          continue
+        }
+      } else {
+        this.logger.warn(`Unsupported websocket data opcode: ${opcode}`)
+        continue
+      }
+
+      /** @type {Buffer} */
+      let finalPayload
+      /** @type {number} */
+      let finalOpcode
+
+      if (this._fragmentedPayloads !== null) {
+        if (opcode === WEBSOCKET_OPCODE_CONTINUATION) {
+          finalPayload = Buffer.concat(this._fragmentedPayloads)
+          finalOpcode = this._fragmentedOpcode ?? WEBSOCKET_OPCODE_TEXT
+        } else {
+          finalPayload = payload
+          finalOpcode = opcode
+        }
+        this._fragmentedPayloads = null
+        this._fragmentedOpcode = null
+      } else {
+        finalPayload = payload
+        finalOpcode = opcode
+      }
+
+      if (finalOpcode !== WEBSOCKET_OPCODE_TEXT) {
+        this.logger.warn(`Unsupported websocket data opcode after reassembly: ${finalOpcode}`)
         continue
       }
 
       try {
-        const message = JSON.parse(payload.toString("utf-8"))
+        const message = JSON.parse(finalPayload.toString("utf-8"))
 
         this._handleMessage(message).catch((error) => {
           this.logger.error(() => ["Websocket message handler failed", error])

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -1634,7 +1634,14 @@ export default class VelociousHttpServerClientWebsocketSession {
       if (handler) {
         this.pendingMessageHandler = false
         this.messageHandlerPromise = undefined
-        this.setMessageHandler(handler)
+        // Install handler and drain onOpen before replaying queued
+        // messages. setMessageHandler() fires onOpen as fire-and-forget;
+        // awaiting _runMessageHandlerOpen() directly here closes the
+        // race where queued subscribe/connection-* frames would
+        // dispatch while an async onOpen is still setting up session
+        // state.
+        this.messageHandler = handler
+        await this._runMessageHandlerOpen()
         await this._flushQueuedMessages({useHandler: typeof handler.onMessage === "function"})
         return
       }

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -364,7 +364,12 @@ export default class VelociousHttpServerClientWebsocketSession {
       return
     }
 
-    if (this.messageHandler) {
+    // The messageHandler short-circuits default routing only when the
+    // app actually declared an `onMessage` hook. Apps that only want
+    // session-lifecycle tracking (`onOpen`/`onClose`) still need the
+    // built-in subscribe/connection/channel-subscribe routing below,
+    // otherwise every incoming message is silently dropped.
+    if (this.messageHandler && typeof this.messageHandler.onMessage === "function") {
       await this._runMessageHandlerMessage(message)
       return
     }
@@ -1479,7 +1484,7 @@ export default class VelociousHttpServerClientWebsocketSession {
         this.pendingMessageHandler = false
         this.messageHandlerPromise = undefined
         this.setMessageHandler(handler)
-        await this._flushQueuedMessages({useHandler: true})
+        await this._flushQueuedMessages({useHandler: typeof handler.onMessage === "function"})
         return
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Two server-side websocket fixes, bundled so they don't fight each other on merge. Both touch `src/http-server/client/websocket-session.js`.

### 1. Fall through to default routing when `messageHandler` has no `onMessage` (root cause of the ticket-app CI failure)

An app that wired `websocketMessageHandlerResolver` only for session-lifecycle tracking (returning `{onOpen, onClose}` — no `onMessage`) silently dropped every inbound message:

1. `_handleMessageInner` sees `this.messageHandler` is set
2. Calls `_runMessageHandlerMessage(message)`
3. That function looks up `handler.onMessage`, finds `undefined`, returns without doing anything
4. The `return` in step 2 skips the built-in `subscribe` / `connection-*` / `channel-subscribe` routing

In production this manifested as: client opens socket, receives `session-established`, marks sessionReady, sends `channel-subscribe` — server logs nothing, client's `waitForReady` hits its 5s timeout.

The fix short-circuits through the handler **only** when `handler.onMessage` is actually defined. Otherwise fall through to the default routing. Pending-handler queue flushing follows the same rule so queued messages still land in the default dispatcher when the resolved handler has no `onMessage`. After addressing review feedback, the flush path also awaits `_runMessageHandlerOpen()` before draining so an async `onOpen` can't race with the first replayed subscribe.

### 2. Reassemble fragmented websocket frames

Browsers are allowed to fragment outbound client→server frames at their discretion, and the server's `_processBuffer` used to drop every frame with `FIN=0` with just a warning log. Track `_fragmentedPayloads`/`_fragmentedOpcode` and dispatch only when `FIN=1` arrives. Control frames (PING/PONG/CLOSE) stay on their fast path so they can interleave between fragments per RFC 6455.

To prevent memory exhaustion from a peer streaming non-final fragments indefinitely, accumulated bytes and fragment count are capped (`16 MB` / `1024 fragments`). On overflow the buffer is reset, a close frame is sent, and the session is torn down.

## Test plan

- [x] `npm run test -- spec/http-server` — 127 tests green (119 prior + 8 new across the two new specs)
- [x] New coverage:
  - `websocket-fragmented-frames-spec.js`: TEXT+CONTINUATION reassembly, PING interleaved mid-fragment, single-frame follow-up doesn't see leaked fragment state, per-fragment cap closes the session
  - `websocket-lifecycle-handler-spec.js`: lifecycle-only handler falls through to default routing, full handler still intercepts all messages, async `onOpen` completes before queued messages are flushed, end-to-end `subscribeChannel` against `/lifecycle-only-socket`
- [x] `npm run typecheck` clean
- [x] `npm run lint` on changed files: 0 errors (only pre-existing JSDoc warnings)

## History

Originally split across two PRs (#601 for fragmented frames, #602 for the message-handler routing). Folded into this single branch so there's no conflict between them — #602 has been closed. Review fixes from both PRs (P1: bound the fragment buffer, P2: await `onOpen` before flushing queued messages) are included as follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)