### PR TITLE
Make instantiateFromResponse idempotent for already-hydrated models

### DIFF
--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -2115,6 +2115,19 @@ describe("Frontend models - base", () => {
     expect(task.getRelationshipByName("project").loaded()).toEqual(beforeProject)
   })
 
+  it("returns an already-hydrated instance unchanged when passed to instantiateFromResponse", () => {
+    const User = buildTestModelClass()
+    const original = User.instantiateFromResponse({email: "john@example.com", id: 5, name: "John"})
+    // Auto-serialized custom-command responses arrive at call sites as
+    // already-hydrated models, so wrapping them in a second
+    // `Model.instantiateFromResponse(...)` call must be a no-op rather
+    // than spreading internal state into a freshly constructed model.
+    const passthrough = User.instantiateFromResponse(original)
+
+    expect(passthrough).toBe(original)
+    expect(passthrough.name()).toEqual("John")
+  })
+
   it("updates a model and refreshes local attributes", async () => {
     const User = buildTestModelClass()
     const fetchStub = stubFetch({model: {email: "johnny@example.com", id: 5, name: "Johnny"}})

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -2316,10 +2316,23 @@ export default class FrontendModelBase {
   /**
    * @template {typeof FrontendModelBase} T
    * @this {T}
-   * @param {Record<string, any>} response - Response payload.
-   * @returns {InstanceType<T>} - New model instance.
+   * @param {Record<string, any> | InstanceType<T>} response - Response payload, or an already-hydrated instance of this class.
+   * @returns {InstanceType<T>} - New model instance, or the same instance unchanged if it was already hydrated.
    */
   static instantiateFromResponse(response) {
+    // Idempotent: if a caller hands us an already-hydrated instance of this
+    // class (now common because the shared frontend-model API auto-serializes
+    // backend `Record` instances returned from custom commands and the
+    // transport deserializer hydrates them into models before the call site
+    // sees the response), return it as-is. Without this, code that has
+    // historically wrapped custom-command responses in
+    // `Model.instantiateFromResponse(response.field)` would spread the live
+    // model instance into a new constructor call and produce a broken model
+    // with internal state keys promoted to attributes.
+    if (response instanceof this) {
+      return /** @type {InstanceType<T>} */ (response)
+    }
+
     const modelData = this.modelDataFromResponse(response)
     const attributes = modelData.attributes
     const preloadedRelationships = modelData.preloadedRelationships


### PR DESCRIPTION
## Summary

Auto-serialization (PR #640) changed the wire format of custom-command responses so backend `Record` instances arrive at the frontend as `frontend_model` transport markers and are hydrated into model instances by the transport deserializer **before the call site sees the response**. Existing tensorbuzz call sites that wrap response fields in `Model.instantiateFromResponse(response.field)` now hand an already-live model into a code path that spreads `...modelData` into a fresh constructor call — promoting internal state keys (`_persistedAttributes`, `_selectedAttributes`, etc.) to "attributes" and producing a broken model.

Symptoms in dependent apps after #640 landed:
- `AttributeNotSelectedError: ProjectEnvironmentInstance#name was not selected` thrown from a screen render after a custom-command response that the screen shouldn't have re-instantiated.
- Screens timing out waiting on selectors after a successful action because the post-action navigation handed a corrupted model into state.

Short-circuit `instantiateFromResponse` when given an instance of the target class so wrapping a hydrated model is a safe no-op. The existing flow for plain attribute hashes (the format built-in `find` / `create` / `update` still uses) is unchanged because plain objects are not `instanceof this`.

## Test plan
- [x] New regression spec asserts `Model.instantiateFromResponse(modelInstance)` returns the same reference and keeps attribute getters working — `npm run test -- spec/frontend-models/base-spec.js` (87 tests, green)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)