### PR TITLE
Add frontend model transport idle wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ Available transport options:
 
 - `url` (can also be a relative path like `"/frontend-models"` on web)
 
+Use `await FrontendModelBase.waitForIdle()` when a test harness or app lifecycle needs to wait for queued, scheduled, and active frontend-model transport requests to finish before resetting state.
+
 Frontend-model HTTP requests always use `credentials: "include"` so shared custom commands can set session cookies without app-level transport overrides.
 
 Unexpected frontend-model endpoint failures stay client-safe in production with `errorMessage: "Request failed."`.

--- a/changelog.d/20260429-frontend-model-wait-for-idle.md
+++ b/changelog.d/20260429-frontend-model-wait-for-idle.md
@@ -1,0 +1,3 @@
+## Frontend model transport idle waits
+
+- Added `FrontendModelBase.waitForIdle()` for teardown flows that need to wait for queued, scheduled, and active frontend-model transport requests before resetting app state.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -3,6 +3,7 @@
 ## Core transport
 - Frontend models run over HTTP transport, not local database connections.
 - Transport should be configured once via `FrontendModelBase.configureTransport(...)` (or wrapper APIs built on top of it).
+- `FrontendModelBase.waitForIdle()` waits until queued, scheduled, and active frontend-model transport requests have resolved. Browser/system-test harnesses can call it during teardown before resetting app state.
 - Keep request execution centralized in Velocious instead of per-project endpoint overrides.
 
 ## Frontend vs backend model API differences

--- a/spec/dummy/src/config/backend-projects.js
+++ b/spec/dummy/src/config/backend-projects.js
@@ -1,3 +1,4 @@
+import wait from "awaitery/build/wait.js"
 import FrontendModelBaseResource from "../../../../src/frontend-model-resource/base-resource.js"
 import Comment from "../models/comment.js"
 import Project from "../models/project.js"
@@ -68,7 +69,7 @@ class UserFrontendResource extends FrontendModelBaseResource {
       attributes: ["id", "email", "name", "createdAt"],
       builtInCollectionCommands: ["index"],
       builtInMemberCommands: ["find"],
-      collectionCommands: ["currentSessionCookie", "setSessionCookie", "lookupByEmail"],
+      collectionCommands: ["currentSessionCookie", "setSessionCookie", "lookupByEmail", "delayedLookupByEmail"],
       memberCommands: ["refreshProfile"]
     }
   }
@@ -101,6 +102,13 @@ class UserFrontendResource extends FrontendModelBaseResource {
     }
 
     return {users: await query.toArray()}
+  }
+
+  /** @returns {Promise<{users: import("../models/user.js").default[]}>} */
+  async delayedLookupByEmail() {
+    await wait(100)
+
+    return await this.lookupByEmail()
   }
 
   /** @returns {Promise<{user: import("../models/user.js").default | null}>} */

--- a/spec/frontend-models/base.browser-spec.js
+++ b/spec/frontend-models/base.browser-spec.js
@@ -71,6 +71,8 @@ class User extends FrontendModelBase {
   }
 }
 
