### PR TITLE
Use instant algorithm for MySQL add-column alters

### DIFF
--- a/changelog.d/20260509-mysql-add-column-instant.md
+++ b/changelog.d/20260509-mysql-add-column-instant.md
@@ -1,0 +1,1 @@
+Use MySQL/MariaDB's instant alter algorithm for simple add-column migrations instead of forcing the in-place algorithm.

--- a/spec/database/drivers/mysql/sql/alter-table-spec.js
+++ b/spec/database/drivers/mysql/sql/alter-table-spec.js
@@ -11,7 +11,7 @@ function buildDriver() {
 }
 
 describe("database/drivers/mysql/sql/alter-table", () => {
-  it("uses the in-place algorithm for simple add-column alters", async () => {
+  it("uses the instant algorithm for simple add-column alters", async () => {
     const tableData = new TableData("builds")
 
     tableData.string("check_run_payload_digest", {maxLength: 64})
@@ -19,7 +19,7 @@ describe("database/drivers/mysql/sql/alter-table", () => {
     const sqls = await buildDriver().alterTableSQLs(tableData)
 
     expect(sqls).toEqual([
-      "ALTER TABLE `builds` ADD COLUMN `check_run_payload_digest` VARCHAR(64), ALGORITHM=INPLACE"
+      "ALTER TABLE `builds` ADD COLUMN `check_run_payload_digest` VARCHAR(64), ALGORITHM=INSTANT"
     ])
   })
 

--- a/src/database/drivers/mysql/sql/alter-table.js
+++ b/src/database/drivers/mysql/sql/alter-table.js
@@ -11,7 +11,7 @@ export default class VelociousDatabaseConnectionDriversMysqlSqlAlterTable extend
 
     if (!this.onlyAddsColumns()) return sqls
 
-    return sqls.map((sql) => `${sql}, ALGORITHM=INPLACE`)
+    return sqls.map((sql) => `${sql}, ALGORITHM=INSTANT`)
   }
 
   /**


### PR DESCRIPTION
## Summary
- switch simple MySQL/MariaDB add-column alters from `ALGORITHM=INPLACE` to `ALGORITHM=INSTANT`
- keep foreign-key alters from forcing an algorithm
- add a changelog fragment for the migration helper fix

## Tests
- `npm run test -- spec/database/drivers/mysql/sql/alter-table-spec.js`
- `NODE_ENV=test npm run test:browser -- spec/database/migration/add-column-referenced-table.browser-spec.js`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`