### PR TITLE
Auto-serialize backend Records returned from custom-command actions

### DIFF
--- a/spec/controller/frontend-model-auto-serialize-spec.js
+++ b/spec/controller/frontend-model-auto-serialize-spec.js
@@ -1,0 +1,187 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Configuration from "../../src/configuration.js"
+import dummyDirectory from "../dummy/dummy-directory.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import FrontendModelController from "../../src/frontend-model-controller.js"
+import Request from "../../src/http-server/client/request.js"
+import Response from "../../src/http-server/client/response.js"
+
+/** @returns {Promise<FrontendModelController>} - Bare controller for direct method calls. */
+async function buildController() {
+  const configuration = new Configuration({
+    database: {test: {}},
+    directory: dummyDirectory(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+
+  const client = {remoteAddress: "127.0.0.1"}
+  const request = new Request({client, configuration})
+  const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+
+  request.feed(Buffer.from([
+    "POST /frontend-models HTTP/1.1",
+    "Host: example.com",
+    "Content-Length: 0",
+    "",
+    ""
+  ].join("\r\n"), "utf8"))
+
+  await donePromise
+
+  return new FrontendModelController({
+    action: "frontendApi",
+    configuration,
+    controller: "frontend-models",
+    params: {},
+    request,
+    response: new Response({configuration}),
+    viewPath: `${dummyDirectory()}/src/routes/frontend-models`
+  })
+}
+
+/**
+ * Minimal duck-typed backend `Record` shape — `isBackendModelInstance` checks
+ * for `attributes()`, `getModelClass()`, and `getRelationshipByName()`. The
+ * walker also reads `constructor.getModelName()` for the marker `modelName`.
+ *
+ * @param {string} id - Model id used in serialized output.
+ * @param {string} [modelName="Build"] - Model name reported by the constructor.
+ * @returns {{attributes: () => Record<string, any>, constructor: {getModelName: () => string, name: string}, getModelClass: () => Record<string, any>, getRelationshipByName: () => Record<string, any>, __id: string}} - Record stand-in.
+ */
+function makeFakeRecord(id, modelName = "Build") {
+  return {
+    __id: id,
+    attributes: () => ({id}),
+    constructor: {getModelName: () => modelName, name: modelName},
+    getModelClass: () => ({getRelationshipsMap: () => ({})}),
+    getRelationshipByName: () => ({getPreloaded: () => false, loaded: () => null})
+  }
+}
+
+describe("FrontendModelController autoSerializeFrontendModelsInPayload", () => {
+  it("replaces a top-level backend Record with a frontend_model marker carrying resource.serialize output", async () => {
+    const controller = await buildController()
+    /** @type {Array<{model: any, action: string}>} */
+    const calls = []
+    const resource = {
+      async serialize(model, action) {
+        calls.push({action, model})
+        return {id: model.attributes().id, name: "build-name"}
+      }
+    }
+    const record = makeFakeRecord("build-1")
+
+    const result = await controller.autoSerializeFrontendModelsInPayload(record, resource, "cancel")
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].action).toEqual("cancel")
+    expect(calls[0].model).toBe(record)
+    expect(result).toEqual({
+      __velocious_type: "frontend_model",
+      attributes: {id: "build-1", name: "build-name"},
+      modelName: "Build"
+    })
+  })
+
+  it("replaces a nested backend Record under a plain-object payload", async () => {
+    const controller = await buildController()
+    const resource = {
+      async serialize(model, action) {
+        return {id: model.attributes().id, action}
+      }
+    }
+    const record = makeFakeRecord("build-7")
+
+    const result = await controller.autoSerializeFrontendModelsInPayload(
+      {build: record, status: "ok"},
+      resource,
+      "cancel"
+    )
+
+    expect(result).toEqual({
+      build: {
+        __velocious_type: "frontend_model",
+        attributes: {id: "build-7", action: "cancel"},
+        modelName: "Build"
+      },
+      status: "ok"
+    })
+  })
+
+  it("walks arrays and replaces backend Records inside them", async () => {
+    const controller = await buildController()
+    const resource = {
+      async serialize(model) {
+        return {id: model.attributes().id}
+      }
+    }
+    const records = [makeFakeRecord("a", "User"), makeFakeRecord("b", "User"), makeFakeRecord("c", "User")]
+
+    const result = await controller.autoSerializeFrontendModelsInPayload({users: records}, resource, "lookupByEmail")
+
+    expect(result).toEqual({
+      users: [
+        {__velocious_type: "frontend_model", attributes: {id: "a"}, modelName: "User"},
+        {__velocious_type: "frontend_model", attributes: {id: "b"}, modelName: "User"},
+        {__velocious_type: "frontend_model", attributes: {id: "c"}, modelName: "User"}
+      ]
+    })
+  })
+
+  it("passes null, undefined, primitives, and Date values through unchanged", async () => {
+    const controller = await buildController()
+    const resource = {
+      async serialize() {
+        throw new Error("Should not be called for non-Record values.")
+      }
+    }
+    const date = new Date("2026-01-01T00:00:00Z")
+
+    const result = await controller.autoSerializeFrontendModelsInPayload(
+      {count: 3, enabled: true, missing: null, name: "alpha", noValue: undefined, when: date},
+      resource,
+      "cancel"
+    )
+
+    expect(result).toEqual({
+      count: 3,
+      enabled: true,
+      missing: null,
+      name: "alpha",
+      noValue: undefined,
+      when: date
+    })
+  })
+
+  it("does not infinite-loop on cyclic plain-object references", async () => {
+    const controller = await buildController()
+    const resource = {
+      async serialize(model) {
+        return {id: model.attributes().id}
+      }
+    }
+    /** @type {Record<string, any>} */
+    const payload = {build: makeFakeRecord("build-x"), status: "ok"}
+
+    payload.self = payload
+
+    const result = /** @type {Record<string, any>} */ (
+      await controller.autoSerializeFrontendModelsInPayload(payload, resource, "cancel")
+    )
+
+    expect(result.build).toEqual({
+      __velocious_type: "frontend_model",
+      attributes: {id: "build-x"},
+      modelName: "Build"
+    })
+    expect(result.status).toEqual("ok")
+    expect(result.self).toBeDefined()
+  })
+})

--- a/spec/controller/frontend-model-auto-serialize-spec.js
+++ b/spec/controller/frontend-model-auto-serialize-spec.js
@@ -160,6 +160,60 @@ describe("FrontendModelController autoSerializeFrontendModelsInPayload", () => {
     })
   })
 