+FrontendModelBase.registerModel(User)
+
 /** Frontend model that uses a stable backend model name different from its class name. */
 class MinifiedUserTransportModel extends FrontendModelBase {
   /**
@@ -110,6 +112,8 @@ class Comment extends FrontendModelBase {
   }
 }
 
+FrontendModelBase.registerModel(Comment)
+
 /** Frontend model task class for browser preload integration tests. */
 class Task extends FrontendModelBase {
   /**
@@ -147,6 +151,8 @@ class Task extends FrontendModelBase {
   primaryInteraction() { return this.getRelationshipByName("primaryInteraction").loaded() }
 }
 
+FrontendModelBase.registerModel(Task)
+
 /** Frontend model project class for browser preload integration tests. */
 class Project extends FrontendModelBase {
   /**
@@ -180,6 +186,8 @@ class Project extends FrontendModelBase {
     }
   }
 }
+
+FrontendModelBase.registerModel(Project)
 
 /** @returns {void} */
 function resetFrontendModelTransport() {

--- a/spec/frontend-models/base.browser-spec.js
+++ b/spec/frontend-models/base.browser-spec.js
@@ -16,7 +16,7 @@ class User extends FrontendModelBase {
       attributes: ["id", "email", "createdAt"],
       builtInCollectionCommands: ["index"],
       builtInMemberCommands: ["find"],
-      collectionCommands: ["currentSessionCookie", "setSessionCookie"],
+      collectionCommands: ["currentSessionCookie", "setSessionCookie", "lookupByEmail", "delayedLookupByEmail"],
       modelName: "User",
       primaryKey: "id"
     }
@@ -55,6 +55,19 @@ class User extends FrontendModelBase {
       payload,
       resourcePath: this.resourcePath()
     })
+  }
+
+  /**
+   * @param {Record<string, any>} [payload={}] - Command payload.
+   * @returns {Promise<{users: User[]}>} - Command response.
+   */
+  static async delayedLookupByEmail(payload = {}) {
+    return /** @type {Promise<{users: User[]}>} */ (this.executeCustomCommand({
+      commandName: "delayed-lookup-by-email",
+      commandType: "delayed-lookup-by-email",
+      payload,
+      resourcePath: this.resourcePath()
+    }))
   }
 }
 
@@ -311,6 +324,33 @@ describe("Frontend models - base browser integration", {databaseCleaning: {trans
       const user = await MinifiedUserTransportModel.findBy({email: "john@example.com"})
 
       expect(user?.email()).toEqual("john@example.com")
+    } finally {
+      resetFrontendModelTransport()
+    }
+  })
+
+  it("waits until pending shared browser requests are resolved", async () => {
+    if (!runBrowserHttpIntegration()) {
+      return
+    }
+
+    configureBrowserTransport()
+
+    try {
+      await seedUsers()
+      /** @type {{users: User[]} | undefined} */
+      let lookupResponse
+      const lookupResponsePromise = (async () => {
+        lookupResponse = await User.delayedLookupByEmail({email: "john@example.com"})
+      })()
+
+      try {
+        await FrontendModelBase.waitForIdle()
+
+        expect(lookupResponse?.users.map((user) => user.email())).toEqual(["john@example.com"])
+      } finally {
+        await lookupResponsePromise
+      }
     } finally {
       resetFrontendModelTransport()
     }

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -387,6 +387,38 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
     })
   })
 
