### PR TITLE
generate:base-models: emit JSDoc for mediumtext / tinytext columns

### DIFF
--- a/spec/cli/commands/generate/base-models-jsdoc-types-spec.js
+++ b/spec/cli/commands/generate/base-models-jsdoc-types-spec.js
@@ -36,4 +36,11 @@ describe("Base-models JSDoc types", () => {
     expect(command.jsDocTypeFromColumn(column)).toEqual("Date")
     expect(command.jsDocSetterTypeFromColumn(column)).toEqual("Date | string")
   })
+
+  it("maps mysql mediumtext and tinytext to string", async () => {
+    const command = buildCommand()
+
+    expect(command.jsDocTypeFromColumn({getType: () => "mediumtext"})).toEqual("string")
+    expect(command.jsDocTypeFromColumn({getType: () => "tinytext"})).toEqual("string")
+  })
 })

--- a/src/environment-handlers/node/cli/commands/generate/base-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/base-models.js
@@ -325,7 +325,7 @@ export default class DbGenerateModel extends BaseCommand {
       return "boolean"
     } else if (type == "json") {
       return "Record<string, any>"
-    } else if (["blob", "char", "nvarchar", "varchar", "text", "longtext", "uuid", "character varying"].includes(type)) {
+    } else if (["blob", "char", "nvarchar", "varchar", "text", "tinytext", "mediumtext", "longtext", "uuid", "character varying"].includes(type)) {
       return "string"
     } else if (["bit", "bigint", "decimal", "float", "int", "integer", "numeric", "smallint", "tinyint"].includes(type)) {
       return "number"


### PR DESCRIPTION
## Summary

`jsDocTypeFromColumn` lists `text` and `longtext` but not the sibling MySQL/MariaDB string types `mediumtext` and `tinytext`. When a column has one of those types, the helper returns `undefined`, the generator skips the JSDoc block, and the produced base-model strips the `string | null` annotation off both the getter and the setter. Consumers that run `npx velocious generate:base-models` after migrating a column to MEDIUMTEXT silently lose type information.

Spotted in tensorbuzz, where a recent migration widened `builds.config_text`, `build_groups.config_text`, and `build_logs.log` to MEDIUMTEXT — the next regeneration silently dropped JSDoc on `configText()` / `setConfigText(...)` etc., which a reviewer caught at PR time.

## Changes

- Add `mediumtext` and `tinytext` to the string-type list in `src/environment-handlers/node/cli/commands/generate/base-models.js`.
- New regression case in `spec/cli/commands/generate/base-models-jsdoc-types-spec.js` covering both types.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` shows no new errors (363 pre-existing warnings unchanged).
- [ ] `npm test -- spec/cli/commands/generate/base-models-jsdoc-types-spec.js` — couldn't run from my dev box (the spec file's existing tests also need a reachable dummy DB, which is unavailable here). The new test is structurally identical to the two passing-on-CI cases above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
