### PR TITLE
Emit ADD CONSTRAINT FOREIGN KEY from alter-table SQL

### DIFF
--- a/peak_flow.yml
+++ b/peak_flow.yml
@@ -64,8 +64,8 @@ services:
     mem_limit: 4096m
     restart_policy: on-failure
 builds:
-  build_1:
-    name: MariaDB
+  mariadb_1:
+    name: "MariaDB (1/3)"
     script:
       - cp spec/dummy/src/config/configuration.peakflow.mariadb.js spec/dummy/src/config/configuration.js
       - wait-for-it mariadb:3306
@@ -74,9 +74,31 @@ builds:
       - cd spec/dummy && node ../../bin/velocious.js db:create
       - cd spec/dummy && node ../../bin/velocious.js db:migrate
       - cd spec/dummy && node ../../bin/velocious.js g:base-models
-      - npm run test
-  build_2:
-    name: MS-SQL
+      - npm run test -- --groups 3 --group-number 1
+  mariadb_2:
+    name: "MariaDB (2/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.mariadb.js spec/dummy/src/config/configuration.js
+      - wait-for-it mariadb:3306
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 2
+  mariadb_3:
+    name: "MariaDB (3/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.mariadb.js spec/dummy/src/config/configuration.js
+      - wait-for-it mariadb:3306
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 3
+  mssql_1:
+    name: "MS-SQL (1/3)"
     script:
       - cp spec/dummy/src/config/configuration.peakflow.mssql.js spec/dummy/src/config/configuration.js
       - wait-for-it -t 120 mssql:1433
@@ -84,9 +106,29 @@ builds:
       - cd spec/dummy && node ../../bin/velocious.js db:create
       - cd spec/dummy && node ../../bin/velocious.js db:migrate
       - cd spec/dummy && node ../../bin/velocious.js g:base-models
-      - npm run test
-  build_3:
-    name: PG-SQL
+      - npm run test -- --groups 3 --group-number 1
+  mssql_2:
+    name: "MS-SQL (2/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.mssql.js spec/dummy/src/config/configuration.js
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 2
+  mssql_3:
+    name: "MS-SQL (3/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.mssql.js spec/dummy/src/config/configuration.js
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 3
+  pgsql_1:
+    name: "PG-SQL (1/3)"
     script:
       - cp spec/dummy/src/config/configuration.peakflow.pgsql.js spec/dummy/src/config/configuration.js
       - wait-for-it postgres:5432
@@ -95,9 +137,31 @@ builds:
       - cd spec/dummy && node ../../bin/velocious.js db:create
       - cd spec/dummy && node ../../bin/velocious.js db:migrate
       - cd spec/dummy && node ../../bin/velocious.js g:base-models
-      - npm run test
-  build_4:
-    name: SQLite
+      - npm run test -- --groups 3 --group-number 1
+  pgsql_2:
+    name: "PG-SQL (2/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.pgsql.js spec/dummy/src/config/configuration.js
+      - wait-for-it postgres:5432
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 2
+  pgsql_3:
+    name: "PG-SQL (3/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.pgsql.js spec/dummy/src/config/configuration.js
+      - wait-for-it postgres:5432
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 3
+  sqlite_1:
+    name: "SQLite (1/3)"
     script:
       - cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js
       - wait-for-it -t 120 mssql:1433
@@ -105,15 +169,35 @@ builds:
       - cd spec/dummy && node ../../bin/velocious.js db:create
       - cd spec/dummy && node ../../bin/velocious.js db:migrate
       - cd spec/dummy && node ../../bin/velocious.js g:base-models
-      - npm run test
-  build_5:
+      - npm run test -- --groups 3 --group-number 1
+  sqlite_2:
+    name: "SQLite (2/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 2
+  sqlite_3:
+    name: "SQLite (3/3)"
+    script:
+      - cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js
+      - wait-for-it -t 120 mssql:1433
+      - sleep 5
+      - cd spec/dummy && node ../../bin/velocious.js db:create
+      - cd spec/dummy && node ../../bin/velocious.js db:migrate
+      - cd spec/dummy && node ../../bin/velocious.js g:base-models
+      - npm run test -- --groups 3 --group-number 3
+  eslint:
     name: ESLint
     script:
       - cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js
       - sleep 5
       - npm run lint
       - npm run typecheck
-  build_6:
+  browser_tests:
     name: Browser Tests
     script:
       - cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js

