### PR TITLE
Cache schema metadata in database drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,7 @@ npx velocious db:schema:load
 
 ## Schema metadata cache
 
-Velocious caches schema metadata on each database driver instance so repeated model initialization, table lookups, column introspection, and structure SQL generation can reuse the same database results. The cache is cleared automatically after schema-changing SQL runs through Velocious, such as migrations, `createTable`, `dropTable`, `renameColumn`, `ALTER TABLE`, and `CREATE INDEX`. See [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md) for details.
+Velocious caches schema metadata on each database driver instance so repeated model initialization, table lookups, column introspection, and structure SQL generation can reuse the same database results. The cache is cleared automatically after schema-changing SQL runs through Velocious, such as migrations, `createTable`, `dropTable`, `renameColumn`, `ALTER TABLE`, `CREATE INDEX`, and `COMMENT ON`. See [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md) for details.
 
 If another process changes the schema outside Velocious while the current process is still running, clear the cache before reading metadata again:
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon` (see [docs/beacon.md](docs/beacon.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
+* In-process driver schema metadata caching (see [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md))
 
 # Setup
 
@@ -1019,6 +1020,33 @@ npx velocious db:schema:load
 ```
 
 `db:schema:load` reads `db/structure-<identifier>.sql` for each configured database identifier and executes those statements against the current connections.
+
+## Schema metadata cache
+
+Velocious caches schema metadata on each database driver instance so repeated model initialization, table lookups, column introspection, and structure SQL generation can reuse the same database results. The cache is cleared automatically after schema-changing SQL runs through Velocious, such as migrations, `createTable`, `dropTable`, `renameColumn`, `ALTER TABLE`, and `CREATE INDEX`. See [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md) for details.
+
+If another process changes the schema outside Velocious while the current process is still running, clear the cache before reading metadata again:
+
+```js
+await configuration.ensureConnections(async (dbs) => {
+  dbs.default.clearSchemaCache()
+})
+```
+
+To disable schema metadata caching for a database connection, set `schemaCache: false` on that database config:
+
+```js
+export default new Configuration({
+  database: {
+    development: {
+      default: {
+        type: "mysql",
+        schemaCache: false
+      }
+    }
+  }
+})
+```
 
 ## Configure CLI commands (Node vs Browser)
 

--- a/changelog.d/20260504-schema-cache.md
+++ b/changelog.d/20260504-schema-cache.md
@@ -1,0 +1,1 @@
+Added in-process schema metadata caching for database drivers, with automatic invalidation after schema-changing SQL and a `schemaCache: false` database config option to disable it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.
 - `docs/query-bulk-operations.md`: `updateAll` for efficient batch updates and `destroyAll` behavior.
 - `docs/logging.md`: Rails-style request and database query logging behavior.
+- `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/routing-hooks-and-autoroutes.md`: Route hook support and frontend-model autoroute behavior.
 - `docs/authorization-and-current.md`: Ability usage, `Current`, and `accessible`/`accessibleBy` behavior.

--- a/docs/schema-metadata-cache.md
+++ b/docs/schema-metadata-cache.md
@@ -1,0 +1,34 @@
+# Schema Metadata Cache
+
+Velocious caches schema metadata on each database driver instance. This avoids repeated schema introspection during startup and model initialization, especially table-list, column-list, foreign-key, index, and structure SQL queries.
+
+The cache is in-process only. It is not written to disk and is discarded when the driver instance is closed.
+
+## Invalidation
+
+Velocious clears the cache automatically after successful schema-changing SQL sent through `db.query(...)`. This covers migrations and helpers such as `createTable`, `dropTable`, `renameColumn`, `ALTER TABLE`, `CREATE INDEX`, and `DROP INDEX`.
+
+If another process changes the schema outside the running Velocious process, clear the cache before reading schema metadata again:
+
+```js
+await configuration.ensureConnections(async (dbs) => {
+  dbs.default.clearSchemaCache()
+})
+```
+
+## Disabling
+
+Schema metadata caching is enabled by default. Disable it for a database by setting `schemaCache: false` on that database config:
+
+```js
+export default new Configuration({
+  database: {
+    development: {
+      default: {
+        type: "mysql",
+        schemaCache: false
+      }
+    }
+  }
+})
+```

--- a/docs/schema-metadata-cache.md
+++ b/docs/schema-metadata-cache.md
@@ -6,7 +6,7 @@ The cache is in-process only. It is not written to disk and is discarded when th
 
 ## Invalidation
 
-Velocious clears the cache automatically after successful schema-changing SQL sent through `db.query(...)`. This covers migrations and helpers such as `createTable`, `dropTable`, `renameColumn`, `ALTER TABLE`, `CREATE INDEX`, and `DROP INDEX`.
+Velocious clears the cache automatically after successful schema-changing SQL sent through `db.query(...)`. This covers migrations and helpers such as `createTable`, `dropTable`, `renameColumn`, `ALTER TABLE`, `CREATE INDEX`, `DROP INDEX`, and `COMMENT ON`.
 
 If another process changes the schema outside the running Velocious process, clear the cache before reading schema metadata again:
 

--- a/spec/database/drivers/schema-cache-spec.js
+++ b/spec/database/drivers/schema-cache-spec.js
@@ -1,0 +1,118 @@
+// @ts-check
+
+import AsyncTrackedMultiConnection from "../../../src/database/pool/async-tracked-multi-connection.js"
+import DatabaseDriverBase from "../../../src/database/drivers/base.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+
+class SchemaCacheTestDriver extends DatabaseDriverBase {
+  /** @type {string[]} */
+  queries = []
+
+  async connect() {}
+
+  /** @returns {string} - Driver type. */
+  getType() { return "test" }
+
+  /** @returns {string} - Primary key type. */
+  primaryKeyType() { return "bigint" }
+
+  /** @returns {string} - Query SQL. */
+  queryToSql() { return "" }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @returns {Promise<import("../../../src/database/drivers/base.js").QueryResultType>} - Query result.
+   */
+  async _queryActual(sql) {
+    this.queries.push(sql)
+
+    return []
+  }
+}
+
+/**
+ * @param {import("../../../src/configuration-types.js").DatabaseConfigurationType} databaseConfig - Database configuration.
+ * @returns {import("../../../src/configuration.js").default} - Configuration-shaped object.
+ */
+function buildConfiguration(databaseConfig) {
+  return /** @type {import("../../../src/configuration.js").default} */ (/** @type {unknown} */ ({
+    getCurrentRequestTiming() {
+      return undefined
+    },
+    getEnvironment() {
+      return "test"
+    },
+    getQueryLoggingEnabled() {
+      return false
+    },
+    resolveDatabaseConfiguration() {
+      return databaseConfig
+    }
+  }))
+}
+
+describe("Database drivers - schema cache", {databaseCleaning: {truncate: false}}, () => {
+  it("clears schema caches across live async-tracked pool connections", async () => {
+    const pool = new AsyncTrackedMultiConnection({
+      configuration: buildConfiguration({driver: SchemaCacheTestDriver, name: "schema-cache-test", type: "sqlite"}),
+      identifier: "default"
+    })
+    const firstConnection = await pool.checkout()
+    const secondConnection = await pool.checkout()
+    let firstLoads = 0
+    let secondLoads = 0
+
+    try {
+      await firstConnection._cachedSchemaMetadata("tables", async () => {
+        firstLoads++
+
+        return ["first"]
+      })
+      await secondConnection._cachedSchemaMetadata("tables", async () => {
+        secondLoads++
+
+        return ["second"]
+      })
+
+      await secondConnection.query("CREATE TABLE schema_cache_pool_test(id int)")
+
+      await firstConnection._cachedSchemaMetadata("tables", async () => {
+        firstLoads++
+
+        return ["first-after-ddl"]
+      })
+      await secondConnection._cachedSchemaMetadata("tables", async () => {
+        secondLoads++
+
+        return ["second-after-ddl"]
+      })
+
+      expect(firstLoads).toBe(2)
+      expect(secondLoads).toBe(2)
+    } finally {
+      pool.checkin(firstConnection)
+      pool.checkin(secondConnection)
+    }
+  })
+
+  it("treats comment statements as schema-cache-invalidating SQL", async () => {
+    const driver = new SchemaCacheTestDriver({}, buildConfiguration({driver: SchemaCacheTestDriver, name: "schema-cache-test", type: "sqlite"}))
+    let loads = 0
+
+    await driver._cachedSchemaMetadata("columns:posts", async () => {
+      loads++
+
+      return ["before-comment"]
+    })
+
+    await driver.query("COMMENT ON COLUMN posts.title IS 'Visible title'")
+
+    await driver._cachedSchemaMetadata("columns:posts", async () => {
+      loads++
+
+      return ["after-comment"]
+    })
+
+    expect(loads).toBe(2)
+  })
+})

