### PR TITLE
Run inline background jobs concurrently up to a configurable cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1768,7 +1768,8 @@ export default new Configuration({
   backgroundJobs: {
     host: "127.0.0.1",
     port: 7331,
-    databaseIdentifier: "default"
+    databaseIdentifier: "default",
+    maxConcurrentInlineJobs: 4
   }
 })
 ```
@@ -1779,7 +1780,10 @@ Or via env vars:
 VELOCIOUS_BACKGROUND_JOBS_HOST=127.0.0.1
 VELOCIOUS_BACKGROUND_JOBS_PORT=7331
 VELOCIOUS_BACKGROUND_JOBS_DATABASE_IDENTIFIER=default
+VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS=4
 ```
+
+`maxConcurrentInlineJobs` (default: `4`) caps how many `forked: false` jobs a single `background-jobs-worker` process runs in parallel. Concurrency is at the JS event-loop level: every job in flight shares the worker's process and DB connection pool, so the cap should fit the pool, not the CPU count. Forking remains the right tool when you need memory isolation across long-running jobs or want to use more cores.
 
 ## Defining jobs
 
@@ -1806,6 +1810,12 @@ await MyJob.performLaterWithOptions({
   args: ["a", "b"],
   options: {forked: false}
 })
+```
+
+Inline jobs share the worker process and run concurrently up to `maxConcurrentInlineJobs`, so a single slow inline job no longer blocks the queue. A single worker can also override the configured cap explicitly:
+
+```js
+new BackgroundJobsWorker({configuration, maxConcurrentInlineJobs: 8})
 ```
 
 ## Scheduled jobs

--- a/changelog.d/20260508-background-jobs-concurrent-inline.md
+++ b/changelog.d/20260508-background-jobs-concurrent-inline.md
@@ -1,0 +1,6 @@
+A `background-jobs-worker` process can now run multiple `forked: false` jobs concurrently inside the same Node process.
+
+- `BackgroundJobsConfiguration` gains `maxConcurrentInlineJobs` (default: `4`).
+- Configurable via the velocious config, the `BackgroundJobsWorker` constructor option, or the `VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS` env var.
+- Concurrency is at the JS event-loop level — every inline job in flight shares the worker's process and DB connection pool, so the cap should fit the pool, not the CPU count. Forking remains the right tool for memory isolation across long-running jobs and for using more cores.
+- A single slow inline job no longer serializes every other inline job behind it.

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -139,4 +139,71 @@ describe("Background jobs - queue", () => {
     await worker.stop()
     await main.stop()
   })
+
+  it("runs multiple inline jobs in parallel up to maxConcurrentInlineJobs", async () => {
+    // Pre-fix: a single slow inline job (e.g. a 135 s docker alive
+    // check) blocked every other inline job. The worker now accepts
+    // up to `maxConcurrentInlineJobs` in parallel — slower jobs share
+    // the worker process via async I/O concurrency rather than
+    // serializing one another.
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+    await store.clearAll()
+
+    const main = new BackgroundJobsMain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+
+    await main.start()
+
+    dummyConfiguration.setBackgroundJobsConfig({
+      host: "127.0.0.1",
+      port: main.getPort()
+    })
+
+    const worker = new BackgroundJobsWorker({configuration: dummyConfiguration, maxConcurrentInlineJobs: 4})
+
+    await worker.start()
+
+    const tmpDir = path.join(dummyConfiguration.getDirectory(), "tmp")
+
+    await fs.mkdir(tmpDir, {recursive: true})
+
+    const outPath1 = path.join(tmpDir, `parallel1-${Date.now()}.json`)
+    const outPath2 = path.join(tmpDir, `parallel2-${Date.now()}.json`)
+    const outPath3 = path.join(tmpDir, `parallel3-${Date.now()}.json`)
+    const startedAt = Date.now()
+
+    await DelayedJob.performLaterWithOptions({args: ["a", outPath1], options: {forked: false}})
+    await DelayedJob.performLaterWithOptions({args: ["b", outPath2], options: {forked: false}})
+    await DelayedJob.performLaterWithOptions({args: ["c", outPath3], options: {forked: false}})
+
+    await timeout({timeout: 4000}, async () => {
+      while (true) {
+        try {
+          const [c1, c2, c3] = await Promise.all([
+            fs.readFile(outPath1, "utf8"),
+            fs.readFile(outPath2, "utf8"),
+            fs.readFile(outPath3, "utf8")
+          ])
+
+          if (c1 && c2 && c3) break
+        } catch {
+          // Ignore missing files.
+        }
+
+        await wait(0.05)
+      }
+    })
+
+    const elapsedMs = Date.now() - startedAt
+
+    // DelayedJob waits 0.5s. Sequential floor would be ~1.5s; parallel
+    // should clock around 0.5s plus framework overhead. 1100ms is
+    // comfortably below the sequential floor and high enough to
+    // tolerate CI noise.
+    expect(elapsedMs < 1100).toEqual(true)
+
+    await worker.stop()
+    await main.stop()
+  })
 })

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -14,14 +14,32 @@ export default class BackgroundJobsWorker {
    * @param {import("../configuration.js").default} [args.configuration] - Configuration.
    * @param {string} [args.host] - Hostname.
    * @param {number} [args.port] - Port.
+   * @param {number} [args.maxConcurrentInlineJobs] - Override the
+   *   concurrency cap from `configuration.getBackgroundJobsConfig()`.
+   *   See `BackgroundJobsConfiguration` for what the value means.
    */
-  constructor({configuration, host, port} = {}) {
+  constructor({configuration, host, port, maxConcurrentInlineJobs} = {}) {
     /** @type {Promise<import("../configuration.js").default>} */
     this.configurationPromise = configuration ? Promise.resolve(configuration) : configurationResolver()
     /** @type {import("../configuration.js").default | undefined} */
     this.configuration = undefined
     this.host = host
     this.port = port
+    /**
+     * Constructor override for the inline-job concurrency cap. When unset
+     * the cap is read from `configuration.getBackgroundJobsConfig()` in
+     * `start()` (default: 4).
+     * @type {number | undefined}
+     */
+    this.maxConcurrentInlineJobsOverride = typeof maxConcurrentInlineJobs === "number" && maxConcurrentInlineJobs >= 1
+      ? maxConcurrentInlineJobs
+      : undefined
+    /**
+     * Resolved cap for inline-job concurrency. Set in `start()`; defaults to
+     * 4 if no configuration value is available.
+     * @type {number}
+     */
+    this.maxConcurrentInlineJobs = this.maxConcurrentInlineJobsOverride || 4
     this.shouldStop = false
     this.workerId = randomUUID()
     /** @type {JsonSocket | undefined} */
@@ -32,6 +50,11 @@ export default class BackgroundJobsWorker {
      * In-flight inline jobs the worker is currently running. Forked jobs run
      * in detached child processes so they don't appear here; the worker
      * doesn't need to wait for them on shutdown — they survive on their own.
+     *
+     * Up to `this.maxConcurrentInlineJobs` of these run in parallel. They
+     * share the worker's process and DB connection pool, so concurrency is
+     * about overlapping I/O waits — use forking for memory isolation across
+     * long-running jobs and for using more cores.
      * @type {Set<Promise<void>>}
      */
     this.inflightInlineJobs = new Set()
@@ -45,6 +68,14 @@ export default class BackgroundJobsWorker {
     this.configuration.setCurrent()
     await this.configuration.initialize({type: "background-jobs-worker"})
     await this.configuration.connectBeacon({peerType: "background-jobs-worker"})
+
+    // Constructor override wins; otherwise pick up the configured cap.
+    if (typeof this.maxConcurrentInlineJobsOverride !== "number") {
+      const config = this.configuration.getBackgroundJobsConfig()
+
+      this.maxConcurrentInlineJobs = config.maxConcurrentInlineJobs || this.maxConcurrentInlineJobs
+    }
+
     this.statusReporter = new BackgroundJobsStatusReporter({
       configuration: this.configuration,
       host: this.host,
@@ -147,16 +178,33 @@ export default class BackgroundJobsWorker {
       return
     }
 
+    // Inline jobs share the worker's process and DB pool, but each one
+    // is its own async chain — there's no semantic reason to serialize
+    // them. We kick off the job, register it with `inflightInlineJobs`
+    // for shutdown drain, and signal capacity to main:
+    // - If we still have a free slot we ask for the next job right
+    //   away, so a slow job (e.g. a docker alive check that waits 15s
+    //   on a gone server) no longer starves every other inline job.
+    // - When the job finishes, if the worker had been at the cap, we
+    //   ask for the next job to refill the slot.
+    // The bookkeeping in `finally()` ratchets capacity back up
+    // regardless of success or failure.
     /** @type {Promise<void>} */
-    const inflight = this._runInlineJobAndReport(identifiedPayload)
-    this.inflightInlineJobs.add(inflight)
-    try {
-      await inflight
-    } finally {
-      this.inflightInlineJobs.delete(inflight)
-    }
+    let inflight
 
-    this._sendReadyIfRunning()
+    inflight = this._runInlineJobAndReport(identifiedPayload).finally(() => {
+      this.inflightInlineJobs.delete(inflight)
+
+      if (!this.shouldStop && this.inflightInlineJobs.size === this.maxConcurrentInlineJobs - 1) {
+        this._sendReadyIfRunning()
+      }
+    })
+
+    this.inflightInlineJobs.add(inflight)
+
+    if (this.inflightInlineJobs.size < this.maxConcurrentInlineJobs) {
+      this._sendReadyIfRunning()
+    }
   }
 
   /**

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -129,6 +129,12 @@
  * @property {string} [host] - Hostname for the background jobs main process.
  * @property {number} [port] - Port for the background jobs main process.
  * @property {string} [databaseIdentifier] - Database identifier used to store background jobs.
+ * @property {number} [maxConcurrentInlineJobs] - How many `forked: false` jobs a single
+ *   `background-jobs-worker` process is allowed to run in parallel. Concurrency
+ *   is at the JS event-loop level: every concurrent job shares the worker's
+ *   process and DB connection pool, so this should fit the pool size, not the
+ *   CPU count. Forking remains the right tool for memory isolation across
+ *   long-running jobs and for using more cores. Default: `4`.
  */
 
 /**

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -460,15 +460,20 @@ export default class VelociousConfiguration {
     const envHost = process.env.VELOCIOUS_BACKGROUND_JOBS_HOST
     const envPortRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_PORT
     const envDatabaseIdentifier = process.env.VELOCIOUS_BACKGROUND_JOBS_DATABASE_IDENTIFIER
+    const envMaxConcurrentRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS
     const envPort = envPortRaw ? Number(envPortRaw) : undefined
+    const envMaxConcurrent = envMaxConcurrentRaw ? Number(envMaxConcurrentRaw) : undefined
     const configured = this._backgroundJobs || {}
     const host = configured.host || envHost || "127.0.0.1"
     const port = typeof configured.port === "number"
       ? configured.port
       : (typeof envPort === "number" && Number.isFinite(envPort) ? envPort : 7331)
     const databaseIdentifier = configured.databaseIdentifier || envDatabaseIdentifier || "default"
+    const maxConcurrentInlineJobs = typeof configured.maxConcurrentInlineJobs === "number" && configured.maxConcurrentInlineJobs >= 1
+      ? configured.maxConcurrentInlineJobs
+      : (typeof envMaxConcurrent === "number" && Number.isFinite(envMaxConcurrent) && envMaxConcurrent >= 1 ? envMaxConcurrent : 4)
 
-    return {host, port, databaseIdentifier}
+    return {host, port, databaseIdentifier, maxConcurrentInlineJobs}
   }
 
   /**


### PR DESCRIPTION
## Summary

`BackgroundJobsWorker._handleJob` awaited each `forked: false` job to completion before sending the next `ready`, so a single slow inline job — e.g. a docker alive check waiting `15 s × 9` unreachable servers in tensorbuzz — serialized every other inline job behind it. Forking solved the symptom downstream, but forking is meant for memory isolation across long-running jobs and for using more cores, not for letting two cheap async-I/O-bound jobs overlap their waits.

This adds a configurable inline-job concurrency cap.

## Changes

- `BackgroundJobsConfiguration` gains `maxConcurrentInlineJobs` (default `4`). Configure via the velocious config, the constructor option, or `VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS`.
- `BackgroundJobsWorker._handleJob` now kicks off the inline job, registers it with `inflightInlineJobs` (so shutdown drain still works), and:
  - if a slot is still free, sends `ready` right away — parallel inline execution;
  - when a job finishes, if we had been at the cap, sends `ready` to refill the slot.
- Forked jobs are unchanged: each spawns a detached child and the worker says ready immediately. The cap only affects inline jobs that share the worker process.

## Trade-offs

- Concurrency is at the JS event-loop level: every inline job in flight shares the worker's process and DB connection pool, so the cap should fit the pool, not the CPU count. Forking remains the right tool for memory isolation across long-running jobs and for using more cores.
- The default `4` is conservative — high enough to absorb one slow alive check without starving the queue runner, low enough not to stress the default DB pool.

## Test plan

- [x] `npm run typecheck` — clean (pre-existing warnings unchanged)
- [x] `npm run lint` — clean (pre-existing warnings unchanged)
- [x] `npm run test -- spec/background-jobs/queue-spec.js:143` — new `runs multiple inline jobs in parallel up to maxConcurrentInlineJobs` spec passes (3 × 0.5 s `DelayedJob`s wall-clock under 1.1 s vs. 1.5 s sequential floor)
- [x] `npm run test -- spec/background-jobs/queue-spec.js` first inline-ordering spec still passes
- [ ] Pre-existing forked-jobs spec (`does not block the worker when running forked jobs`) reproduces an unrelated test-runner connection-pool timeout on `master` too — out of scope here, will look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