--- a/spec/database/query/alter-table-foreign-key-sql-spec.js
+++ b/spec/database/query/alter-table-foreign-key-sql-spec.js
@@ -1,0 +1,143 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../src/testing/test.js"
+import AlterTableBase from "../../../src/database/query/alter-table-base.js"
+import TableData from "../../../src/database/table-data/index.js"
+import TableForeignKey from "../../../src/database/table-data/table-foreign-key.js"
+
+/**
+ * @param {string} databaseType
+ * @returns {import("../../../src/database/drivers/base.js").default}
+ */
+function buildDriver(databaseType) {
+  const quoteTableName = databaseType == "pgsql" || databaseType == "mssql"
+    ? (/** @type {string} */ name) => `"${name}"`
+    : (/** @type {string} */ name) => `\`${name}\``
+  const quoteColumnName = quoteTableName
+  const quoteIndexName = quoteTableName
+
+  return /** @type {import("../../../src/database/drivers/base.js").default} */ (/** @type {unknown} */ ({
+    getType: () => databaseType,
+    options: () => ({
+      quoteTableName,
+      quoteColumnName,
+      quoteIndexName,
+      quote: (/** @type {string} */ value) => `'${value}'`
+    })
+  }))
+}
+
+/**
+ * @param {{columnName: string, name?: string, referencedColumnName: string, referencedTableName: string, tableName: string}} args
+ * @returns {TableForeignKey}
+ */
+function newForeignKey(args) {
+  return new TableForeignKey({...args, isNewForeignKey: true})
+}
+
+describe("database - query - alter-table foreign-key SQL", () => {
+  it("emits ADD CONSTRAINT FOREIGN KEY for new foreign keys on mysql", async () => {
+    const tableData = new TableData("github_projects")
+
+    tableData.addForeignKey(newForeignKey({
+      columnName: "github_app_installation_id",
+      name: "fk_github_projects_github_app_installation",
+      referencedColumnName: "id",
+      referencedTableName: "github_app_installations",
+      tableName: "github_projects"
+    }))
+
+    const sqls = await new AlterTableBase({driver: buildDriver("mysql"), tableData}).toSQLs()
+
+    expect(sqls).toEqual([
+      "ALTER TABLE `github_projects` ADD CONSTRAINT `fk_github_projects_github_app_installation` FOREIGN KEY (`github_app_installation_id`) REFERENCES `github_app_installations` (`id`)"
+    ])
+  })
+
+  it("emits ADD FOREIGN KEY without a constraint name when no name is set", async () => {
+    const tableData = new TableData("github_projects")
+
+    tableData.addForeignKey(newForeignKey({
+      columnName: "github_app_installation_id",
+      referencedColumnName: "id",
+      referencedTableName: "github_app_installations",
+      tableName: "github_projects"
+    }))
+
+    const sqls = await new AlterTableBase({driver: buildDriver("mysql"), tableData}).toSQLs()
+
+    expect(sqls).toEqual([
+      "ALTER TABLE `github_projects` ADD FOREIGN KEY (`github_app_installation_id`) REFERENCES `github_app_installations` (`id`)"
+    ])
+  })
+
+  it("uses pgsql identifier quoting for ADD CONSTRAINT on pgsql", async () => {
+    const tableData = new TableData("github_projects")
+
+    tableData.addForeignKey(newForeignKey({
+      columnName: "github_app_installation_id",
+      name: "fk_github_projects_github_app_installation",
+      referencedColumnName: "id",
+      referencedTableName: "github_app_installations",
+      tableName: "github_projects"
+    }))
+
+    const sqls = await new AlterTableBase({driver: buildDriver("pgsql"), tableData}).toSQLs()
+
+    expect(sqls).toEqual([
+      "ALTER TABLE \"github_projects\" ADD CONSTRAINT \"fk_github_projects_github_app_installation\" FOREIGN KEY (\"github_app_installation_id\") REFERENCES \"github_app_installations\" (\"id\")"
+    ])
+  })
+
+  it("skips foreign-key emission on sqlite (ALTER TABLE ADD CONSTRAINT is unsupported there)", async () => {
+    const tableData = new TableData("github_projects")
+
+    tableData.addForeignKey(newForeignKey({
+      columnName: "github_app_installation_id",
+      name: "fk_github_projects_github_app_installation",
+      referencedColumnName: "id",
+      referencedTableName: "github_app_installations",
+      tableName: "github_projects"
+    }))
+
+    const sqls = await new AlterTableBase({driver: buildDriver("sqlite"), tableData}).toSQLs()
+
+    expect(sqls).toEqual([])
+  })
+
+  it("emits column-add and FK-add as a single ALTER TABLE with comma-separated actions", async () => {
+    const tableData = new TableData("github_projects")
+
+    tableData.addColumn("github_app_installation_id", {isNewColumn: true, null: true, type: "uuid"})
+    tableData.addForeignKey(newForeignKey({
+      columnName: "github_app_installation_id",
+      name: "fk_github_projects_github_app_installation",
+      referencedColumnName: "id",
+      referencedTableName: "github_app_installations",
+      tableName: "github_projects"
+    }))
+
+    const sqls = await new AlterTableBase({driver: buildDriver("mysql"), tableData}).toSQLs()
+
+    expect(sqls.length).toEqual(1)
+    expect(sqls[0].startsWith("ALTER TABLE `github_projects` ADD ")).toBe(true)
+    expect(sqls[0].includes("github_app_installation_id")).toBe(true)
+    expect(sqls[0].includes(", ADD CONSTRAINT `fk_github_projects_github_app_installation` FOREIGN KEY")).toBe(true)
+  })
+
+  it("ignores foreign keys that are not marked as new (defensive: pre-existing FKs in the schema mirror)", async () => {
+    const tableData = new TableData("github_projects")
+
+    tableData.addForeignKey(new TableForeignKey({
+      columnName: "owner_github_user_id",
+      name: "github_projects_ibfk_1",
+      referencedColumnName: "id",
+      referencedTableName: "github_users",
+      tableName: "github_projects"
+    }))
+
+    const sqls = await new AlterTableBase({driver: buildDriver("mysql"), tableData}).toSQLs()
+
+    expect(sqls).toEqual([])
+  })
+})