--- a/spec/database/drivers/schema-cache.browser-spec.js
+++ b/spec/database/drivers/schema-cache.browser-spec.js
@@ -1,0 +1,235 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import LoggerArrayOutput from "../../../src/logger/outputs/array-output.js"
+import Migration from "../../../src/database/migration/index.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+
+/** @typedef {import("../../../src/configuration-types.js").LoggingConfiguration} LoggingConfiguration */
+/** @typedef {Configuration & {_logging?: LoggingConfiguration}} MutableLoggingConfiguration */
+/** @typedef {import("../../../src/database/drivers/base.js").default} Driver */
+
+/**
+ * @param {function(LoggerArrayOutput): Promise<void>} callback - Callback with captured query logs.
+ * @returns {Promise<void>} - Resolves when complete.
+ */
+async function withQueryLogOutput(callback) {
+  const configuration = /** @type {MutableLoggingConfiguration} */ (Configuration.current())
+  const previousLogging = configuration._logging
+  const arrayOutput = new LoggerArrayOutput({limit: 10000})
+
+  configuration._logging = {
+    console: false,
+    file: false,
+    outputs: [{output: arrayOutput, levels: ["info"]}],
+    queryLogging: true
+  }
+
+  try {
+    await callback(arrayOutput)
+  } finally {
+    configuration._logging = previousLogging
+  }
+}
+
+/**
+ * @param {LoggerArrayOutput} arrayOutput - Query log output.
+ * @returns {string[]} - SQL log messages.
+ */
+function sqlMessages(arrayOutput) {
+  return arrayOutput
+    .getLogs()
+    .filter((log) => log.subject == "SQL")
+    .map((log) => log.message)
+}
+
+/**
+ * @param {LoggerArrayOutput} arrayOutput - Query log output.
+ * @param {function(string): boolean} callback - Message matcher.
+ * @returns {number} - Matching SQL query count.
+ */
+function countSqlMessages(arrayOutput, callback) {
+  return sqlMessages(arrayOutput).filter(callback).length
+}
+
+/**
+ * @param {Driver} driver - Database driver.
+ * @param {string} message - Log message.
+ * @returns {boolean} - Whether the query lists database tables.
+ */
+function isTableListQuery(driver, message) {
+  if (driver.getType() == "mysql") return message.includes("SHOW FULL TABLES")
+  if (driver.getType() == "pgsql") return message.includes("SELECT * FROM information_schema.tables")
+  if (driver.getType() == "sqlite") return message.includes("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+  if (driver.getType() == "mssql") return message.includes("[INFORMATION_SCHEMA].[TABLES]")
+
+  throw new Error(`Unknown driver type: ${driver.getType()}`)
+}
+
+/**
+ * @param {Driver} driver - Database driver.
+ * @param {string} tableName - Table name.
+ * @param {string} message - Log message.
+ * @returns {boolean} - Whether the query introspects table columns.
+ */
+function isColumnListQuery(driver, tableName, message) {
+  if (driver.getType() == "mysql") return message.includes(`SHOW FULL COLUMNS FROM \`${tableName}\``)
+  if (driver.getType() == "pgsql") return message.includes("information_schema.columns AS columns") && message.includes(`columns.table_name = '${tableName}'`)
+  if (driver.getType() == "sqlite") return message.includes(`PRAGMA table_info('${tableName}')`)
+  if (driver.getType() == "mssql") return message.includes("[INFORMATION_SCHEMA].[COLUMNS]") && message.includes(tableName)
+
+  throw new Error(`Unknown driver type: ${driver.getType()}`)
+}
+
+/**
+ * @param {object} args - Options object.
+ * @param {Configuration} args.configuration - Configuration instance.
+ * @param {Driver} args.driver - Database driver.
+ * @param {string} args.tableName - Table name.
+ * @returns {Promise<void>} - Resolves when complete.
+ */
+async function createSchemaCacheTable({configuration, driver, tableName}) {
+  const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+  await migration.createTable(tableName, {id: false}, (table) => {
+    table.string("name")
+  })
+}
+
+/**
+ * @param {Driver} driver - Database driver.
+ * @param {string} tableName - Table name.
+ * @returns {Promise<void>} - Resolves when complete.
+ */
+async function dropSchemaCacheTable(driver, tableName) {
+  await driver.dropTable(tableName, {cascade: true, ifExists: true})
+  driver.clearSchemaCache()
+}
+
+describe("database - drivers - schema cache", {tags: ["dummy"]}, () => {
+  it("reuses cached table list metadata for repeated lookups", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      driver.clearSchemaCache()
+
+      await withQueryLogOutput(async (arrayOutput) => {
+        const tables = await driver.getTables()
+
+        tables.length = 0
+
+        expect((await driver.getTables()).length).toBeGreaterThan(0)
+        await driver.getTableByNameOrFail("projects")
+
+        expect(countSqlMessages(arrayOutput, (message) => isTableListQuery(driver, message))).toBe(1)
+      })
+    })
+  })
+
+  it("reuses cached table column metadata", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const table = await driver.getTableByNameOrFail("projects")
+
+      driver.clearSchemaCache()
+
+      await withQueryLogOutput(async (arrayOutput) => {
+        await table.getColumns()
+        await table.getColumns()
+
+        expect(countSqlMessages(arrayOutput, (message) => isColumnListQuery(driver, "projects", message))).toBe(1)
+      })
+    })
+  })
+
+  it("invalidates cached table metadata after schema changes", async () => {
+    const configuration = Configuration.current()
+    const tableName = "schema_cache_probe"
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      await dropSchemaCacheTable(driver, tableName)
+      driver.clearSchemaCache()
+
+      try {
+        await withQueryLogOutput(async (arrayOutput) => {
+          expect(await driver.tableExists(tableName)).toBe(false)
+          expect(await driver.tableExists(tableName)).toBe(false)
+          expect(countSqlMessages(arrayOutput, (message) => isTableListQuery(driver, message))).toBe(1)
+
+          await createSchemaCacheTable({configuration, driver, tableName})
+
+          expect(await driver.tableExists(tableName)).toBe(true)
+          expect(countSqlMessages(arrayOutput, (message) => isTableListQuery(driver, message))).toBe(2)
+        })
+      } finally {
+        await dropSchemaCacheTable(driver, tableName)
+      }
+    })
+  })
+
+  it("reuses cached structure sql until schema changes", async () => {
+    const configuration = Configuration.current()
+    const tableName = "schema_cache_structure_probe"
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      await dropSchemaCacheTable(driver, tableName)
+      driver.clearSchemaCache()
+
+      try {
+        await withQueryLogOutput(async (arrayOutput) => {
+          await driver.structureSql()
+
+          const afterFirstStructureSql = sqlMessages(arrayOutput).length
+
+          expect(afterFirstStructureSql).toBeGreaterThan(0)
+
+          await driver.structureSql()
+
+          expect(sqlMessages(arrayOutput).length).toBe(afterFirstStructureSql)
+
+          await createSchemaCacheTable({configuration, driver, tableName})
+
+          const afterCreateTable = sqlMessages(arrayOutput).length
+
+          await driver.structureSql()
+
+          expect(sqlMessages(arrayOutput).length).toBeGreaterThan(afterCreateTable)
+        })
+      } finally {
+        await dropSchemaCacheTable(driver, tableName)
+      }
+    })
+  })
+
+  it("can disable schema cache usage through the driver args", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const args = driver.getArgs()
+      const previousSchemaCache = args.schemaCache
+
+      args.schemaCache = false
+      driver.clearSchemaCache()
+
+      try {
+        await withQueryLogOutput(async (arrayOutput) => {
+          await driver.getTables()
+          await driver.getTables()
+
+          expect(countSqlMessages(arrayOutput, (message) => isTableListQuery(driver, message))).toBe(2)
+        })
+      } finally {
+        if (previousSchemaCache === undefined) {
+          delete args.schemaCache
+        } else {
+          args.schemaCache = previousSchemaCache
+        }
+
+        driver.clearSchemaCache()
+      }
+    })
+  })
+})

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -67,6 +67,7 @@
  * @property {(file: string) => string} [locateFile] - Optional sqlite-web sql.js wasm resolver (`initSqlJs({locateFile})`).
  * @property {boolean} [readOnly] - Whether writes should be blocked for this database.
  * @property {string} [schema] - Default schema for unqualified table lookups (MSSQL).
