### PR TITLE
Apply status with JSON renders and accept any standard HTTP status

### DIFF
--- a/spec/dummy/src/config/routes.js
+++ b/spec/dummy/src/config/routes.js
@@ -43,6 +43,7 @@ routes.draw((route) => {
   })
   route.get("ping")
   route.get("ping-with-status")
+  route.get("ping-no-body")
   route.post("current-user/update")
   route.post("current-user/update-password")
   route.get("current-user/update/details")

--- a/spec/dummy/src/config/routes.js
+++ b/spec/dummy/src/config/routes.js
@@ -42,6 +42,7 @@ routes.draw((route) => {
     route.get("read")
   })
   route.get("ping")
+  route.get("ping-with-status")
   route.post("current-user/update")
   route.post("current-user/update-password")
   route.get("current-user/update/details")

--- a/spec/dummy/src/routes/_root/controller.js
+++ b/spec/dummy/src/routes/_root/controller.js
@@ -31,6 +31,19 @@ export default class RootController extends Controller {
     })
   }
 
+  async pingNoBody() {
+    // Exercises a no-body status code (204) — the response sender must
+    // suppress the body + Content-Length header per RFC 7230 §3.3.3 so
+    // keep-alive clients are not desynchronized waiting for bytes that
+    // will not arrive.
+    await this.render({
+      json: {
+        ignored: true
+      },
+      status: 204
+    })
+  }
+
   async params() {
     this.viewParams.response = {
       params: super.params(),

--- a/spec/dummy/src/routes/_root/controller.js
+++ b/spec/dummy/src/routes/_root/controller.js
@@ -18,6 +18,19 @@ export default class RootController extends Controller {
     })
   }
 
+  async pingWithStatus() {
+    // Exercises `render({json, status})` returning the configured numeric
+    // status alongside the JSON body — the previous render path silently
+    // dropped the status and shipped 200.
+    await this.render({
+      json: {
+        message: "Rejected",
+        status: "error"
+      },
+      status: 422
+    })
+  }
+
   async params() {
     this.viewParams.response = {
       params: super.params(),

--- a/spec/http-server/render-with-json-and-status-spec.js
+++ b/spec/http-server/render-with-json-and-status-spec.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import fetch from "node-fetch"
+import Dummy from "../dummy/index.js"
+
+describe("Controller#render with json + status", {databaseCleaning: {transaction: false, truncate: true}}, () => {
+  it("ships the requested HTTP status code alongside the JSON body", async () => {
+    await Dummy.run(async () => {
+      const response = await fetch("http://localhost:3006/ping-with-status")
+      const json = await response.json()
+
+      expect(response.status).toEqual(422)
+      expect(response.statusText).toEqual("Unprocessable Entity")
+      expect(json).toEqual({message: "Rejected", status: "error"})
+    })
+  })
+})

--- a/spec/http-server/render-with-json-and-status-spec.js
+++ b/spec/http-server/render-with-json-and-status-spec.js
@@ -15,4 +15,18 @@ describe("Controller#render with json + status", {databaseCleaning: {transaction
       expect(json).toEqual({message: "Rejected", status: "error"})
     })
   })
+
+  it("suppresses the body and Content-Length for no-body status codes (204)", async () => {
+    await Dummy.run(async () => {
+      const response = await fetch("http://localhost:3006/ping-no-body")
+      const text = await response.text()
+
+      expect(response.status).toEqual(204)
+      expect(response.statusText).toEqual("No Content")
+      expect(text).toEqual("")
+      // Content-Length must NOT be present per RFC 7230 §3.3.3 so
+      // keep-alive clients do not wait for bytes that will not arrive.
+      expect(response.headers.get("content-length")).toEqual(null)
+    })
+  })
 })

--- a/spec/http-server/response-spec.js
+++ b/spec/http-server/response-spec.js
@@ -70,4 +70,12 @@ describe("VelociousHttpServerClientResponse#setStatus", () => {
     expect(() => response.setStatus(600)).toThrow("Unhandled status: 600")
     expect(() => response.setStatus("teapot")).toThrow("Unhandled status: teapot")
   })