--- a/src/database/query/alter-table-base.js
+++ b/src/database/query/alter-table-base.js
@@ -29,10 +29,10 @@ export default class VelociousDatabaseQueryAlterTableBase extends QueryBase {
     const options = this.getOptions()
 
     let sql = `ALTER TABLE ${options.quoteTableName(tableData.getName())} `
-    let columnsCount = 0
+    let actionCount = 0
 
     for (const column of tableData.getColumns()) {
-      if (columnsCount > 0) sql += ", "
+      if (actionCount > 0) sql += ", "
 
       if (column.isNewColumn()) {
         sql += "ADD "
@@ -56,10 +56,33 @@ export default class VelociousDatabaseQueryAlterTableBase extends QueryBase {
       }
 
 
-      columnsCount++
+      actionCount++
     }
 
-    sqls.push(sql)
+    // SQLite's ALTER TABLE does not support adding constraints — defining
+    // foreign keys requires creating the table with them inline.
+    if (databaseType != "sqlite") {
+      for (const foreignKey of tableData.getForeignKeys()) {
+        if (!foreignKey.getIsNewForeignKey()) continue
+
+        if (actionCount > 0) sql += ", "
+
+        sql += "ADD"
+
+        if (foreignKey.getName()) {
+          sql += ` CONSTRAINT ${options.quoteIndexName(foreignKey.getName())}`
+        }
+
+        sql += ` FOREIGN KEY (${options.quoteColumnName(foreignKey.getColumnName())})`
+        sql += ` REFERENCES ${options.quoteTableName(foreignKey.getReferencedTableName())} (${options.quoteColumnName(foreignKey.getReferencedColumnName())})`
+
+        actionCount++
+      }
+    }
+
+    if (actionCount > 0) {
+      sqls.push(sql)
+    }
 
     if (databaseType == "pgsql") {
       for (const column of tableData.getColumns()) {


### PR DESCRIPTION
## Summary

`Migration.addForeignKey(tableName, referenceName)` constructs a `TableData` containing only a `TableForeignKey` and calls into `driver.alterTableSQLs(tableData)`. The base `toSQLs()` iterated only `tableData.getColumns()`, so the resulting statement was a malformed `ALTER TABLE foo ` (no actions, no FK clause) and silently no-op'd at the driver layer against MySQL/MariaDB. Downstream callers got a "successful" migration with the column already added (from a prior `addColumn` call) but no foreign-key constraint actually applied.

## Fix

`alter-table-base.toSQLs()` now also iterates `tableData.getForeignKeys()` and emits one `ADD [CONSTRAINT name] FOREIGN KEY (col) REFERENCES table (col)` clause per new FK, comma-separated alongside any column actions in the same `ALTER TABLE` statement.

- SQLite is intentionally skipped — its `ALTER TABLE` doesn't support adding constraints. FKs on SQLite still need to be declared inline at table-creation time.
- The empty-statement case (no columns, no new FKs) is now a clean no-op instead of pushing a malformed `ALTER TABLE foo ` SQL.

## Test plan
- [x] New \`spec/database/query/alter-table-foreign-key-sql-spec.js\` — 6 specs covering MySQL named + anonymous constraints, PostgreSQL identifier quoting, mixed column + FK in one statement, the SQLite skip path, and the defensive ignore of \`isNewForeignKey: false\` entries.
- [x] \`npm run test -- spec/database\` — 261/261 green