+ * @property {boolean} [schemaCache] - Whether schema metadata should be cached on the driver. Defaults to true.
  * @property {object} [record] - Record-level configuration.
  * @property {boolean} [record.transactions] - Whether record operations should use transactions.
  * @property {boolean} [reset] - Whether to reset the database on startup.

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -94,6 +94,8 @@ export default class VelociousDatabaseDriversBase {
   _afterCommitCallbackFrames
   /** @type {Map<string, Promise<unknown>>} */
   _schemaCache
+  /** @type {(() => void) | undefined} */
+  _schemaCacheInvalidator
 
   /**
    * @param {import("../../configuration-types.js").DatabaseConfigurationType} config - Configuration object.
@@ -315,7 +317,28 @@ export default class VelociousDatabaseDriversBase {
    * @returns {void} - No return value.
    */
   clearSchemaCache() {
+    if (this._schemaCacheInvalidator) {
+      this._schemaCacheInvalidator()
+      return
+    }
+
+    this._clearLocalSchemaCache()
+  }
+
+  /**
+   * Clears only the metadata cached on this driver instance.
+   * @returns {void} - No return value.
+   */
+  _clearLocalSchemaCache() {
     this._schemaCache.clear()
+  }
+
+  /**
+   * @param {() => void} invalidator - Callback used to clear schema caches that share this driver pool.
+   * @returns {void} - No return value.
+   */
+  setSchemaCacheInvalidator(invalidator) {
+    this._schemaCacheInvalidator = invalidator
   }
 
   /**
@@ -884,6 +907,7 @@ export default class VelociousDatabaseDriversBase {
 
     if (!normalized) return false
     if (/^(create|alter|drop|rename)\b/.test(normalized)) return true
+    if (/^comment\s+on\b/.test(normalized)) return true
     if (/^exec(?:ute)?\s+sp_rename\b/.test(normalized)) return true
     if (/^if\b[\s\S]*\bbegin\s+(create|alter|drop|rename)\b/.test(normalized)) return true
 

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -92,6 +92,8 @@ export default class VelociousDatabaseDriversBase {
   idSeq = undefined
   /** @type {Array<Array<() => void | Promise<void>>>} */
   _afterCommitCallbackFrames
+  /** @type {Map<string, Promise<unknown>>} */
+  _schemaCache
 
   /**
    * @param {import("../../configuration-types.js").DatabaseConfigurationType} config - Configuration object.
@@ -105,6 +107,7 @@ export default class VelociousDatabaseDriversBase {
     this._afterCommitCallbackFrames = []
     this._transactionsCount = 0
     this._transactionsActionsMutex = new Mutex()
+    this._schemaCache = new Map()
   }
 
   /**
@@ -175,6 +178,7 @@ export default class VelociousDatabaseDriversBase {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async reconnect() {
+    this.clearSchemaCache()
     await this.close()
     await this.connect()
   }
@@ -304,6 +308,72 @@ export default class VelociousDatabaseDriversBase {
    */
   getIdSeq() {
     return this.idSeq
+  }
+
+  /**
+   * Clears cached schema metadata for this driver instance.
+   * @returns {void} - No return value.
+   */
+  clearSchemaCache() {
+    this._schemaCache.clear()
+  }
+
+  /**
+   * @returns {boolean} - Whether schema metadata caching is enabled.
+   */
+  _schemaCacheEnabled() {
+    return this.getArgs().schemaCache !== false
+  }
+
+  /**
+   * @template T
+   * @param {string} cacheKey - Schema cache key.
+   * @param {() => Promise<T>} callback - Cache miss callback.
+   * @returns {Promise<T>} - Resolves with the cached metadata.
+   */
+  async _cachedSchemaMetadata(cacheKey, callback) {
+    if (!this._schemaCacheEnabled()) return await callback()
+
+    const existingPromise = this._schemaCache.get(cacheKey)
+
+    if (existingPromise) {
+      return /** @type {T} */ (this._schemaCacheReturnValue(await existingPromise))
+    }
+
+    const promise = (async () => await callback())()
+
+    this._schemaCache.set(cacheKey, promise)
+
+    try {
+      return /** @type {T} */ (this._schemaCacheReturnValue(await promise))
+    } catch (error) {
+      if (this._schemaCache.get(cacheKey) === promise) {
+        this._schemaCache.delete(cacheKey)
+      }
+
+      throw error
+    }
+  }
+
+  /**
+   * @template T
+   * @param {string} tableName - Table name.
+   * @param {string} metadataName - Metadata name.
+   * @param {() => Promise<T>} callback - Cache miss callback.
+   * @returns {Promise<T>} - Resolves with the cached table metadata.
+   */
+  async _cachedTableSchemaMetadata(tableName, metadataName, callback) {
+    return await this._cachedSchemaMetadata(`table:${tableName}:${metadataName}`, callback)
+  }
+
+  /**
+   * @param {unknown} value - Cached value.
+   * @returns {unknown} - Value returned to callers.
+   */
+  _schemaCacheReturnValue(value) {
+    if (Array.isArray(value)) return value.slice()
+
+    return value
   }
 
   /**
@@ -792,7 +862,32 @@ export default class VelociousDatabaseDriversBase {
       })
     }
 
+    if (this._schemaCacheInvalidatingSql(sql)) {
+      this.clearSchemaCache()
+    }
+
     return result
+  }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @returns {boolean} - Whether the SQL should invalidate schema metadata.
+   */
+  _schemaCacheInvalidatingSql(sql) {
+    const normalized = sql
+      .trim()
+      .replace(/^\ufeff/, "")
+      .replace(/\/\*[\s\S]*?\*\//g, " ")
+      .replace(/--[^\n]*(\n|$)/g, " ")
+      .replace(/\s+/g, " ")
+      .toLowerCase()
+
+    if (!normalized) return false
+    if (/^(create|alter|drop|rename)\b/.test(normalized)) return true
+    if (/^exec(?:ute)?\s+sp_rename\b/.test(normalized)) return true
+    if (/^if\b[\s\S]*\bbegin\s+(create|alter|drop|rename)\b/.test(normalized)) return true
+
+    return false
   }
 
   /**

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -271,45 +271,22 @@ export default class VelociousDatabaseDriversMssql extends Base{
    * @returns {Promise<Array<import("../base-table.js").default>>} - Resolves with the tables.
    */
   async getTables() {
-    const schema = this.getArgs()?.schema || this.getArgs()?.sqlConfig?.options?.schema
-    const schemaClause = schema
-      ? ` AND [TABLE_SCHEMA] = ${this.quote(schema)}`
-      : " AND [TABLE_SCHEMA] = SCHEMA_NAME()"
-    const result = await this.query(`SELECT [TABLE_NAME] FROM [INFORMATION_SCHEMA].[TABLES] WHERE [TABLE_CATALOG] = DB_NAME()${schemaClause}`)
-    const tables = []
+    return await this._cachedSchemaMetadata("tables", async () => {
+      const schema = this.getArgs()?.schema || this.getArgs()?.sqlConfig?.options?.schema
+      const schemaClause = schema
+        ? ` AND [TABLE_SCHEMA] = ${this.quote(schema)}`
+        : " AND [TABLE_SCHEMA] = SCHEMA_NAME()"
+      const result = await this.query(`SELECT [TABLE_NAME] FROM [INFORMATION_SCHEMA].[TABLES] WHERE [TABLE_CATALOG] = DB_NAME()${schemaClause}`)
+      const tables = []
 
-    for (const row of result) {
-      const table = new Table(this, /** @type {Record<string, string>} */ (row))
+      for (const row of result) {
+        const table = new Table(this, /** @type {Record<string, string>} */ (row))
 
-      tables.push(table)
-    }
+        tables.push(table)
+      }
 
-    return tables
-  }
-
-  /**
-   * @param {string} name - Name.
-   * @param {object} [args] - Options object.
-   * @param {boolean} args.throwError - Whether throw error.
-   * @returns {Promise<import("../base-table.js").default | undefined>} - Resolves with the table by name.
-   */
-  async getTableByName(name, args) {
-    const schema = this.getArgs()?.schema || this.getArgs()?.sqlConfig?.options?.schema
-    const schemaClause = schema
-      ? ` AND [TABLE_SCHEMA] = ${this.quote(schema)}`
-      : " AND [TABLE_SCHEMA] = SCHEMA_NAME()"
-    const result = await this.query(`SELECT [TABLE_NAME] FROM [INFORMATION_SCHEMA].[TABLES] WHERE [TABLE_CATALOG] = DB_NAME()${schemaClause} AND [TABLE_NAME] = ${this.quote(name)}`)
-
-    if (result[0]) {
-      return new Table(this, /** @type {Record<string, string>} */ (result[0]))
-    }
-
-    if (args?.throwError !== false) {
-      const tables = await this.getTables()
-      const tableNames = tables.map((table) => table.getName())
-
-      throw new Error(this._missingTableErrorMessage(name, tableNames))
-    }
+      return tables
+    })
   }
 
   async lastInsertID() {
@@ -450,7 +427,7 @@ export default class VelociousDatabaseDriversMssql extends Base{
    * @returns {Promise<string | null>} - Resolves with SQL string.
    */
   async structureSql() {
-    return await new StructureSql({driver: this}).toSql()
+    return await this._cachedSchemaMetadata("structureSql", async () => await new StructureSql({driver: this}).toSql())
   }
 
   /**

--- a/src/database/drivers/mssql/table.js
+++ b/src/database/drivers/mssql/table.js
@@ -18,95 +18,101 @@ export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
   }
 
   async getColumns() {
-    const result = await this.driver.query(`
-      SELECT
-        *,
-        COLUMNPROPERTY(object_id(TABLE_SCHEMA + '.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity') AS isIdentity
-      FROM [INFORMATION_SCHEMA].[COLUMNS]
-      WHERE [TABLE_NAME] = ${this.driver.quote(this.getName())}
-    `)
-    const columns = []
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "columns", async () => {
+      const result = await this.driver.query(`
+        SELECT
+          *,
+          COLUMNPROPERTY(object_id(TABLE_SCHEMA + '.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity') AS isIdentity
+        FROM [INFORMATION_SCHEMA].[COLUMNS]
+        WHERE [TABLE_NAME] = ${this.driver.quote(this.getName())}
+      `)
+      const columns = []
 
-    for (const data of result) {
-      const column = new Column(this, data)
+      for (const data of result) {
+        const column = new Column(this, data)
 
-      columns.push(column)
-    }
+        columns.push(column)
+      }
 
-    return columns
+      return columns
+    })
   }
 
   async getForeignKeys() {
-    const sql = `
-      SELECT
-          fk.name AS ForeignKeyName,
-          tp.name AS ParentTable,
-          ref.name AS ReferencedTable,
-          cp.name AS ParentColumn,
-          cref.name AS ReferencedColumn,
-          tp.name AS TableName
-      FROM sys.foreign_keys fk
-      INNER JOIN sys.foreign_key_columns fkc
-          ON fkc.constraint_object_id = fk.object_id
-      INNER JOIN sys.tables tp
-          ON fkc.parent_object_id = tp.object_id
-      INNER JOIN sys.columns cp
-          ON fkc.parent_object_id = cp.object_id
-          AND fkc.parent_column_id = cp.column_id
-      INNER JOIN sys.tables ref
-          ON fkc.referenced_object_id = ref.object_id
-      INNER JOIN sys.columns cref
-          ON fkc.referenced_object_id = cref.object_id
-          AND fkc.referenced_column_id = cref.column_id
-      WHERE tp.name = ${this.driver.quote(this.getName())}
-      ORDER BY ForeignKeyName, ParentTable, ReferencedTable;
-    `
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "foreignKeys", async () => {
+      const sql = `
+        SELECT
+            fk.name AS ForeignKeyName,
+            tp.name AS ParentTable,
+            ref.name AS ReferencedTable,
+            cp.name AS ParentColumn,
+            cref.name AS ReferencedColumn,
+            tp.name AS TableName
+        FROM sys.foreign_keys fk
+        INNER JOIN sys.foreign_key_columns fkc
+            ON fkc.constraint_object_id = fk.object_id
+        INNER JOIN sys.tables tp
+            ON fkc.parent_object_id = tp.object_id
+        INNER JOIN sys.columns cp
+            ON fkc.parent_object_id = cp.object_id
+            AND fkc.parent_column_id = cp.column_id
+        INNER JOIN sys.tables ref
+            ON fkc.referenced_object_id = ref.object_id
+        INNER JOIN sys.columns cref
+            ON fkc.referenced_object_id = cref.object_id
+            AND fkc.referenced_column_id = cref.column_id
+        WHERE tp.name = ${this.driver.quote(this.getName())}
+        ORDER BY ForeignKeyName, ParentTable, ReferencedTable;
+      `
 
-    const foreignKeyRows = await this.driver.query(sql)
-    const foreignKeys = []
+      const foreignKeyRows = await this.driver.query(sql)
+      const foreignKeys = []
 
-    for (const foreignKeyRow of foreignKeyRows) {
-      const foreignKey = new ForeignKey(foreignKeyRow)
+      for (const foreignKeyRow of foreignKeyRows) {
+        const foreignKey = new ForeignKey(foreignKeyRow)
 
-      foreignKeys.push(foreignKey)
-    }
+        foreignKeys.push(foreignKey)
+      }
 
-    return foreignKeys
+      return foreignKeys
+    })
   }
 
   async getIndexes() {
-    const options = this.getOptions()
-    const sql = `
-      SELECT
-        sys.tables.name AS TableName,
-        sys.columns.name AS ColumnName,
-        sys.indexes.name AS index_name,
-        sys.indexes.type_desc AS IndexType,
-        sys.index_columns.is_included_column AS IsIncludedColumn,
-        sys.indexes.is_unique,
-        sys.indexes.is_primary_key,
-        sys.indexes.is_unique_constraint
-      FROM sys.indexes
-      INNER JOIN sys.index_columns ON sys.indexes.object_id = sys.index_columns.object_id AND sys.indexes.index_id = sys.index_columns.index_id
-      INNER JOIN sys.columns ON sys.index_columns.object_id = sys.columns.object_id AND sys.index_columns.column_id = sys.columns.column_id
-      INNER JOIN sys.tables ON sys.indexes.object_id = sys.tables.object_id
-      WHERE
-        sys.tables.name = ${options.quote(this.getName())}
-      ORDER BY
-        sys.indexes.name,
-        sys.index_columns.key_ordinal
-    `
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "indexes", async () => {
+      const options = this.getOptions()
+      const sql = `
+        SELECT
+          sys.tables.name AS TableName,
+          sys.columns.name AS ColumnName,
+          sys.indexes.name AS index_name,
+          sys.indexes.type_desc AS IndexType,
+          sys.index_columns.is_included_column AS IsIncludedColumn,
+          sys.indexes.is_unique,
+          sys.indexes.is_primary_key,
+          sys.indexes.is_unique_constraint
+        FROM sys.indexes
+        INNER JOIN sys.index_columns ON sys.indexes.object_id = sys.index_columns.object_id AND sys.indexes.index_id = sys.index_columns.index_id
+        INNER JOIN sys.columns ON sys.index_columns.object_id = sys.columns.object_id AND sys.index_columns.column_id = sys.columns.column_id
+        INNER JOIN sys.tables ON sys.indexes.object_id = sys.tables.object_id
+        WHERE
+          sys.tables.name = ${options.quote(this.getName())}
+        ORDER BY
+          sys.indexes.name,
+          sys.index_columns.key_ordinal
+      `
 
-    const rows = await this.getDriver().query(sql)
-    const indexes = []
+      const rows = await this.getDriver().query(sql)
+      const indexes = []
 
-    for (const row of rows) {
-      const index = new ColumnsIndex(this, row)
+      for (const row of rows) {
+        const index = new ColumnsIndex(this, row)
 
-      indexes.push(index)
-    }
+        indexes.push(index)
+      }
 
-    return indexes
+      return indexes
+    })
   }
 
   /** @returns {string} - The table name. */
@@ -132,4 +138,3 @@ export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
     }
   }
 }
-

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -279,23 +279,25 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<Array<import("../base-table.js").default>>} - Resolves with the tables.
    */
   async getTables() {
-    const result = await this.query("SHOW FULL TABLES")
-    const tables = []
+    return await this._cachedSchemaMetadata("tables", async () => {
+      const result = await this.query("SHOW FULL TABLES")
+      const tables = []
 
-    for (const row of result) {
-      const table = new Table(this, /** @type {Record<string, string>} */ (row))
+      for (const row of result) {
+        const table = new Table(this, /** @type {Record<string, string>} */ (row))
 
-      tables.push(table)
-    }
+        tables.push(table)
+      }
 
-    return tables
+      return tables
+    })
   }
 
   /**
    * @returns {Promise<string | null>} - Resolves with SQL string.
    */
   async structureSql() {
-    return await new StructureSql({driver: this}).toSql()
+    return await this._cachedSchemaMetadata("structureSql", async () => await new StructureSql({driver: this}).toSql())
   }
 
   /**

--- a/src/database/drivers/mysql/table.js
+++ b/src/database/drivers/mysql/table.js
@@ -17,77 +17,83 @@ export default class VelociousDatabaseDriversMysqlTable extends BaseTable {
   }
 
   async getColumns() {
-    const result = await this.driver.query(`SHOW FULL COLUMNS FROM \`${this.getName()}\``)
-    const columns = []
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "columns", async () => {
+      const result = await this.driver.query(`SHOW FULL COLUMNS FROM \`${this.getName()}\``)
+      const columns = []
 
-    for (const data of result) {
-      const column = new Column(this, data)
+      for (const data of result) {
+        const column = new Column(this, data)
 
-      columns.push(column)
-    }
+        columns.push(column)
+      }
 
-    return columns
+      return columns
+    })
   }
 
   async getForeignKeys() {
-    const sql = `
-      SELECT TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
-      FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-      WHERE
-        REFERENCED_TABLE_SCHEMA = (SELECT DATABASE()) AND
-        TABLE_NAME = ${this.driver.quote(this.getName())}
-    `
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "foreignKeys", async () => {
+      const sql = `
+        SELECT TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+        WHERE
+          REFERENCED_TABLE_SCHEMA = (SELECT DATABASE()) AND
+          TABLE_NAME = ${this.driver.quote(this.getName())}
+      `
 
-    const foreignKeyRows = await this.driver.query(sql)
-    const foreignKeys = []
+      const foreignKeyRows = await this.driver.query(sql)
+      const foreignKeys = []
 
-    for (const foreignKeyRow of foreignKeyRows) {
-      const foreignKey = new ForeignKey(foreignKeyRow)
+      for (const foreignKeyRow of foreignKeyRows) {
+        const foreignKey = new ForeignKey(foreignKeyRow)
 
-      foreignKeys.push(foreignKey)
-    }
+        foreignKeys.push(foreignKey)
+      }
 
-    return foreignKeys
+      return foreignKeys
+    })
   }
 
   async getIndexes() {
-    const options = this.getOptions()
-    const sql = `
-      SELECT
-        TABLE_SCHEMA,
-        TABLE_NAME,
-        INDEX_NAME AS index_name,
-        COLUMN_NAME,
-        SEQ_IN_INDEX,
-        NON_UNIQUE,
-        INDEX_TYPE
-      FROM INFORMATION_SCHEMA.STATISTICS
-      WHERE
-        TABLE_SCHEMA = DATABASE() AND
-        TABLE_NAME = ${options.quote(this.getName())}
-    `
-    const indexesRows = await this.getDriver().query(sql)
-    const indexes = []
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "indexes", async () => {
+      const options = this.getOptions()
+      const sql = `
+        SELECT
+          TABLE_SCHEMA,
+          TABLE_NAME,
+          INDEX_NAME AS index_name,
+          COLUMN_NAME,
+          SEQ_IN_INDEX,
+          NON_UNIQUE,
+          INDEX_TYPE
+        FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE
+          TABLE_SCHEMA = DATABASE() AND
+          TABLE_NAME = ${options.quote(this.getName())}
+      `
+      const indexesRows = await this.getDriver().query(sql)
+      const indexes = []
 
-    for (const indexRow of indexesRows) {
-      if (indexRow.NON_UNIQUE == 1) {
-        indexRow.is_unique = false
-      } else {
-        indexRow.is_unique = true
+      for (const indexRow of indexesRows) {
+        if (indexRow.NON_UNIQUE == 1) {
+          indexRow.is_unique = false
+        } else {
+          indexRow.is_unique = true
+        }
+
+        if (indexRow.index_name == "PRIMARY") {
+          indexRow.is_primary_key = true
+        } else {
+          indexRow.is_primary_key = false
+        }
+
+        const index = new ColumnsIndex(this, indexRow)
+
+        indexes.push(index)
       }
 
-      if (indexRow.index_name == "PRIMARY") {
-        indexRow.is_primary_key = true
-      } else {
-        indexRow.is_primary_key = false
-      }
-
-      const index = new ColumnsIndex(this, indexRow)
-
-      indexes.push(index)
-    }
-
-    return indexes
+      return indexes
+    })
   }
 
   /** @returns {string} - The table name. */

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -242,16 +242,18 @@ export default class VelociousDatabaseDriversPgsql extends Base{
   }
 
   async getTables() {
-    const result = await this.query("SELECT * FROM information_schema.tables WHERE table_catalog = CURRENT_DATABASE() AND table_schema = 'public'")
-    const tables = []
+    return await this._cachedSchemaMetadata("tables", async () => {
+      const result = await this.query("SELECT * FROM information_schema.tables WHERE table_catalog = CURRENT_DATABASE() AND table_schema = 'public'")
+      const tables = []
 
-    for (const row of result) {
-      const table = new Table(this, /** @type {Record<string, string>} */ (row))
+      for (const row of result) {
+        const table = new Table(this, /** @type {Record<string, string>} */ (row))
 
-      tables.push(table)
-    }
+        tables.push(table)
+      }
 
-    return tables
+      return tables
+    })
   }
 
   async lastInsertID() {
@@ -295,7 +297,7 @@ export default class VelociousDatabaseDriversPgsql extends Base{
    * @returns {Promise<string | null>} - Resolves with SQL string.
    */
   async structureSql() {
-    return await new StructureSql({driver: this}).toSql()
+    return await this._cachedSchemaMetadata("structureSql", async () => await new StructureSql({driver: this}).toSql())
   }
 
   /**

--- a/src/database/drivers/pgsql/table.js
+++ b/src/database/drivers/pgsql/table.js
@@ -17,105 +17,111 @@ export default class VelociousDatabaseDriversPgsqlTable extends BaseTable {
   }
 
   async getColumns() {
-    const result = await this.driver.query(`
-      SELECT
-        columns.*,
-        CASE WHEN key_column_usage.column_name IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key,
-        col_description((columns.table_schema || '.' || columns.table_name)::regclass, columns.ordinal_position) AS column_comment
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "columns", async () => {
+      const result = await this.driver.query(`
+        SELECT
+          columns.*,
+          CASE WHEN key_column_usage.column_name IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key,
+          col_description((columns.table_schema || '.' || columns.table_name)::regclass, columns.ordinal_position) AS column_comment
 
-      FROM
-        information_schema.columns AS columns
+        FROM
+          information_schema.columns AS columns
 
-      LEFT JOIN information_schema.table_constraints AS table_constraints ON
-        table_constraints.table_name = columns.table_name AND
-        table_constraints.table_schema = columns.table_schema AND
-        table_constraints.constraint_type = 'PRIMARY KEY'
+        LEFT JOIN information_schema.table_constraints AS table_constraints ON
+          table_constraints.table_name = columns.table_name AND
+          table_constraints.table_schema = columns.table_schema AND
+          table_constraints.constraint_type = 'PRIMARY KEY'
 
-      LEFT JOIN information_schema.key_column_usage AS key_column_usage ON
-        key_column_usage.constraint_name = table_constraints.constraint_name AND
-        key_column_usage.table_schema = table_constraints.table_schema AND
-        key_column_usage.table_name = columns.table_name AND
-        key_column_usage.column_name = columns.column_name
+        LEFT JOIN information_schema.key_column_usage AS key_column_usage ON
+          key_column_usage.constraint_name = table_constraints.constraint_name AND
+          key_column_usage.table_schema = table_constraints.table_schema AND
+          key_column_usage.table_name = columns.table_name AND
+          key_column_usage.column_name = columns.column_name
 
-      WHERE
-        columns.table_catalog = CURRENT_DATABASE() AND
-        columns.table_schema = 'public' AND
-        columns.table_name = '${this.getName()}'
-    `)
-    const columns = []
+        WHERE
+          columns.table_catalog = CURRENT_DATABASE() AND
+          columns.table_schema = 'public' AND
+          columns.table_name = '${this.getName()}'
+      `)
+      const columns = []
 
-    for (const data of result) {
-      const column = new Column(this, data)
+      for (const data of result) {
+        const column = new Column(this, data)
 
-      columns.push(column)
-    }
+        columns.push(column)
+      }
 
-    return columns
+      return columns
+    })
   }
 
   async getForeignKeys() {
-    const sql = `
-      SELECT
-        tc.constraint_name,
-        tc.table_name,
-        kcu.column_name,
-        ccu.table_name AS foreign_table_name,
-        ccu.column_name AS foreign_column_name
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "foreignKeys", async () => {
+      const sql = `
+        SELECT
+          tc.constraint_name,
+          tc.table_name,
+          kcu.column_name,
+          ccu.table_name AS foreign_table_name,
+          ccu.column_name AS foreign_column_name
 
-      FROM
-        information_schema.table_constraints AS tc
+        FROM
+          information_schema.table_constraints AS tc
 
-      JOIN information_schema.key_column_usage AS kcu ON
-        tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.key_column_usage AS kcu ON
+          tc.constraint_name = kcu.constraint_name
 
-      JOIN information_schema.constraint_column_usage AS ccu
-        ON ccu.constraint_name = tc.constraint_name
+        JOIN information_schema.constraint_column_usage AS ccu
+          ON ccu.constraint_name = tc.constraint_name
 
-      WHERE
-        constraint_type = 'FOREIGN KEY' AND
-        tc.table_catalog = CURRENT_DATABASE() AND
-        tc.table_name = ${this.getDriver().quote(this.getName())}
-    `
+        WHERE
+          constraint_type = 'FOREIGN KEY' AND
+          tc.table_catalog = CURRENT_DATABASE() AND
+          tc.table_name = ${this.getDriver().quote(this.getName())}
+      `
 
-    const foreignKeyRows = await this.getDriver().query(sql)
-    const foreignKeys = []
+      const foreignKeyRows = await this.getDriver().query(sql)
+      const foreignKeys = []
 
-    for (const foreignKeyRow of foreignKeyRows) {
-      const foreignKey = new ForeignKey(foreignKeyRow)
+      for (const foreignKeyRow of foreignKeyRows) {
+        const foreignKey = new ForeignKey(foreignKeyRow)
 
-      foreignKeys.push(foreignKey)
-    }
+        foreignKeys.push(foreignKey)
+      }
 
-    return foreignKeys
+      return foreignKeys
+    })
   }
 
   async getIndexes() {
-    const options = this.getOptions()
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "indexes", async () => {
+      const options = this.getOptions()
 
-    const indexesRows = await this.getDriver().query(`
-      SELECT
-        pg_attribute.attname AS column_name,
-        pg_index.indexrelid::regclass as index_name,
-        pg_class.relnamespace::regnamespace as schema_name,
-        pg_class.relname as table_name,
-        pg_index.indisprimary as is_primary_key,
-        pg_index.indisunique as is_unique
-      FROM pg_index
-      JOIN pg_class ON pg_class.oid = pg_index.indrelid
-      JOIN pg_attribute ON pg_attribute.attrelid = pg_class.oid AND pg_attribute.attnum = ANY(pg_index.indkey)
-      WHERE
-        pg_class.relname = ${options.quote(this.getName())}
-    `)
+      const indexesRows = await this.getDriver().query(`
+        SELECT
+          pg_attribute.attname AS column_name,
+          pg_index.indexrelid::regclass as index_name,
+          pg_class.relnamespace::regnamespace as schema_name,
+          pg_class.relname as table_name,
+          pg_index.indisprimary as is_primary_key,
+          pg_index.indisunique as is_unique
+        FROM pg_index
+        JOIN pg_class ON pg_class.oid = pg_index.indrelid
+        JOIN pg_attribute ON pg_attribute.attrelid = pg_class.oid AND pg_attribute.attnum = ANY(pg_index.indkey)
+        WHERE
+          pg_class.relname = ${options.quote(this.getName())}
+      `)
 
-    const indexes = []
+      const indexes = []
 
-    for (const indexRow of indexesRows) {
-      const columnsIndex = new ColumnsIndex(this, indexRow)
+      for (const indexRow of indexesRows) {
+        const columnsIndex = new ColumnsIndex(this, indexRow)
 
-      indexes.push(columnsIndex)
-    }
+        indexes.push(columnsIndex)
+      }
 
-    return indexes
+      return indexes
+    })
   }
 
   /** @returns {string} - The table name. */

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -101,40 +101,20 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
    */
   insertSql(args) { return new Insert(Object.assign({driver: this}, args)).toSql() }
 
-  /**
-   * @param {string} name - Name.
-   * @param {object} [args] - Options object.
-   * @param {boolean} args.throwError - Whether throw error.
-   * @returns {Promise<import("../base-table.js").default | undefined>} - Resolves with the table by name.
-   */
-  async getTableByName(name, args) {
-    const result = await this.query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${this.quote(name)} LIMIT 1`)
-    const row = result[0]
-
-    if (row) {
-      return new Table({driver: this, row: /** @type {Record<string, string | number | null>} */ (row)})
-    }
-
-    if (args?.throwError !== false) {
-      const tables = await this.getTables()
-      const tableNames = tables.map((table) => table.getName())
-
-      throw new Error(this._missingTableErrorMessage(name, tableNames))
-    }
-  }
-
   /** @returns {Promise<Array<import("../base-table.js").default>>} - Resolves with the tables.  */
   async getTables() {
-    const result = await this.query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
-    const tables = []
+    return await this._cachedSchemaMetadata("tables", async () => {
+      const result = await this.query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      const tables = []
 
-    for (const row of result) {
-      const table = new Table({driver: this, row: /** @type {Record<string, string | number | null>} */ (row)})
+      for (const row of result) {
+        const table = new Table({driver: this, row: /** @type {Record<string, string | number | null>} */ (row)})
 
-      tables.push(table)
-    }
+        tables.push(table)
+      }
 
-    return tables
+      return tables
+    })
   }
 
   /**
@@ -338,7 +318,7 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
    * @returns {Promise<string | null>} - Resolves with SQL string.
    */
   async structureSql() {
-    return await new StructureSql({driver: this}).toSql()
+    return await this._cachedSchemaMetadata("structureSql", async () => await new StructureSql({driver: this}).toSql())
   }
 
   /**

--- a/src/database/drivers/sqlite/table.js
+++ b/src/database/drivers/sqlite/table.js
@@ -19,57 +19,63 @@ export default class VelociousDatabaseDriversSqliteTable extends BaseTable {
 
   /** @returns {Promise<Array<import("../base-column.js").default>>} - Resolves with the columns.  */
   async getColumns() {
-    const result = await this.driver.query(`PRAGMA table_info('${this.getName()}')`)
-    const columns = []
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "columns", async () => {
+      const result = await this.driver.query(`PRAGMA table_info('${this.getName()}')`)
+      const columns = []
 
-    for (const columnData of result) {
-      const column = new Column({column: columnData, driver: this.driver, table: this})
+      for (const columnData of result) {
+        const column = new Column({column: columnData, driver: this.driver, table: this})
 
-      columns.push(column)
-    }
+        columns.push(column)
+      }
 
-    return columns
+      return columns
+    })
   }
 
   async getForeignKeys() {
-    const foreignKeysData = await this.driver.query(`SELECT * FROM pragma_foreign_key_list(${this.driver.quote(this.getName())})`)
-    const foreignKeys = []
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "foreignKeys", async () => {
+      const foreignKeysData = await this.driver.query(`SELECT * FROM pragma_foreign_key_list(${this.driver.quote(this.getName())})`)
+      const foreignKeys = []
 
-    for (const foreignKeyData of foreignKeysData) {
-      const foreignKey = new ForeignKey(foreignKeyData, {tableName: this.getName()})
+      for (const foreignKeyData of foreignKeysData) {
+        const foreignKey = new ForeignKey(foreignKeyData, {tableName: this.getName()})
 
-      foreignKeys.push(foreignKey)
-    }
+        foreignKeys.push(foreignKey)
+      }
 
-    return foreignKeys
+      return foreignKeys
+    })
   }
 
   async getIndexes() {
-    const rows = await this.getDriver().query(`PRAGMA index_list(${this.getOptions().quoteTableName(this.getName())})`)
-    const indexes = []
+    return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "indexes", async () => {
+      const rows = await this.getDriver().query(`PRAGMA index_list(${this.getOptions().quoteTableName(this.getName())})`)
+      const indexes = []
 
-    for (const row of rows) {
-      const indexName = row.name
+      for (const row of rows) {
+        const indexName = row.name
 
-      if (typeof indexName == "string" && indexName.startsWith("sqlite_autoindex_")) {
-        // Skip SQLite internal auto indexes (e.g. primary key / unique constraints)
-        continue
+        if (typeof indexName == "string" && indexName.startsWith("sqlite_autoindex_")) {
+          // Skip SQLite internal auto indexes (e.g. primary key / unique constraints)
+          continue
+        }
+
+        const columnsIndex = new ColumnsIndex(this, row)
+        const indexMasterData = await this.getDriver().query(`SELECT * FROM sqlite_master WHERE type = 'index' AND name = ${this.getOptions().quote(columnsIndex.getName())}`)
+        const sql = indexMasterData[0]?.sql
+
+        if (!sql) throw new Error(`Could not find SQL for index ${columnsIndex.getName()}`)
+
+        const indexData = /** @type {typeof columnsIndex.data & {columnNames?: string[]}} */ (columnsIndex.data)
+
+        indexData.columnNames = this._parseColumnsFromSQL(String(sql))
+
+        indexes.push(columnsIndex)
       }
 
-      const columnsIndex = new ColumnsIndex(this, row)
-      const indexMasterData = await this.getDriver().query(`SELECT * FROM sqlite_master WHERE type = 'index' AND name = ${this.getOptions().quote(columnsIndex.getName())}`)
-      const sql = indexMasterData[0]?.sql
-
-      if (!sql) throw new Error(`Could not find SQL for index ${columnsIndex.getName()}`)
-
-      const indexData = /** @type {typeof columnsIndex.data & {columnNames?: string[]}} */ (columnsIndex.data)
-
-      indexData.columnNames = this._parseColumnsFromSQL(String(sql))
-
-      indexes.push(columnsIndex)
-    }
-
-    return indexes
+      return indexes
+    })
   }
 
   /**

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -203,6 +203,23 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   }
 
   /**
+   * Clears schema metadata cached by every live connection owned by this pool.
+   * @returns {void} - No return value.
+   */
+  clearSchemaCache() {
+    const connections = new Set([
+      ...this.connections,
+      ...Object.values(this.connectionsInUse),
+      this.getGlobalConnection(),
+      this._testSharedConnection
+    ].filter(Boolean))
+
+    for (const connection of connections) {
+      if (connection) this._clearConnectionSchemaCache(connection)
+    }
+  }
+
+  /**
    * Closes all active and cached connections for this pool.
    * @returns {Promise<void>} - Resolves when complete.
    */

--- a/src/database/pool/base-methods-forward.js
+++ b/src/database/pool/base-methods-forward.js
@@ -8,7 +8,6 @@ export default function baseMethodsForward(PoolBase) {
   const forwardMethods = [
     "alterTable",
     "alterTableSQLs",
-    "clearSchemaCache",
     "createIndex",
     "createIndexSQLs",
     "createTable",

--- a/src/database/pool/base-methods-forward.js
+++ b/src/database/pool/base-methods-forward.js
@@ -8,6 +8,7 @@ export default function baseMethodsForward(PoolBase) {
   const forwardMethods = [
     "alterTable",
     "alterTableSQLs",
+    "clearSchemaCache",
     "createIndex",
     "createIndexSQLs",
     "createTable",

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -134,6 +134,23 @@ class VelociousDatabasePoolBase {
   }
 
   /**
+   * Clears schema metadata cached by this pool's current connection.
+   * Pools that keep multiple connections alive should override this to clear every live connection.
+   * @returns {void} - No return value.
+   */
+  clearSchemaCache() {
+    this._clearConnectionSchemaCache(this.getCurrentConnection())
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection whose local schema cache should be cleared.
+   * @returns {void} - No return value.
+   */
+  _clearConnectionSchemaCache(connection) {
+    connection._clearLocalSchemaCache()
+  }
+
+  /**
    * @abstract
    * @returns {string} - The primary key type.
    */
@@ -167,6 +184,7 @@ class VelociousDatabasePoolBase {
 
     const connectionWithPoolKey = /** @type {import("../drivers/base.js").default & {[POOL_CONFIGURATION_KEY]?: string}} */ (connection)
     connectionWithPoolKey[POOL_CONFIGURATION_KEY] = this.getConfigurationReuseKey()
+    connection.setSchemaCacheInvalidator(() => this.clearSchemaCache())
 
     return connection
   }

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -115,6 +115,7 @@ class VelociousDatabasePoolBase {
       name: databaseConfiguration.name,
       port: databaseConfiguration.port,
       schema: databaseConfiguration.schema,
+      schemaCache: databaseConfiguration.schemaCache,
       sqlConfig: databaseConfiguration.sqlConfig,
       type: databaseConfiguration.type,
       useDatabase: databaseConfiguration.useDatabase,

--- a/src/database/pool/single-multi-use.js
+++ b/src/database/pool/single-multi-use.js
@@ -45,6 +45,14 @@ export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
   }
 
   /**
+   * Clears schema metadata cached by the reusable connection if it exists.
+   * @returns {void} - No return value.
+   */
+  clearSchemaCache() {
+    if (this.connection) this._clearConnectionSchemaCache(this.connection)
+  }
+
+  /**
    * Closes the cached connection if it exists.
    * @returns {Promise<void>} - Resolves when complete.
    */


### PR DESCRIPTION
## Summary
- Add in-process schema metadata caching on database drivers with automatic DDL invalidation.
- Cache table, column, index, foreign-key, and structure SQL metadata across supported drivers.
- Add `schemaCache: false`, `clearSchemaCache()`, docs, changelog, and dummy-app integration coverage.

## Verification
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `git diff --check`
- direct driver-cache sanity script

## Not run
- `npm run test -- spec/database/drivers/schema-cache.browser-spec.js` could not complete locally because the existing dirty dummy config points at MariaDB and fails during setup with access denied for user `peakflow`.