### PR TITLE
Fix MySQL add-column alters on referenced tables

### DIFF
--- a/changelog.d/20260509-mysql-add-column-algorithm.md
+++ b/changelog.d/20260509-mysql-add-column-algorithm.md
@@ -1,0 +1,1 @@
+Fix MySQL/MariaDB add-column migrations to use an in-place alter algorithm so adding nullable columns to parent tables with child foreign keys does not fall back to a copy/rebuild path.

--- a/spec/database/drivers/mssql/sql/alter-table-spec.js
+++ b/spec/database/drivers/mssql/sql/alter-table-spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../src/testing/test.js"
+import MssqlDriver from "../../../../../src/database/drivers/mssql/index.js"
+import TableData from "../../../../../src/database/table-data/index.js"
+
+/** @returns {MssqlDriver} */
+function buildDriver() {
+  return new MssqlDriver({sqlConfig: {}})
+}
+
+describe("database/drivers/mssql/sql/alter-table", () => {
+  it("emits add-column alters without the COLUMN keyword", async () => {
+    const tableData = new TableData("builds")
+
+    tableData.string("check_run_payload_digest", {maxLength: 64})
+
+    const sqls = await buildDriver().alterTableSQLs(tableData)
+
+    expect(sqls).toEqual([
+      "ALTER TABLE [builds] ADD [check_run_payload_digest] NVARCHAR(64)"
+    ])
+  })
+})

--- a/spec/database/drivers/mysql/sql/alter-table-spec.js
+++ b/spec/database/drivers/mysql/sql/alter-table-spec.js
@@ -1,0 +1,42 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../src/testing/test.js"
+import MysqlDriver from "../../../../../src/database/drivers/mysql/index.js"
+import TableData from "../../../../../src/database/table-data/index.js"
+import TableForeignKey from "../../../../../src/database/table-data/table-foreign-key.js"
+
+/** @returns {MysqlDriver} */
+function buildDriver() {
+  return new MysqlDriver({type: "mysql"})
+}
+
+describe("database/drivers/mysql/sql/alter-table", () => {
+  it("uses the in-place algorithm for simple add-column alters", async () => {
+    const tableData = new TableData("builds")
+
+    tableData.string("check_run_payload_digest", {maxLength: 64})
+
+    const sqls = await buildDriver().alterTableSQLs(tableData)
+
+    expect(sqls).toEqual([
+      "ALTER TABLE `builds` ADD COLUMN `check_run_payload_digest` VARCHAR(64), ALGORITHM=INPLACE"
+    ])
+  })
+
+  it("does not force the in-place algorithm for foreign-key alters", async () => {
+    const tableData = new TableData("build_artifacts")
+
+    tableData.addForeignKey(new TableForeignKey({
+      columnName: "build_id",
+      isNewForeignKey: true,
+      referencedColumnName: "id",
+      referencedTableName: "builds",
+      tableName: "build_artifacts"
+    }))
+
+    const sqls = await buildDriver().alterTableSQLs(tableData)
+
+    expect(sqls[0]).toContain("ADD FOREIGN KEY")
+    expect(sqls[0]).not.toContain("ALGORITHM=INPLACE")
+  })
+})

--- a/spec/database/migration/add-column-referenced-table.browser-spec.js
+++ b/spec/database/migration/add-column-referenced-table.browser-spec.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration - addColumn on referenced table", {tags: ["dummy"]}, () => {
+  it("adds a column to a parent table that is already referenced by a child foreign key", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      try {
+        await dropAddColumnReferencedTableFixtures(driver)
+
+        await migration.createTable("fk_add_column_parents", {id: {type: "uuid"}}, (table) => {
+          table.string("name", {null: false})
+        })
+        await migration.createTable("fk_add_column_children", {id: {type: "uuid"}}, (table) => {
+          table.uuid("fk_add_column_parent_id", {null: true})
+        })
+        await migration.addForeignKey("fk_add_column_children", "fk_add_column_parent")
+
+        await migration.addColumn("fk_add_column_parents", "payload_digest", "string", {maxLength: 64})
+
+        const table = await driver.getTableByNameOrFail("fk_add_column_parents")
+        const addedColumn = await table.getColumnByNameOrFail("payload_digest")
+
+        expect(addedColumn.getMaxLength()).toEqual(64)
+      } finally {
+        await dropAddColumnReferencedTableFixtures(driver)
+      }
+    })
+  })
+})
+
+/**
+ * @param {import("../../../src/database/drivers/base.js").default} driver - Database driver.
+ * @returns {Promise<void>}
+ */
+async function dropAddColumnReferencedTableFixtures(driver) {
+  for (const tableName of ["fk_add_column_children", "fk_add_column_parents"]) {
+    await driver.dropTable(tableName, {cascade: true, ifExists: true})
+  }
+}

--- a/src/database/drivers/mysql/sql/alter-table.js
+++ b/src/database/drivers/mysql/sql/alter-table.js
@@ -3,4 +3,26 @@
 import AlterTableBase from "../../../query/alter-table-base.js"
 
 export default class VelociousDatabaseConnectionDriversMysqlSqlAlterTable extends AlterTableBase {
+  /**
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async toSQLs() {
+    const sqls = await super.toSQLs()
+
+    if (!this.onlyAddsColumns()) return sqls
+
+    return sqls.map((sql) => `${sql}, ALGORITHM=INPLACE`)
+  }
+
+  /**
+   * @returns {boolean} - Whether this ALTER only adds columns.
+   */
+  onlyAddsColumns() {
+    const columns = this.tableData.getColumns()
+
+    if (columns.length == 0) return false
+    if (this.tableData.getForeignKeys().some((foreignKey) => foreignKey.getIsNewForeignKey())) return false
+
+    return columns.every((column) => column.isNewColumn() && !column.getDropColumn() && !column.getNewName())
+  }
 }

--- a/src/database/query/alter-table-base.js
+++ b/src/database/query/alter-table-base.js
@@ -35,7 +35,7 @@ export default class VelociousDatabaseQueryAlterTableBase extends QueryBase {
       if (actionCount > 0) sql += ", "
 
       if (column.isNewColumn()) {
-        sql += "ADD "
+        sql += databaseType == "mssql" ? "ADD " : "ADD COLUMN "
         sql += column.getSQL({driver: this.getDriver(), forAlterTable: false})
       } else if (column.getNewName()) {
         const newColumnName = column.getNewName()


### PR DESCRIPTION
## Summary
- Emit `ADD COLUMN` in generic alter-table SQL
- Append `ALGORITHM=INPLACE` for MySQL/MariaDB simple add-column alters so parent tables with child FKs avoid copy/rebuild behavior
- Add SQL-level and real migration coverage for adding a column to a referenced table

## Tests
- `npm run test -- spec/database/drivers/mysql/sql/alter-table-spec.js`
- `npm run test -- spec/database/migration/add-column-referenced-table.browser-spec.js`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`
- `npm run build`