### PR TITLE
[codex] Add Rails-style query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1403,6 +1403,8 @@ Task Load (1.9ms)  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`id` = 1 LIMIT 1
 
 Model queries use operation names such as `Task Load`, `Task Count`, `Task Pluck`, `Task Create`, `Task Update`, and `Task Destroy`. Raw driver queries use `SQL`. The source arrow is included only when Velocious can identify an application frame; dependency and framework frames such as `node_modules` are omitted.
 
+Query logging defaults to off in the `test` environment to keep CI output quiet. Override it with `logging: {queryLogging: true}` when a test build should write SQL timing logs, and use the normal logging output settings to send those logs to console or file.
+
 ## Listen for framework errors
 
 Velocious emits framework errors (including uncaught controller action errors) on the configuration error event bus:

--- a/README.md
+++ b/README.md
@@ -1403,7 +1403,7 @@ Task Load (1.9ms)  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`id` = 1 LIMIT 1
 
 Model queries use operation names such as `Task Load`, `Task Count`, `Task Pluck`, `Task Create`, `Task Update`, and `Task Destroy`. Raw driver queries use `SQL`. The source arrow is included only when Velocious can identify an application frame; dependency and framework frames such as `node_modules` are omitted.
 
-Query logging defaults to off in the `test` environment to keep CI output quiet. Override it with `logging: {queryLogging: true}` when a test build should write SQL timing logs, and use the normal logging output settings to send those logs to console or file.
+Query logging defaults to off in the `test` environment to keep CI output quiet and is skipped when no output emits `info`. Override it with `logging: {queryLogging: true}` when a test build should write SQL timing logs, and use the normal logging output settings to send those logs to console or file.
 
 ## Listen for framework errors
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)` on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon` (see [docs/beacon.md](docs/beacon.md))
+* Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 
 # Setup
 
