### PR TITLE
Fall through to default routing when message handler has no onMessage

### DIFF
--- a/spec/dummy/src/config/configuration.example.js
+++ b/spec/dummy/src/config/configuration.example.js
@@ -38,6 +38,14 @@ async function websocketMessageHandlerResolver({request}) {
       }
     }
   }
+
+  if (pathValue === "/lifecycle-only-socket") {
+    return {
+      onOpen: ({session}) => {
+        session.sendJson({type: "welcome"})
+      }
+    }
+  }
 }
 
 export default new Configuration({

--- a/spec/dummy/src/config/configuration.js
+++ b/spec/dummy/src/config/configuration.js
@@ -50,6 +50,14 @@ async function websocketMessageHandlerResolver({request}) {
       }
     }
   }
+
+  if (pathValue === "/lifecycle-only-socket") {
+    return {
+      onOpen: ({session}) => {
+        session.sendJson({type: "welcome"})
+      }
+    }
+  }
 }
 
 /**

--- a/spec/http-server/websocket-lifecycle-handler-spec.js
+++ b/spec/http-server/websocket-lifecycle-handler-spec.js
@@ -1,0 +1,81 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Dummy from "../dummy/index.js"
+import EventEmitter from "../../src/utils/event-emitter.js"
+import WebsocketClient from "../../src/http-client/websocket-client.js"
+import WebsocketSession from "../../src/http-server/client/websocket-session.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+describe("WebsocketSession lifecycle-only message handler", () => {
+  it("falls through to default routing for channel-subscribe when handler has no onMessage", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration,
+      messageHandler: {
+        onOpen: () => {},
+        onClose: () => {}
+      }
+    })
+
+    /** @type {any[]} */
+    const handledChannelSubscribes = []
+
+    session._handleChannelSubscribe = async (message) => { handledChannelSubscribes.push(message) }
+
+    await session._handleMessage({
+      type: "channel-subscribe",
+      subscriptionId: "s1",
+      channelType: "Counter",
+      params: {allow: true}
+    })
+
+    expect(handledChannelSubscribes.length).toBe(1)
+    expect(handledChannelSubscribes[0]).toMatchObject({
+      type: "channel-subscribe",
+      subscriptionId: "s1",
+      channelType: "Counter"
+    })
+  })
+
+  it("still routes every message through onMessage when the handler defines one", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration,
+      messageHandler: {
+        onMessage: async ({message}) => { received.push(message) }
+      }
+    })
+
+    /** @type {any[]} */
+    const received = []
+
+    await session._handleMessage({type: "channel-subscribe", subscriptionId: "s1", channelType: "X"})
+    await session._handleMessage({type: "metadata", data: {locale: "en"}})
+
+    expect(received.length).toBe(2)
+    expect(received[0]).toMatchObject({type: "channel-subscribe", subscriptionId: "s1"})
+    expect(received[1]).toMatchObject({type: "metadata"})
+    expect(session.getMetadata()).toEqual({})
+  })
+
+  it("subscribes via the lifecycle-only socket path when the server only tracks open/close", async () => {
+    await Dummy.run(async () => {
+      const client = new WebsocketClient({url: "ws://127.0.0.1:3006/lifecycle-only-socket"})
+
+      try {
+        const subscription = client.subscribeChannel("Counter", {
+          params: {allow: true, topic: "lifecycle-handler"}
+        })
+
+        await client.connect()
+
+        await subscription.waitForReady({timeoutMs: 3000})
+        expect(subscription.isReady()).toBe(true)
+        expect(subscription.isSubscribed()).toBe(true)
+      } finally {
+        await client.disconnectAndStopReconnect()
+      }
+    })
+  })
+})

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -364,7 +364,12 @@ export default class VelociousHttpServerClientWebsocketSession {
       return
     }
 
-    if (this.messageHandler) {
+    // The messageHandler short-circuits default routing only when the
+    // app actually declared an `onMessage` hook. Apps that only want
+    // session-lifecycle tracking (`onOpen`/`onClose`) still need the
+    // built-in subscribe/connection/channel-subscribe routing below,
+    // otherwise every incoming message is silently dropped.
+    if (this.messageHandler && typeof this.messageHandler.onMessage === "function") {
       await this._runMessageHandlerMessage(message)
       return
     }
@@ -1479,7 +1484,7 @@ export default class VelociousHttpServerClientWebsocketSession {
         this.pendingMessageHandler = false
         this.messageHandlerPromise = undefined
         this.setMessageHandler(handler)
-        await this._flushQueuedMessages({useHandler: true})
+        await this._flushQueuedMessages({useHandler: typeof handler.onMessage === "function"})
         return
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Root cause for the ticket-app CI websocket failures. An app that wired \`websocketMessageHandlerResolver\` only for session-lifecycle tracking (returning \`{onOpen, onClose}\` — no \`onMessage\`) silently dropped every inbound message:

1. \`_handleMessageInner\` sees \`this.messageHandler\` is set
2. Calls \`_runMessageHandlerMessage(message)\`
3. That function looks up \`handler.onMessage\`, finds \`undefined\`, returns without doing anything
4. \`return\` in step 2 skips the built-in \`subscribe\` / \`connection-*\` / \`channel-subscribe\` routing

In production this manifested as: client opens socket, receives \`session-established\`, marks sessionReady, sends \`channel-subscribe\` — server logs nothing, client's \`waitForReady\` hits its 5s timeout.

The fix is to short-circuit through the handler **only** when \`handler.onMessage\` is actually defined. Otherwise fall through to the default routing. Pending-handler queue flushing follows the same rule so queued messages still land in the default dispatcher when the resolved handler has no \`onMessage\`.

## Test plan

- [x] New \`spec/http-server/websocket-lifecycle-handler-spec.js\`:
  - \`_handleMessageInner\` routes \`channel-subscribe\` to \`_handleChannelSubscribe\` when the handler only defines \`onOpen\`/\`onClose\`
  - When the handler defines \`onMessage\` it still intercepts every message (unchanged behavior)
  - End-to-end: a client \`subscribeChannel\` against \`/lifecycle-only-socket\` reaches the server and the subscription becomes ready
- [x] \`npm run test -- spec/http-server\` — 122 tests green (119 prior + 3 new)
- [x] Existing \`raw-socket\` / \`raw-async-socket\` tests still pass (full-handler path unchanged)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` on changed files: 0 errors (only pre-existing JSDoc warnings)

## Related

- #601 adds fragmented-frame reassembly — a separate defensive improvement surfaced while diagnosing this bug, but not the root cause; this PR is the actual fix for the silent message drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)