+  it("walks a plain-object container that is referenced twice (shared but non-cyclic) so backend Records inside both references are serialized", async () => {
+    const controller = await buildController()
+    let serializeCalls = 0
+    const resource = {
+      async serialize(model) {
+        serializeCalls += 1
+
+        return {id: model.attributes().id}
+      }
+    }
+    const sharedRecord = makeFakeRecord("shared", "Build")
+    const sharedContainer = /** @type {Record<string, any>} */ ({build: sharedRecord})
+
+    const result = /** @type {Record<string, any>} */ (
+      await controller.autoSerializeFrontendModelsInPayload(
+        {first: sharedContainer, second: sharedContainer, status: "ok"},
+        resource,
+        "cancel"
+      )
+    )
+
+    expect(serializeCalls).toEqual(2)
+    expect(result.first).toEqual({
+      build: {__velocious_type: "frontend_model", attributes: {id: "shared"}, modelName: "Build"}
+    })
+    expect(result.second).toEqual({
+      build: {__velocious_type: "frontend_model", attributes: {id: "shared"}, modelName: "Build"}
+    })
+    expect(result.status).toEqual("ok")
+  })
+
+  it("stores a `__proto__` key as an own data property without polluting Object.prototype", async () => {
+    const controller = await buildController()
+    const resource = {
+      async serialize(model) {
+        return {id: model.attributes().id}
+      }
+    }
+    const payload = /** @type {Record<string, any>} */ (JSON.parse('{"safe":1,"__proto__":{"polluted":true}}'))
+
+    try {
+      const result = /** @type {Record<string, any>} */ (
+        await controller.autoSerializeFrontendModelsInPayload(payload, resource, "cancel")
+      )
+
+      expect(/** @type {Record<string, any>} */ (Object.prototype).polluted).toEqual(undefined)
+      expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toEqual(true)
+      expect(result["__proto__"].polluted).toEqual(true)
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+    } finally {
+      delete /** @type {Record<string, any>} */ (Object.prototype).polluted
+    }
+  })
+
   it("does not infinite-loop on cyclic plain-object references", async () => {
     const controller = await buildController()
     const resource = {

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -5,7 +5,7 @@ import Controller from "./controller.js"
 import Response from "./http-server/client/response.js"
 import FrontendModelBaseResource from "./frontend-model-resource/base-resource.js"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
-import {deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
+import {assignSafeProperty, deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
 import RoutesResolver from "./routes/resolver.js"
 import VelociousError from "./velocious-error.js"
 
@@ -3530,7 +3530,7 @@ export default class FrontendModelController extends Controller {
    * @param {unknown} value - Payload value.
    * @param {{serialize: (model: unknown, action: string) => Promise<Record<string, any>>}} resource - Resource instance providing `serialize`.
    * @param {string} action - Custom command method name passed to `resource.serialize` for per-action authorization filtering.
-   * @param {WeakSet<object>} [seen] - Tracks visited plain-object containers to avoid cycles.
+   * @param {WeakSet<object>} [seen] - Recursion stack of plain-object containers currently being walked. Membership is added on entry and removed on exit so a container shared between siblings (i.e. referenced twice but not cyclically) is walked on each reference instead of being short-circuited the second time, which would let backend `Record` instances inside it bypass `resource.serialize`.
    * @returns {Promise<unknown>} - Payload with backend `Record` instances replaced by serialized markers.
    */
   async autoSerializeFrontendModelsInPayload(value, resource, action, seen = new WeakSet()) {
@@ -3570,19 +3570,35 @@ export default class FrontendModelController extends Controller {
       const container = /** @type {Record<string, unknown>} */ (value)
 
       if (seen.has(container)) {
+        // Cyclic back-reference along the current recursion path; the
+        // ancestor frame is still walking this container and will produce
+        // its serialized form. Returning the original container here
+        // breaks the cycle without bypassing the walker for siblings that
+        // share a non-cyclic reference (those re-enter the branch below
+        // because the container is removed from `seen` on stack exit).
         return container
       }
 
       seen.add(container)
 
-      /** @type {Record<string, unknown>} */
-      const result = {}
+      try {
+        /** @type {Record<string, unknown>} */
+        const result = {}
 
-      for (const [key, nested] of Object.entries(container)) {
-        result[key] = await this.autoSerializeFrontendModelsInPayload(nested, resource, action, seen)
+        for (const [key, nested] of Object.entries(container)) {
+          // `assignSafeProperty` stores keys like `__proto__` as own
+          // data properties instead of invoking the prototype setter,
+          // so a custom-command response that echoes parsed client
+          // input cannot pollute `Object.prototype` here. The transport
+          // serializer applies the same protection on its own pass; we
+          // just preserve it across the auto-serialize walk.
+          assignSafeProperty(result, key, await this.autoSerializeFrontendModelsInPayload(nested, resource, action, seen))
+        }
+
+        return result
+      } finally {
+        seen.delete(container)
       }
-
-      return result
     }
 
     return value

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -5,7 +5,7 @@ import Controller from "./controller.js"
 import Response from "./http-server/client/response.js"
 import FrontendModelBaseResource from "./frontend-model-resource/base-resource.js"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
-import {deserializeFrontendModelTransportValue, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
+import {deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
 import RoutesResolver from "./routes/resolver.js"
 import VelociousError from "./velocious-error.js"
 
@@ -3510,7 +3510,82 @@ export default class FrontendModelController extends Controller {
       return {status: "success"}
     }
 
-    return /** @type {Record<string, any>} */ (responsePayload)
+    return /** @type {Record<string, any>} */ (
+      await this.autoSerializeFrontendModelsInPayload(
+        responsePayload,
+        /** @type {{serialize: (model: unknown, action: string) => Promise<Record<string, any>>}} */ (resource),
+        methodName
+      )
+    )
+  }
+
+  /**
+   * Walks a custom-command response payload and replaces any backend `Record`
+   * instance with the resource's per-action serialized form so handlers can
+   * return `{record, status: "ok"}` instead of explicitly calling
+   * `await this.serialize(record, action)`. Plain objects, arrays, and
+   * primitive values pass through and are later encoded by
+   * `serializeFrontendModelTransportValue`.
+   *
+   * @param {unknown} value - Payload value.
+   * @param {{serialize: (model: unknown, action: string) => Promise<Record<string, any>>}} resource - Resource instance providing `serialize`.
+   * @param {string} action - Custom command method name passed to `resource.serialize` for per-action authorization filtering.
+   * @param {WeakSet<object>} [seen] - Tracks visited plain-object containers to avoid cycles.
+   * @returns {Promise<unknown>} - Payload with backend `Record` instances replaced by serialized markers.
+   */
+  async autoSerializeFrontendModelsInPayload(value, resource, action, seen = new WeakSet()) {
+    if (value === null || value === undefined) {
+      return value
+    }
+
+    if (isBackendModelInstance(value)) {
+      const richSerialized = await resource.serialize(value, action)
+      const modelClass = /** @type {{constructor: {getModelName?: () => string, name?: string}}} */ (value).constructor
+      const modelName = typeof modelClass.getModelName === "function" ? modelClass.getModelName() : (modelClass.name || "")
+
+      // Wrap the resource-serialized payload in the frontend_model transport
+      // marker. Marker-based decoding routes through `instantiateFromResponse`,
+      // so abilities / queryData / associationCounts / preloadedRelationships
+      // baked into the rich attributes by `resource.serialize` are restored on
+      // the client without callers needing to wrap models manually.
+      return {
+        __velocious_type: "frontend_model",
+        attributes: richSerialized,
+        modelName
+      }
+    }
+
+    if (Array.isArray(value)) {
+      /** @type {unknown[]} */
+      const result = []
+
+      for (const entry of value) {
+        result.push(await this.autoSerializeFrontendModelsInPayload(entry, resource, action, seen))
+      }
+
+      return result
+    }
+
+    if (typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+      const container = /** @type {Record<string, unknown>} */ (value)
+
+      if (seen.has(container)) {
+        return container
+      }
+
+      seen.add(container)
+
+      /** @type {Record<string, unknown>} */
+      const result = {}
+
+      for (const [key, nested] of Object.entries(container)) {
+        result[key] = await this.autoSerializeFrontendModelsInPayload(nested, resource, action, seen)
+      }
+
+      return result
+    }
+
+    return value
   }
 
 }

--- a/src/frontend-models/transport-serialization.js
+++ b/src/frontend-models/transport-serialization.js
@@ -138,7 +138,7 @@ function isFrontendModelMarker(value) {
  * @param {unknown} value - Candidate value.
  * @returns {value is {attributes: () => Record<string, any>, constructor: {getModelName?: () => string, name?: string}, getModelClass: () => {getRelationshipsMap: () => Record<string, any>}, getRelationshipByName: (relationshipName: string) => {getPreloaded: () => boolean, loaded: () => any}}} - Whether value looks like a backend model instance.
  */
-function isBackendModelInstance(value) {
+export function isBackendModelInstance(value) {
   if (!value || typeof value !== "object") return false
 
   const candidate = /** @type {Record<string, any>} */ (value)
@@ -277,18 +277,21 @@ function deserializeFrontendModelMarker(marker) {
     }
   }
 
-  const model = new modelClass(attributes)
+  // Route hydration through `instantiateFromResponse` so
+  // `__abilities` / `__queryData` / `__associationCounts` /
+  // `__preloadedRelationships` baked into the marker's attributes blob (e.g.
+  // by `resource.serialize` in custom-command auto-serialization) get
+  // extracted and applied. Legacy markers that used a separate top-level
+  // `preloadedRelationships` field merge them under the standard key first
+  // so `modelDataFromResponse` picks them up.
+  const responseAttributes = Object.keys(preloadedRelationships).length > 0
+    ? {
+      ...attributes,
+      [PRELOADED_RELATIONSHIPS_KEY]: preloadedRelationships
+    }
+    : attributes
 
-  model._selectedAttributes = new Set(Object.keys(attributes))
-
-  for (const [relationshipName, relationshipValue] of Object.entries(preloadedRelationships)) {
-    model.getRelationshipByName(relationshipName).setLoaded(relationshipValue)
-  }
-
-  model.setIsNewRecord(false)
-  model._persistedAttributes = cloneFrontendModelAttributes(model.attributes())
-
-  return model
+  return modelClass.instantiateFromResponse(responseAttributes)
 }
 
 /**

--- a/src/frontend-models/transport-serialization.js
+++ b/src/frontend-models/transport-serialization.js
@@ -24,7 +24,7 @@ const PRELOADED_RELATIONSHIPS_KEY = "__preloadedRelationships"
  * @param {unknown} value - Property value.
  * @returns {void}
  */
-function assignSafeProperty(target, key, value) {
+export function assignSafeProperty(target, key, value) {
   Object.defineProperty(target, key, {
     value,
     writable: true,
@@ -148,14 +148,6 @@ export function isBackendModelInstance(value) {
     && typeof candidate.getModelClass === "function"
     && typeof candidate.getRelationshipByName === "function"
   )
-}
-
-/**
- * @param {Record<string, any>} value - Attributes hash.
- * @returns {Record<string, any>} - Cloned attributes hash.
- */
-function cloneFrontendModelAttributes(value) {
-  return /** @type {Record<string, any>} */ (deserializeFrontendModelTransportValue(serializeFrontendModelTransportValue(value)))
 }
 
 /**


### PR DESCRIPTION
## Summary

- Custom collection/member commands can now `return {record, status: "ok"}` directly — the framework walks the response payload and replaces backend `Record` instances with the resource-serialized form, so authors no longer have to call `await this.serialize(record, action)` manually.
- Reuses the existing `isBackendModelInstance` duck-type check (now exported) and wraps each match in a `frontend_model` transport marker carrying the rich serialized attributes (including `__abilities`, `__queryData`, `__associationCounts`, and `__preloadedRelationships`).
- Updates `deserializeFrontendModelMarker` to route through `instantiateFromResponse` when the model class is registered locally, so embedded metadata is restored on the client. Legacy markers that used a separate top-level `preloadedRelationships` field are merged into the attributes blob first, preserving backward compatibility.

### Why
Today, returning a raw `Record` from a custom command goes through the transport encoder's `isBackendModelInstance` branch, which calls `model.attributes()` directly — no per-action authorization filter, no `${name}Attribute` virtual attributes, no abilities tagging. The only way to get the full wire shape was an explicit `await this.serialize(record, action)` in every action, which is easy to forget. After this change the two patterns produce equivalent wire output.

Cycles, arrays, `Date` / `null` / `undefined` / primitive payload values, and unknown-class fallbacks all preserve their existing behavior.

## Test plan
- [x] `npm run test -- spec/controller/frontend-model-auto-serialize-spec.js` (new — 5 cases covering top-level Record, nested Record, arrays of Records, primitive/Date passthrough, cyclic plain-object payloads)
- [x] `npm run test -- spec/frontend-models/ spec/frontend-model-resource/ spec/controller/` (249 tests, all green — exercises both built-in command paths and the existing `lookupByEmail` / `refreshProfile` resource custom commands end-to-end over real HTTP)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)