@@ -1392,6 +1393,15 @@ Completed 200 OK in 1603ms (Controller: 107.8ms | Views: 1097.4ms | DB: 381.8ms 
 ```
 
 `Controller` measures before callbacks plus action work, excluding nested view rendering and database queries. `Views` measures JSON/view rendering and file-response setup. `DB` measures database driver query time and query count. `Velocious` is the remaining framework overhead, including routing, request setup, timeout handling, and response writing.
+
+- **Query logging**: Database queries log at `info` level by default with Rails-style elapsed time:
+
+```text
+Task Load (1.9ms)  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`id` = 1 LIMIT 1
+  ↳ src/routes/tasks/controller.js:12:in show
+```
+
+Model queries use operation names such as `Task Load`, `Task Count`, `Task Pluck`, `Task Create`, `Task Update`, and `Task Destroy`. Raw driver queries use `SQL`. The source arrow is included only when Velocious can identify an application frame; dependency and framework frames such as `node_modules` are omitted.
 
 ## Listen for framework errors
 

--- a/changelog.d/20260503-query-logging.md
+++ b/changelog.d/20260503-query-logging.md
@@ -1,0 +1,1 @@
+Add default-on Rails-style database query logging with elapsed timing and application source lines when available.

--- a/changelog.d/20260503-query-logging.md
+++ b/changelog.d/20260503-query-logging.md
@@ -1,1 +1,1 @@
-Add default-on Rails-style database query logging with elapsed timing and application source lines when available.
+Add Rails-style database query logging with elapsed timing and application source lines when available, defaulting off in test builds to keep CI output quiet.

--- a/changelog.d/20260503-query-logging.md
+++ b/changelog.d/20260503-query-logging.md
@@ -1,1 +1,1 @@
-Add Rails-style database query logging with elapsed timing and application source lines when available, defaulting off in test builds to keep CI output quiet.
+Add Rails-style database query logging with elapsed timing and application source lines when available, defaulting off in test builds and skipping stack capture when `info` logs are disabled.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.
 - `docs/query-bulk-operations.md`: `updateAll` for efficient batch updates and `destroyAll` behavior.
+- `docs/logging.md`: Rails-style request and database query logging behavior.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/routing-hooks-and-autoroutes.md`: Route hook support and frontend-model autoroute behavior.
 - `docs/authorization-and-current.md`: Ability usage, `Current`, and `accessible`/`accessibleBy` behavior.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Velocious logs database queries by default at `info` level using Rails-style query names and elapsed time:
+Velocious logs database queries by default at `info` level using Rails-style query names and elapsed time. Query logging defaults to off in the `test` environment so CI output stays focused on failures:
 
 ```text
 Task Load (1.9ms)  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`id` = 1 LIMIT 1
@@ -11,4 +11,4 @@ Model-backed reads use names such as `Task Load`, `Task Count`, and `Task Pluck`
 
 The source arrow is included only when Velocious can identify application code. Dependency and framework frames, including `node_modules`, are filtered out; if no application frame is available, Velocious logs only the timed SQL line.
 
-Query logs use the same configured logger outputs as other Velocious logs. Disable them by changing your logging outputs or levels so `info` logs are not emitted.
+Query logs use the same configured logger outputs as other Velocious logs. Disable them with `logging: {queryLogging: false}`. Enable them in tests with `logging: {queryLogging: true}` and choose the output you want, such as `console: true` for local debugging or `file: true` for a test log file.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,14 @@
+# Logging
+
+Velocious logs database queries by default at `info` level using Rails-style query names and elapsed time:
+
+```text
+Task Load (1.9ms)  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`id` = 1 LIMIT 1
+  ↳ src/routes/tasks/controller.js:12:in show
+```
+
+Model-backed reads use names such as `Task Load`, `Task Count`, and `Task Pluck`. Model writes use names such as `Task Create`, `Task Update`, and `Task Destroy`. Raw `db.query(...)` calls use `SQL`.
+
+The source arrow is included only when Velocious can identify application code. Dependency and framework frames, including `node_modules`, are filtered out; if no application frame is available, Velocious logs only the timed SQL line.
+
+Query logs use the same configured logger outputs as other Velocious logs. Disable them by changing your logging outputs or levels so `info` logs are not emitted.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -11,4 +11,4 @@ Model-backed reads use names such as `Task Load`, `Task Count`, and `Task Pluck`
 
 The source arrow is included only when Velocious can identify application code. Dependency and framework frames, including `node_modules`, are filtered out; if no application frame is available, Velocious logs only the timed SQL line.
 
-Query logs use the same configured logger outputs as other Velocious logs. Disable them with `logging: {queryLogging: false}`. Enable them in tests with `logging: {queryLogging: true}` and choose the output you want, such as `console: true` for local debugging or `file: true` for a test log file.
+Query logs use the same configured logger outputs as other Velocious logs and are skipped when no output emits `info`. Disable them with `logging: {queryLogging: false}` or by removing `info` from your configured levels. Enable them in tests with `logging: {queryLogging: true}` and choose the output you want, such as `console: true` for local debugging or `file: true` for a test log file.

--- a/spec/background-jobs/basic-spec.js
+++ b/spec/background-jobs/basic-spec.js
@@ -9,6 +9,7 @@ import BackgroundJobsMain from "../../src/background-jobs/main.js"
 import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
 import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
+import SlowTestJob from "../dummy/src/jobs/slow-test-job.js"
 import TestJob from "../dummy/src/jobs/test-job.js"
 
 describe("Background jobs", () => {
@@ -169,5 +170,60 @@ describe("Background jobs", () => {
       await new Promise((resolve) => rebindingServer.close(() => resolve(undefined)))
       dummyConfiguration.setScheduledBackgroundJobsConfig(undefined)
     }
+  })
+
+  it("waits for in-flight inline jobs to finish during a graceful stop", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    await store.clearAll()
+
+    const main = new BackgroundJobsMain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+    await main.start()
+
+    dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: main.getPort()})
+
+    const worker = new BackgroundJobsWorker({configuration: dummyConfiguration})
+    await worker.start()
+
+    const tmpDir = path.join(dummyConfiguration.getDirectory(), "tmp")
+    await fs.mkdir(tmpDir, {recursive: true})
+    const outputPath = path.join(tmpDir, `slow-job-${Date.now()}.json`)
+
+    const jobId = await SlowTestJob.performLaterWithOptions({
+      args: ["graceful", outputPath, 0.4],
+      options: {forked: false}
+    })
+
+    // Wait until the worker has actually picked the job up; otherwise
+    // stop() might race ahead before there's anything in flight.
+    await timeout({timeout: 2000}, async () => {
+      while (worker.inflightInlineJobs.size === 0) {
+        await wait(0.01)
+      }
+    })
+
+    const stopStartedAtMs = Date.now()
+
+    await worker.stop()
+
+    const stopElapsedMs = Date.now() - stopStartedAtMs
+
+    // The job pauses for 400ms inside `perform`, so a graceful stop should
+    // have waited at least that long before resolving.
+    expect(stopElapsedMs).toBeGreaterThanOrEqual(300)
+
+    // The job should have written its output and been marked completed.
+    const result = JSON.parse(await fs.readFile(outputPath, "utf8"))
+    expect(result).toEqual({message: "graceful"})
+
+    await timeout({timeout: 2000}, async () => {
+      while (true) {
+        const job = await store.getJob(jobId)
+        if (job?.status === "completed") break
+        await wait(0.05)
+      }
+    })
+
+    await main.stop()
   })
 })

--- a/spec/background-jobs/basic-spec.js
+++ b/spec/background-jobs/basic-spec.js
@@ -190,7 +190,7 @@ describe("Background jobs", () => {
     const outputPath = path.join(tmpDir, `slow-job-${Date.now()}.json`)
 
     const jobId = await SlowTestJob.performLaterWithOptions({
-      args: ["graceful", outputPath, 0.4],
+      args: ["graceful", outputPath, 400],
       options: {forked: false}
     })
 

--- a/spec/database/query-logging.browser-spec.js
+++ b/spec/database/query-logging.browser-spec.js
@@ -1,17 +1,69 @@
 // @ts-check
 
 import Configuration from "../../src/configuration.js"
+import DatabaseDriverBase from "../../src/database/drivers/base.js"
+import RequestTiming from "../../src/http-server/client/request-timing.js"
 import LoggerArrayOutput from "../../src/logger/outputs/array-output.js"
 import Project from "../dummy/src/models/project.js"
 import Task from "../dummy/src/models/task.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 
+/** @typedef {import("../../src/configuration-types.js").LogLevel} LogLevel */
 /** @typedef {import("../../src/configuration-types.js").LoggingConfiguration} LoggingConfiguration */
 /** @typedef {Configuration & {_logging?: LoggingConfiguration}} MutableLoggingConfiguration */
+
+class TestDriver extends DatabaseDriverBase {
+  /** @type {string | undefined} */
+  lastSourceStack = undefined
+
+  async _queryActual() {
+    return []
+  }
+
+  async _queryActualWithLogging(sql, options, requestTiming, tries) {
+    this.lastSourceStack = options.sourceStack
+
+    return await super._queryActualWithLogging(sql, options, requestTiming, tries)
+  }
+
+  async connect() {}
+
+  getType() { return "test" }
+  primaryKeyType() { return "bigint" }
+  queryToSql() { return "" }
+}
+
+class TimingDriver extends TestDriver {
+  /** @type {function(number): void} */
+  advanceTime
+
+  /**
+   * @param {import("../../src/configuration-types.js").DatabaseConfigurationType} config - Database config.
+   * @param {Configuration} configuration - Configuration.
+   * @param {object} args - Options object.
+   * @param {function(number): void} args.advanceTime - Advances fake time.
+   */
+  constructor(config, configuration, {advanceTime}) {
+    super(config, configuration)
+
+    this.advanceTime = advanceTime
+  }
+
+  async _queryActual() {
+    this.advanceTime(5)
+
+    return []
+  }
+
+  async _logQuery() {
+    this.advanceTime(100)
+  }
+}
 
 /**
  * @param {function(LoggerArrayOutput): Promise<void>} callback - Callback with captured query logs.
  * @param {object} [args] - Options object.
+ * @param {LogLevel[]} [args.levels] - Enabled output levels.
  * @param {boolean | undefined} [args.queryLogging] - Query logging override.
  * @returns {Promise<void>} - Resolves when complete.
  */
@@ -19,11 +71,12 @@ async function withQueryLogOutput(callback, args = {}) {
   const configuration = /** @type {MutableLoggingConfiguration} */ (Configuration.current())
   const previousLogging = configuration._logging
   const arrayOutput = new LoggerArrayOutput()
+  const levels = args.levels || ["info"]
   const queryLogging = "queryLogging" in args ? args.queryLogging : true
   const logging = /** @type {LoggingConfiguration} */ ({
     console: false,
     file: false,
-    outputs: [{output: arrayOutput, levels: ["info"]}]
+    outputs: [{output: arrayOutput, levels}]
   })
 
   if (queryLogging !== undefined) logging.queryLogging = queryLogging
@@ -53,6 +106,47 @@ describe("Database - query logging", {tags: ["dummy"]}, () => {
 
       expect(messages.some((message) => message.includes("query_logging_disabled_result"))).toBeFalse()
     }, {queryLogging: undefined})
+  })
+
+  it("does not prepare source stacks when info logs are filtered", async () => {
+    await withQueryLogOutput(async () => {
+      const driver = new TestDriver({}, Configuration.current())
+
+      await driver.query("SELECT 1 AS query_logging_filtered_result")
+
+      expect(driver.lastSourceStack).toBeUndefined()
+    }, {levels: ["warn"], queryLogging: true})
+  })
+
+  it("excludes query log work from request database timing", async () => {
+    const configuration = Configuration.current()
+    const requestTiming = new RequestTiming()
+    const originalNow = Date.now
+    let currentTime = 1000
+    let summary
+
+    try {
+      Date.now = () => currentTime
+      requestTiming.startedAtMs = currentTime
+
+      await withQueryLogOutput(async () => {
+        const driver = new TimingDriver({}, configuration, {
+          advanceTime: (ms) => {
+            currentTime += ms
+          }
+        })
+
+        await configuration.runWithRequestTiming(requestTiming, async () => {
+          await driver.query("SELECT 1 AS query_logging_timing_result")
+        })
+      })
+
+      summary = requestTiming.summary()
+    } finally {
+      Date.now = originalNow
+    }
+
+    expect(summary?.dbMs).toEqual(5)
   })
 
   it("logs model loads with elapsed time at info level", async () => {

--- a/spec/database/query-logging.browser-spec.js
+++ b/spec/database/query-logging.browser-spec.js
@@ -11,18 +11,24 @@ import {describe, expect, it} from "../../src/testing/test.js"
 
 /**
  * @param {function(LoggerArrayOutput): Promise<void>} callback - Callback with captured query logs.
+ * @param {object} [args] - Options object.
+ * @param {boolean | undefined} [args.queryLogging] - Query logging override.
  * @returns {Promise<void>} - Resolves when complete.
  */
-async function withQueryLogOutput(callback) {
+async function withQueryLogOutput(callback, args = {}) {
   const configuration = /** @type {MutableLoggingConfiguration} */ (Configuration.current())
   const previousLogging = configuration._logging
   const arrayOutput = new LoggerArrayOutput()
-
-  configuration._logging = {
+  const queryLogging = "queryLogging" in args ? args.queryLogging : true
+  const logging = /** @type {LoggingConfiguration} */ ({
     console: false,
     file: false,
     outputs: [{output: arrayOutput, levels: ["info"]}]
-  }
+  })
+
+  if (queryLogging !== undefined) logging.queryLogging = queryLogging
+
+  configuration._logging = logging
 
   try {
     await callback(arrayOutput)
@@ -37,6 +43,18 @@ function logMessages(arrayOutput) {
 }
 
 describe("Database - query logging", {tags: ["dummy"]}, () => {
+  it("does not log database queries by default in test", async () => {
+    await withQueryLogOutput(async (arrayOutput) => {
+      await Configuration.current().ensureConnections(async (dbs) => {
+        await dbs.default.query("SELECT 1 AS query_logging_disabled_result")
+      })
+
+      const messages = logMessages(arrayOutput)
+
+      expect(messages.some((message) => message.includes("query_logging_disabled_result"))).toBeFalse()
+    }, {queryLogging: undefined})
+  })
+
   it("logs model loads with elapsed time at info level", async () => {
     const project = await Project.create({name: "Query logging project"})
     const task = await Task.create({name: "Query logging task", project})

--- a/spec/database/query-logging.browser-spec.js
+++ b/spec/database/query-logging.browser-spec.js
@@ -1,0 +1,85 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import LoggerArrayOutput from "../../src/logger/outputs/array-output.js"
+import Project from "../dummy/src/models/project.js"
+import Task from "../dummy/src/models/task.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/** @typedef {import("../../src/configuration-types.js").LoggingConfiguration} LoggingConfiguration */
+/** @typedef {Configuration & {_logging?: LoggingConfiguration}} MutableLoggingConfiguration */
+
+/**
+ * @param {function(LoggerArrayOutput): Promise<void>} callback - Callback with captured query logs.
+ * @returns {Promise<void>} - Resolves when complete.
+ */
+async function withQueryLogOutput(callback) {
+  const configuration = /** @type {MutableLoggingConfiguration} */ (Configuration.current())
+  const previousLogging = configuration._logging
+  const arrayOutput = new LoggerArrayOutput()
+
+  configuration._logging = {
+    console: false,
+    file: false,
+    outputs: [{output: arrayOutput, levels: ["info"]}]
+  }
+
+  try {
+    await callback(arrayOutput)
+  } finally {
+    configuration._logging = previousLogging
+  }
+}
+
+/** @param {LoggerArrayOutput} arrayOutput - Log output. */
+function logMessages(arrayOutput) {
+  return arrayOutput.getLogs().map((log) => log.message)
+}
+
+describe("Database - query logging", {tags: ["dummy"]}, () => {
+  it("logs model loads with elapsed time at info level", async () => {
+    const project = await Project.create({name: "Query logging project"})
+    const task = await Task.create({name: "Query logging task", project})
+
+    await withQueryLogOutput(async (arrayOutput) => {
+      await Task.find(task.id())
+
+      const logs = arrayOutput.getLogs()
+      const loadLog = logs.find((log) => log.subject == "Task Load")
+
+      expect(loadLog?.level).toEqual("info")
+      expect(loadLog?.message).toMatch(/^Task Load \(\d+\.\dms\) {2}SELECT /)
+      expect(loadLog?.message).toContain("tasks")
+    })
+  })
+
+  it("logs raw driver queries as SQL", async () => {
+    await withQueryLogOutput(async (arrayOutput) => {
+      await Configuration.current().ensureConnections(async (dbs) => {
+        await dbs.default.query("SELECT 1 AS query_logging_result")
+      })
+
+      const messages = logMessages(arrayOutput)
+
+      expect(messages.some((message) => /^SQL \(\d+\.\dms\) {2}SELECT 1 AS query_logging_result/.test(message))).toBeTrue()
+    })
+  })
+
+  it("logs model write operation names", async () => {
+    const project = await Project.create({name: "Query logging write project"})
+
+    await withQueryLogOutput(async (arrayOutput) => {
+      const task = await Task.create({name: "Query logging write task", project})
+
+      task.setName("Query logging write task updated")
+      await task.save()
+      await task.destroy()
+
+      const subjects = arrayOutput.getLogs().map((log) => log.subject)
+
+      expect(subjects).toContain("Task Create")
+      expect(subjects).toContain("Task Update")
+      expect(subjects).toContain("Task Destroy")
+    })
+  })
+})

--- a/spec/dummy/src/jobs/slow-test-job.js
+++ b/spec/dummy/src/jobs/slow-test-job.js
@@ -1,0 +1,10 @@
+import VelociousJob from "../../../../src/background-jobs/job.js"
+import fs from "fs/promises"
+import wait from "awaitery/build/wait.js"
+
+export default class SlowTestJob extends VelociousJob {
+  async perform(message, outputPath, delaySeconds) {
+    await wait(delaySeconds)
+    await fs.writeFile(outputPath, JSON.stringify({message}))
+  }
+}

--- a/spec/dummy/src/jobs/slow-test-job.js
+++ b/spec/dummy/src/jobs/slow-test-job.js
@@ -3,8 +3,8 @@ import fs from "fs/promises"
 import wait from "awaitery/build/wait.js"
 
 export default class SlowTestJob extends VelociousJob {
-  async perform(message, outputPath, delaySeconds) {
-    await wait(delaySeconds)
+  async perform(message, outputPath, delayMs) {
+    await wait(delayMs)
     await fs.writeFile(outputPath, JSON.stringify({message}))
   }
 }

--- a/spec/utils/backtrace-cleaner-spec.js
+++ b/spec/utils/backtrace-cleaner-spec.js
@@ -21,4 +21,37 @@ describe("BacktraceCleaner", () => {
     expect(cleanedBacktrace).toContain("handleRequest")
     expect(cleanedBacktrace?.includes("node_modules")).toEqual(false)
   })
+
+  it("returns the first application source line and skips dependencies", () => {
+    const error = new Error("Query source")
+
+    error.stack = [
+      "Error: Query source",
+      "    at VelociousDatabaseDriversBase.query (/app/node_modules/velocious/build/src/database/drivers/base.js:700:10)",
+      "    at parseInput (/app/node_modules/some-lib/index.js:1:1)",
+      "    at CountryController.show (/app/src/routes/countries/controller.js:44:8)"
+    ].join("\n")
+
+    const sourceLine = BacktraceCleaner.getApplicationSourceLine(error, {
+      applicationDirectory: "/app"
+    })
+
+    expect(sourceLine).toEqual("src/routes/countries/controller.js:44:in CountryController.show")
+  })
+
+  it("does not return a source line when no application frame is available", () => {
+    const error = new Error("Query source")
+
+    error.stack = [
+      "Error: Query source",
+      "    at VelociousDatabaseDriversBase.query (/app/node_modules/velocious/build/src/database/drivers/base.js:700:10)",
+      "    at processTicksAndRejections (node:internal/process/task_queues:95:5)"
+    ].join("\n")
+
+    const sourceLine = BacktraceCleaner.getApplicationSourceLine(error, {
+      applicationDirectory: "/app"
+    })
+
+    expect(sourceLine).toBeUndefined()
+  })
 })

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -158,6 +158,14 @@ export default class BackgroundJobsMain {
         return
       }
 
+      if (role === "worker" && message?.type === "draining") {
+        // The worker is shutting down gracefully. Stop dispatching new jobs
+        // to it but keep the connection in `workers` so any in-flight job
+        // it's still draining can report its result.
+        this.readyWorkers.delete(jsonSocket)
+        return
+      }
+
       if ((role === "worker" || role === "reporter") && message?.type === "job-complete") {
         this._handleJobComplete({jsonSocket, message})
         return

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -38,6 +38,7 @@
 /**
  * @typedef {{type: "hello", role: BackgroundJobSocketRole, workerId?: string}} BackgroundJobHelloMessage
  * @typedef {{type: "ready"}} BackgroundJobReadyMessage
+ * @typedef {{type: "draining"}} BackgroundJobDrainingMessage
  * @typedef {{type: "enqueue", jobName: string, args?: any[], options?: BackgroundJobOptions}} BackgroundJobEnqueueMessage
  * @typedef {{type: "job", payload: BackgroundJobPayload}} BackgroundJobJobMessage
  * @typedef {{type: "job-complete", jobId: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobCompleteMessage
@@ -46,7 +47,7 @@
  * @typedef {{type: "job-update-error", jobId: string, error?: string}} BackgroundJobUpdateErrorMessage
  */
 /**
- * @typedef {BackgroundJobHelloMessage | BackgroundJobReadyMessage | BackgroundJobEnqueueMessage | BackgroundJobJobMessage | BackgroundJobCompleteMessage | BackgroundJobFailedMessage | BackgroundJobUpdatedMessage | BackgroundJobUpdateErrorMessage} BackgroundJobSocketMessage
+ * @typedef {BackgroundJobHelloMessage | BackgroundJobReadyMessage | BackgroundJobDrainingMessage | BackgroundJobEnqueueMessage | BackgroundJobJobMessage | BackgroundJobCompleteMessage | BackgroundJobFailedMessage | BackgroundJobUpdatedMessage | BackgroundJobUpdateErrorMessage} BackgroundJobSocketMessage
  */
 
 export const nothing = {}

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -166,14 +166,14 @@ export default class BackgroundJobsWorker {
   async _runInlineJobAndReport(payload) {
     try {
       await this._runJobInline(payload)
-      void this._reportJobResult({
+      await this._reportJobResult({
         jobId: payload.id,
         status: "completed",
         handedOffAtMs: payload.handedOffAtMs,
         workerId: payload.workerId || this.workerId
       })
     } catch (error) {
-      void this._reportJobResult({
+      await this._reportJobResult({
         jobId: payload.id,
         status: "failed",
         error,

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -28,6 +28,13 @@ export default class BackgroundJobsWorker {
     this.jsonSocket = undefined
     /** @type {BackgroundJobsStatusReporter | undefined} */
     this.statusReporter = undefined
+    /**
+     * In-flight inline jobs the worker is currently running. Forked jobs run
+     * in detached child processes so they don't appear here; the worker
+     * doesn't need to wait for them on shutdown — they survive on their own.
+     * @type {Set<Promise<void>>}
+     */
+    this.inflightInlineJobs = new Set()
   }
 
   /**
@@ -47,10 +54,44 @@ export default class BackgroundJobsWorker {
   }
 
   /**
+   * Gracefully stops the worker: announces draining to the main process so
+   * no new jobs are dispatched, waits for any in-flight inline jobs to
+   * finish (so their results can be reported), then closes the socket and
+   * disconnects from the beacon. Forked jobs are detached child processes
+   * and continue running on their own across the worker exit.
+   *
+   * Pass `{timeoutMs}` to bound how long to wait for in-flight inline jobs
+   * before forcing the socket closed.
+   * @param {object} [args] - Options.
+   * @param {number} [args.timeoutMs] - Max wait for in-flight inline jobs in ms.
    * @returns {Promise<void>} - Resolves when stopped.
    */
-  async stop() {
+  async stop({timeoutMs} = {}) {
+    if (this.shouldStop) return
     this.shouldStop = true
+
+    // Announce drain so main stops dispatching but keeps the connection
+    // open until we close it ourselves below.
+    if (this.jsonSocket) {
+      try {
+        this.jsonSocket.send({type: "draining"})
+      } catch {
+        // Socket may already be closing; nothing to do.
+      }
+    }
+
+    if (this.inflightInlineJobs.size > 0) {
+      const drain = Promise.allSettled([...this.inflightInlineJobs])
+      if (typeof timeoutMs === "number" && timeoutMs >= 0) {
+        let timer
+        const timeout = new Promise((resolve) => { timer = setTimeout(resolve, timeoutMs) })
+        await Promise.race([drain, timeout])
+        clearTimeout(timer)
+      } else {
+        await drain
+      }
+    }
+
     if (this.jsonSocket) this.jsonSocket.close()
     if (this.configuration) await this.configuration.disconnectBeacon()
   }
@@ -94,16 +135,35 @@ export default class BackgroundJobsWorker {
    */
   async _handleJob(payload) {
     if (!payload.id) throw new Error("Background job payload missing id")
+    /** @type {import("./types.js").BackgroundJobPayload & {id: string}} */
+    const identifiedPayload = /** @type {any} */ (payload)
 
-    const options = payload.options || {}
+    const options = identifiedPayload.options || {}
     const shouldFork = options.forked !== false
 
     if (shouldFork) {
-      await this._spawnDetachedJob(payload)
-      this.jsonSocket?.send({type: "ready"})
+      await this._spawnDetachedJob(identifiedPayload)
+      this._sendReadyIfRunning()
       return
     }
 
+    /** @type {Promise<void>} */
+    const inflight = this._runInlineJobAndReport(identifiedPayload)
+    this.inflightInlineJobs.add(inflight)
+    try {
+      await inflight
+    } finally {
+      this.inflightInlineJobs.delete(inflight)
+    }
+
+    this._sendReadyIfRunning()
+  }
+
+  /**
+   * @param {import("./types.js").BackgroundJobPayload & {id: string}} payload - Payload with required id.
+   * @returns {Promise<void>} - Resolves when complete (success or failure reported).
+   */
+  async _runInlineJobAndReport(payload) {
     try {
       await this._runJobInline(payload)
       void this._reportJobResult({
@@ -121,6 +181,16 @@ export default class BackgroundJobsWorker {
         workerId: payload.workerId || this.workerId
       })
     }
+  }
+
+  /**
+   * Tells main we're ready for the next job — but only if we haven't been
+   * asked to drain. Once we've sent `draining` we don't want to take more
+   * work.
+   * @returns {void}
+   */
+  _sendReadyIfRunning() {
+    if (this.shouldStop) return
     this.jsonSocket?.send({type: "ready"})
   }
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -112,6 +112,7 @@
  * @property {string} [filePath] - Explicit path for the log file. Defaults to "<directory>/<environment>.log".
  * @property {Array<"debug-low-level" | "debug" | "info" | "warn" | "error">} [levels] - Override which log levels are emitted.
  * @property {boolean} [debugLowLevel] - Convenience flag to include very low-level debug logs.
+ * @property {boolean} [queryLogging] - Enable/disable database query logging. Defaults to true outside test and false in test.
  * @property {LoggerConfig[]} [loggers] - Logger instances (converted to outputs when configured).
  * @property {LoggingOutputConfig[]} [outputs] - Explicit logger outputs (overrides console/file defaults when provided).
  */

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -423,6 +423,15 @@ export default class VelociousConfiguration {
   }
 
   /**
+   * @returns {boolean} - Whether database query logging is enabled.
+   */
+  getQueryLoggingEnabled() {
+    if (this._logging?.queryLogging !== undefined) return this._logging.queryLogging
+
+    return this.getEnvironment() !== "test"
+  }
+
+  /**
    * @returns {Required<import("./configuration-types.js").BackgroundJobsConfiguration>} - Background jobs configuration.
    */
   getBackgroundJobsConfig() {

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -39,6 +39,11 @@
  * @property {number} [waitMs] - Wait time before retrying in milliseconds.
  */
 /**
+ * @typedef {object} QueryOptions
+ * @property {string} [logName] - Query log subject.
+ * @property {string} [sourceStack] - Stack captured at the caller boundary.
+ */
+/**
  * @typedef {object}UpdateSqlArgsType
  * @property {object} conditions - Conditions used to build the update WHERE clause.
  * @property {object} data - Column/value pairs to update.
@@ -52,6 +57,7 @@
  * @property {string[]} updateColumns - Columns to update on conflict.
  */
 
+import BacktraceCleaner from "../../utils/backtrace-cleaner.js"
 import Logger from "../../logger.js"
 import Query from "../query/index.js"
 import Handler from "../handler.js"
@@ -62,6 +68,23 @@ import TableData from "../table-data/index.js"
 import TableColumn from "../table-data/table-column.js"
 import TableForeignKey from "../table-data/table-foreign-key.js"
 import wait from "awaitery/build/wait.js"
+
+/** @returns {number} - Current high-resolution-ish timestamp in milliseconds. */
+function nowMs() {
+  if (globalThis.performance && typeof globalThis.performance.now == "function") {
+    return globalThis.performance.now()
+  }
+
+  return Date.now()
+}
+
+/**
+ * @param {number} elapsedMs - Elapsed milliseconds.
+ * @returns {string} - Formatted elapsed milliseconds.
+ */
+function formatElapsedMs(elapsedMs) {
+  return `${Math.max(elapsedMs, 0).toFixed(1)}ms`
+}
 
 export default class VelociousDatabaseDriversBase {
   /** @type {number | undefined} */
@@ -693,26 +716,28 @@ export default class VelociousDatabaseDriversBase {
 
   /**
    * @param {string} sql - SQL string.
+   * @param {QueryOptions} [options] - Query options.
    * @returns {Promise<QueryResultType>} - Resolves with the query.
    */
-  async query(sql) {
+  async query(sql, options = {}) {
     this._assertWritableQuery(sql)
 
     let tries = 0
     const maxTries = 5
     const requestTiming = this.configuration.getCurrentRequestTiming()
+    const sourceStack = options.sourceStack || Error().stack
 
     while (tries < maxTries) {
       tries++
 
       try {
         if (requestTiming && tries === 1) {
-          return await requestTiming.measureDbQuery(async () => await this._queryActual(sql))
+          return await requestTiming.measureDbQuery(async () => await this._queryActualWithLogging(sql, {...options, sourceStack}))
         } else if (requestTiming) {
-          return await requestTiming.measure("db", async () => await this._queryActual(sql))
+          return await requestTiming.measure("db", async () => await this._queryActualWithLogging(sql, {...options, sourceStack}))
         }
 
-        return await this._queryActual(sql)
+        return await this._queryActualWithLogging(sql, {...options, sourceStack})
       } catch (error) {
         if (!(error instanceof Error)) throw error
 
@@ -739,6 +764,59 @@ export default class VelociousDatabaseDriversBase {
     }
 
     throw new Error("'query' unexpected came here")
+  }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @param {QueryOptions} options - Query options.
+   * @returns {Promise<QueryResultType>} - Resolves with the query.
+   */
+  async _queryActualWithLogging(sql, options) {
+    const startedAtMs = nowMs()
+    const result = await this._queryActual(sql)
+
+    await this._logQuery({
+      elapsedMs: nowMs() - startedAtMs,
+      logName: options.logName || "SQL",
+      sourceStack: options.sourceStack,
+      sql
+    })
+
+    return result
+  }
+
+  /**
+   * @param {object} args - Options object.
+   * @param {number} args.elapsedMs - Elapsed milliseconds.
+   * @param {string} args.logName - Query log subject.
+   * @param {string | undefined} args.sourceStack - Source stack.
+   * @param {string} args.sql - SQL string.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _logQuery({elapsedMs, logName, sourceStack, sql}) {
+    const logger = new Logger(logName, {configuration: this.configuration})
+    const sourceLine = this._querySourceLine(sourceStack)
+    const message = sourceLine
+      ? `(${formatElapsedMs(elapsedMs)})  ${sql}\n  ↳ ${sourceLine}`
+      : `(${formatElapsedMs(elapsedMs)})  ${sql}`
+
+    await logger.info(message)
+  }
+
+  /**
+   * @param {string | undefined} sourceStack - Source stack.
+   * @returns {string | undefined} - Source line when an application frame is available.
+   */
+  _querySourceLine(sourceStack) {
+    if (!sourceStack || typeof this.configuration?.getDirectory !== "function") return undefined
+
+    const error = new Error("Query source")
+
+    error.stack = sourceStack
+
+    return BacktraceCleaner.getApplicationSourceLine(error, {
+      applicationDirectory: this.configuration.getDirectory()
+    })
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -733,13 +733,7 @@ export default class VelociousDatabaseDriversBase {
       tries++
 
       try {
-        if (requestTiming && tries === 1) {
-          return await requestTiming.measureDbQuery(async () => await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack}))
-        } else if (requestTiming) {
-          return await requestTiming.measure("db", async () => await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack}))
-        }
-
-        return await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack})
+        return await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack}, requestTiming, tries)
       } catch (error) {
         if (!(error instanceof Error)) throw error
 
@@ -771,15 +765,27 @@ export default class VelociousDatabaseDriversBase {
   /**
    * @param {string} sql - SQL string.
    * @param {QueryOptions} options - Query options.
+   * @param {import("../../http-server/client/request-timing.js").default | undefined} requestTiming - Request timing.
+   * @param {number} tries - Query attempt count.
    * @returns {Promise<QueryResultType>} - Resolves with the query.
    */
-  async _queryActualWithLogging(sql, options) {
+  async _queryActualWithLogging(sql, options, requestTiming, tries) {
     const startedAtMs = nowMs()
-    const result = await this._queryActual(sql)
+    let result
+
+    if (requestTiming && tries === 1) {
+      result = await requestTiming.measureDbQuery(async () => await this._queryActual(sql))
+    } else if (requestTiming) {
+      result = await requestTiming.measure("db", async () => await this._queryActual(sql))
+    } else {
+      result = await this._queryActual(sql)
+    }
+
+    const elapsedMs = nowMs() - startedAtMs
 
     if (options.logQuery !== false) {
       await this._logQuery({
-        elapsedMs: nowMs() - startedAtMs,
+        elapsedMs,
         logName: options.logName || "SQL",
         sourceStack: options.sourceStack,
         sql
@@ -794,8 +800,11 @@ export default class VelociousDatabaseDriversBase {
    */
   _queryLoggingEnabled() {
     if (typeof this.configuration?.getQueryLoggingEnabled !== "function") return true
+    if (!this.configuration.getQueryLoggingEnabled()) return false
 
-    return this.configuration.getQueryLoggingEnabled()
+    const logger = new Logger("SQL", {configuration: this.configuration})
+
+    return logger.isLevelEnabled("info")
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -41,6 +41,7 @@
 /**
  * @typedef {object} QueryOptions
  * @property {string} [logName] - Query log subject.
+ * @property {boolean} [logQuery] - Whether to log the query.
  * @property {string} [sourceStack] - Stack captured at the caller boundary.
  */
 /**
@@ -725,19 +726,20 @@ export default class VelociousDatabaseDriversBase {
     let tries = 0
     const maxTries = 5
     const requestTiming = this.configuration.getCurrentRequestTiming()
-    const sourceStack = options.sourceStack || Error().stack
+    const logQuery = options.logQuery ?? this._queryLoggingEnabled()
+    const sourceStack = logQuery ? (options.sourceStack || Error().stack) : undefined
 
     while (tries < maxTries) {
       tries++
 
       try {
         if (requestTiming && tries === 1) {
-          return await requestTiming.measureDbQuery(async () => await this._queryActualWithLogging(sql, {...options, sourceStack}))
+          return await requestTiming.measureDbQuery(async () => await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack}))
         } else if (requestTiming) {
-          return await requestTiming.measure("db", async () => await this._queryActualWithLogging(sql, {...options, sourceStack}))
+          return await requestTiming.measure("db", async () => await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack}))
         }
 
-        return await this._queryActualWithLogging(sql, {...options, sourceStack})
+        return await this._queryActualWithLogging(sql, {...options, logQuery, sourceStack})
       } catch (error) {
         if (!(error instanceof Error)) throw error
 
@@ -775,14 +777,25 @@ export default class VelociousDatabaseDriversBase {
     const startedAtMs = nowMs()
     const result = await this._queryActual(sql)
 
-    await this._logQuery({
-      elapsedMs: nowMs() - startedAtMs,
-      logName: options.logName || "SQL",
-      sourceStack: options.sourceStack,
-      sql
-    })
+    if (options.logQuery !== false) {
+      await this._logQuery({
+        elapsedMs: nowMs() - startedAtMs,
+        logName: options.logName || "SQL",
+        sourceStack: options.sourceStack,
+        sql
+      })
+    }
 
     return result
+  }
+
+  /**
+   * @returns {boolean} - Whether query logging is enabled for this driver.
+   */
+  _queryLoggingEnabled() {
+    if (typeof this.configuration?.getQueryLoggingEnabled !== "function") return true
+
+    return this.configuration.getQueryLoggingEnabled()
   }
 
   /**

--- a/src/database/query/index.js
+++ b/src/database/query/index.js
@@ -383,13 +383,13 @@ export default class VelociousDatabaseQuery {
   }
 
   /**
+   * @param {object} [args] - Options object.
+   * @param {string} [args.logName] - Query log name.
    * @returns {Promise<Array<object>>} Array of results from the database
    */
-  async _executeQuery() {
+  async _executeQuery({logName = this.queryLogName("Load")} = {}) {
     const sql = this.toSql()
-    const results = await this.driver.query(sql)
-
-    this.logger.debug(() => ["SQL:", sql])
+    const results = await this.driver.query(sql, {logName})
 
     return results
   }
@@ -397,6 +397,15 @@ export default class VelociousDatabaseQuery {
   /** @returns {Promise<Array<object>>} Array of results from the database */
   async results() {
     return await this._executeQuery()
+  }
+
+  /**
+   * @param {string} operation - Query operation.
+   * @returns {string} - Query log name.
+   */
+  queryLogName(operation) {
+    void operation
+    return "SQL"
   }
 
   /**

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -270,7 +270,9 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
     countQuery._selects = []
     countQuery.select(sql)
 
-    const results = /** @type {{count: number}[]} */ (await countQuery._executeQuery())
+    const results = /** @type {{count: number}[]} */ (await countQuery._executeQuery({
+      logName: countQuery.queryLogName("Count")
+    }))
 
     // The query isn't grouped and a single result has been given
     if (results.length == 1) {
@@ -616,7 +618,7 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       sql = `UPDATE ${driver.quoteTable(tableName)} SET ${setCols}${whereSql}`
     }
 
-    await driver.query(sql)
+    await driver.query(sql, {logName: this.queryLogName("Update All")})
   }
 
   /**
@@ -815,7 +817,7 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       query.select(selectSql)
     })
 
-    const rows = await query._executeQuery()
+    const rows = await query._executeQuery({logName: query.queryLogName("Pluck")})
 
     if (columnNames.length === 1) {
       const [columnName] = columnNames
@@ -924,6 +926,14 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
     }
 
     throw new Error(`Invalid type of where: ${typeof where} (${where.constructor.name})`)
+  }
+
+  /**
+   * @param {string} operation - Query operation.
+   * @returns {string} - Query log name.
+   */
+  queryLogName(operation) {
+    return `${this.getModelClass().name} ${operation}`
   }
 }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -528,7 +528,7 @@ class VelociousDatabaseRecord {
 
       const sql = `UPDATE ${connection.quoteTable(parentTable)} SET ${connection.quoteColumn(counterColumn)} = (SELECT COUNT(*) FROM ${connection.quoteTable(childTable)} WHERE ${connection.quoteColumn(fk)} = ${quoted}) WHERE ${connection.quoteColumn(pkColumn)} = ${quoted}`
 
-      await connection.query(sql)
+      await connection.query(sql, {logName: `${ParentModel.name} Update`})
     }
 
     /**
@@ -2542,7 +2542,7 @@ class VelociousDatabaseRecord {
       tableName: this._tableName()
     })
 
-    await this._connection().query(sql)
+    await this._connection().query(sql, {logName: `${this.getModelClass().name} Destroy`})
     await this._runLifecycleCallbacks("afterDestroy")
   }
 
@@ -2957,7 +2957,7 @@ class VelociousDatabaseRecord {
       tableName: this._tableName(),
       data
     })
-    const insertResult = await this._connection().query(sql)
+    const insertResult = await this._connection().query(sql, {logName: `${this.getModelClass().name} Create`})
 
     if (Array.isArray(insertResult) && insertResult[0] && insertResult[0][primaryKey]) {
       this._attributes = insertResult[0]
@@ -3029,7 +3029,7 @@ class VelociousDatabaseRecord {
         data: changes,
         conditions
       })
-      await this._connection().query(sql)
+      await this._connection().query(sql, {logName: `${this.getModelClass().name} Update`})
       await this._reloadWithId(this.id())
     }
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -263,6 +263,22 @@ function isOutputLevelAllowed({level, outputConfig, loggingConfiguration, debugF
 
 /**
  * @param {object} args - Options object.
+ * @param {LogLevel} args.level - Level.
+ * @param {import("./configuration-types.js").LoggingOutputConfig[]} args.outputs - Output configurations.
+ * @param {import("./configuration-types.js").LoggingConfiguration} args.loggingConfiguration - Logging configuration.
+ * @param {boolean} [args.debugFlag] - Whether debug flag.
+ * @returns {import("./configuration-types.js").LoggingOutputConfig[]} - Outputs enabled for the level.
+ */
+function enabledOutputConfigs({level, outputs, loggingConfiguration, debugFlag}) {
+  return outputs.filter((outputConfig) => {
+    if (!outputConfig || !outputConfig.output || typeof outputConfig.output.write !== "function") return false
+
+    return isOutputLevelAllowed({level, outputConfig, loggingConfiguration, debugFlag})
+  })
+}
+
+/**
+ * @param {object} args - Options object.
  * @param {string} args.subject - Log subject.
  * @param {LogLevel} args.level - Level.
  * @param {Parameters<typeof functionOrMessages>} args.messages - Messages.
@@ -274,8 +290,14 @@ function isOutputLevelAllowed({level, outputConfig, loggingConfiguration, debugF
 async function writeLog({subject, level, messages, configuration, loggingConfiguration, debugFlag}) {
   const resolvedLoggingConfiguration = loggingConfiguration || resolveLoggingConfiguration(configuration)
   const outputs = resolveLoggingOutputs({loggingConfiguration: resolvedLoggingConfiguration, configuration})
+  const enabledOutputs = enabledOutputConfigs({
+    level,
+    outputs,
+    loggingConfiguration: resolvedLoggingConfiguration,
+    debugFlag
+  })
 
-  if (outputs.length === 0) return
+  if (enabledOutputs.length === 0) return
 
   const writes = []
   /** @type {Array<any> | undefined} */
@@ -285,10 +307,7 @@ async function writeLog({subject, level, messages, configuration, loggingConfigu
   /** @type {import("./configuration-types.js").LoggingOutputPayload | null} */
   let payload = null
 
-  for (const outputConfig of outputs) {
-    if (!outputConfig || !outputConfig.output || typeof outputConfig.output.write !== "function") continue
-    if (!isOutputLevelAllowed({level, outputConfig, loggingConfiguration: resolvedLoggingConfiguration, debugFlag})) continue
-
+  for (const outputConfig of enabledOutputs) {
     if (!payload) {
       resolvedMessages = functionOrMessages(...messages)
       message = messagesToMessage(subject, ...resolvedMessages)
@@ -355,6 +374,23 @@ export default class Logger {
     } catch {
       return undefined
     }
+  }
+
+  /**
+   * @param {LogLevel} level - Level.
+   * @returns {boolean} - Whether any configured output emits this level.
+   */
+  isLevelEnabled(level) {
+    const configuration = this._safeConfiguration()
+    const loggingConfiguration = this._loggingConfiguration || resolveLoggingConfiguration(configuration)
+    const outputs = resolveLoggingOutputs({loggingConfiguration, configuration})
+
+    return enabledOutputConfigs({
+      level,
+      outputs,
+      loggingConfiguration,
+      debugFlag: this._debug
+    }).length > 0
   }
 
   /**

--- a/src/utils/backtrace-cleaner.js
+++ b/src/utils/backtrace-cleaner.js
@@ -8,6 +8,113 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
+/**
+ * @typedef {object} ParsedStackFrame
+ * @property {string | undefined} methodName - Method/function name from the stack frame.
+ * @property {string} sourcePath - File or URL path from the stack frame.
+ * @property {number} lineNumber - Source line number.
+ * @property {number | undefined} columnNumber - Source column number.
+ */
+
+/**
+ * @returns {string | undefined} - The framework source directory.
+ */
+function frameworkSourceDirectory() {
+  try {
+    const sourceUrl = new URL("../", import.meta.url)
+
+    if (sourceUrl.protocol !== "file:") return undefined
+
+    return normalizePath(sourceUrl.pathname)
+  } catch {
+    return undefined
+  }
+}
+
+const FRAMEWORK_SOURCE_DIRECTORY = frameworkSourceDirectory()
+
+/**
+ * @param {string | undefined} value - Path or file URL.
+ * @returns {string | undefined} - Normalized path.
+ */
+function normalizePath(value) {
+  if (!value) return undefined
+
+  let normalized = value
+
+  if (normalized.startsWith("file://")) {
+    try {
+      normalized = new URL(normalized).pathname
+    } catch {
+      // Keep original value when URL parsing fails.
+    }
+  }
+
+  try {
+    normalized = decodeURIComponent(normalized)
+  } catch {
+    // Keep encoded value when decoding fails.
+  }
+
+  return normalized.replace(/\\/g, "/")
+}
+
+/**
+ * @param {string | undefined} value - Directory path.
+ * @returns {string | undefined} - Normalized directory path ending with slash.
+ */
+function normalizeDirectory(value) {
+  const normalized = normalizePath(value)
+
+  if (!normalized) return undefined
+
+  return normalized.endsWith("/") ? normalized : `${normalized}/`
+}
+
+/**
+ * @param {string} line - Stack line.
+ * @returns {ParsedStackFrame | undefined} - Parsed frame when possible.
+ */
+function parseStackFrame(line) {
+  const trimmed = line.trim()
+
+  if (!trimmed.startsWith("at ")) return undefined
+
+  const frame = trimmed.slice(3)
+  const frameWithMethodMatch = frame.match(/^(.*?) \((.*)\)$/)
+  const methodName = frameWithMethodMatch ? frameWithMethodMatch[1] : undefined
+  const location = frameWithMethodMatch ? frameWithMethodMatch[2] : frame
+  const locationMatch = location.match(/^(.*):(\d+):(\d+)$/) || location.match(/^(.*):(\d+)$/)
+
+  if (!locationMatch) return undefined
+
+  const sourcePath = normalizePath(locationMatch[1])
+  const lineNumber = Number(locationMatch[2])
+  const columnNumber = locationMatch[3] === undefined ? undefined : Number(locationMatch[3])
+
+  if (!sourcePath || !Number.isFinite(lineNumber)) return undefined
+
+  return {
+    columnNumber: Number.isFinite(columnNumber) ? columnNumber : undefined,
+    lineNumber,
+    methodName,
+    sourcePath
+  }
+}
+
+/**
+ * @param {string} sourcePath - Source path.
+ * @param {string} applicationDirectory - Application directory.
+ * @returns {string} - Path relative to the application directory when possible.
+ */
+function relativeApplicationPath(sourcePath, applicationDirectory) {
+  if (sourcePath.startsWith(applicationDirectory)) {
+    return sourcePath.slice(applicationDirectory.length)
+  }
+
+  return sourcePath
+}
+
 export default class BacktraceCleaner {
   /**
    * @param {Error} error - Error instance.
@@ -17,6 +124,16 @@ export default class BacktraceCleaner {
    */
   static getCleanedStack(error, args) {
     return new BacktraceCleaner(error).getCleanedStack(args)
+  }
+
+  /**
+   * @param {Error} error - Error instance.
+   * @param {object} args - Options object.
+   * @param {string} args.applicationDirectory - Application directory.
+   * @returns {string | undefined} - Source line for the first application frame.
+   */
+  static getApplicationSourceLine(error, args) {
+    return new BacktraceCleaner(error).getApplicationSourceLine(args)
   }
 
   /**
@@ -52,7 +169,27 @@ export default class BacktraceCleaner {
   getCleanedStackLines() {
     const backtrace = this.error?.stack?.split("\n")
 
-    return backtrace?.filter((line) => !line.includes("node_modules") && !line.includes("(node:internal/process/"))
+    return backtrace?.filter((line) => this._shouldKeepStackLine(line))
+  }
+
+  /**
+   * @param {object} args - Options object.
+   * @param {string} args.applicationDirectory - Application directory.
+   * @returns {string | undefined} - Source line for the first application frame.
+   */
+  getApplicationSourceLine({applicationDirectory}) {
+    const normalizedApplicationDirectory = normalizeDirectory(applicationDirectory)
+
+    if (!normalizedApplicationDirectory) return undefined
+
+    const frame = this._firstApplicationFrame(normalizedApplicationDirectory)
+
+    if (!frame) return undefined
+
+    const relativePath = relativeApplicationPath(frame.sourcePath, normalizedApplicationDirectory)
+    const methodSuffix = frame.methodName ? `:in ${frame.methodName.replace(/^async /, "")}` : ""
+
+    return `${relativePath}:${frame.lineNumber}${methodSuffix}`
   }
 
   /**
@@ -71,5 +208,50 @@ export default class BacktraceCleaner {
     const errorNamePattern = new RegExp(`^${escapeRegExp(this.error.name)}(?:\\s*\\[[^\\]]+\\])?:`)
 
     return errorNamePattern.test(trimmedLine)
+  }
+
+  /**
+   * @param {string} applicationDirectory - Normalized application directory.
+   * @returns {ParsedStackFrame | undefined} - First app-owned frame.
+   */
+  _firstApplicationFrame(applicationDirectory) {
+    const backtrace = this.getCleanedStackLines()
+
+    if (!backtrace) return undefined
+
+    for (const line of backtrace) {
+      const frame = parseStackFrame(line)
+
+      if (!frame) continue
+      if (!frame.sourcePath.startsWith(applicationDirectory)) continue
+      if (this._frameworkSourcePath(frame.sourcePath)) continue
+
+      return frame
+    }
+
+    return undefined
+  }
+
+  /**
+   * @param {string} sourcePath - Source path.
+   * @returns {boolean} - Whether the path belongs to Velocious internals.
+   */
+  _frameworkSourcePath(sourcePath) {
+    if (!FRAMEWORK_SOURCE_DIRECTORY) return false
+
+    return sourcePath.startsWith(FRAMEWORK_SOURCE_DIRECTORY)
+  }
+
+  /**
+   * @param {string} line - Stack line.
+   * @returns {boolean} - Whether to keep the stack line.
+   */
+  _shouldKeepStackLine(line) {
+    if (line.includes("node_modules")) return false
+    if (line.includes("(node:internal/")) return false
+    if (line.includes("(node:internal/process/")) return false
+    if (line.trim().startsWith("at node:internal/")) return false
+
+    return true
   }
 }


### PR DESCRIPTION
## What
- Add Rails-style info-level SQL logs with operation labels and query timing.
- Add app-source stack frame annotations while filtering dependency and framework frames.
- Document query logging and add focused coverage.

## Why
- Make database activity visible by default at the same level as Rails-style query logs.
- Keep source annotations focused on application code when possible.

## Checks
- npm run lint
- npm run typecheck
- git diff --check
- targeted TestRunner checks for backtrace cleaner, query logging, request-completed logging, and MySQL reconnect behavior using the sqlite dummy config