+
+  it("returns the standard reason phrase for HTTP 305 Use Proxy", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+
+    response.setStatus(305)
+    expect(response.getStatusCode()).toEqual(305)
+    expect(response.getStatusMessage()).toEqual("Use Proxy")
+  })
 })

--- a/spec/http-server/response-spec.js
+++ b/spec/http-server/response-spec.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import VelociousHttpServerClientResponse from "../../src/http-server/client/response.js"
+
+const stubConfiguration = /** @type {any} */ ({})
+
+describe("VelociousHttpServerClientResponse#setStatus", () => {
+  it("accepts the existing named aliases", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+
+    response.setStatus("success")
+    expect(response.getStatusCode()).toEqual(200)
+    expect(response.getStatusMessage()).toEqual("OK")
+
+    response.setStatus("not-found")
+    expect(response.getStatusCode()).toEqual(404)
+    expect(response.getStatusMessage()).toEqual("Not Found")
+
+    response.setStatus("internal-server-error")
+    expect(response.getStatusCode()).toEqual(500)
+    expect(response.getStatusMessage()).toEqual("Internal server error")
+  })
+
+  it("accepts arbitrary numeric HTTP status codes with their standard reason phrases", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+
+    response.setStatus(201)
+    expect(response.getStatusCode()).toEqual(201)
+    expect(response.getStatusMessage()).toEqual("Created")
+
+    response.setStatus(204)
+    expect(response.getStatusCode()).toEqual(204)
+    expect(response.getStatusMessage()).toEqual("No Content")
+
+    response.setStatus(401)
+    expect(response.getStatusCode()).toEqual(401)
+    expect(response.getStatusMessage()).toEqual("Unauthorized")
+
+    // The status code that originally motivated this change.
+    response.setStatus(422)
+    expect(response.getStatusCode()).toEqual(422)
+    expect(response.getStatusMessage()).toEqual("Unprocessable Entity")
+
+    response.setStatus(503)
+    expect(response.getStatusCode()).toEqual(503)
+    expect(response.getStatusMessage()).toEqual("Service Unavailable")
+  })
+
+  it("accepts numeric strings for codes from the standard range", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+
+    response.setStatus("422")
+    expect(response.getStatusCode()).toEqual(422)
+    expect(response.getStatusMessage()).toEqual("Unprocessable Entity")
+  })
+
+  it("falls back to OK as the message when an unknown numeric code in range is provided", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+
+    response.setStatus(299)
+    expect(response.getStatusCode()).toEqual(299)
+    expect(response.getStatusMessage()).toEqual("OK")
+  })
+
+  it("rejects values outside the 1xx-5xx range", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+
+    expect(() => response.setStatus(99)).toThrow("Unhandled status: 99")
+    expect(() => response.setStatus(600)).toThrow("Unhandled status: 600")
+    expect(() => response.setStatus("teapot")).toThrow("Unhandled status: teapot")
+  })
+})

