### PR TITLE
Stop forcing MySQL add-column algorithms

### DIFF
--- a/changelog.d/20260510-mysql-add-column-default-algorithm.md
+++ b/changelog.d/20260510-mysql-add-column-default-algorithm.md
@@ -1,0 +1,1 @@
+Do not force a MySQL/MariaDB alter-table algorithm for simple add-column migrations.

--- a/spec/database/drivers/mysql/sql/alter-table-spec.js
+++ b/spec/database/drivers/mysql/sql/alter-table-spec.js
@@ -11,7 +11,7 @@ function buildDriver() {
 }
 
 describe("database/drivers/mysql/sql/alter-table", () => {
-  it("uses the instant algorithm for simple add-column alters", async () => {
+  it("does not force an algorithm for simple add-column alters", async () => {
     const tableData = new TableData("builds")
 
     tableData.string("check_run_payload_digest", {maxLength: 64})
@@ -19,11 +19,11 @@ describe("database/drivers/mysql/sql/alter-table", () => {
     const sqls = await buildDriver().alterTableSQLs(tableData)
 
     expect(sqls).toEqual([
-      "ALTER TABLE `builds` ADD COLUMN `check_run_payload_digest` VARCHAR(64), ALGORITHM=INSTANT"
+      "ALTER TABLE `builds` ADD COLUMN `check_run_payload_digest` VARCHAR(64)"
     ])
   })
 
-  it("does not force the in-place algorithm for foreign-key alters", async () => {
+  it("does not force an algorithm for foreign-key alters", async () => {
     const tableData = new TableData("build_artifacts")
 
     tableData.addForeignKey(new TableForeignKey({
@@ -37,6 +37,6 @@ describe("database/drivers/mysql/sql/alter-table", () => {
     const sqls = await buildDriver().alterTableSQLs(tableData)
 
     expect(sqls[0]).toContain("ADD FOREIGN KEY")
-    expect(sqls[0]).not.toContain("ALGORITHM=INPLACE")
+    expect(sqls[0]).not.toContain("ALGORITHM=")
   })
 })

--- a/src/database/drivers/mysql/sql/alter-table.js
+++ b/src/database/drivers/mysql/sql/alter-table.js
@@ -3,26 +3,4 @@
 import AlterTableBase from "../../../query/alter-table-base.js"
 
 export default class VelociousDatabaseConnectionDriversMysqlSqlAlterTable extends AlterTableBase {
-  /**
-   * @returns {Promise<string[]>} - Resolves with SQL statements.
-   */
-  async toSQLs() {
-    const sqls = await super.toSQLs()
-
-    if (!this.onlyAddsColumns()) return sqls
-
-    return sqls.map((sql) => `${sql}, ALGORITHM=INSTANT`)
-  }
-
-  /**
-   * @returns {boolean} - Whether this ALTER only adds columns.
-   */
-  onlyAddsColumns() {
-    const columns = this.tableData.getColumns()
-
-    if (columns.length == 0) return false
-    if (this.tableData.getForeignKeys().some((foreignKey) => foreignKey.getIsNewForeignKey())) return false
-
-    return columns.every((column) => column.isNewColumn() && !column.getDropColumn() && !column.getNewName())
-  }
 }


### PR DESCRIPTION
## Summary
- remove the MySQL/MariaDB alter-table algorithm override for simple add-column migrations
- keep the base `ADD COLUMN` SQL generation without `ALGORITHM=` clauses
- add a changelog fragment for the migration behavior cleanup

## Tests
- `npm run test -- spec/database/drivers/mysql/sql/alter-table-spec.js`
- `NODE_ENV=test npm run test:browser -- spec/database/migration/add-column-referenced-table.browser-spec.js`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`