+  it("waits for shared Node HTTP requests scheduled during the idle quiet period", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        const {john} = await seedHttpFrontendModels()
+        /** @type {{users: User[]} | undefined} */
+        let lookupResponse
+        const lookupResponsePromise = new Promise((resolve, reject) => {
+          setTimeout(async () => {
+            try {
+              lookupResponse = await User.delayedLookupByEmail({email: john.email()})
+              resolve(undefined)
+            } catch (error) {
+              reject(error)
+            }
+          }, 0)
+        })
+
+        try {
+          await FrontendModelBase.waitForIdle({quietMs: 25})
+
+          expect(lookupResponse?.users.map((user) => user.email())).toEqual([john.email()])
+        } finally {
+          await lookupResponsePromise
+        }
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
   it("delivers Phase 3 model lifecycle events via onCreate/onUpdate/onDestroy", async () => {
     await Dummy.run(async () => {
       const websocketClient = new WebsocketClient()

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -21,7 +21,7 @@ class User extends FrontendModelBase {
       attributes: ["id", "email", "createdAt"],
       builtInCollectionCommands: ["index"],
       builtInMemberCommands: ["find"],
-      collectionCommands: ["currentSessionCookie", "setSessionCookie"],
+      collectionCommands: ["currentSessionCookie", "setSessionCookie", "lookupByEmail", "delayedLookupByEmail"],
       modelName: "User",
       primaryKey: "id"
     }
@@ -70,6 +70,19 @@ class User extends FrontendModelBase {
     return /** @type {Promise<{users: User[]}>} */ (this.executeCustomCommand({
       commandName: "lookup-by-email",
       commandType: "lookup-by-email",
+      payload,
+      resourcePath: this.resourcePath()
+    }))
+  }
+
+  /**
+   * @param {Record<string, any>} [payload={}] - Command payload.
+   * @returns {Promise<{users: User[]}>} - Command response.
+   */
+  static async delayedLookupByEmail(payload = {}) {
+    return /** @type {Promise<{users: User[]}>} */ (this.executeCustomCommand({
+      commandName: "delayed-lookup-by-email",
+      commandType: "delayed-lookup-by-email",
       payload,
       resourcePath: this.resourcePath()
     }))
@@ -343,6 +356,31 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
         expect(lookupResponse.users[0].email()).toEqual(john.email())
         expect(refreshResponse.user instanceof User).toEqual(true)
         expect(refreshResponse.user?.email()).toEqual(jane.email())
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("waits until pending shared Node HTTP requests are resolved", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        const {john} = await seedHttpFrontendModels()
+        /** @type {{users: User[]} | undefined} */
+        let lookupResponse
+        const lookupResponsePromise = (async () => {
+          lookupResponse = await User.delayedLookupByEmail({email: john.email()})
+        })()
+
+        try {
+          await FrontendModelBase.waitForIdle()
+
+          expect(lookupResponse?.users.map((user) => user.email())).toEqual([john.email()])
+        } finally {
+          await lookupResponsePromise
+        }
       } finally {
         resetFrontendModelTransport()
       }

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -29,6 +29,7 @@ import {defineModelScope} from "../utils/model-scope.js"
  */
 /**
  * @typedef {object} FrontendModelIdleWaitArgs
+ * @property {number} [quietMs] - Milliseconds the transport must stay idle before resolving.
  * @property {number} [timeout] - Timeout in milliseconds.
  */
 
@@ -70,13 +71,30 @@ function resolveFrontendModelIdleWaiters() {
   }
 }
 
-/** @returns {Promise<void>} */
-async function waitForFrontendModelTransportIdle() {
+/**
+ * @param {number} milliseconds - Quiet period length.
+ * @returns {Promise<void>} Resolves after the quiet period.
+ */
+async function waitForFrontendModelTransportQuietPeriod(milliseconds) {
+  if (milliseconds <= 0) return
+
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+/**
+ * @param {number} quietMs - Milliseconds the transport must stay idle before resolving.
+ * @returns {Promise<void>} Resolves when transport stays idle.
+ */
+async function waitForFrontendModelTransportIdle(quietMs = 0) {
   while (true) {
     if (frontendModelTransportIsIdle()) {
       await new Promise((resolve) => queueMicrotask(() => resolve(undefined)))
 
-      if (frontendModelTransportIsIdle()) return
+      if (frontendModelTransportIsIdle()) {
+        await waitForFrontendModelTransportQuietPeriod(quietMs)
+
+        if (frontendModelTransportIsIdle()) return
+      }
     } else {
       await new Promise((resolve) => {
         frontendModelIdleResolvers.push(() => resolve(undefined))
@@ -1977,16 +1995,20 @@ export default class FrontendModelBase {
    * @returns {Promise<void>} - Resolves when transport is idle.
    */
   static async waitForIdle(args = {}) {
-    const {timeout: timeoutMs = 5000, ...restArgs} = args
+    const {quietMs = 0, timeout: timeoutMs = 5000, ...restArgs} = args
     const restArgKeys = Object.keys(restArgs)
 
     if (restArgKeys.length > 0) {
       throw new Error(`Unknown waitForIdle args: ${restArgKeys.join(", ")}`)
     }
 
+    if (!Number.isFinite(quietMs) || quietMs < 0) {
+      throw new Error(`Expected waitForIdle quietMs to be a non-negative number, got: ${quietMs}`)
+    }
+
     await timeout(
       {timeout: timeoutMs, errorMessage: "Timed out waiting for frontend model transport to become idle"},
-      async () => await waitForFrontendModelTransportIdle()
+      async () => await waitForFrontendModelTransportIdle(quietMs)
     )
   }
 

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import * as inflection from "inflection"
+import timeout from "awaitery/build/timeout.js"
 import FrontendModelQuery from "./query.js"
 import {registerFrontendModel, resolveFrontendModelClass} from "./model-registry.js"
 import {validateFrontendModelResourceCommandName, validateFrontendModelResourcePath} from "./resource-config-validation.js"
@@ -26,6 +27,10 @@ import {defineModelScope} from "../utils/model-scope.js"
  * @property {Record<string, string> | (() => Record<string, string>)} [requestHeaders] - Extra HTTP/WS headers to attach to every frontend-model API request. Pass a function to compute them at request time (for example to include the current locale).
  * @property {{get: () => string | null | undefined | Promise<string | null | undefined>, set: (sessionId: string) => void | Promise<void>, clear: () => void | Promise<void>}} [sessionStore] - Optional sessionId persistence hook forwarded to the internal `VelociousWebsocketClient` so WS sessions can be resumed across page reloads / app restarts.
  */
+/**
+ * @typedef {object} FrontendModelIdleWaitArgs
+ * @property {number} [timeout] - Timeout in milliseconds.
+ */
 
 /** @type {FrontendModelTransportConfig} */
 const frontendModelTransportConfig = {}
@@ -39,9 +44,62 @@ const ABILITIES_KEY = "__abilities"
 let pendingSharedFrontendModelRequests = []
 let sharedFrontendModelRequestId = 0
 let sharedFrontendModelFlushScheduled = false
+let activeFrontendModelTransportRequestCount = 0
+/** @type {Array<() => void>} */
+let frontendModelIdleResolvers = []
 
 /** @type {VelociousWebsocketClient | null} */
 let internalWebsocketClient = null
+
+/** @returns {boolean} - Whether all queued and active frontend-model transport requests are done. */
+function frontendModelTransportIsIdle() {
+  return activeFrontendModelTransportRequestCount === 0
+    && pendingSharedFrontendModelRequests.length === 0
+    && !sharedFrontendModelFlushScheduled
+}
+
+/** @returns {void} */
+function resolveFrontendModelIdleWaiters() {
+  if (!frontendModelTransportIsIdle()) return
+
+  const resolvers = frontendModelIdleResolvers
+  frontendModelIdleResolvers = []
+
+  for (const resolve of resolvers) {
+    resolve()
+  }
+}
+
+/** @returns {Promise<void>} */
+async function waitForFrontendModelTransportIdle() {
+  while (true) {
+    if (frontendModelTransportIsIdle()) {
+      await new Promise((resolve) => queueMicrotask(() => resolve(undefined)))
+
+      if (frontendModelTransportIsIdle()) return
+    } else {
+      await new Promise((resolve) => {
+        frontendModelIdleResolvers.push(() => resolve(undefined))
+      })
+    }
+  }
+}
+
+/**
+ * @template T
+ * @param {() => Promise<T>} callback - Transport callback.
+ * @returns {Promise<T>} - Callback result.
+ */
+async function trackFrontendModelTransportRequest(callback) {
+  activeFrontendModelTransportRequestCount += 1
+
+  try {
+    return await callback()
+  } finally {
+    activeFrontendModelTransportRequestCount -= 1
+    resolveFrontendModelIdleWaiters()
+  }
+}
 
 /**
  * Resolve the internal websocket client from websocketUrl config.
@@ -903,7 +961,10 @@ async function performSharedFrontendModelApiRequest(requestPayload) {
 async function flushPendingSharedFrontendModelRequests() {
   sharedFrontendModelFlushScheduled = false
 
-  if (pendingSharedFrontendModelRequests.length < 1) return
+  if (pendingSharedFrontendModelRequests.length < 1) {
+    resolveFrontendModelIdleWaiters()
+    return
+  }
 
   const batchedRequests = pendingSharedFrontendModelRequests
   pendingSharedFrontendModelRequests = []
@@ -930,27 +991,29 @@ async function flushPendingSharedFrontendModelRequests() {
     })
   }
 
-  try {
-    void url
-    const decodedResponse = await performSharedFrontendModelApiRequest(requestPayload)
-    const responses = Array.isArray(decodedResponse.responses) ? decodedResponse.responses : []
-    const responsesById = new Map(responses.map((entry) => [entry.requestId, entry.response]))
+  await trackFrontendModelTransportRequest(async () => {
+    try {
+      void url
+      const decodedResponse = await performSharedFrontendModelApiRequest(requestPayload)
+      const responses = Array.isArray(decodedResponse.responses) ? decodedResponse.responses : []
+      const responsesById = new Map(responses.map((entry) => [entry.requestId, entry.response]))
 
-    for (const request of batchedRequests) {
-      const responsePayload = responsesById.get(request.requestId)
+      for (const request of batchedRequests) {
+        const responsePayload = responsesById.get(request.requestId)
 
-      if (!responsePayload || typeof responsePayload !== "object") {
-        request.reject(new Error(`Missing batched response for ${request.modelClass.name}#${request.commandType}`))
-        continue
+        if (!responsePayload || typeof responsePayload !== "object") {
+          request.reject(new Error(`Missing batched response for ${request.modelClass.name}#${request.commandType}`))
+          continue
+        }
+
+        request.resolve(/** @type {Record<string, any>} */ (responsePayload))
       }
-
-      request.resolve(/** @type {Record<string, any>} */ (responsePayload))
+    } catch (error) {
+      for (const request of batchedRequests) {
+        request.reject(error)
+      }
     }
-  } catch (error) {
-    for (const request of batchedRequests) {
-      request.reject(error)
-    }
-  }
+  })
 }
 
 /** @returns {void} */
@@ -1906,6 +1969,25 @@ export default class FrontendModelBase {
     if (!internalWebsocketClient) return
 
     await internalWebsocketClient.disconnectAndStopReconnect()
+  }
+
+  /**
+   * Waits until queued and active frontend-model transport requests finish.
+   * @param {FrontendModelIdleWaitArgs} [args] - Wait options.
+   * @returns {Promise<void>} - Resolves when transport is idle.
+   */
+  static async waitForIdle(args = {}) {
+    const {timeout: timeoutMs = 5000, ...restArgs} = args
+    const restArgKeys = Object.keys(restArgs)
+
+    if (restArgKeys.length > 0) {
+      throw new Error(`Unknown waitForIdle args: ${restArgKeys.join(", ")}`)
+    }
+
+    await timeout(
+      {timeout: timeoutMs, errorMessage: "Timed out waiting for frontend model transport to become idle"},
+      async () => await waitForFrontendModelTransportIdle()
+    )
   }
 
   /**
@@ -3088,29 +3170,31 @@ export default class FrontendModelBase {
       return decodedBatchResponse
     }
 
-    const directResponse = await fetch(url, {
-      body: JSON.stringify(serializedPayload),
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      method: "POST"
+    return await trackFrontendModelTransportRequest(async () => {
+      const directResponse = await fetch(url, {
+        body: JSON.stringify(serializedPayload),
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        method: "POST"
+      })
+
+      if (!directResponse.ok) {
+        throw new Error(`Request failed (${directResponse.status}) for ${this.name}#${commandType}`)
+      }
+
+      const directResponseText = await directResponse.text()
+      const directJson = directResponseText.length > 0 ? JSON.parse(directResponseText) : {}
+      const decodedDirectResponse = /** @type {Record<string, any>} */ (deserializeFrontendModelTransportValue(directJson))
+
+      this.throwOnErrorFrontendModelResponse({
+        commandType,
+        response: decodedDirectResponse
+      })
+
+      return decodedDirectResponse
     })
-
-    if (!directResponse.ok) {
-      throw new Error(`Request failed (${directResponse.status}) for ${this.name}#${commandType}`)
-    }
-
-    const directResponseText = await directResponse.text()
-    const directJson = directResponseText.length > 0 ? JSON.parse(directResponseText) : {}
-    const decodedDirectResponse = /** @type {Record<string, any>} */ (deserializeFrontendModelTransportValue(directJson))
-
-    this.throwOnErrorFrontendModelResponse({
-      commandType,
-      response: decodedDirectResponse
-    })
-
-    return decodedDirectResponse
   }
 
   /**


### PR DESCRIPTION
## Summary
- add FrontendModelBase.waitForIdle() for queued, scheduled, and active frontend-model transport requests
- track shared-batch and direct command transport work until caller promises are resolved
- document the teardown use case and add Node/browser integration coverage

## Verification
- npm run typecheck
- npm run lint
- npm run build
- npm test -- spec/frontend-models/base.http-integration-spec.js (blocked: local dummy DB user cannot run SET FOREIGN_KEY_CHECKS = 0 against configured MySQL)