### PR TITLE
Per-record ability checks: FrontendModelQuery#abilities + record.can

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))
 * Per-row association counts via `.withCount(...)` on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)` on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
+* Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 
 # Setup
 

--- a/changelog.d/20260424-frontend-model-per-record-abilities.md
+++ b/changelog.d/20260424-frontend-model-per-record-abilities.md
@@ -1,0 +1,25 @@
+# Per-record ability checks via `.abilities(...)`
+
+- Add `FrontendModelQuery#abilities(spec)` so the frontend can ask the
+  backend to evaluate one or more ability actions against each
+  returned record, and ship the per-record results back for
+  `record.can(action)` reads. Supports the flat-array shorthand
+  (applies to the query's own model class) and the keyed
+  `{ModelName: [action, ...]}` form — the keyed form also walks
+  preloaded relationships of any depth, so a single
+  `.preload("timelogs").abilities({Timelog: ["update", "destroy"]})`
+  request attaches results to every preloaded child without per-row
+  round trips. The backend evaluates each (modelClass, action) pair
+  as a single `accessibleFor(action).where({id: IN (ids)}).pluck("id")`
+  batched check, regardless of how many records were loaded.
+- Available on `find`, `findBy`, and `toArray` — the spec rides the
+  same wire format used by `withCount` and `queryData`. Results are
+  read on the frontend via `record.can(action)`, and default to
+  `false` for actions that weren't requested (so UI code can branch
+  on `record.can("update")` without guarding against an unloaded
+  value).
+- Backend enforcement is unchanged: the existing
+  `abilities.update/destroy/...` resource config still gates the
+  underlying commands. `.abilities(...)` is purely a read-side API
+  for the UI to know which buttons to show; the actual
+  authorization still runs on every mutation.

--- a/docs/abilities.md
+++ b/docs/abilities.md
@@ -1,0 +1,92 @@
+# Per-record ability checks — `.abilities(...)` + `record.can(...)`
+
+`query.abilities(spec)` tells the backend to evaluate one or more
+ability actions against each returned record and ship the results
+back so UI code can read them via `record.can(action)`. Read-side
+only: backend enforcement on the actual `update` / `destroy` /
+`create` commands is unchanged (the existing
+`abilities.update` / `abilities.destroy` / etc. in the resource
+config still guard every mutation).
+
+## Shapes
+
+Flat form — actions apply to the query's own model class:
+
+```js
+const timelogs = await Timelog
+  .where({taskId})
+  .abilities(["update", "destroy"])
+  .toArray()
+
+if (timelogs[0].can("update")) {
+  // ...render the edit button
+}
+```
+
+Keyed form — targets records by model name. Useful for preloaded
+children at any depth:
+
+```js
+const project = await Project
+  .preload({timelogs: true})
+  .abilities({Timelog: ["update", "destroy"]})
+  .first()
+
+const firstTimelog = project.timelogs().loaded()[0]
+firstTimelog.can("update") // → boolean
+```
+
+Keys in the keyed form are backend model names (as returned by
+`ModelClass.getModelName()` or the `modelName` field of the
+frontend-model resource config). Values are the ability-action
+strings — typically `"update"` / `"destroy"` / `"create"` /
+`"read"`, but any custom action registered on the resource's
+authorization ability is accepted.
+
+## How it runs
+
+After the main query loads its rows and applies preloads, the
+controller walks the loaded cohort and, for each
+`(modelClass, action)` pair in the spec, runs one batched
+`ModelClass.accessibleFor(action).where({id: IN (...loadedIds)}).pluck("id")`
+query. Each record's ability result lands on a dedicated
+`_computedAbilities` map and rides back on the wire as
+`__abilities: {update: true, destroy: false}` alongside the record's
+attributes. The frontend hydrates these into a per-record map that
+`record.can(action)` reads from.
+
+Defaults and edge cases:
+
+- `record.can(action)` returns `false` for actions that weren't
+  requested — so UI branches don't need to guard against unloaded
+  values.
+- An ability with no allow rules for the requested action on the
+  target model class returns `false` for every record, rather than
+  propagating the `accessibleFor` error to the UI.
+- Records that are filtered out by the base `read` ability never
+  reach the abilities evaluator (the authorized index query drops
+  them first). `.abilities(...)` only annotates records that are
+  already readable.
+
+## Interaction with other query methods
+
+- Combines cleanly with `.where(...)` / `.ransack(...)` /
+  `.preload(...)` / `.page(n).perPage(pp)` / `.withCount(...)` /
+  `.queryData(...)`. Each of those contributes its own payload
+  piece; the `abilities` key is additive.
+- `.find(id)` and `.findBy(conditions)` both carry the abilities
+  payload, so the `__abilities` attachment works for single-record
+  reads too.
+- `.count()` is unaffected — ability results don't change the row
+  count.
+
+## Wire format
+
+`FrontendModelQuery#abilities(spec)` normalizes the spec into an
+array of `{modelName, actions}` entries and sends them as the
+`abilities` key of the `index` / `find` command payload. The
+backend controller's `frontendModelAbilities()` parser reads them
+back out, `_frontendModelClassForAbilities(modelName)` resolves
+the model class via the configured `backendProjects[].frontendModels`
+registry, and `frontendModelComputeAbilities` attaches the results
+to the loaded records before serialization.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -26,6 +26,9 @@
 ## Association counts
 - `query.withCount("tasks")` attaches a per-row has-many count to each loaded record, read via `record.readCount("tasksCount")`. Accepts a relationship name, an array of names, or an object form with custom attribute names and per-association `where` filters. Polymorphic has-many is supported. See [with-count.md](with-count.md) for full usage and semantics.
 
