### PR TITLE
Add test attempt failure event

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,18 @@ it("retries a flaky check", {retry: 2}, async () => {})
 
 During a failing run, Velocious captures all console output emitted while each test executes. At the end of a failed run, those logs are saved under `tmp/screenshots` next to failure screenshots/browser logs/HTML, and each failed test summary prints the saved console log path.
 
-Listen for retry events if you need to restart services between attempts.
+Listen for attempt and retry events if you need to reset shared state after a failed attempt or log retry lifecycle details. `testAttemptFailed` fires after every failed attempt, including the final failed attempt when no retries remain. `testRetrying` only fires before a retry, and `testFailed` only fires after retries are exhausted.
 
 ```js
 import {testEvents} from "velocious/build/src/testing/test.js"
+
+testEvents.on("testAttemptFailed", async ({testDescription, attemptNumber, willRetry}) => {
+  console.log(`Failed ${testDescription} attempt ${attemptNumber}`)
+
+  if (willRetry) {
+    await resetBrowserOrExternalServices()
+  }
+})
 
 testEvents.on("testRetrying", ({testDescription, nextAttempt}) => {
   console.log(`Retrying ${testDescription} (attempt ${nextAttempt})`)

--- a/changelog.d/20260430-test-attempt-failed-event.md
+++ b/changelog.d/20260430-test-attempt-failed-event.md
@@ -1,0 +1,1 @@
+Add a `testAttemptFailed` event for test runners that need to reset shared state after any failed attempt, including retryable attempts.

--- a/spec/testing/test-runner-events-spec.js
+++ b/spec/testing/test-runner-events-spec.js
@@ -239,6 +239,86 @@ describe("TestRunner events", () => {
     expect(retriedEvents[0].testRunner).toBe(testRunner)
   })
 
+  it("emits and waits for testAttemptFailed for every failed attempt", async () => {
+    const environmentHandler = new EnvironmentHandlerNode()
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler,
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const testRunner = new TestRunner({configuration, testFiles: []})
+
+    /** @type {any[]} */
+    const attemptFailedEvents = []
+    let firstAttemptFailureHandled = false
+    const handler = async (payload) => {
+      attemptFailedEvents.push(payload)
+
+      if (payload.attemptNumber === 1) {
+        await delay(20)
+        firstAttemptFailureHandled = true
+      }
+    }
+
+    testEvents.on("testAttemptFailed", handler)
+
+    try {
+      let attempts = 0
+      const tests = {
+        args: {},
+        afterEaches: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "fails twice": {
+            args: {retry: 1},
+            function: async () => {
+              attempts++
+
+              if (attempts === 2) {
+                expect(firstAttemptFailureHandled).toBe(true)
+              }
+
+              throw new Error(`boom ${attempts}`)
+            }
+          }
+        }
+      }
+
+      await testRunner.runTests({
+        afterEaches: [],
+        beforeEaches: [],
+        tests,
+        descriptions: [],
+        indentLevel: 0
+      })
+    } finally {
+      testEvents.off("testAttemptFailed", handler)
+    }
+
+    expect(attemptFailedEvents.length).toBe(2)
+    expect(attemptFailedEvents[0].testDescription).toBe("fails twice")
+    expect(attemptFailedEvents[0].attemptNumber).toBe(1)
+    expect(attemptFailedEvents[0].retriesUsed).toBe(1)
+    expect(attemptFailedEvents[0].retryCount).toBe(1)
+    expect(attemptFailedEvents[0].nextAttempt).toBe(2)
+    expect(attemptFailedEvents[0].willRetry).toBe(true)
+    expect(attemptFailedEvents[0].error.message).toBe("boom 1")
+    expect(attemptFailedEvents[0].testRunner).toBe(testRunner)
+    expect(attemptFailedEvents[1].attemptNumber).toBe(2)
+    expect(attemptFailedEvents[1].retriesUsed).toBe(1)
+    expect(attemptFailedEvents[1].retryCount).toBe(1)
+    expect(attemptFailedEvents[1].nextAttempt).toBeUndefined()
+    expect(attemptFailedEvents[1].willRetry).toBe(false)
+    expect(attemptFailedEvents[1].error.message).toBe("boom 2")
+    expect(attemptFailedEvents[1].testRunner).toBe(testRunner)
+  })
+
   it("collects failed test details for summary output", async () => {
     const environmentHandler = new EnvironmentHandlerNode()
     const configuration = new Configuration({

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -718,8 +718,28 @@ export default class TestRunner {
               })
             } catch (error) {
               lastError = error
-              if (retriesUsed < retryCount) {
+              const willRetry = retriesUsed < retryCount
+
+              if (willRetry) {
                 retriesUsed++
+              }
+
+              await this.emitEvent("testAttemptFailed", {
+                configuration: this.getConfiguration(),
+                descriptions,
+                error,
+                attemptNumber,
+                nextAttempt: willRetry ? attemptNumber + 1 : undefined,
+                retriesUsed,
+                retryCount,
+                testArgs,
+                testData,
+                testDescription,
+                testRunner: this,
+                willRetry
+              })
+
+              if (willRetry) {
                 shouldRetry = true
                 console.warn(picocolors.red(`${leftPadding}  Retrying (${retriesUsed}/${retryCount}) after error: ${error instanceof Error ? error.message : String(error)}`))
                 await this.emitEvent("testRetrying", {


### PR DESCRIPTION
## Summary
- add testAttemptFailed for every failed test attempt
- document retry/failure event semantics
- cover the new event in runner specs

## Verification
- npm run lint (passes with existing warnings)
- npm run typecheck
- npm run build
- npm run test -- spec/testing/test-runner-events-spec.js in a clean temporary worktree