### PR TITLE
Log framework-error to stderr when no listener is attached

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -660,7 +660,13 @@ export default class VelociousConfiguration {
    * listener is attached to either `framework-error` or `all-error`,
    * also schedules an unhandled promise rejection so process-level bug
    * reporters (which subscribe to `unhandledRejection` by default) pick
-   * the failure up.
+   * the failure up — and ALSO writes a one-line summary to `stderr` so
+   * the failure isn't completely silent on Node 24+ where the default
+   * behavior of `unhandledRejection` is to terminate the process. An
+   * app that sees its server suddenly exit needs at least one
+   * breadcrumb in the logs to know Beacon was the cause; the previous
+   * behavior left a stack-only crash with no context tying it back to
+   * the broker.
    * @param {object} args - Options.
    * @param {"beacon-connect" | "beacon-disconnect"} args.stage - Failure stage.
    * @param {Error} args.error - Error instance.
@@ -679,6 +685,10 @@ export default class VelociousConfiguration {
     errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
 
     if (!hasListener) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      // eslint-disable-next-line no-console
+      console.error(`[velocious framework-error stage=${stage}] ${message} — register a listener via configuration.getErrorEvents().on("framework-error", …) to suppress this stderr fallback`)
       void Promise.reject(error)
     }
   }


### PR DESCRIPTION
## Summary

When an app boots a velocious server but doesn't register a listener on the `framework-error` (or `all-error`) channel, transient infra failures — Beacon broker disconnects mid-session, request middleware errors, etc. — currently trigger an `unhandledRejection`. On Node 24+, where that's fatal by default, the entire server process dies with a stack-only crash that gives operators no breadcrumb tying the failure back to the underlying broker / middleware.

We hit this in [tensorbuzz](https://github.com/kaspernj/tensorbuzz) while killing the local Beacon broker for a verification test. The velocious server died with `Error: Beacon broker disconnected at JsonSocket…` — no context indicating Beacon was the cause.

## Behavior change

The `unhandledRejection` fallback stays exactly as before (per the existing `schedules an unhandled rejection only when no listener is attached to framework-error or all-error` spec — process-level bug reporters that subscribe to `unhandledRejection` continue to pick the failure up).

What's added: a single `console.error("[velocious framework-error stage=<stage>] <message> — register a listener via configuration.getErrorEvents().on(\"framework-error\", …) to suppress this stderr fallback")` line right before the rejection. Operators get a readable breadcrumb in their server logs pointing at the source plus a hint to register a listener if they want the stderr line silenced.

## Test plan
- [x] `npm run test -- spec/beacon/error-reporting-spec.js` — all 7 specs pass; the new stderr line appears in the test output for the `schedules an unhandled rejection…` case but doesn't change the assertion (the test verifies the rejection still happens, not that stderr is silent).
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors (warnings unchanged from master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)