+## Per-record abilities
+- `query.abilities(["update", "destroy"])` (flat form) or `query.abilities({Timelog: ["update"]})` (keyed form) asks the backend to evaluate the current ability against each returned record and attach the results for `record.can(action)` reads. The keyed form also walks preloaded children. See [abilities.md](abilities.md) for full usage and semantics.
+
 ## Ransack filtering and sorting
 - `ransack(params)` applies Rails-compatible ransack filters and sorting on both frontend and database model queries.
 - Supported predicates: `eq`, `notEq`, `in`, `notIn`, `gt`, `gteq`, `lt`, `lteq`, `cont`, `start`, `end`, `null`.

--- a/spec/frontend-models/abilities.http-integration-spec.js
+++ b/spec/frontend-models/abilities.http-integration-spec.js
@@ -1,0 +1,244 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Dummy from "../dummy/index.js"
+import FrontendModelBase from "../../src/frontend-models/base.js"
+import Project from "../dummy/src/models/project.js"
+import TaskModel from "../dummy/src/models/task.js"
+
+/** Frontend model used for per-record ability HTTP integration tests against dummy backend routes. */
+class Task extends FrontendModelBase {
+  /**
+   * @returns {{attributes: string[], commands: {destroy: string, find: string, index: string, update: string}}} - Resource config.
+   */
+  static resourceConfig() {
+    return {
+      attributes: ["id", "identifier", "isDone", "name"],
+      commands: {
+        destroy: "destroy",
+        find: "find",
+        index: "list",
+        update: "update"
+      }
+    }
+  }
+
+  /** @returns {unknown} */
+  id() { return this.readAttribute("id") }
+
+  /** @returns {unknown} */
+  name() { return this.readAttribute("name") }
+}
+
+/**
+ * @param {"destroy" | "read" | "update" | undefined} deniedAbilityAction - Ability action to deny.
+ * @param {() => Promise<void>} callback - Callback.
+ * @returns {Promise<void>}
+ */
+async function withDeniedTaskAbilityAction(deniedAbilityAction, callback) {
+  const previousDeniedAction = process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_DENY_ACTION
+
+  try {
+    process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_DENY_ACTION = deniedAbilityAction
+    await callback()
+  } finally {
+    if (previousDeniedAction === undefined) {
+      delete process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_DENY_ACTION
+    } else {
+      process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_DENY_ACTION = previousDeniedAction
+    }
+  }
+}
+
+/**
+ * @param {string} userReference - Scoped user reference for the subquery condition.
+ * @param {() => Promise<void>} callback - Callback.
+ * @returns {Promise<void>}
+ */
+async function withSubqueryAbilityScope(userReference, callback) {
+  const previous = process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_SUBQUERY_SCOPE
+
+  try {
+    process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_SUBQUERY_SCOPE = userReference
+    await callback()
+  } finally {
+    if (previous === undefined) {
+      delete process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_SUBQUERY_SCOPE
+    } else {
+      process.env.VELOCIOUS_DUMMY_FRONTEND_MODEL_SUBQUERY_SCOPE = previous
+    }
+  }
+}
+
+/** @returns {void} */
+function resetFrontendModelTransport() {
+  FrontendModelBase.configureTransport({
+    shared: undefined,
+    url: undefined,
+    websocketClient: undefined
+  })
+}
+
+/** @returns {void} */
+function configureNodeTransport() {
+  FrontendModelBase.configureTransport({
+    url: "http://127.0.0.1:3006"
+  })
+}
+
+/**
+ * @param {object} args - Arguments.
+ * @param {string} args.taskName - Task name.
+ * @param {string} [args.creatingUserReference] - Optional project owner reference.
+ * @returns {Promise<TaskModel>} - Created task model.
+ */
+async function createTaskWithProject({taskName, creatingUserReference}) {
+  const project = await Project.create({
+    creatingUserReference,
+    name: `Project for ${taskName}`
+  })
+
+  return /** @type {TaskModel} */ (await TaskModel.create({
+    name: taskName,
+    projectId: project.id()
+  }))
+}
+
+describe("Frontend models - per-record abilities http integration", {databaseCleaning: {transaction: false, truncate: true}}, () => {
+  it("hydrates record.can(action) for actions the ability allows in the flat-array form", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        await createTaskWithProject({taskName: "Allowed abilities task"})
+
+        const tasks = await Task.query().abilities(["update", "destroy"]).toArray()
+
+        expect(tasks.length).toBe(1)
+        expect(tasks[0].can("update")).toBe(true)
+        expect(tasks[0].can("destroy")).toBe(true)
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("returns can(action) === false for actions the current ability denies", async () => {
+    await withDeniedTaskAbilityAction("update", async () => {
+      await Dummy.run(async () => {
+        configureNodeTransport()
+
+        try {
+          await createTaskWithProject({taskName: "Denied update abilities task"})
+
+          const tasks = await Task.query().abilities(["update", "destroy"]).toArray()
+
+          expect(tasks.length).toBe(1)
+          expect(tasks[0].can("update")).toBe(false)
+          expect(tasks[0].can("destroy")).toBe(true)
+        } finally {
+          resetFrontendModelTransport()
+        }
+      })
+    })
+  })
+
+  it("evaluates abilities on records that pass a subquery-scoped allow rule", async () => {
+    await withSubqueryAbilityScope("owner-a", async () => {
+      await Dummy.run(async () => {
+        configureNodeTransport()
+
+        try {
+          await createTaskWithProject({
+            creatingUserReference: "owner-a",
+            taskName: "In-scope abilities task"
+          })
+          // The out-of-scope task is unreadable under the subquery
+          // scope, so it's filtered out by the authorized index query
+          // before abilities run — confirming that `abilities(...)`
+          // never attaches results to rows the base ability denies.
+          await createTaskWithProject({
+            creatingUserReference: "owner-b",
+            taskName: "Out-of-scope abilities task"
+          })
+
+          const scoped = await Task.query().abilities(["update", "destroy"]).toArray()
+
+          expect(scoped.length).toBe(1)
+          expect(scoped[0].name()).toBe("In-scope abilities task")
+          expect(scoped[0].can("update")).toBe(true)
+          expect(scoped[0].can("destroy")).toBe(true)
+        } finally {
+          resetFrontendModelTransport()
+        }
+      })
+    })
+  })
+
+  it("attaches record.can(action) on the find command", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        const backendTask = await createTaskWithProject({taskName: "Find-with-abilities task"})
+
+        const task = await Task.query().abilities(["update"]).find(backendTask.id())
+
+        expect(task.can("update")).toBe(true)
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("accepts the keyed `{ModelName: [actions]}` form for the root model", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        await createTaskWithProject({taskName: "Keyed-form task"})
+
+        const tasks = await Task.query().abilities({Task: ["update", "destroy"]}).toArray()
+
+        expect(tasks.length).toBe(1)
+        expect(tasks[0].can("update")).toBe(true)
+        expect(tasks[0].can("destroy")).toBe(true)
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("ignores unknown model names in the keyed form instead of crashing", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        await createTaskWithProject({taskName: "Unknown model key task"})
+
+        const tasks = await Task.query()
+          .abilities(/** @type {any} */ ({NoSuchModel: ["update"]}))
+          .toArray()
+
+        expect(tasks.length).toBe(1)
+        expect(tasks[0].can("update")).toBe(false)
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("rejects malformed action values at the frontend boundary", () => {
+    expect(() => {
+      Task.query().abilities(/** @type {any} */ ([""]))
+    }).toThrow(/abilities flat-form actions must be non-empty strings/)
+
+    expect(() => {
+      Task.query().abilities(/** @type {any} */ ({Task: "update"}))
+    }).toThrow(/must be an array of action names/)
+
+    expect(() => {
+      Task.query().abilities(/** @type {any} */ ({Task: [42]}))
+    }).toThrow(/entries must be non-empty strings/)
+  })
+})

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2759,6 +2759,63 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * Read a per-record ability result attached by `.abilities(...)`. The
+   * backend evaluates each requested action against the current ability
+   * for this record instance and ships the result alongside the
+   * record's attributes. Returns `false` when the action wasn't
+   * requested for this record — so UI code can safely branch on
+   * `record.can("update")` without first checking whether the ability
+   * was loaded.
+   *
+   * @param {string} action - Ability action name, e.g. `"update"`.
+   * @returns {boolean}
+   */
+  can(action) {
+    if (!this._computedAbilities) return false
+    if (!this._computedAbilities.has(action)) return false
+
+    return Boolean(this._computedAbilities.get(action))
+  }
+
+  /**
+   * Attach a per-record ability result to this record. Internal helper
+   * used by the `abilities` runner and by frontend-model hydration;
+   * outside code should not call this directly.
+   *
+   * @param {string} action - Ability action name.
+   * @param {boolean} value - Whether the current ability permits the action on this record.
+   * @returns {void}
+   */
+  _setComputedAbility(action, value) {
+    if (!this._computedAbilities) {
+      /** @type {Map<string, boolean>} */
+      this._computedAbilities = new Map()
+    }
+
+    this._computedAbilities.set(action, Boolean(value))
+  }
+
+  /**
+   * All attached per-record ability results as a plain object. Used
+   * by the frontend-model serializer to ship results alongside the
+   * record attributes on the wire.
+   *
+   * @returns {Record<string, boolean>}
+   */
+  computedAbilities() {
+    /** @type {Record<string, boolean>} */
+    const result = {}
+
+    if (!this._computedAbilities) return result
+
+    for (const [action, value] of this._computedAbilities) {
+      result[action] = value
+    }
+
+    return result
+  }
+
+  /**
    * Reads a column value from the record.
    * @param {string} attributeName The name of the column to read. This is the column name, not the attribute name.
    * @returns {any} - The column.

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -1511,6 +1511,190 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
+   * Resolve an entry from the frontend-model `abilities` payload to
+   * its backend model class by looking up the resource by modelName
+   * across all configured backend projects. Returns null when no
+   * resource matches — the spec entry is then silently ignored so a
+   * caller requesting abilities for a model they cannot resolve does
+   * not crash the request.
+   *
+   * @param {string} modelName
+   * @returns {typeof import("./database/record/index.js").default | null}
+   */
+  _frontendModelClassForAbilities(modelName) {
+    if (typeof modelName !== "string" || modelName.length === 0) return null
+
+    const configuration = this.getConfiguration()
+    const backendProjects = configuration?.getBackendProjects?.() ?? []
+
+    for (const backendProject of backendProjects) {
+      const frontendModels = backendProject?.frontendModels
+      if (!frontendModels || typeof frontendModels !== "object") continue
+
+      const resourceDefinition = frontendModels[modelName]
+      if (!resourceDefinition) continue
+
+      const resourceClass = frontendModelResourceClassFromDefinition(resourceDefinition)
+      if (!resourceClass) continue
+
+      const modelClass = typeof resourceClass.modelClass === "function"
+        ? resourceClass.modelClass()
+        : resourceClass.ModelClass
+
+      if (typeof modelClass === "function") return modelClass
+    }
+
+    return null
+  }
+
+  /**
+   * Collect every loaded record whose `getModelName()` matches the
+   * requested name, walking across the root-level slice plus any
+   * preloaded relationships at any depth. Used to evaluate per-record
+   * abilities against nested preloaded children with a single batched
+   * query per (modelClass, action) pair.
+   *
+   * @param {import("./database/record/index.js").default[]} rootModels
+   * @param {string} modelName
+   * @returns {import("./database/record/index.js").default[]}
+   */
+  _frontendModelCollectRecordsForName(rootModels, modelName) {
+    /** @type {import("./database/record/index.js").default[]} */
+    const out = []
+    /** @type {Set<import("./database/record/index.js").default>} */
+    const seen = new Set()
+
+    /** @param {import("./database/record/index.js").default | null | undefined} record */
+    const walk = (record) => {
+      if (!record || typeof record !== "object") return
+      if (seen.has(record)) return
+      seen.add(record)
+
+      const ModelClass = typeof record.getModelClass === "function"
+        ? record.getModelClass()
+        : null
+      if (ModelClass && typeof ModelClass.getModelName === "function" && ModelClass.getModelName() === modelName) {
+        out.push(record)
+      }
+
+      const relationshipsMap = typeof ModelClass?.getRelationshipsMap === "function"
+        ? ModelClass.getRelationshipsMap()
+        : null
+      if (!relationshipsMap) return
+
+      for (const relationshipName of Object.keys(relationshipsMap)) {
+        const relationship = typeof record.getRelationshipByName === "function"
+          ? record.getRelationshipByName(relationshipName)
+          : null
+        if (!relationship || typeof relationship.getLoadedOrUndefined !== "function") continue
+
+        const loaded = relationship.getLoadedOrUndefined()
+        if (loaded === undefined) continue
+
+        if (Array.isArray(loaded)) {
+          for (const child of loaded) walk(child)
+        } else {
+          walk(loaded)
+        }
+      }
+    }
+
+    for (const root of rootModels) walk(root)
+
+    return out
+  }
+
+  /**
+   * Evaluate every ability requested via the frontend `abilities`
+   * param against the loaded model cohort (plus any preloaded
+   * children), attaching the results to each record via
+   * `_setComputedAbility`. Runs one batched `authorized query + pluck`
+   * per (modelClass, action) pair, regardless of how many records
+   * were loaded.
+   *
+   * @param {import("./database/record/index.js").default[]} rootModels
+   * @returns {Promise<void>}
+   */
+  async frontendModelComputeAbilities(rootModels) {
+    const entries = this.frontendModelAbilities()
+    if (entries.length === 0) return
+    if (!Array.isArray(rootModels) || rootModels.length === 0) return
+
+    const ability = this.currentAbility()
+    if (!ability) return
+
+    for (const entry of entries) {
+      const modelClass = this._frontendModelClassForAbilities(entry.modelName)
+      if (!modelClass) continue
+
+      const candidates = this._frontendModelCollectRecordsForName(rootModels, entry.modelName)
+      if (candidates.length === 0) continue
+
+      const primaryKey = modelClass.primaryKey()
+      const ids = candidates
+        .map((record) => record.readAttribute(primaryKey))
+        .filter((value) => value !== null && value !== undefined)
+      if (ids.length === 0) continue
+
+      for (const action of entry.actions) {
+        let allowedIds
+        try {
+          const authorizedQuery = modelClass.accessibleFor(action, ability).where({[primaryKey]: ids})
+          const plucked = await authorizedQuery.pluck(primaryKey)
+          allowedIds = new Set(plucked.map((value) => String(value)))
+        } catch (error) {
+          // An ability with no allow rules for the action throws via
+          // `accessibleFor`; treat as a universal deny so the frontend
+          // gets `can(action) === false` for every candidate, instead
+          // of surfacing an error that the UI can't act on.
+          void error
+          allowedIds = new Set()
+        }
+
+        for (const record of candidates) {
+          const idValue = record.readAttribute(primaryKey)
+          const allowed = idValue !== null && idValue !== undefined && allowedIds.has(String(idValue))
+          record._setComputedAbility(action, allowed)
+        }
+      }
+    }
+  }
+
+  /**
+   * Parse the frontend-model `abilities` param into a list of
+   * `{modelName, actions}` entries to evaluate against loaded records.
+   * Unknown entries are silently skipped — downstream code resolves
+   * model names to classes when applying the check, so unresolved
+   * names naturally become no-ops.
+   *
+   * @returns {Array<{modelName: string, actions: string[]}>}
+   */
+  frontendModelAbilities() {
+    const raw = this.frontendModelParams().abilities
+
+    if (!Array.isArray(raw)) return []
+
+    /** @type {Array<{modelName: string, actions: string[]}>} */
+    const entries = []
+
+    for (const entry of raw) {
+      if (!entry || typeof entry !== "object") continue
+      if (typeof entry.modelName !== "string" || entry.modelName.length === 0) continue
+      if (!Array.isArray(entry.actions)) continue
+
+      const actions = entry.actions.filter(
+        (/** @type {unknown} */ action) => typeof action === "string" && action.length > 0
+      )
+
+      if (actions.length === 0) continue
+
+      entries.push({actions, modelName: entry.modelName})
+    }
+
+    return entries
+  }
+
+  /**
    * Read the frontend-model `queryData` param. The wire format carries
    * only **names** (the keys the frontend wants attached) plus the
    * optional nested-relationship chain leading to them — the actual SQL
@@ -2616,11 +2800,15 @@ export default class FrontendModelController extends Controller {
       const queryDataValues = typeof model.queryDataValues === "function"
         ? model.queryDataValues()
         : {}
+      const computedAbilities = typeof model.computedAbilities === "function"
+        ? model.computedAbilities()
+        : {}
       const hasCounts = Object.keys(associationCounts).length > 0
       const hasQueryData = Object.keys(queryDataValues).length > 0
+      const hasAbilities = Object.keys(computedAbilities).length > 0
       const hasPreloaded = Object.keys(preloadedRelationships).length > 0
 
-      if (!hasPreloaded && !hasCounts && !hasQueryData) {
+      if (!hasPreloaded && !hasCounts && !hasQueryData && !hasAbilities) {
         serializedModels.push(serializedAttributes)
         continue
       }
@@ -2631,6 +2819,7 @@ export default class FrontendModelController extends Controller {
       if (hasPreloaded) serialized.__preloadedRelationships = preloadedRelationships
       if (hasCounts) serialized.__associationCounts = associationCounts
       if (hasQueryData) serialized.__queryData = queryDataValues
+      if (hasAbilities) serialized.__abilities = computedAbilities
 
       serializedModels.push(serialized)
     }
@@ -2791,6 +2980,7 @@ export default class FrontendModelController extends Controller {
       }
 
       const models = await this.frontendModelRecords()
+      await this.frontendModelComputeAbilities(models)
       const serializedModels = await Promise.all(models.map(async (model) => await resource.serialize(model, "index")))
 
       return {
@@ -2925,6 +3115,7 @@ export default class FrontendModelController extends Controller {
         return this.frontendModelErrorPayload(`${modelClass.name} not found.`)
       }
 
+      await this.frontendModelComputeAbilities([model])
       const serializedModel = await resource.serialize(model, "find")
 
       return {

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -34,6 +34,7 @@ const PRELOADED_RELATIONSHIPS_KEY = "__preloadedRelationships"
 const SELECTED_ATTRIBUTES_KEY = "__selectedAttributes"
 const ASSOCIATION_COUNTS_KEY = "__associationCounts"
 const QUERY_DATA_KEY = "__queryData"
+const ABILITIES_KEY = "__abilities"
 /** @type {Array<{commandName?: string, commandType: FrontendModelRequestCommandType, customPath?: string, modelClass: typeof FrontendModelBase, payload: Record<string, any>, requestId: string, resolve: (response: Record<string, any>) => void, reject: (error: unknown) => void, resourcePath?: string | null}>} */
 let pendingSharedFrontendModelRequests = []
 let sharedFrontendModelRequestId = 0
@@ -1644,6 +1645,43 @@ export default class FrontendModelBase {
   }
 
   /**
+   * Read a per-record ability result attached by `.abilities(...)`. The
+   * backend evaluates each requested action against the current
+   * ability for this record instance and ships the result alongside
+   * the record's attributes. Returns `false` when the action wasn't
+   * requested (or the ability denied it), so UI code can safely branch
+   * on `record.can("update")` without first checking whether the
+   * ability was loaded.
+   *
+   * @param {string} action - Ability action name, e.g. `"update"`.
+   * @returns {boolean}
+   */
+  can(action) {
+    if (!this._computedAbilities) return false
+    if (!this._computedAbilities.has(action)) return false
+
+    return Boolean(this._computedAbilities.get(action))
+  }
+
+  /**
+   * Internal setter called by `instantiateFromResponse` when hydrating
+   * per-record ability results that rode along with the record
+   * payload.
+   *
+   * @param {string} action - Ability action name.
+   * @param {boolean} value - Whether the current ability permits the action on this record.
+   * @returns {void}
+   */
+  _setComputedAbility(action, value) {
+    if (!this._computedAbilities) {
+      /** @type {Map<string, boolean>} */
+      this._computedAbilities = new Map()
+    }
+
+    this._computedAbilities.set(action, Boolean(value))
+  }
+
+  /**
    * Read a consumer-defined value attached by `.queryData(...)`. Stored
    * on a dedicated map rather than `_attributes`, so a virtual alias
    * like `tasksCount` cannot silently shadow a real column of the same
@@ -2065,7 +2103,7 @@ export default class FrontendModelBase {
   /**
    * @this {typeof FrontendModelBase}
    * @param {object} response - Response payload.
-   * @returns {{attributes: Record<string, any>, associationCounts: Record<string, number>, queryData: Record<string, unknown>, preloadedRelationships: Record<string, any>, selectedAttributes: Set<string>}} - Attributes, preloaded relationships, association counts, queryData, and the selected-attributes set.
+   * @returns {{abilities: Record<string, boolean>, attributes: Record<string, any>, associationCounts: Record<string, number>, queryData: Record<string, unknown>, preloadedRelationships: Record<string, any>, selectedAttributes: Set<string>}} - Attributes, preloaded relationships, association counts, queryData, abilities, and the selected-attributes set.
    */
   static modelDataFromResponse(response) {
     if (!response || typeof response !== "object") {
@@ -2095,6 +2133,9 @@ export default class FrontendModelBase {
     const queryData = isPlainObject(attributes[QUERY_DATA_KEY])
       ? /** @type {Record<string, unknown>} */ (attributes[QUERY_DATA_KEY])
       : {}
+    const abilities = isPlainObject(attributes[ABILITIES_KEY])
+      ? /** @type {Record<string, boolean>} */ (attributes[ABILITIES_KEY])
+      : {}
     const selectedAttributesFromPayload = Array.isArray(attributes[SELECTED_ATTRIBUTES_KEY])
       ? new Set(/** @type {string[]} */ (attributes[SELECTED_ATTRIBUTES_KEY]).filter((attributeName) => typeof attributeName === "string"))
       : null
@@ -2103,10 +2144,11 @@ export default class FrontendModelBase {
     delete attributes[SELECTED_ATTRIBUTES_KEY]
     delete attributes[ASSOCIATION_COUNTS_KEY]
     delete attributes[QUERY_DATA_KEY]
+    delete attributes[ABILITIES_KEY]
 
     const selectedAttributes = selectedAttributesFromPayload || new Set(Object.keys(attributes))
 
-    return {attributes, associationCounts, queryData, preloadedRelationships, selectedAttributes}
+    return {abilities, attributes, associationCounts, queryData, preloadedRelationships, selectedAttributes}
   }
 
   /**
@@ -2155,6 +2197,7 @@ export default class FrontendModelBase {
     const preloadedRelationships = modelData.preloadedRelationships
     const associationCounts = modelData.associationCounts
     const queryData = modelData.queryData
+    const abilities = modelData.abilities
     const selectedAttributes = modelData.selectedAttributes
     const model = /** @type {InstanceType<T>} */ (new this(attributes))
     model._selectedAttributes = selectedAttributes ? new Set(selectedAttributes) : null
@@ -2167,6 +2210,10 @@ export default class FrontendModelBase {
 
     for (const [name, value] of Object.entries(queryData || {})) {
       model._setQueryData(name, value)
+    }
+
+    for (const [action, value] of Object.entries(abilities || {})) {
+      model._setComputedAbility(action, Boolean(value))
     }
 
     model.setIsNewRecord(false)

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -139,6 +139,63 @@ function normalizeWithCountFrontend(spec) {
 }
 
 /**
+ * Normalize a frontend `.abilities(...)` spec into a flat list of
+ * `{modelName, actions}` entries. Accepts the flat actions-array
+ * shorthand (applies to the query's own model class) and the keyed
+ * `{ModelName: [action, ...]}` form (applies to records of that model
+ * class, useful for preloaded children).
+ *
+ * @param {string[] | Record<string, string[]>} spec
+ * @param {{getModelName: () => string}} rootModelClass
+ * @returns {Array<{modelName: string, actions: string[]}>}
+ */
+function normalizeAbilitiesSpec(spec, rootModelClass) {
+  if (spec == null) return []
+
+  if (Array.isArray(spec)) {
+    for (const action of spec) {
+      if (typeof action !== "string" || action.length < 1) {
+        throw new Error(`abilities flat-form actions must be non-empty strings; got ${typeof action}`)
+      }
+    }
+
+    const rootModelName = typeof rootModelClass?.getModelName === "function"
+      ? rootModelClass.getModelName()
+      : undefined
+    if (!rootModelName) {
+      throw new Error("abilities flat-form requires a root model class with getModelName()")
+    }
+
+    return [{actions: [...spec], modelName: rootModelName}]
+  }
+
+  if (!isPlainObject(spec)) {
+    throw new Error(`Invalid abilities spec: ${typeof spec}`)
+  }
+
+  /** @type {Array<{modelName: string, actions: string[]}>} */
+  const entries = []
+
+  for (const [modelName, actions] of Object.entries(spec)) {
+    if (!Array.isArray(actions)) {
+      throw new Error(`abilities[${modelName}] must be an array of action names; got ${typeof actions}`)
+    }
+
+    const sanitized = actions.map((action) => {
+      if (typeof action !== "string" || action.length < 1) {
+        throw new Error(`abilities[${modelName}] entries must be non-empty strings; got ${typeof action}`)
+      }
+
+      return action
+    })
+
+    entries.push({actions: sanitized, modelName})
+  }
+
+  return entries
+}
+
+/**
  * @param {import("../database/query/index.js").NestedPreloadRecord} targetPreload - Existing preload data.
  * @param {import("../database/query/index.js").NestedPreloadRecord} incomingPreload - New preload data.
  * @returns {void}
@@ -977,6 +1034,74 @@ export default class FrontendModelQuery {
     this._withCount = []
     /** @type {Array<string | Record<string, any>>} */
     this._queryData = []
+    /**
+     * Per-record ability spec. Normalized to a list of
+     * `{modelName, actions}` entries — one entry per model that should
+     * have ability results attached. The root query's model class
+     * name is implicit via `"__root__"` when the caller used the flat
+     * array form.
+     * @type {Array<{modelName: string, actions: string[]}>}
+     */
+    this._abilities = []
+  }
+
+  /**
+   * Tell the backend to evaluate one or more ability actions against
+   * each returned record (and its preloaded relations, when keyed by
+   * model name) and ship the results back so the frontend can read
+   * them via `record.can(action)`.
+   *
+   * Flat form — applies to the query's own model class:
+   *   ```
+   *   const timelogs = await Timelog.where({taskId})
+   *     .abilities(["update", "destroy"])
+   *     .toArray()
+   *   timelogs[0].can("update") // → boolean
+   *   ```
+   *
+   * Keyed form — targets records by model name, useful for preloaded
+   * children:
+   *   ```
+   *   const project = await Project
+   *     .preload("timelogs")
+   *     .abilities({Timelog: ["update", "destroy"]})
+   *     .first()
+   *   project.timelogs().loaded()[0].can("update") // → boolean
+   *   ```
+   *
+   * Keys in the keyed form are the backend model names (as returned by
+   * `ModelClass.getModelName()` / the `modelName` field of the
+   * frontend-model resource config). Values are the ability-action
+   * strings — typically `"update"` / `"destroy"` / `"create"` /
+   * `"read"`, but any custom action registered on the resource's
+   * authorization ability is accepted.
+   *
+   * @param {string[] | Record<string, string[]>} spec
+   * @returns {this}
+   */
+  abilities(spec) {
+    for (const entry of normalizeAbilitiesSpec(spec, this.modelClass)) {
+      this._mergeAbilityEntry(entry)
+    }
+
+    return this
+  }
+
+  /**
+   * @param {{modelName: string, actions: string[]}} entry
+   * @returns {void}
+   */
+  _mergeAbilityEntry(entry) {
+    const existing = this._abilities.find((candidate) => candidate.modelName === entry.modelName)
+
+    if (!existing) {
+      this._abilities.push({actions: [...entry.actions], modelName: entry.modelName})
+      return
+    }
+
+    for (const action of entry.actions) {
+      if (!existing.actions.includes(action)) existing.actions.push(action)
+    }
   }
 
   /**
@@ -1299,6 +1424,10 @@ export default class FrontendModelQuery {
     newQuery._queryData = this._queryData.map((entry) => (
       typeof entry === "string" ? entry : JSON.parse(JSON.stringify(entry))
     ))
+    newQuery._abilities = this._abilities.map((entry) => ({
+      actions: [...entry.actions],
+      modelName: entry.modelName
+    }))
 
     return newQuery
   }
@@ -1328,6 +1457,20 @@ export default class FrontendModelQuery {
         attributeName: entry.attributeName,
         relationshipName: entry.relationshipName,
         where: entry.where || undefined
+      }))
+    }
+  }
+
+  /**
+   * @returns {Record<string, any>} - Payload abilities array when present.
+   */
+  abilitiesPayload() {
+    if (this._abilities.length === 0) return {}
+
+    return {
+      abilities: this._abilities.map((entry) => ({
+        actions: [...entry.actions],
+        modelName: entry.modelName
       }))
     }
   }
@@ -1465,6 +1608,7 @@ export default class FrontendModelQuery {
       ...this.sortPayload(),
       ...this.wherePayload(),
       ...this.withCountPayload(),
+      ...this.abilitiesPayload(),
       ...this.queryDataPayload(),
       ...this.paginationPayload()
     })
@@ -1621,6 +1765,7 @@ export default class FrontendModelQuery {
       ...this.groupPayload(),
       ...this.distinctPayload(),
       ...this.sortPayload(),
+      ...this.abilitiesPayload(),
       ...this.paginationPayload(),
       where: mergedWhere
     })


### PR DESCRIPTION
## Summary

Read-side API so UI code can ask the backend *"which actions does the current ability let the signed-in user perform on each of these records?"* and branch on the answer — without duplicating ability logic in the frontend or issuing one probe request per row.

```js
// Flat form — applies to the query's own model class
const timelogs = await Timelog.where({taskId})
  .abilities(["update", "destroy"])
  .toArray()
timelogs[0].can("update") // → boolean

// Keyed form — walks preloaded relationships of any depth
const project = await Project
  .preload({timelogs: true})
  .abilities({Timelog: ["update", "destroy"]})
  .first()
project.timelogs().loaded()[0].can("update") // → boolean
```

## Implementation

- `FrontendModelQuery#abilities(spec)` accepts the flat-array or keyed-object form, normalizes to `[{modelName, actions}]`, and ships on the `index` / `findBy` payload next to `withCount` / `queryData`.
- Backend controller resolves each `modelName` to its model class via `backendProjects[].frontendModels`, walks the loaded + preloaded record cohort, and runs one batched `modelClass.accessibleFor(action).where({id: IN (ids)}).pluck("id")` per `(modelClass, action)` pair — regardless of how many rows loaded.
- Results land on each record's `_computedAbilities` map, serialize as `__abilities: {update: true, destroy: false}`, and hydrate on the frontend so `record.can(action)` returns a boolean. Actions that weren't requested return `false` so UI branches don't need to guard against unloaded values.
- An `accessibleFor` throw (no allow rules for the requested action on the target model) is treated as a universal deny rather than propagated to the UI — matching the "can't do it" semantics.
- Backend enforcement on the actual update/destroy/create commands is unchanged. `.abilities(...)` is purely a read-side hint for which buttons the UI should show; mutations still go through the resource's ability config.

## Test plan
- [x] `npm run typecheck` + `npm run lint` clean (same warning count as master; no new lint errors).
- [x] New `spec/frontend-models/abilities.http-integration-spec.js` covers: flat form happy path, denied action returns `false`, subquery-scoped rule with base-read filtering, `find()` path, keyed form, unknown-model-name no-op, frontend-side validation of malformed input.
- [x] Full `spec/frontend-models` suite passes: 175 tests, 0 failures.

## Docs
- New `docs/abilities.md` (full usage and semantics).
- README bullet + cross-link from `docs/frontend-models.md`.
- Changelog fragment at `changelog.d/20260424-frontend-model-per-record-abilities.md`.