### PR TITLE
[codex] Add completed request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1360,6 +1360,14 @@ class MyLogger extends BaseLogger {
 
 - **Per-instance control**: You can create a `new Logger("Subject", {configuration, debug: false})` to honor the configuration defaults, or toggle `logger.setDebug(true)` for verbose output in specific cases.
 
+- **Request completion logging**: HTTP and websocket-routed controller requests log a Rails-style completion line after the response is served:
+
+```text
+Completed 200 OK in 1603ms (Controller: 107.8ms | Views: 1097.4ms | DB: 381.8ms (2 queries) | Velocious: 16.0ms)
+```
+
+`Controller` measures before callbacks plus action work, excluding nested view rendering and database queries. `Views` measures JSON/view rendering and file-response setup. `DB` measures database driver query time and query count. `Velocious` is the remaining framework overhead, including routing, request setup, timeout handling, and response writing.
+
 ## Listen for framework errors
 
 Velocious emits framework errors (including uncaught controller action errors) on the configuration error event bus:

--- a/changelog.d/20260430-rails-style-completed-request-logging.md
+++ b/changelog.d/20260430-rails-style-completed-request-logging.md
@@ -1,0 +1,1 @@
+Add Rails-style completed request logging with Controller, Views, DB, and Velocious timing buckets plus per-request DB query counts.

--- a/spec/database/drivers/mssql/query-reconnect-spec.js
+++ b/spec/database/drivers/mssql/query-reconnect-spec.js
@@ -4,7 +4,7 @@ import mssql from "mssql"
 import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
 import {describe, expect, it} from "../../../../src/testing/test.js"
 
-describe("Database - drivers - mssql query reconnect", () => {
+describe("Database - drivers - mssql query reconnect", {databaseCleaning: {transaction: false, truncate: false}}, () => {
   it("recreates requests after reconnecting", async () => {
     const originalRequest = mssql.Request
     let tries = 0
@@ -28,7 +28,11 @@ describe("Database - drivers - mssql query reconnect", () => {
     mssql.Request = FakeRequest
 
     try {
-      const driver = new MssqlDriver({sqlConfig: {}}, {debug: false})
+      const configuration = /** @type {any} */ ({
+        debug: false,
+        getCurrentRequestTiming: () => undefined
+      })
+      const driver = new MssqlDriver({sqlConfig: {}}, configuration)
       driver.connection = undefined
 
       driver.connect = async () => {

--- a/spec/database/drivers/mysql/reconnect-spec.js
+++ b/spec/database/drivers/mysql/reconnect-spec.js
@@ -3,9 +3,14 @@
 import MysqlDriver from "../../../../src/database/drivers/mysql/index.js"
 import {describe, expect, it} from "../../../../src/testing/test.js"
 
-describe("Database - drivers - mysql reconnect", () => {
+const configuration = /** @type {any} */ ({
+  debug: false,
+  getCurrentRequestTiming: () => undefined
+})
+
+describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction: false, truncate: false}}, () => {
   it("connects when the pool is missing", async () => {
-    const driver = new MysqlDriver({}, {debug: false})
+    const driver = new MysqlDriver({}, configuration)
     let didConnect = false
 
     driver.connect = async () => {
@@ -25,7 +30,7 @@ describe("Database - drivers - mysql reconnect", () => {
   })
 
   it("escapes values without a pool", () => {
-    const driver = new MysqlDriver({}, {debug: false})
+    const driver = new MysqlDriver({}, configuration)
 
     const escaped = driver.escape("hello")
     const quoted = driver.quote("hello")
@@ -35,7 +40,7 @@ describe("Database - drivers - mysql reconnect", () => {
   })
 
   it("retries and reconnects after connection failures", async () => {
-    const driver = new MysqlDriver({}, {debug: false})
+    const driver = new MysqlDriver({}, configuration)
     let connectCount = 0
     let closeCount = 0
     let attempts = 0
@@ -70,7 +75,7 @@ describe("Database - drivers - mysql reconnect", () => {
   })
 
   it("raises when a reconnect would bypass an active transaction", async () => {
-    const driver = new MysqlDriver({}, {debug: false})
+    const driver = new MysqlDriver({}, configuration)
     let didReconnect = false
 
     driver._transactionsCount = 1

--- a/spec/http-server/request-completed-logging-spec.js
+++ b/spec/http-server/request-completed-logging-spec.js
@@ -177,4 +177,24 @@ describe("HttpServer - request completed logging", {databaseCleaning: {transacti
 
     expect(summary.dbQueryCount).toEqual(1)
   })
+
+  it("includes active bucket elapsed time in request timing summaries", () => {
+    const requestTiming = new RequestTiming()
+
+    requestTiming.startedAtMs = 1000
+    requestTiming.responseServedAtMs = 1500
+    requestTiming.buckets.controller = 100
+    requestTiming.buckets.db = 25
+    requestTiming.buckets.views = 50
+    requestTiming.bucketStack.push({bucket: "controller", startedAtMs: 1200})
+
+    const summary = requestTiming.summary()
+
+    expect(summary.totalMs).toEqual(500)
+    expect(summary.controllerMs).toEqual(400)
+    expect(summary.dbMs).toEqual(25)
+    expect(summary.viewsMs).toEqual(50)
+    expect(summary.velociousMs).toEqual(25)
+    expect(requestTiming.buckets.controller).toEqual(100)
+  })
 })

--- a/spec/http-server/request-completed-logging-spec.js
+++ b/spec/http-server/request-completed-logging-spec.js
@@ -1,0 +1,180 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import Controller from "../../src/controller.js"
+import DatabaseDriverBase from "../../src/database/drivers/base.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import LoggerArrayOutput from "../../src/logger/outputs/array-output.js"
+import Request from "../../src/http-server/client/request.js"
+import RequestRunner from "../../src/http-server/client/request-runner.js"
+import RequestTiming from "../../src/http-server/client/request-timing.js"
+import dummyDirectory from "../dummy/dummy-directory.js"
+import dummyRoutes from "../dummy/src/config/routes.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class DbTimingController extends Controller {
+  async show() {
+    const requestTiming = this.getConfiguration().getCurrentRequestTiming()
+
+    if (!requestTiming) throw new Error("Missing request timing")
+
+    await requestTiming.measureDbQuery(async () => {})
+    await this.render({json: {status: "success"}})
+  }
+}
+
+class TestDriver extends DatabaseDriverBase {
+  async _queryActual() {
+    return []
+  }
+
+  async connect() {}
+
+  getType() { return "test" }
+  primaryKeyType() { return "bigint" }
+  queryToSql() { return "" }
+}
+
+/** @returns {{arrayOutput: LoggerArrayOutput, configuration: Configuration, restore: () => void}} - Test configuration. */
+function buildConfiguration() {
+  const arrayOutput = new LoggerArrayOutput()
+  const configuration = new Configuration({
+    database: {test: {}},
+    directory: dummyDirectory(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    logging: {loggers: [arrayOutput]}
+  })
+  let previousConfiguration
+
+  try {
+    previousConfiguration = Configuration.current()
+  } catch {
+    // Ignore missing current configuration.
+  }
+
+  configuration.setCurrent()
+  configuration.setRoutes(dummyRoutes.routes)
+
+  return {
+    arrayOutput,
+    configuration,
+    restore: () => {
+      if (previousConfiguration) previousConfiguration.setCurrent()
+    }
+  }
+}
+
+/**
+ * @param {Configuration} configuration - Configuration.
+ * @param {string} path - Request path.
+ * @returns {Promise<RequestRunner>} - Completed request runner.
+ */
+async function runRequest(configuration, path) {
+  const request = new Request({client: {remoteAddress: "127.0.0.1"}, configuration})
+  const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+  const requestLines = [
+    `GET ${path} HTTP/1.1`,
+    "Host: example.com",
+    "",
+    ""
+  ].join("\r\n")
+
+  request.feed(Buffer.from(requestLines, "utf8"))
+  await donePromise
+
+  const requestRunner = new RequestRunner({configuration, request})
+
+  await requestRunner.run()
+  await requestRunner.logCompletedRequest()
+
+  return requestRunner
+}
+
+/** @param {import("../../src/configuration-types.js").LoggingOutputPayload[]} logs - Logs. */
+function completedMessages(logs) {
+  return logs
+    .map((log) => log.message)
+    .filter((message) => message.includes("Completed "))
+}
+
+describe("HttpServer - request completed logging", {databaseCleaning: {transaction: false, truncate: false}}, async () => {
+  it("logs completed request metrics after the matching request start log", async () => {
+    const {arrayOutput, configuration, restore} = buildConfiguration()
+
+    try {
+      await runRequest(configuration, "/ping")
+    } finally {
+      restore()
+    }
+
+    const logs = arrayOutput.getLogs()
+    const startedIndex = logs.findIndex((log) => log.message.includes("Started GET \"/ping\""))
+    const completedIndex = logs.findIndex((log) => log.message.includes("Completed 200 OK"))
+    const completed = logs[completedIndex]
+
+    expect(startedIndex).toBeGreaterThanOrEqual(0)
+    expect(completedIndex).toBeGreaterThan(startedIndex)
+    expect(completed.subject).toEqual("RootController")
+    expect(completed.level).toEqual("debug")
+    expect(completed.message).toMatch(/^RootController Completed 200 OK in \d+ms \(Controller: \d+\.\dms \| Views: \d+\.\dms \| DB: 0\.0ms \(0 queries\) \| Velocious: \d+\.\dms\)$/)
+  })
+
+  it("includes DB query count in completed request logs", async () => {
+    const {arrayOutput, configuration, restore} = buildConfiguration()
+
+    configuration.addRouteResolverHook(({currentPath}) => {
+      if (currentPath !== "/db-timing") return null
+
+      return {
+        action: "show",
+        controller: "db-timing",
+        controllerClass: DbTimingController
+      }
+    })
+
+    try {
+      await runRequest(configuration, "/db-timing")
+    } finally {
+      restore()
+    }
+
+    expect(completedMessages(arrayOutput.getLogs())[0]).toMatch(/^DbTimingController Completed 200 OK in \d+ms \(Controller: \d+\.\dms \| Views: \d+\.\dms \| DB: \d+\.\dms \(1 query\) \| Velocious: \d+\.\dms\)$/)
+  })
+
+  it("logs completed request metrics for error responses", async () => {
+    const {arrayOutput, configuration, restore} = buildConfiguration()
+
+    try {
+      const requestRunner = await runRequest(configuration, "/missing-view")
+
+      expect(requestRunner.response.getStatusCode()).toEqual(500)
+    } finally {
+      restore()
+    }
+
+    expect(completedMessages(arrayOutput.getLogs())[0]).toMatch(/^RootController Completed 500 Internal server error in \d+ms \(Controller: \d+\.\dms \| Views: \d+\.\dms \| DB: 0\.0ms \(0 queries\) \| Velocious: \d+\.\dms\)$/)
+  })
+
+  it("tracks database driver query metrics through the current request timing context", async () => {
+    const {configuration, restore} = buildConfiguration()
+    const requestTiming = new RequestTiming()
+    const driver = new TestDriver({}, configuration)
+
+    try {
+      await configuration.runWithRequestTiming(requestTiming, async () => {
+        await driver.query("SELECT 1")
+      })
+    } finally {
+      restore()
+    }
+
+    const summary = requestTiming.summary()
+
+    expect(summary.dbQueryCount).toEqual(1)
+  })
+})

--- a/spec/http-server/request-runner-spec.js
+++ b/spec/http-server/request-runner-spec.js
@@ -3,7 +3,7 @@
 import VelociousHttpServerClientRequestRunner from "../../src/http-server/client/request-runner.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 
-describe("HttpServer - request runner", async () => {
+describe("HttpServer - request runner", {databaseCleaning: {transaction: false, truncate: false}}, async () => {
   it("logs a cleaned backtrace when request processing fails", async () => {
     const originalConsoleError = console.error
     const consoleErrorWrites = []
@@ -28,7 +28,8 @@ describe("HttpServer - request runner", async () => {
         },
         getErrorEvents: () => ({
           emit: () => {}
-        })
+        }),
+        runWithRequestTiming: async (_requestTiming, callback) => await callback()
       })
       const request = /** @type {any} */ ({
         header: () => undefined,
@@ -73,7 +74,8 @@ describe("HttpServer - request runner", async () => {
         },
         getErrorEvents: () => ({
           emit: () => {}
-        })
+        }),
+        runWithRequestTiming: async (_requestTiming, callback) => await callback()
       })
       const request = /** @type {any} */ ({
         header: () => undefined,
@@ -117,7 +119,8 @@ describe("HttpServer - request runner", async () => {
         },
         getErrorEvents: () => ({
           emit: () => {}
-        })
+        }),
+        runWithRequestTiming: async (_requestTiming, callback) => await callback()
       })
       const request = /** @type {any} */ ({
         header: () => undefined,

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1250,10 +1250,26 @@ export default class VelociousConfiguration {
   }
 
   /**
+   * @param {import("./http-server/client/request-timing.js").default | undefined} requestTiming - Request timing collector.
+   * @param {() => Promise<any>} callback - Callback.
+   * @returns {Promise<any>} - Callback result.
+   */
+  async runWithRequestTiming(requestTiming, callback) {
+    return await this.getEnvironmentHandler().runWithRequestTiming(requestTiming, callback)
+  }
+
+  /**
    * @returns {import("./authorization/ability.js").default | undefined} - Current ability from context.
    */
   getCurrentAbility() {
     return this.getEnvironmentHandler().getCurrentAbility()
+  }
+
+  /**
+   * @returns {import("./http-server/client/request-timing.js").default | undefined} - Current request timing collector.
+   */
+  getCurrentRequestTiming() {
+    return this.getEnvironmentHandler().getCurrentRequestTiming()
   }
 
   /**

--- a/src/controller.js
+++ b/src/controller.js
@@ -217,14 +217,25 @@ export default class VelociousController {
 
   /** @param {object} json - JSON payload. */
   renderJsonArg(json) {
-    const body = JSON.stringify(serializeFrontendModelTransportValue(json))
+    return this._measureViewRender(() => {
+      const body = JSON.stringify(serializeFrontendModelTransportValue(json))
 
-    this._response.setHeader("Content-Type", "application/json; charset=UTF-8")
-    this._response.setBody(body)
+      this._response.setHeader("Content-Type", "application/json; charset=UTF-8")
+      this._response.setBody(body)
+    })
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
   renderView() {
+    const requestTiming = this.getConfiguration().getCurrentRequestTiming?.()
+
+    return requestTiming
+      ? requestTiming.measure("views", async () => await this._renderViewActual())
+      : this._renderViewActual()
+  }
+
+  /** @returns {Promise<void>} - Resolves when complete. */
+  _renderViewActual() {
     return new Promise((resolve, reject) => {
       const viewPath = `${this._viewPath}/${inflection.dasherize(inflection.underscore(this._action))}.ejs`
       const actualViewParams = incorporate({controller: this}, this.viewParams)
@@ -271,25 +282,40 @@ export default class VelociousController {
    * @returns {void} - No return value.
    */
   sendFile(filePath, args = {}) {
-    const {contentType, status, ...restArgs} = args
+    this._measureViewRender(() => {
+      const {contentType, status, ...restArgs} = args
 
-    restArgsError(restArgs)
+      restArgsError(restArgs)
 
-    if (typeof filePath !== "string" || filePath.length < 1) {
-      throw new Error(`Expected file path to be a non-empty string, got: ${String(filePath)}`)
-    }
+      if (typeof filePath !== "string" || filePath.length < 1) {
+        throw new Error(`Expected file path to be a non-empty string, got: ${String(filePath)}`)
+      }
 
-    const detectedContentType = contentType || this.sendFileContentType(filePath)
+      const detectedContentType = contentType || this.sendFileContentType(filePath)
 
-    if (detectedContentType) {
-      this._response.setHeader("Content-Type", detectedContentType)
-    }
+      if (detectedContentType) {
+        this._response.setHeader("Content-Type", detectedContentType)
+      }
 
-    if (status) {
-      this._response.setStatus(status)
-    }
+      if (status) {
+        this._response.setStatus(status)
+      }
 
-    this._response.setFilePath(filePath)
+      this._response.setFilePath(filePath)
+    })
+  }
+
+  /**
+   * @template T
+   * @param {() => T} callback - Callback to measure.
+   * @returns {T} - Callback result.
+   */
+  _measureViewRender(callback) {
+    const requestTiming = this.getConfiguration().getCurrentRequestTiming?.()
+
+    return requestTiming
+      ? requestTiming.measureSync("views", callback)
+      : callback()
   }
 
   /**

--- a/src/controller.js
+++ b/src/controller.js
@@ -227,7 +227,7 @@ export default class VelociousController {
 
   /** @returns {Promise<void>} - Resolves when complete.  */
   renderView() {
-    const requestTiming = this.getConfiguration().getCurrentRequestTiming?.()
+    const requestTiming = this.getConfiguration().getCurrentRequestTiming()
 
     return requestTiming
       ? requestTiming.measure("views", async () => await this._renderViewActual())
@@ -311,7 +311,7 @@ export default class VelociousController {
    * @returns {T} - Callback result.
    */
   _measureViewRender(callback) {
-    const requestTiming = this.getConfiguration().getCurrentRequestTiming?.()
+    const requestTiming = this.getConfiguration().getCurrentRequestTiming()
 
     return requestTiming
       ? requestTiming.measureSync("views", callback)

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -700,11 +700,18 @@ export default class VelociousDatabaseDriversBase {
 
     let tries = 0
     const maxTries = 5
+    const requestTiming = this.configuration.getCurrentRequestTiming?.()
 
     while (tries < maxTries) {
       tries++
 
       try {
+        if (requestTiming && tries === 1) {
+          return await requestTiming.measureDbQuery(async () => await this._queryActual(sql))
+        } else if (requestTiming) {
+          return await requestTiming.measure("db", async () => await this._queryActual(sql))
+        }
+
         return await this._queryActual(sql)
       } catch (error) {
         if (!(error instanceof Error)) throw error

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -700,7 +700,7 @@ export default class VelociousDatabaseDriversBase {
 
     let tries = 0
     const maxTries = 5
-    const requestTiming = this.configuration.getCurrentRequestTiming?.()
+    const requestTiming = this.configuration.getCurrentRequestTiming()
 
     while (tries < maxTries) {
       tries++

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -69,6 +69,28 @@ export default class VelociousEnvironmentHandlerBase {
   }
 
   /**
+   * @param {import("../http-server/client/request-timing.js").default | undefined} requestTiming - Request timing collector.
+   * @param {() => Promise<any>} callback - Callback.
+   * @returns {Promise<any>} - Callback result.
+   */
+  async runWithRequestTiming(requestTiming, callback) {
+    this._currentRequestTiming = requestTiming
+
+    try {
+      return await callback()
+    } finally {
+      this._currentRequestTiming = undefined
+    }
+  }
+
+  /**
+   * @returns {import("../http-server/client/request-timing.js").default | undefined} - Current request timing collector.
+   */
+  getCurrentRequestTiming() {
+    return this._currentRequestTiming
+  }
+
+  /**
    * @param {import("../authorization/ability.js").default | undefined} ability - Ability to set for callback scope.
    * @param {() => Promise<any>} callback - Callback.
    * @returns {Promise<any>} - Callback result.

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -28,7 +28,7 @@ import path from "path"
 import {AsyncLocalStorage as NodeAsyncLocalStorage} from "node:async_hooks"
 import toImportSpecifier from "../utils/to-import-specifier.js"
 
-/** @typedef {{ability?: import("../authorization/ability.js").default, offsetMinutes: number, tenant?: unknown}} TimezoneStore */
+/** @typedef {{ability?: import("../authorization/ability.js").default, offsetMinutes: number, requestTiming?: import("../http-server/client/request-timing.js").default, tenant?: unknown}} TimezoneStore */
 
 /**
  * @param {string} filePath - Input file path.
@@ -173,6 +173,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
     return await this._timezoneAsyncLocalStorage.run({
       ability: existingStore?.ability,
       offsetMinutes,
+      requestTiming: existingStore?.requestTiming,
       tenant: existingStore?.tenant
     }, callback)
   }
@@ -194,6 +195,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       this._timezoneAsyncLocalStorage.enterWith({
         ability: existingStore?.ability,
         offsetMinutes,
+        requestTiming: existingStore?.requestTiming,
         tenant: existingStore?.tenant
       })
     }
@@ -230,6 +232,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
     return await this._timezoneAsyncLocalStorage.run({
       ability,
       offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
+      requestTiming: existingStore?.requestTiming,
       tenant: existingStore?.tenant
     }, callback)
   }
@@ -252,6 +255,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       this._timezoneAsyncLocalStorage.enterWith({
         ability,
         offsetMinutes: this.getTimezoneOffsetMinutes(this.getConfiguration()),
+        requestTiming: undefined,
         tenant: undefined
       })
     }
@@ -269,6 +273,37 @@ export default class VelociousEnvironmentHandlerNode extends Base{
   }
 
   /**
+   * @param {import("../http-server/client/request-timing.js").default | undefined} requestTiming - Request timing collector.
+   * @param {() => Promise<any>} callback - Callback.
+   * @returns {Promise<any>} - Callback result.
+   */
+  async runWithRequestTiming(requestTiming, callback) {
+    if (!this._timezoneAsyncLocalStorage) {
+      return await super.runWithRequestTiming(requestTiming, callback)
+    }
+
+    const existingStore = this._timezoneAsyncLocalStorage.getStore()
+
+    return await this._timezoneAsyncLocalStorage.run({
+      ability: existingStore?.ability,
+      offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
+      requestTiming,
+      tenant: existingStore?.tenant
+    }, callback)
+  }
+
+  /**
+   * @returns {import("../http-server/client/request-timing.js").default | undefined} - Current request timing collector.
+   */
+  getCurrentRequestTiming() {
+    if (!this._timezoneAsyncLocalStorage) {
+      return super.getCurrentRequestTiming()
+    }
+
+    return this._timezoneAsyncLocalStorage.getStore()?.requestTiming
+  }
+
+  /**
    * @param {unknown} tenant - Tenant to set for callback scope.
    * @param {() => Promise<any>} callback - Callback.
    * @returns {Promise<any>} - Callback result.
@@ -283,6 +318,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
     return await this._timezoneAsyncLocalStorage.run({
       ability: existingStore?.ability,
       offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
+      requestTiming: existingStore?.requestTiming,
       tenant
     }, callback)
   }
@@ -305,6 +341,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       this._timezoneAsyncLocalStorage.enterWith({
         ability: undefined,
         offsetMinutes: this.getTimezoneOffsetMinutes(this.getConfiguration()),
+        requestTiming: undefined,
         tenant
       })
     }

--- a/src/http-server/client/index.js
+++ b/src/http-server/client/index.js
@@ -402,6 +402,8 @@ export default class VeoliciousHttpServerClient {
       this.logger.debug(() => ["sendResponse body emitted", {clientCount: this.clientCount, bodyLength: bodyIsString ? body.length : body.byteLength}])
     }
 
+    await requestRunner.logCompletedRequest()
+
     if ("getRequestParser" in request) {
       const httpRequest = /** @type {import("./request.js").default} */ (request)
       httpRequest.getRequestParser().destroy()

--- a/src/http-server/client/request-runner.js
+++ b/src/http-server/client/request-runner.js
@@ -4,6 +4,7 @@ import BacktraceCleaner from "../../utils/backtrace-cleaner.js"
 import ensureError from "../../utils/ensure-error.js"
 import EventEmitter from "../../utils/event-emitter.js"
 import Logger from "../../logger.js"
+import RequestTiming from "./request-timing.js"
 import Response from "./response.js"
 import RoutesResolver from "../../routes/resolver.js"
 
@@ -81,6 +82,22 @@ function responseBodyTypeForLog(response) {
   }
 }
 
+/**
+ * @param {number} value - Milliseconds.
+ * @returns {string} - Formatted milliseconds with one decimal place.
+ */
+function formatBucketMs(value) {
+  return `${value.toFixed(1)}ms`
+}
+
+/**
+ * @param {number} count - Query count.
+ * @returns {string} - Query count label.
+ */
+function queryCountLabel(count) {
+  return `${count} ${count === 1 ? "query" : "queries"}`
+}
+
 export default class VelociousHttpServerClientRequestRunner {
   events = new EventEmitter()
 
@@ -97,6 +114,8 @@ export default class VelociousHttpServerClientRequestRunner {
     this.configuration = configuration
     this.request = request
     this.response = new Response({configuration})
+    this.completedRequestLogged = false
+    this.requestTiming = new RequestTiming()
     this.state = "running"
   }
 
@@ -104,6 +123,14 @@ export default class VelociousHttpServerClientRequestRunner {
   getState() { return this.state }
 
   async run() {
+    this.requestTiming.startedAtMs = Date.now()
+
+    return await this.configuration.runWithRequestTiming(this.requestTiming, async () => {
+      await this._run()
+    })
+  }
+
+  async _run() {
     const {configuration, request, response} = this
 
     if (!request) throw new Error("No request?")
@@ -240,5 +267,32 @@ export default class VelociousHttpServerClientRequestRunner {
     }])
     this.state = "done"
     this.events.emit("done", this)
+  }
+
+  /** @returns {Promise<void>} - Logs the completed request line after the response has been served. */
+  async logCompletedRequest() {
+    if (this.completedRequestLogged) return
+
+    this.completedRequestLogged = true
+
+    const requestTiming = this.requestTiming
+
+    requestTiming.markResponseServed()
+
+    if (!requestTiming.completedLogSubject || !requestTiming.completedLogMethod) return
+
+    const logger = new Logger(requestTiming.completedLogSubject, {configuration: this.configuration})
+    const summary = requestTiming.summary()
+    const response = this.response
+    const completedMessage = [
+      `Completed ${response.getStatusCode()} ${response.getStatusMessage()} in ${Math.round(summary.totalMs)}ms (`,
+      `Controller: ${formatBucketMs(summary.controllerMs)}`,
+      ` | Views: ${formatBucketMs(summary.viewsMs)}`,
+      ` | DB: ${formatBucketMs(summary.dbMs)} (${queryCountLabel(summary.dbQueryCount)})`,
+      ` | Velocious: ${formatBucketMs(summary.velociousMs)}`,
+      `)`
+    ].join("")
+
+    await logger[requestTiming.completedLogMethod](completedMessage)
   }
 }

--- a/src/http-server/client/request-timing.js
+++ b/src/http-server/client/request-timing.js
@@ -1,0 +1,130 @@
+// @ts-check
+
+/**
+ * @typedef {"controller" | "db" | "views"} RequestTimingBucket
+ */
+
+/**
+ * @typedef {{bucket: RequestTimingBucket, startedAtMs: number}} ActiveTimingBucket
+ */
+
+/**
+ * Tracks exclusive request timing buckets. When a nested bucket starts,
+ * the currently active bucket is paused until the nested bucket exits.
+ */
+export default class RequestTiming {
+  /** @type {Record<RequestTimingBucket, number>} */
+  buckets = {
+    controller: 0,
+    db: 0,
+    views: 0
+  }
+
+  /** @type {ActiveTimingBucket[]} */
+  bucketStack = []
+
+  dbQueryCount = 0
+  /** @type {"debug" | "info" | undefined} */
+  completedLogMethod = undefined
+  /** @type {string | undefined} */
+  completedLogSubject = undefined
+  /** @type {number | undefined} */
+  responseServedAtMs = undefined
+  startedAtMs = Date.now()
+
+  /**
+   * @template T
+   * @param {RequestTimingBucket} bucket - Bucket name.
+   * @param {() => Promise<T> | T} callback - Callback to measure.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async measure(bucket, callback) {
+    this._pushBucket(bucket)
+
+    try {
+      return await callback()
+    } finally {
+      this._popBucket()
+    }
+  }
+
+  /**
+   * @template T
+   * @param {RequestTimingBucket} bucket - Bucket name.
+   * @param {() => T} callback - Callback to measure.
+   * @returns {T} - Callback result.
+   */
+  measureSync(bucket, callback) {
+    this._pushBucket(bucket)
+
+    try {
+      return callback()
+    } finally {
+      this._popBucket()
+    }
+  }
+
+  /**
+   * @template T
+   * @param {() => Promise<T>} callback - Query callback.
+   * @returns {Promise<T>} - Query result.
+   */
+  async measureDbQuery(callback) {
+    this.dbQueryCount += 1
+
+    return await this.measure("db", callback)
+  }
+
+  /** @returns {void} - Marks the response as fully served. */
+  markResponseServed() {
+    this.responseServedAtMs = Date.now()
+  }
+
+  /**
+   * @returns {{controllerMs: number, dbMs: number, totalMs: number, velociousMs: number, viewsMs: number, dbQueryCount: number}} - Timing summary.
+   */
+  summary() {
+    const totalMs = (this.responseServedAtMs || Date.now()) - this.startedAtMs
+    const controllerMs = this.buckets.controller
+    const dbMs = this.buckets.db
+    const viewsMs = this.buckets.views
+    const velociousMs = Math.max(totalMs - controllerMs - dbMs - viewsMs, 0)
+
+    return {
+      controllerMs,
+      dbMs,
+      dbQueryCount: this.dbQueryCount,
+      totalMs,
+      velociousMs,
+      viewsMs
+    }
+  }
+
+  /**
+   * @param {RequestTimingBucket} bucket - Bucket name.
+   * @returns {void} - No return value.
+   */
+  _pushBucket(bucket) {
+    const now = Date.now()
+    const activeBucket = this.bucketStack[this.bucketStack.length - 1]
+
+    if (activeBucket) {
+      this.buckets[activeBucket.bucket] += now - activeBucket.startedAtMs
+    }
+
+    this.bucketStack.push({bucket, startedAtMs: now})
+  }
+
+  /** @returns {void} - No return value. */
+  _popBucket() {
+    const now = Date.now()
+    const activeBucket = this.bucketStack.pop()
+
+    if (!activeBucket) throw new Error("No active request timing bucket")
+
+    this.buckets[activeBucket.bucket] += now - activeBucket.startedAtMs
+
+    const parentBucket = this.bucketStack[this.bucketStack.length - 1]
+    if (parentBucket) parentBucket.startedAtMs = now
+  }
+}

--- a/src/http-server/client/request-timing.js
+++ b/src/http-server/client/request-timing.js
@@ -84,10 +84,12 @@ export default class RequestTiming {
    * @returns {{controllerMs: number, dbMs: number, totalMs: number, velociousMs: number, viewsMs: number, dbQueryCount: number}} - Timing summary.
    */
   summary() {
-    const totalMs = (this.responseServedAtMs || Date.now()) - this.startedAtMs
-    const controllerMs = this.buckets.controller
-    const dbMs = this.buckets.db
-    const viewsMs = this.buckets.views
+    const now = this.responseServedAtMs || Date.now()
+    const buckets = this._bucketTotalsAt(now)
+    const totalMs = now - this.startedAtMs
+    const controllerMs = buckets.controller
+    const dbMs = buckets.db
+    const viewsMs = buckets.views
     const velociousMs = Math.max(totalMs - controllerMs - dbMs - viewsMs, 0)
 
     return {
@@ -98,6 +100,21 @@ export default class RequestTiming {
       velociousMs,
       viewsMs
     }
+  }
+
+  /**
+   * @param {number} now - Timestamp to calculate active bucket elapsed time against.
+   * @returns {Record<RequestTimingBucket, number>} - Bucket totals.
+   */
+  _bucketTotalsAt(now) {
+    const buckets = Object.assign({}, this.buckets)
+    const activeBucket = this.bucketStack[this.bucketStack.length - 1]
+
+    if (activeBucket) {
+      buckets[activeBucket.bucket] += Math.max(now - activeBucket.startedAtMs, 0)
+    }
+
+    return buckets
   }
 
   /**

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -511,6 +511,9 @@ export default class VelociousHttpServerClientWebsocketSession {
         statusMessage: response.getStatusMessage(),
         type: "response"
       })
+      void requestRunner.logCompletedRequest().catch((error) => {
+        this.logger.warn("Failed to log completed request", error)
+      })
     })
 
     await requestRunner.run()

--- a/src/routes/resolver.js
+++ b/src/routes/resolver.js
@@ -181,7 +181,10 @@ export default class VelociousRoutesResolver {
 
     const actionHandlers = /** @type {Record<string, () => void | Promise<void>>} */ (/** @type {unknown} */ (controllerInstance))
 
-    await this._logActionStart({action, controllerClass})
+    const logMethod = this._logMethod()
+
+    this._setCompletedLogMetadata({controllerClass, logMethod})
+    await this._logActionStart({action, controllerClass, logMethod})
 
     try {
       const tenant = await this.configuration.resolveTenant({
@@ -200,8 +203,10 @@ export default class VelociousRoutesResolver {
             })
 
             await this.configuration.runWithAbility(ability, async () => {
-              await controllerInstance._runBeforeCallbacks()
-              await actionHandlers[action]()
+              await this._measureController(async () => {
+                await controllerInstance._runBeforeCallbacks()
+                await actionHandlers[action]()
+              })
             })
           })
         })
@@ -362,14 +367,14 @@ export default class VelociousRoutesResolver {
    * @param {object} args - Options object.
    * @param {string} args.action - Action.
    * @param {typeof import("../controller.js").default} args.controllerClass - Controller class.
+   * @param {"debug" | "info"} args.logMethod - Logger method.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async _logActionStart({action, controllerClass}) {
+  async _logActionStart({action, controllerClass, logMethod}) {
     const request = this.request
     const timestamp = this._formatTimestamp(new Date())
     const remoteAddress = request.remoteAddress?.() || request.header("x-forwarded-for") || "unknown"
     const loggedParams = /** @type {Record<string, unknown>} */ (this._sanitizeParamsForLogging(this.params))
-    const logMethod = this.configuration.getEnvironment() === "test" ? "debug" : "info"
 
     delete loggedParams.action
     delete loggedParams.controller
@@ -379,6 +384,39 @@ export default class VelociousRoutesResolver {
     await controllerLogger[logMethod](() => `Started ${request.httpMethod()} "${request.path()}" for ${remoteAddress} at ${timestamp}`)
     await controllerLogger[logMethod](() => `Processing by ${controllerClass.name}#${action}`)
     await controllerLogger[logMethod](() => [`  Parameters:`, loggedParams])
+  }
+
+  /** @returns {"debug" | "info"} - Request log method. */
+  _logMethod() {
+    return this.configuration.getEnvironment() === "test" ? "debug" : "info"
+  }
+
+  /**
+   * @template T
+   * @param {() => Promise<T>} callback - Callback to measure.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async _measureController(callback) {
+    const requestTiming = this.configuration.getCurrentRequestTiming?.()
+
+    return requestTiming
+      ? await requestTiming.measure("controller", callback)
+      : await callback()
+  }
+
+  /**
+   * @param {object} args - Options object.
+   * @param {typeof import("../controller.js").default} args.controllerClass - Controller class.
+   * @param {"debug" | "info"} args.logMethod - Logger method.
+   * @returns {void} - No return value.
+   */
+  _setCompletedLogMetadata({controllerClass, logMethod}) {
+    const requestTiming = this.configuration.getCurrentRequestTiming?.()
+
+    if (!requestTiming) return
+
+    requestTiming.completedLogSubject = controllerClass.name
+    requestTiming.completedLogMethod = logMethod
   }
 
   /**

--- a/src/routes/resolver.js
+++ b/src/routes/resolver.js
@@ -397,7 +397,7 @@ export default class VelociousRoutesResolver {
    * @returns {Promise<T>} - Callback result.
    */
   async _measureController(callback) {
-    const requestTiming = this.configuration.getCurrentRequestTiming?.()
+    const requestTiming = this.configuration.getCurrentRequestTiming()
 
     return requestTiming
       ? await requestTiming.measure("controller", callback)
@@ -411,7 +411,7 @@ export default class VelociousRoutesResolver {
    * @returns {void} - No return value.
    */
   _setCompletedLogMetadata({controllerClass, logMethod}) {
-    const requestTiming = this.configuration.getCurrentRequestTiming?.()
+    const requestTiming = this.configuration.getCurrentRequestTiming()
 
     if (!requestTiming) return
 


### PR DESCRIPTION
## Summary
- add Rails-style completed request logs with Controller, Views, DB, and Velocious timing buckets
- track per-request DB query count and DB timing through the database driver query path
- document the completed log format and add a changelog fragment

## Validation
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm run test -- spec/http-server/request-completed-logging-spec.js

## Notes
- `spec/dummy/src/config/configuration.js` has pre-existing local changes and is intentionally not included in this PR.