--- a/src/controller.js
+++ b/src/controller.js
@@ -204,12 +204,16 @@ export default class VelociousController {
   async render({json, status, ...restArgs} = {}) {
     restArgsError(restArgs)
 
-    if (json) {
-      return this.renderJsonArg(json)
-    }
-
+    // Apply the status BEFORE delegating to renderJsonArg/renderView so
+    // `render({json: {...}, status: 422})` produces a 422 response with
+    // a JSON body. The previous order short-circuited via `return
+    // this.renderJsonArg(json)` and silently dropped the status arg.
     if (status) {
       this._response.setStatus(status)
+    }
+
+    if (json) {
+      return this.renderJsonArg(json)
     }
 
     return await this.renderView()

--- a/src/http-server/client/index.js
+++ b/src/http-server/client/index.js
@@ -367,16 +367,26 @@ export default class VeoliciousHttpServerClient {
       response.setHeader("Connection", "Keep-Alive")
     }
 
-    let contentLength
+    // Per RFC 7230 §3.3.3, responses with status codes 1xx, 204, and 304
+    // MUST NOT carry a message body and MUST NOT include Content-Length
+    // (with a narrow 304 exception we don't lean on). Sending one would
+    // desynchronize keep-alive clients waiting for bytes that never
+    // arrive — drop the body entirely for those codes.
+    const isBodylessStatus = isNoBodyStatusCode(response.getStatusCode())
 
-    if (hasFilePath) {
-      const stats = await fs.stat(filePath)
-      contentLength = stats.size
-    } else {
-      contentLength = bodyIsString ? new TextEncoder().encode(body).length : body.byteLength
+    if (!isBodylessStatus) {
+      let contentLength
+
+      if (hasFilePath) {
+        const stats = await fs.stat(filePath)
+        contentLength = stats.size
+      } else {
+        contentLength = bodyIsString ? new TextEncoder().encode(body).length : body.byteLength
+      }
+
+      response.setHeader("Content-Length", contentLength)
     }
 
-    response.setHeader("Content-Length", contentLength)
     response.setHeader("Date", date.toUTCString())
     response.setHeader("Server", "Velocious")
 
@@ -395,7 +405,9 @@ export default class VeoliciousHttpServerClient {
     this.events.emit("output", headers)
     this.logger.debug(() => ["sendResponse headers emitted", {clientCount: this.clientCount, headersLength: headers.length}])
 
-    if (hasFilePath) {
+    if (isBodylessStatus) {
+      this.logger.debug(() => ["sendResponse body suppressed for no-body status", {clientCount: this.clientCount, statusCode: response.getStatusCode()}])
+    } else if (hasFilePath) {
       await this.sendFileOutput(filePath)
     } else {
       this.events.emit("output", body)
@@ -451,4 +463,16 @@ export default class VeoliciousHttpServerClient {
 
     return false
   }
+}
+
+/**
+ * Returns true for the status codes that RFC 7230 §3.3.3 declares
+ * cannot carry a message body: every 1xx informational, 204 No
+ * Content, and 304 Not Modified.
+ *
+ * @param {number} statusCode - HTTP status code.
+ * @returns {boolean}
+ */
+function isNoBodyStatusCode(statusCode) {
+  return (statusCode >= 100 && statusCode < 200) || statusCode === 204 || statusCode === 304
 }

--- a/src/http-server/client/response.js
+++ b/src/http-server/client/response.js
@@ -1,5 +1,77 @@
 // @ts-check
 
+/** @type {Record<string, number>} */
+const NAMED_STATUS_ALIASES = {
+  "success": 200,
+  "not-found": 404,
+  "internal-server-error": 500
+}
+
+/** @type {Record<number, string>} */
+const STANDARD_STATUS_MESSAGES = {
+  100: "Continue",
+  101: "Switching Protocols",
+  102: "Processing",
+  103: "Early Hints",
+  200: "OK",
+  201: "Created",
+  202: "Accepted",
+  203: "Non-Authoritative Information",
+  204: "No Content",
+  205: "Reset Content",
+  206: "Partial Content",
+  207: "Multi-Status",
+  208: "Already Reported",
+  226: "IM Used",
+  300: "Multiple Choices",
+  301: "Moved Permanently",
+  302: "Found",
+  303: "See Other",
+  304: "Not Modified",
+  307: "Temporary Redirect",
+  308: "Permanent Redirect",
+  400: "Bad Request",
+  401: "Unauthorized",
+  402: "Payment Required",
+  403: "Forbidden",
+  404: "Not Found",
+  405: "Method Not Allowed",
+  406: "Not Acceptable",
+  407: "Proxy Authentication Required",
+  408: "Request Timeout",
+  409: "Conflict",
+  410: "Gone",
+  411: "Length Required",
+  412: "Precondition Failed",
+  413: "Payload Too Large",
+  414: "URI Too Long",
+  415: "Unsupported Media Type",
+  416: "Range Not Satisfiable",
+  417: "Expectation Failed",
+  418: "I'm a teapot",
+  421: "Misdirected Request",
+  422: "Unprocessable Entity",
+  423: "Locked",
+  424: "Failed Dependency",
+  425: "Too Early",
+  426: "Upgrade Required",
+  428: "Precondition Required",
+  429: "Too Many Requests",
+  431: "Request Header Fields Too Large",
+  451: "Unavailable For Legal Reasons",
+  500: "Internal server error",
+  501: "Not Implemented",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+  504: "Gateway Timeout",
+  505: "HTTP Version Not Supported",
+  506: "Variant Also Negotiates",
+  507: "Insufficient Storage",
+  508: "Loop Detected",
+  510: "Not Extended",
+  511: "Network Authentication Required"
+}
+
 export default class VelociousHttpServerClientResponse {
   /** @type {string | Uint8Array | null} */
   body = null
@@ -102,22 +174,25 @@ export default class VelociousHttpServerClientResponse {
   }
 
   /**
+   * Accepts a numeric HTTP status code (e.g. `422`) or one of the
+   * named aliases (`"success"`, `"not-found"`, `"internal-server-error"`).
+   * Numeric inputs in the standard 1xx-5xx range resolve their own
+   * status messages from the IANA registry; aliases keep the
+   * back-compatible code mapping.
+   *
    * @param {number | string} status - Status.
    * @returns {void} - No return value.
    */
   setStatus(status) {
-    if (status == "success" || status == 200) {
-      this.statusCode = 200
-      this.statusMessage = "OK"
-    } else if (status == "not-found" || status == 404) {
-      this.statusCode = 404
-      this.statusMessage = "Not Found"
-    } else if (status == "internal-server-error" || status == 500) {
-      this.statusCode = 500
-      this.statusMessage = "Internal server error"
-    } else {
+    const aliasCode = NAMED_STATUS_ALIASES[String(status)]
+    const numericStatus = aliasCode ?? Number(status)
+
+    if (!Number.isInteger(numericStatus) || numericStatus < 100 || numericStatus > 599) {
       throw new Error(`Unhandled status: ${status}`)
     }
+
+    this.statusCode = numericStatus
+    this.statusMessage = STANDARD_STATUS_MESSAGES[numericStatus] || "OK"
   }
 
   /**

--- a/src/http-server/client/response.js
+++ b/src/http-server/client/response.js
@@ -28,6 +28,7 @@ const STANDARD_STATUS_MESSAGES = {
   302: "Found",
   303: "See Other",
   304: "Not Modified",
+  305: "Use Proxy",
   307: "Temporary Redirect",
   308: "Permanent Redirect",
   400: "Bad Request",


### PR DESCRIPTION
## Summary

Two coupled gaps surfaced together while shipping a 422 error envelope from a tensorbuzz controller:

1. **`Controller#render({json, status})` silently dropped `status`.** The render method returned early from `renderJsonArg(json)` before reaching the `status` branch, so `render({json: {...}, status: 422})` produced a 200 with the JSON body. Now applies `status` first.
2. **`Response#setStatus(...)` only whitelisted `success`/`not-found`/`internal-server-error` + 200/404/500.** Every other status (e.g. 422) threw `Unhandled status: <x>`, which would have surfaced the prior fix as a request runner crash. Now accepts any integer in the 1xx-5xx range and resolves a standard reason phrase from the IANA registry; the named aliases keep working unchanged.

500 keeps its existing `"Internal server error"` message (lowercase) so existing missing-view + completed-logging specs stay green.

## Test plan

- [x] `spec/http-server/response-spec.js` — aliases, numeric codes (incl. 422 + 503), numeric strings, unknown-but-in-range fallback to "OK", rejection of out-of-range / unparseable values
- [x] `spec/http-server/render-with-json-and-status-spec.js` — dummy `/ping-with-status` route asserts `response.status === 422`, `statusText === "Unprocessable Entity"`, and the JSON body
- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (clean — pre-existing warnings unchanged)
- [ ] `npm test` — local DB setup unrelated to this fix prevented running the full suite locally; relies on CI

## Why it matters

Without these fixes any controller that wants to render an error envelope with a non-200 status (`render({json: {errorMessage}, status: 422})`) either silently shipped 200 (status dropped) or crashed the request runner (`Unhandled status: 422`). The two paths together mean the documented `status` arg of `render` was effectively unusable for anything but plain 200/404/500 view renders. tensorbuzz's M6 process-snapshot endpoint hit both stacked failures back-to-back.