### PR TITLE
[codex] Add aggregate frontend model count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,9 @@ Velocious does not support running multiple test processes simultaneously. Alway
 
 ## Pull requests
 Use the `gh` CLI to open GitHub pull requests when needed.
-Do not push to GitHub unless explicitly asked.
+When the user asks to implement, fix, or continue feature work on a non-master branch, treat that as permission to commit, push, and open or update the matching PR after validation unless the user explicitly says to keep the work local-only.
+Do not stop after verified local changes on a feature branch; either publish the PR in the same flow or clearly document the blocker that prevents publishing.
+For investigation-only tasks, do not push to GitHub unless explicitly asked.
 
 ## Branches and commits
 When asked to create branches and commit changes, come up with fitting branch names and commit messages. Split commits into smaller commits for each distinct change.

--- a/README.md
+++ b/README.md
@@ -1223,7 +1223,7 @@ const totalTasks = await Task.count()
 const distinctProjects = await Task.joins({project: true}).distinct().count()
 ```
 
-Frontend-model `count()` runs as a backend aggregate, so paginated list UIs can request totals without loading and serializing every matching model.
+Frontend-model `count()` runs as a backend aggregate, so list UIs can request counts without loading and serializing every matching model.
 
 ### First and last
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ This creates `src/frontend-models/user.js` (and one file per configured resource
 - `await Task.sort({project: {account: [["name", "desc"], ["createdAt", "asc"]]}}).toArray()`
 - `await Task.group({project: {account: ["id"]}}).toArray()`
 - `await Task.sort({comments: ["body", "asc"]}).distinct().toArray()`
+- `await Task.count()`
 - `await Task.pluck("id")`
 - `await Task.pluck({project: ["id"]})`
 - `await User.preload({projects: ["tasks"]}).toArray()`
@@ -1221,6 +1222,8 @@ const tasks = await Task.page(2).perPage(25).toArray()
 const totalTasks = await Task.count()
 const distinctProjects = await Task.joins({project: true}).distinct().count()
 ```
+
+Frontend-model `count()` runs as a backend aggregate, so paginated list UIs can request totals without loading and serializing every matching model.
 
 ### First and last
 

--- a/changelog.d/20260506-frontend-model-count.md
+++ b/changelog.d/20260506-frontend-model-count.md
@@ -1,0 +1,1 @@
+Frontend-model `count()` now executes as a backend aggregate instead of loading every matching model and counting client-side.

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -17,6 +17,10 @@ Without a resource definition, frontend models should not silently work.
 - Resource `commands` can map `attach`, `download`, and `url` in addition to CRUD/index commands.
 - Resource `attachments` defines attachment helpers generated on frontend models.
 
+## Custom index records
+- Resources that override `records()` opt out of aggregate `count()` automatically because Velocious cannot infer whether the default query still matches the custom records.
+- Override `count()` on the resource when a custom index needs frontend-model `count()` support.
+
 ## Naming conventions
 - Resource files should use concise domain naming (for example `battle.js`, `challenge-level.js`) instead of frontend-specific suffixes.
 - Frontend imports should use model names without `FrontendModel` suffix (for example `Account`, not `AccountFrontendModel`).

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -43,6 +43,7 @@
 - `all()` returns a query builder (parity with backend `all()`).
 - `order(...)` is available as alias parity with backend `order(...)` (and forwards to frontend sort payloads).
 - `first()` and `last()` are available on frontend query/model classes.
+- `count()` executes as a backend aggregate, preserving filters, joins, grouping, distinct, and pagination without loading serialized model records.
 - `search(path, column, operator, value)` supports both named operators (`gt`, `lt`, `gteq`, `lteq`) and symbolic aliases (`>`, `<`, `>=`, `<=`).
 - `defineScope(...)` creates reusable named query scopes. Call `Model.scopeName(args...)` to start a new query, or `query.scope(Model.scopeName.scope(args...))` to apply the same scope to an existing frontend query.
 - Frontend scope callbacks receive `{query, modelClass}` plus `table: null` and `driver: null`; frontend scopes should stay descriptor-based (`where`, `joins`, `sort`, etc.) rather than building raw SQL.

