### PR TITLE
Surface backend errorMessage envelope from 4xx shared frontend-model responses

### DIFF
--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -368,6 +368,97 @@ describe("Frontend models - base", () => {
     }
   })
 
+  it("surfaces the backend errorMessage envelope from a 4xx shared frontend-model response", async () => {
+    const originalFetch = globalThis.fetch
+
+    /** Shared API user model. */
+    class ErrorEnvelopeUser extends FrontendModelBase {
+      /**
+       * @returns {{attributes: string[], commands: string[], primaryKey: string}}
+       */
+      static resourceConfig() {
+        return {
+          attributes: ["id", "name"],
+          commands: ["index"],
+          primaryKey: "id"
+        }
+      }
+    }
+
+    globalThis.fetch = /** @type {typeof fetch} */ (async () => /** @type {any} */ ({
+      ok: false,
+      status: 422,
+      headers: {
+        get: (key) => key.toLowerCase() === "content-type" ? "application/json; charset=UTF-8" : null
+      },
+      /** @returns {Promise<string>} */
+      text: async () => JSON.stringify({
+        errorMessage: "Resource is unavailable.",
+        status: "error"
+      })
+    }))
+
+    try {
+      let captured
+
+      try {
+        await ErrorEnvelopeUser.toArray()
+      } catch (error) {
+        captured = error
+      }
+
+      expect(captured instanceof Error).toEqual(true)
+      expect(captured.message).toEqual("Resource is unavailable.")
+    } finally {
+      resetFrontendModelTransport()
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("falls back to the status-only error when a 4xx response has no errorMessage envelope", async () => {
+    const originalFetch = globalThis.fetch
+
+    /** Shared API user model. */
+    class StatusOnlyErrorUser extends FrontendModelBase {
+      /**
+       * @returns {{attributes: string[], commands: string[], primaryKey: string}}
+       */
+      static resourceConfig() {
+        return {
+          attributes: ["id", "name"],
+          commands: ["index"],
+          primaryKey: "id"
+        }
+      }
+    }
+
+    globalThis.fetch = /** @type {typeof fetch} */ (async () => /** @type {any} */ ({
+      ok: false,
+      status: 503,
+      headers: {
+        get: () => "text/plain"
+      },
+      /** @returns {Promise<string>} */
+      text: async () => "service unavailable"
+    }))
+
+    try {
+      let captured
+
+      try {
+        await StatusOnlyErrorUser.toArray()
+      } catch (error) {
+        captured = error
+      }
+
+      expect(captured instanceof Error).toEqual(true)
+      expect(captured.message).toEqual("Request failed (503) for shared frontend model API")
+    } finally {
+      resetFrontendModelTransport()
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it("keeps built-in command aliases as built-in command types in shared requests", async () => {
     const originalFetch = globalThis.fetch
     /** @type {FetchCall[]} */

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -963,11 +963,34 @@ async function performSharedFrontendModelApiRequest(requestPayload) {
     method: "POST"
   })
 
+  const responseText = await response.text()
+
   if (!response.ok) {
+    // Surface the backend's friendly errorMessage envelope (the
+    // `{status: "error", errorMessage: "..."}` shape every controller
+    // ships on its 4xx/5xx responses) instead of the generic status
+    // string. Fall through to the status-only message when the body is
+    // missing, non-JSON, or has no usable errorMessage field.
+    const responseContentType = response.headers.get("content-type")
+
+    if (responseContentType && responseContentType.includes("application/json") && responseText.length > 0) {
+      /** @type {Record<string, any> | null} */
+      let errorBody
+
+      try {
+        errorBody = JSON.parse(responseText)
+      } catch {
+        errorBody = null
+      }
+
+      if (errorBody && typeof errorBody.errorMessage === "string" && errorBody.errorMessage.trim().length > 0) {
+        throw new Error(errorBody.errorMessage.trim())
+      }
+    }
+
     throw new Error(`Request failed (${response.status}) for shared frontend model API`)
   }
 
-  const responseText = await response.text()
   const json = responseText.length > 0 ? JSON.parse(responseText) : {}
 
   return /** @type {Record<string, any>} */ (deserializeFrontendModelTransportValue(json))


### PR DESCRIPTION
## Summary

The fetch path of `performSharedFrontendModelApiRequest` previously threw a generic `Request failed (${status}) for shared frontend model API` before reading the response body — so a backend that shipped a `{status: "error", errorMessage: "..."}` envelope (the standard shape controllers use to surface authorization denials, missing records, etc.) had its message silently dropped on every frontend-model command. Callers' catch blocks rendered the generic status string in the UI instead of the friendly message.

Now the path reads the body, and if the response is JSON with a non-empty `errorMessage` field, throws with that message. Falls through to the status-only message when the body is missing, non-JSON, or carries no usable `errorMessage`. Mirrors the same fix applied at the http-server end in #628 — together they make the documented `render({json, status})` envelope round-trip end-to-end.

The `websocketClient` transport path is unaffected: it always read the body and let `throwOnErrorFrontendModelResponse` handle the envelope downstream. Bringing the fetch path in line with that behavior keeps the two transports symmetric.

## Test plan

- [x] `spec/frontend-models/base-spec.js` gains two stubbed-fetch specs:
  - "surfaces the backend errorMessage envelope from a 4xx shared frontend-model response" — 422 + `{errorMessage, status: "error"}` JSON envelope ⇒ thrown error message equals the envelope's errorMessage
  - "falls back to the status-only error when a 4xx response has no errorMessage envelope" — 503 + text/plain body ⇒ thrown error message is `Request failed (503) for shared frontend model API`
- [x] `npm run typecheck` clean, `npm run lint` clean (warnings unchanged)
- [x] Programmatic sanity check confirms both paths

## Why it matters

In the consumer (tensorbuzz), the AdminProjectBuildDebugScreen surfaced "Request failed for /admin/projects/.../debug-data with status 404" instead of "Build debug data is unavailable." after velocious 1.0.361 started correctly applying status codes. The direct-HTTP path was already fixed there in `ServerConnection.parseResponse`. This PR closes the same gap on the frontend-model side so any caller that catches and renders error messages from a frontend-model command also gets the friendly envelope text.