--- a/spec/database/query/model-class-query.browser-spec.js
+++ b/spec/database/query/model-class-query.browser-spec.js
@@ -62,6 +62,31 @@ describe("Database - query - model class query", {databaseCleaning: {transaction
     expect(count).toEqual(4)
   })
 
+  it("counts records after limit and offset are applied", async () => {
+    const project = await Project.create({nameEn: "Paginated count", nameDe: "Seitennummerierte Anzahl"})
+    await Task.create({name: "Paginated count task 1", project})
+    await Task.create({name: "Paginated count task 2", project})
+    await Task.create({name: "Paginated count task 3", project})
+
+    const limitedCount = await Task
+      .order("tasks.id ASC")
+      .limit(2)
+      .count()
+    const offsetCount = await Task
+      .order("tasks.id ASC")
+      .offset(2)
+      .count()
+    const pageCount = await Task
+      .order("tasks.id ASC")
+      .page(2)
+      .perPage(2)
+      .count()
+
+    expect(limitedCount).toEqual(2)
+    expect(offsetCount).toEqual(1)
+    expect(pageCount).toEqual(1)
+  })
+
   it("findOrInitializeBy marks new records as new and changed", async () => {
     const record = await Task.where({name: "New Task"}).findOrInitializeBy({name: "New Task"})
 

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -1169,6 +1169,33 @@ describe("Frontend models - base", () => {
     }
   })
 
+  it("sends pagination payload when using count()", async () => {
+    const User = buildTestModelClass()
+    const fetchStub = stubFetch({count: 5})
+
+    try {
+      const usersCount = await User
+        .limit(5)
+        .offset(10)
+        .count()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            count: true,
+            limit: 5,
+            offset: 10
+          },
+          url: "/frontend-models"
+        }
+      ])
+      expect(usersCount).toEqual(5)
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
   it("throws when using ransack with an unknown attribute", async () => {
     const User = buildTestModelClass()
     const sevenDaysAgo = new Date("2026-02-24T10:00:00.000Z")

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -869,10 +869,7 @@ describe("Frontend models - base", () => {
   it("returns model count with count", async () => {
     const User = buildTestModelClass()
     const fetchStub = stubFetch({
-      models: [
-        {email: "john@example.com", id: 5, name: "John"},
-        {email: "jane@example.com", id: 6, name: "Jane"}
-      ]
+      count: 2
     })
 
     try {
@@ -880,7 +877,7 @@ describe("Frontend models - base", () => {
 
       expect(fetchStub.calls).toEqual([
         {
-          body: {},
+          body: {count: true},
           url: "/frontend-models"
         }
       ])
@@ -1074,7 +1071,7 @@ describe("Frontend models - base", () => {
 
   it("sends relationship-path searches payload when using search(...).count()", async () => {
     const User = buildTestModelClass()
-    const fetchStub = stubFetch({models: [{id: 1}, {id: 2}]})
+    const fetchStub = stubFetch({count: 2})
 
     try {
       const oneDayAgo = new Date("2026-02-24T10:00:00.000Z")
@@ -1085,6 +1082,7 @@ describe("Frontend models - base", () => {
       expect(fetchStub.calls).toEqual([
         {
           body: {
+            count: true,
             searches: [
               {
                 column: "createdAt",
@@ -1134,6 +1132,37 @@ describe("Frontend models - base", () => {
           url: "/frontend-models"
         }
       ])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("omits model serialization payload when using count()", async () => {
+    const {Project} = buildPreloadTestModelClasses()
+    const fetchStub = stubFetch({count: 1})
+
+    try {
+      const projectsCount = await Project
+        .preload(["tasks"])
+        .select({
+          Project: ["id"],
+          Task: ["id"]
+        })
+        .where({id: 1})
+        .order("name")
+        .count()
+
+      expect(fetchStub.calls).toEqual([
+        {
+          body: {
+            count: true,
+            where: {id: 1}
+          },
+          url: "/frontend-models"
+        }
+      ])
+      expect(projectsCount).toEqual(1)
     } finally {
       resetFrontendModelTransport()
       fetchStub.restore()

--- a/spec/frontend-models/base.browser-spec.js
+++ b/spec/frontend-models/base.browser-spec.js
@@ -375,8 +375,12 @@ describe("Frontend models - base browser integration", {databaseCleaning: {trans
       await seedUsers()
 
       const usersCount = await User.count()
+      const filteredUsersCount = await User
+        .search([], "email", "like", "%john%")
+        .count()
 
       expect(usersCount).toEqual(2)
+      expect(filteredUsersCount).toEqual(1)
     } finally {
       resetFrontendModelTransport()
     }

--- a/spec/frontend-models/base.browser-spec.js
+++ b/spec/frontend-models/base.browser-spec.js
@@ -378,9 +378,13 @@ describe("Frontend models - base browser integration", {databaseCleaning: {trans
       const filteredUsersCount = await User
         .search([], "email", "like", "%john%")
         .count()
+      const limitedUsersCount = await User.limit(1).count()
+      const offsetUsersCount = await User.offset(1).count()
 
       expect(usersCount).toEqual(2)
       expect(filteredUsersCount).toEqual(1)
+      expect(limitedUsersCount).toEqual(1)
+      expect(offsetUsersCount).toEqual(1)
     } finally {
       resetFrontendModelTransport()
     }

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -577,9 +577,13 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
         const filteredUsersCount = await User
           .search([], "email", "like", "%john%")
           .count()
+        const limitedUsersCount = await User.limit(1).count()
+        const offsetUsersCount = await User.offset(1).count()
 
         expect(usersCount).toEqual(2)
         expect(filteredUsersCount).toEqual(1)
+        expect(limitedUsersCount).toEqual(1)
+        expect(offsetUsersCount).toEqual(1)
       } finally {
         resetFrontendModelTransport()
       }

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -574,8 +574,12 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
         await seedHttpFrontendModels()
 
         const usersCount = await User.count()
+        const filteredUsersCount = await User
+          .search([], "email", "like", "%john%")
+          .count()
 
         expect(usersCount).toEqual(2)
+        expect(filteredUsersCount).toEqual(1)
       } finally {
         resetFrontendModelTransport()
       }

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -253,6 +253,10 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
 
   /** @returns {Promise<number>} - Resolves with the count.  */
   async count() {
+    if (this._limit !== null || this._offset !== null) {
+      return await this.paginatedCount()
+    }
+
     // Generate count SQL
     const primaryKey = `${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(this.getModelClass().primaryKey())}`
     const distinctPrefix = this._distinct ? "DISTINCT " : ""
@@ -291,6 +295,26 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
     }
 
     return countResult
+  }
+
+  /** @returns {Promise<number>} - Resolves with the count after pagination is applied. */
+  async paginatedCount() {
+    const countQuery = this.clone()
+    const countSql = this.driver.getType() == "pgsql" ? "COUNT(*)::int" : "COUNT(*)"
+    const sql = [
+      `SELECT ${countSql} AS ${this.driver.quoteColumn("count")}`,
+      `FROM (${countQuery.toSql()}) AS ${this.driver.quoteTable("paginated_count_rows")}`
+    ].join(" ")
+    const results = /** @type {{count: number}[]} */ (await this.driver.query(
+      sql,
+      {logName: this.queryLogName("Count")}
+    ))
+
+    if (results.length != 1 || !("count" in results[0])) {
+      throw new Error("Invalid count result")
+    }
+
+    return results[0].count
   }
 
   /**

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -1514,6 +1514,11 @@ export default class FrontendModelController extends Controller {
     return normalizeFrontendModelPluck(this.frontendModelParams().pluck)
   }
 
+  /** @returns {boolean} - Whether the request asks for an aggregate count. */
+  frontendModelCountRequested() {
+    return this.frontendModelParams().count === true
+  }
+
   /**
    * @returns {Array<{attributeName: string, relationshipName: string, where?: Record<string, unknown>}>}
    *   Frontend withCount entries. Empty array when not requested.
@@ -3002,6 +3007,17 @@ export default class FrontendModelController extends Controller {
     const resource = this.frontendModelResourceInstance()
 
     if (action === "index") {
+      if (this.frontendModelCountRequested()) {
+        if (!(await resource.supportsCount("index"))) {
+          throw new Error("count is not supported when resource records are customized")
+        }
+
+        return {
+          count: await resource.count(),
+          status: "success"
+        }
+      }
+
       const pluck = this.frontendModelPluck()
 
       if (pluck.length > 0) {

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -195,6 +195,17 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
 
   /**
    * @param {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url"} action - Action.
+   * @returns {boolean | Promise<boolean>} - Whether count is supported.
+   */
+  supportsCount(action) {
+    void action
+
+    return Object.getPrototypeOf(this).records === FrontendModelBaseResource.prototype.records ||
+      Object.getPrototypeOf(this).count !== FrontendModelBaseResource.prototype.count
+  }
+
+  /**
+   * @param {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url"} action - Action.
    * @returns {boolean | void | Promise<boolean | void>} - Continue processing unless false.
    */
   beforeAction(action) {
@@ -208,6 +219,13 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    */
   async records() {
     return await this.typedControllerInstance().frontendModelIndexQuery().toArray()
+  }
+
+  /**
+   * @returns {Promise<number>} - Records count for index action.
+   */
+  async count() {
+    return await this.typedControllerInstance().frontendModelIndexQuery().count()
   }
 
   /**
@@ -782,4 +800,3 @@ function filterWritableFrontendModelAttributes(receiver, attributes, resource = 
 
   return writableAttributes
 }
-

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -1642,9 +1642,25 @@ export default class FrontendModelQuery {
    * @returns {Promise<number>} - Number of loaded model instances.
    */
   async count() {
-    const models = await this.toArray()
+    const response = await this.modelClass.executeCommand("index", {
+      ...this.joinsPayload(),
+      ...this.searchPayload(),
+      ...this.groupPayload(),
+      ...this.distinctPayload(),
+      ...this.wherePayload(),
+      ...this.paginationPayload(),
+      count: true
+    })
 
-    return models.length
+    if (!response || typeof response !== "object") {
+      throw new Error(`Expected object response but got: ${response}`)
+    }
+
+    if (!Number.isFinite(response.count)) {
+      throw new Error(`Expected numeric count response but got: ${response.count}`)
+    }
+
+    return response.count
   }
 
   /**


### PR DESCRIPTION
## Summary

- change frontend model `count()` to request a backend aggregate instead of materializing all rows
- add backend `count` handling and a resource override hook for custom index record sets
- document the count behavior and tighten the repo PR workflow note so verified feature-branch work is published as a PR

## Root Cause

`FrontendModelQuery.count()` used `toArray().length`, so selects like Awesome Tasks' task select pagination counted by fetching every matching task with default attributes.

## Validation

- `npm test -- spec/frontend-models/base-spec.js`
- `npm test -- spec/frontend-models/base.http-integration-spec.js`
- `NODE_ENV=test npm run test:browser -- spec/frontend-models/base.browser-spec.js`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `git diff --check`
