### PR TITLE
Add tenant database lifecycle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1989,7 +1989,7 @@ export default new Configuration({
 
 Use `configuration.runWithTenant(tenant, callback)` or `Current.tenant()` when custom model/database routing needs to read the active tenant manually.
 
-For Apartment-style project/account databases, mark the per-tenant identifier with `tenantOnly: true`, provide `tenantDatabaseProviders`, and run tenant lifecycle commands explicitly:
+For Apartment-style project/account databases, mark the logical per-tenant identifier with `tenantOnly: true`, provide `tenantDatabaseProviders`, and run tenant lifecycle commands explicitly. One logical identifier can resolve to any number of physical tenant databases at runtime; provider `listTenants` is queried for every command run so added/removed tenants do not require configuration changes or redeploys.
 
 ```sh
 npx velocious db:tenants:create projectTenant

--- a/README.md
+++ b/README.md
@@ -1988,3 +1988,13 @@ export default new Configuration({
 ```
 
 Use `configuration.runWithTenant(tenant, callback)` or `Current.tenant()` when custom model/database routing needs to read the active tenant manually.
+
+For Apartment-style project/account databases, mark the per-tenant identifier with `tenantOnly: true`, provide `tenantDatabaseProviders`, and run tenant lifecycle commands explicitly:
+
+```sh
+npx velocious db:tenants:create projectTenant
+npx velocious db:tenants:check projectTenant
+npx velocious db:tenants:migrate projectTenant
+```
+
+See [docs/tenant-databases.md](docs/tenant-databases.md) for the full configuration and migration pattern.

--- a/changelog.d/20260517-tenant-databases.md
+++ b/changelog.d/20260517-tenant-databases.md
@@ -1,0 +1,1 @@
+Add tenant-only database identifiers plus `db:tenants:create`, `db:tenants:check`, and `db:tenants:migrate` commands for Apartment-style project/account databases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/query-bulk-operations.md`: `updateAll` for efficient batch updates and `destroyAll` behavior.
 - `docs/logging.md`: Rails-style request and database query logging behavior.
 - `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
+- `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/routing-hooks-and-autoroutes.md`: Route hook support and frontend-model autoroute behavior.
 - `docs/authorization-and-current.md`: Ability usage, `Current`, and `accessible`/`accessibleBy` behavior.

--- a/docs/authorization-and-current.md
+++ b/docs/authorization-and-current.md
@@ -17,6 +17,8 @@
 ## Tenant and elevator hooks
 - `configuration.tenantResolver(...)` can resolve a request-scoped tenant object from request params, websocket subscriptions, or other request metadata.
 - `configuration.tenantDatabaseResolver(...)` can override a configured database identifier per resolved tenant.
+- Database identifiers configured with `tenantOnly: true` are active only inside a tenant context where `tenantDatabaseResolver(...)` returns an override; normal `db:migrate` and global connection setup skip them.
+- `tenantDatabaseProviders` powers `db:tenants:create`, `db:tenants:check`, and `db:tenants:migrate` for Apartment-style project/account databases.
 - `configuration.runWithTenant(tenant, callback)` and `Current.tenant()` expose the active tenant for custom model/database routing.
 - Model classes can declare tenant-aware database routing with `ModelClass.switchesTenantDatabase(...)` instead of overriding `getDatabaseIdentifier()` manually.
 - HTTP routes and websocket subscriptions/events run inside the resolved tenant context before abilities and controller/channel code execute.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -1,0 +1,70 @@
+# Tenant Databases
+
+Velocious supports tenant-specific database identifiers for apps that keep global records in one database and project/account records in separate tenant databases.
+
+Configure the tenant database as `tenantOnly: true`. Tenant-only identifiers are skipped by normal connection setup and `db:migrate` until a tenant context activates them through `tenantDatabaseResolver`.
+
+```js
+export default new Configuration({
+  database: {
+    production: {
+      default: {
+        // global database
+      },
+      projectTenant: {
+        // base tenant connection details
+        migrations: true,
+        tenantOnly: true
+      }
+    }
+  },
+  tenantDatabaseResolver: ({databaseConfiguration, identifier, tenant}) => {
+    if (identifier !== "projectTenant" || !tenant?.databaseName) return
+
+    return {
+      ...databaseConfiguration,
+      database: tenant.databaseName
+    }
+  },
+  tenantDatabaseProviders: {
+    projectTenant: {
+      listTenants: async ({configuration}) => {
+        // Return tenant objects that tenantDatabaseResolver can resolve.
+        return await Project.all().select(["id", "databaseName"]).toArray()
+      },
+      createDatabase: async ({databaseConfiguration, tenant}) => {
+        // App-specific database creation, grants, and structure loading.
+      },
+      checkTenant: async ({databaseConfiguration, tenant}) => {
+        // Optional preflight checks before generic connection validation.
+      }
+    }
+  }
+})
+```
+
+Run tenant lifecycle commands by database identifier:
+
+```sh
+npx velocious db:tenants:create projectTenant
+npx velocious db:tenants:check projectTenant
+npx velocious db:tenants:migrate projectTenant
+```
+
+Tenant migrations should explicitly target the tenant identifier:
+
+```js
+class CreateBuilds extends Migration {
+  async change() {
+    await this.createTable("builds", (table) => {
+      table.string("name")
+    })
+  }
+}
+
+CreateBuilds.onDatabases(["projectTenant"])
+
+export default CreateBuilds
+```
+
+Normal `db:migrate` continues to migrate non-tenant databases only. Use `db:tenants:migrate <identifier>` when you want to run migrations for every tenant returned by the provider.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -2,6 +2,8 @@
 
 Velocious supports tenant-specific database identifiers for apps that keep global records in one database and project/account records in separate tenant databases.
 
+A tenant database identifier is a logical slot, not one physical database. For example `projectTenant` can represent thousands of project databases. The physical database is resolved from the current tenant object at request/command time, so projects can be added or removed without changing Velocious configuration or redeploying the app.
+
 Configure the tenant database as `tenantOnly: true`. Tenant-only identifiers are skipped by normal connection setup and `db:migrate` until a tenant context activates them through `tenantDatabaseResolver`.
 
 ```js
@@ -29,7 +31,8 @@ export default new Configuration({
   tenantDatabaseProviders: {
     projectTenant: {
       listTenants: async ({configuration}) => {
-        // Return tenant objects that tenantDatabaseResolver can resolve.
+        // Query the current global database state each time the command runs.
+        // Adding/removing projects changes the next command run immediately.
         return await Project.all().select(["id", "databaseName"]).toArray()
       },
       createDatabase: async ({databaseConfiguration, tenant}) => {
@@ -68,3 +71,11 @@ export default CreateBuilds
 ```
 
 Normal `db:migrate` continues to migrate non-tenant databases only. Use `db:tenants:migrate <identifier>` when you want to run migrations for every tenant returned by the provider.
+
+Because `listTenants` runs every time, tenant databases are dynamic:
+
+- newly created tenants are included in the next `db:tenants:create/check/migrate` run;
+- removed tenants disappear from the next provider result and are no longer migrated;
+- the app can still serve any one tenant immediately by resolving its tenant object through `tenantDatabaseResolver`.
+
+If the targeted identifier is disabled with `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS`, tenant lifecycle commands fail fast instead of silently skipping the tenant connection.

--- a/spec/cli/commands/db/tenants/migrate-spec.js
+++ b/spec/cli/commands/db/tenants/migrate-spec.js
@@ -1,0 +1,119 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../src/testing/test.js"
+import AsyncTrackedMultiConnection from "../../../../../src/database/pool/async-tracked-multi-connection.js"
+import Cli from "../../../../../src/cli/index.js"
+import Configuration from "../../../../../src/configuration.js"
+import EnvironmentHandlerNode from "../../../../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import SqliteDriver from "../../../../../src/database/drivers/sqlite/index.js"
+
+describe("Cli - Commands - db:tenants:migrate", () => {
+  it("runs targeted migrations for every tenant of a tenant-only database", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-migrate-"))
+    const migrationsDirectory = path.join(directory, "src", "database", "migrations")
+    const migrationModuleUrl = new URL("../../../../../src/database/migration/index.js", import.meta.url).href
+
+    await fs.mkdir(migrationsDirectory, {recursive: true})
+    await fs.writeFile(path.join(migrationsDirectory, "20260517000000-create-tenant-widgets.js"), `
+import Migration from ${JSON.stringify(migrationModuleUrl)}
+
+class CreateTenantWidgets extends Migration {
+  async change() {
+    await this.createTable("tenant_widgets", (table) => {
+      table.string("name", {null: false})
+    })
+  }
+}
+
+CreateTenantWidgets.onDatabases(["projectTenant"])
+
+export default CreateTenantWidgets
+`, "utf8")
+
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-migrate-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-migrate-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          listTenants: async () => [{slug: "alpha"}, {slug: "beta"}]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-migrate-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:tenants:migrate", "projectTenant"],
+      testing: true
+    })
+
+    try {
+      expect(configuration.getDatabaseIdentifiers()).toEqual(["default"])
+
+      const result = await cli.execute()
+
+      expect(result).toEqual({
+        identifier: "projectTenant",
+        migrationCount: 1,
+        tenantCount: 2
+      })
+
+      await configuration.runWithTenant({slug: "alpha"}, async () => {
+        await configuration.ensureConnections(async (dbs) => {
+          const table = await dbs.projectTenant.getTableByName("tenant_widgets")
+          const migrations = await dbs.projectTenant.select("schema_migrations")
+
+          expect(dbs.projectTenant.getArgs().name).toEqual("velocious-cli-tenants-migrate-project-alpha")
+          expect(table?.getName()).toEqual("tenant_widgets")
+          expect(migrations.map((migration) => migration.version)).toEqual(["20260517000000"])
+        })
+      })
+
+      await configuration.runWithTenant({slug: "beta"}, async () => {
+        await configuration.ensureConnections(async (dbs) => {
+          const table = await dbs.projectTenant.getTableByName("tenant_widgets")
+
+          expect(dbs.projectTenant.getArgs().name).toEqual("velocious-cli-tenants-migrate-project-beta")
+          expect(table?.getName()).toEqual("tenant_widgets")
+        })
+      })
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+})

--- a/spec/cli/commands/db/tenants/migrate-spec.js
+++ b/spec/cli/commands/db/tenants/migrate-spec.js
@@ -116,4 +116,202 @@ export default CreateTenantWidgets
       await fs.rm(directory, {force: true, recursive: true})
     }
   })
+
+  it("uses the provider tenant list at command execution time", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-dynamic-"))
+    const migrationsDirectory = path.join(directory, "src", "database", "migrations")
+    const migrationModuleUrl = new URL("../../../../../src/database/migration/index.js", import.meta.url).href
+    /** @type {Array<{slug: string}>} */
+    let tenants = [{slug: "alpha"}]
+
+    await fs.mkdir(migrationsDirectory, {recursive: true})
+    await fs.writeFile(path.join(migrationsDirectory, "20260517000000-create-tenant-widgets.js"), `
+import Migration from ${JSON.stringify(migrationModuleUrl)}
+
+class CreateTenantWidgets extends Migration {
+  async change() {
+    await this.createTable("tenant_widgets", (table) => {
+      table.string("name", {null: false})
+    })
+  }
+}
+
+CreateTenantWidgets.onDatabases(["projectTenant"])
+
+export default CreateTenantWidgets
+`, "utf8")
+
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-dynamic-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-dynamic-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          listTenants: async () => tenants
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-dynamic-project-${tenantObject.slug}`}
+      }
+    })
+
+    try {
+      const firstCli = new Cli({
+        configuration,
+        directory,
+        environmentHandler: new EnvironmentHandlerNode(),
+        processArgs: ["db:tenants:migrate", "projectTenant"],
+        testing: true
+      })
+
+      expect(await firstCli.execute()).toEqual({
+        identifier: "projectTenant",
+        migrationCount: 1,
+        tenantCount: 1
+      })
+
+      tenants = [{slug: "beta"}]
+      await fs.writeFile(path.join(migrationsDirectory, "20260517000001-create-tenant-gadgets.js"), `
+import Migration from ${JSON.stringify(migrationModuleUrl)}
+
+class CreateTenantGadgets extends Migration {
+  async change() {
+    await this.createTable("tenant_gadgets", (table) => {
+      table.string("name", {null: false})
+    })
+  }
+}
+
+CreateTenantGadgets.onDatabases(["projectTenant"])
+
+export default CreateTenantGadgets
+`, "utf8")
+
+      const secondCli = new Cli({
+        configuration,
+        directory,
+        environmentHandler: new EnvironmentHandlerNode(),
+        processArgs: ["db:tenants:migrate", "projectTenant"],
+        testing: true
+      })
+
+      expect(await secondCli.execute()).toEqual({
+        identifier: "projectTenant",
+        migrationCount: 2,
+        tenantCount: 1
+      })
+
+      await configuration.runWithTenant({slug: "alpha"}, async () => {
+        await configuration.ensureConnections(async (dbs) => {
+          expect(await dbs.projectTenant.getTableByName("tenant_widgets")).toBeTruthy()
+          expect(await dbs.projectTenant.getTableByName("tenant_gadgets", {throwError: false})).toEqual(null)
+        })
+      })
+
+      await configuration.runWithTenant({slug: "beta"}, async () => {
+        await configuration.ensureConnections(async (dbs) => {
+          expect(await dbs.projectTenant.getTableByName("tenant_widgets")).toBeTruthy()
+          expect(await dbs.projectTenant.getTableByName("tenant_gadgets")).toBeTruthy()
+        })
+      })
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("rejects disabled tenant database identifiers", async () => {
+    const previousDisabledIdentifiers = process.env.VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-disabled-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-disabled-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory: await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-disabled-")),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          listTenants: async () => [{slug: "alpha"}]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-disabled-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory: configuration.getDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:tenants:migrate", "projectTenant"],
+      testing: true
+    })
+
+    process.env.VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS = "projectTenant"
+
+    try {
+      await expect(async () => {
+        await cli.execute()
+      }).toThrow(/projectTenant is disabled/)
+    } finally {
+      if (previousDisabledIdentifiers === undefined) {
+        delete process.env.VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS
+      } else {
+        process.env.VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS = previousDisabledIdentifiers
+      }
+
+      await configuration.closeDatabaseConnections()
+      await fs.rm(configuration.getDirectory(), {force: true, recursive: true})
+    }
+  })
 })

--- a/spec/cli/commands/db/tenants/migrate-spec.js
+++ b/spec/cli/commands/db/tenants/migrate-spec.js
@@ -11,6 +11,68 @@ import path from "path"
 import SqliteDriver from "../../../../../src/database/drivers/sqlite/index.js"
 
 describe("Cli - Commands - db:tenants:migrate", () => {
+  it("initializes the app runtime before listing provider tenants", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-initialize-"))
+    let initialized = false
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-initialize-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-initialize-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {
+        initialized = true
+      },
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          listTenants: async () => {
+            expect(initialized).toEqual(true)
+
+            return []
+          }
+        }
+      },
+      tenantDatabaseResolver: () => {}
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:tenants:check", "projectTenant"],
+      testing: true
+    })
+
+    try {
+      expect(await cli.execute()).toEqual({
+        identifier: "projectTenant",
+        tenantCount: 0
+      })
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
   it("runs targeted migrations for every tenant of a tenant-only database", async () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-migrate-"))
     const migrationsDirectory = path.join(directory, "src", "database", "migrations")

--- a/spec/configuration/tenant-spec.js
+++ b/spec/configuration/tenant-spec.js
@@ -17,10 +17,12 @@ describe("Configuration tenant support", () => {
       }
 
       configuration.setCurrent()
+      expect(configuration.getDatabaseIdentifiers()).toEqual(["analytics", "default"])
       await seedTenantValue(configuration, "default", undefined, "default-default")
       await seedTenantValue(configuration, "analytics", undefined, "default-analytics")
       await seedTenantValue(configuration, "default", "alpha", "alpha-default")
       await seedTenantValue(configuration, "analytics", "alpha", "alpha-analytics")
+      await seedTenantValue(configuration, "projectTenant", "alpha", "alpha-project-tenant")
       await seedTenantValue(configuration, "default", "beta", "beta-default")
       await seedTenantValue(configuration, "analytics", "beta", "beta-analytics")
 
@@ -33,10 +35,12 @@ describe("Configuration tenant support", () => {
       expect(await readTenantValue(configuration, "analytics", undefined)).toEqual("default-analytics")
       expect(await readTenantValue(configuration, "default", "alpha")).toEqual("alpha-default")
       expect(await readTenantValue(configuration, "analytics", "alpha")).toEqual("alpha-analytics")
+      expect(await readTenantValue(configuration, "projectTenant", "alpha")).toEqual("alpha-project-tenant")
       expect(await readTenantValue(configuration, "default", "beta")).toEqual("beta-default")
       expect(await readTenantValue(configuration, "analytics", "beta")).toEqual("beta-analytics")
 
       await configuration.runWithTenant({slug: "alpha"}, async () => {
+        expect(configuration.getDatabaseIdentifiers()).toEqual(["analytics", "default", "projectTenant"])
         expect(Current.tenant()).toEqual({slug: "alpha"})
         expect(configuration.getCurrentTenant()).toEqual({slug: "alpha"})
       })

--- a/spec/helpers/tenant-test-helpers.js
+++ b/spec/helpers/tenant-test-helpers.js
@@ -35,6 +35,14 @@ export async function createTenantTestConfiguration(prefix) {
           name: `${prefix}-default`,
           poolType: AsyncTrackedMultiConnection,
           type: "sqlite"
+        },
+        projectTenant: {
+          driver: SqliteDriver,
+          migrations: false,
+          name: `${prefix}-project-tenant-default`,
+          poolType: AsyncTrackedMultiConnection,
+          tenantOnly: true,
+          type: "sqlite"
         }
       }
     },
@@ -49,6 +57,7 @@ export async function createTenantTestConfiguration(prefix) {
       const tenantSlug = tenantSlugFromUnknownTenant(tenant)
 
       if (!tenantSlug) return
+      if (identifier == "projectTenant") return {name: `${prefix}-${identifier}-${tenantSlug}`}
 
       return {name: `${prefix}-${identifier}-${tenantSlug}`}
     },
@@ -72,7 +81,7 @@ export async function createTenantTestConfiguration(prefix) {
 
 /**
  * @param {Configuration} configuration - Configuration.
- * @param {"analytics" | "default"} identifier - Database identifier.
+ * @param {"analytics" | "default" | "projectTenant"} identifier - Database identifier.
  * @param {string | undefined} tenantSlug - Tenant slug.
  * @param {string} value - Stored value.
  * @returns {Promise<void>} - Resolves when complete.
@@ -93,7 +102,7 @@ export async function seedTenantValue(configuration, identifier, tenantSlug, val
 
 /**
  * @param {Configuration} configuration - Configuration.
- * @param {"analytics" | "default"} identifier - Database identifier.
+ * @param {"analytics" | "default" | "projectTenant"} identifier - Database identifier.
  * @param {string | undefined} tenantSlug - Tenant slug.
  * @returns {Promise<string | undefined>} - Stored value.
  */

--- a/src/cli/commands/db/tenants/check.js
+++ b/src/cli/commands/db/tenants/check.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+import BaseCommand from "../../../base-command.js"
+import TenantDatabaseCommandHelper from "../../../tenant-database-command-helper.js"
+
+export default class DbTenantsCheck extends BaseCommand {
+  /** @returns {Promise<{identifier: string, tenantCount: number} | void>} - Result in test mode. */
+  async execute() {
+    const helper = new TenantDatabaseCommandHelper({
+      command: this,
+      identifier: this.processArgs?.[1]
+    })
+    const provider = helper.provider
+    const tenantCount = await helper.eachTenant(async ({databaseConfiguration, tenant}) => {
+      if (typeof provider.checkTenant === "function") {
+        await provider.checkTenant({
+          configuration: this.getConfiguration(),
+          databaseConfiguration,
+          identifier: helper.identifier,
+          tenant
+        })
+      }
+
+      await this.getConfiguration().ensureConnections(async (dbs) => {
+        const db = dbs[helper.identifier]
+
+        if (!db) throw new Error(`Tenant database identifier ${helper.identifier} did not open a connection`)
+
+        await db.query("SELECT 1")
+      })
+    })
+
+    if (this.args.testing) return {identifier: helper.identifier, tenantCount}
+  }
+}

--- a/src/cli/commands/db/tenants/create.js
+++ b/src/cli/commands/db/tenants/create.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+import BaseCommand from "../../../base-command.js"
+import TenantDatabaseCommandHelper from "../../../tenant-database-command-helper.js"
+
+export default class DbTenantsCreate extends BaseCommand {
+  /** @returns {Promise<{identifier: string, tenantCount: number} | void>} - Result in test mode. */
+  async execute() {
+    const helper = new TenantDatabaseCommandHelper({
+      command: this,
+      identifier: this.processArgs?.[1]
+    })
+    const provider = helper.provider
+
+    if (typeof provider.createDatabase !== "function") {
+      throw new Error(`Tenant database provider for ${helper.identifier} must define createDatabase to use db:tenants:create`)
+    }
+
+    const tenantCount = await helper.eachTenant(async ({databaseConfiguration, tenant}) => {
+      await provider.createDatabase?.({
+        configuration: this.getConfiguration(),
+        databaseConfiguration,
+        identifier: helper.identifier,
+        tenant
+      })
+    })
+
+    if (this.args.testing) return {identifier: helper.identifier, tenantCount}
+  }
+}

--- a/src/cli/commands/db/tenants/migrate.js
+++ b/src/cli/commands/db/tenants/migrate.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+import {digg} from "diggerize"
+import BaseCommand from "../../../base-command.js"
+import Migrator from "../../../../database/migrator.js"
+import TenantDatabaseCommandHelper from "../../../tenant-database-command-helper.js"
+
+export default class DbTenantsMigrate extends BaseCommand {
+  /** @returns {Promise<{identifier: string, migrationCount: number, tenantCount: number} | void>} - Result in test mode. */
+  async execute() {
+    const helper = new TenantDatabaseCommandHelper({
+      command: this,
+      identifier: this.processArgs?.[1]
+    })
+    const migrations = await this.getEnvironmentHandler().findMigrations()
+    const tenantCount = await helper.eachTenant(async () => {
+      const migrator = new Migrator({
+        configuration: this.getConfiguration(),
+        databaseIdentifiers: [helper.identifier]
+      })
+
+      await this.getConfiguration().ensureConnections(async () => {
+        await migrator.prepare()
+        await migrator.migrateFiles(migrations, digg(this.getEnvironmentHandler(), "requireMigration"))
+      })
+    })
+
+    if (this.args.testing) {
+      return {
+        identifier: helper.identifier,
+        migrationCount: migrations.length,
+        tenantCount
+      }
+    }
+  }
+}

--- a/src/cli/tenant-database-command-helper.js
+++ b/src/cli/tenant-database-command-helper.js
@@ -27,6 +27,10 @@ export default class TenantDatabaseCommandHelper {
       throw new Error(`Database identifier ${this.identifier} is not configured with tenantOnly: true`)
     }
 
+    if (this.configuration.getDisabledDatabaseIdentifiers().has(this.identifier)) {
+      throw new Error(`Tenant database identifier ${this.identifier} is disabled by VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS`)
+    }
+
     if (typeof this.provider.listTenants !== "function") {
       throw new Error(`Tenant database provider for ${this.identifier} must define listTenants`)
     }

--- a/src/cli/tenant-database-command-helper.js
+++ b/src/cli/tenant-database-command-helper.js
@@ -36,9 +36,15 @@ export default class TenantDatabaseCommandHelper {
     }
   }
 
+  /** @returns {Promise<void>} - Resolves when app runtime is initialized. */
+  async initializeRuntime() {
+    await this.configuration.initialize({type: "db-tenants"})
+  }
+
   /** @returns {Promise<unknown[]>} - Tenants. */
   async listTenants() {
     this.validateTenantDatabaseIdentifier()
+    await this.initializeRuntime()
 
     const tenants = await this.configuration.ensureConnections(async () => {
       return await this.provider.listTenants({

--- a/src/cli/tenant-database-command-helper.js
+++ b/src/cli/tenant-database-command-helper.js
@@ -1,0 +1,91 @@
+// @ts-check
+
+export default class TenantDatabaseCommandHelper {
+  /**
+   * @param {object} args - Options object.
+   * @param {import("./base-command.js").default} args.command - CLI command instance.
+   * @param {string | undefined} args.identifier - Tenant database identifier.
+   */
+  constructor({command, identifier}) {
+    if (!identifier) throw new Error("Missing tenant database identifier argument")
+
+    this.command = command
+    this.configuration = command.getConfiguration()
+    this.identifier = identifier
+    this.provider = this.configuration.getTenantDatabaseProvider(identifier)
+  }
+
+  /** @returns {void} */
+  validateTenantDatabaseIdentifier() {
+    const databaseConfiguration = this.configuration.getDatabaseConfiguration()[this.identifier]
+
+    if (!databaseConfiguration) {
+      throw new Error(`No such database identifier configured: ${this.identifier}`)
+    }
+
+    if (!databaseConfiguration.tenantOnly) {
+      throw new Error(`Database identifier ${this.identifier} is not configured with tenantOnly: true`)
+    }
+
+    if (typeof this.provider.listTenants !== "function") {
+      throw new Error(`Tenant database provider for ${this.identifier} must define listTenants`)
+    }
+  }
+
+  /** @returns {Promise<unknown[]>} - Tenants. */
+  async listTenants() {
+    this.validateTenantDatabaseIdentifier()
+
+    const tenants = await this.configuration.ensureConnections(async () => {
+      return await this.provider.listTenants({
+        configuration: this.configuration,
+        identifier: this.identifier
+      })
+    })
+
+    if (!Array.isArray(tenants)) {
+      throw new Error(`Tenant database provider for ${this.identifier} must return an array from listTenants`)
+    }
+
+    return tenants
+  }
+
+  /**
+   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: unknown}) : Promise<void>} callback - Callback.
+   * @returns {Promise<number>} - Number of tenants processed.
+   */
+  async eachTenant(callback) {
+    const tenants = await this.listTenants()
+
+    for (const tenant of tenants) {
+      await this.configuration.runWithTenant(tenant, async () => {
+        if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
+          throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${this.tenantLabel(tenant)}`)
+        }
+
+        await callback({
+          databaseConfiguration: this.configuration.resolveDatabaseConfiguration(this.identifier),
+          tenant
+        })
+      })
+    }
+
+    return tenants.length
+  }
+
+  /**
+   * @param {unknown} tenant - Tenant.
+   * @returns {string} - Human readable tenant label.
+   */
+  tenantLabel(tenant) {
+    if (tenant && typeof tenant === "object") {
+      const tenantObject = /** @type {{id?: unknown, name?: unknown, slug?: unknown}} */ (tenant)
+
+      if (tenantObject.slug) return String(tenantObject.slug)
+      if (tenantObject.name) return String(tenantObject.name)
+      if (tenantObject.id) return String(tenantObject.id)
+    }
+
+    return JSON.stringify(tenant)
+  }
+}

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -72,6 +72,7 @@
  * @property {boolean} [record.transactions] - Whether record operations should use transactions.
  * @property {boolean} [reset] - Whether to reset the database on startup.
  * @property {SqlConfig} [sqlConfig] - Driver-specific SQL config.
+ * @property {boolean} [tenantOnly] - Whether this database identifier is only active inside a resolved tenant context.
  * @property {"mssql" | "mysql" | "pgsql" | "sqlite"} [type] - Database type identifier.
  * @property {string} [useDatabase] - Database to switch to after connecting.
  * @property {string} [username] - Username for database authentication.
@@ -321,6 +322,14 @@
  */
 
 /**
+ * @typedef {object} TenantDatabaseProviderType
+ * @property {function({configuration: import("./configuration.js").default, identifier: string}) : unknown[] | Promise<unknown[]>} listTenants - Lists tenants that should be created, checked, or migrated for this database identifier.
+ * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [createDatabase] - Creates the tenant database/schema for one tenant.
+ * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [dropDatabase] - Drops the tenant database/schema for one tenant.
+ * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [checkTenant] - Checks one tenant database before generic connection validation.
+ */
+
+/**
  * @typedef {object} ConfigurationArgsType
  * @property {boolean} [autoload] - Globally enable auto-batch-preload of relationships on lazy access. Default true.
  * @property {CorsType} [cors] - CORS configuration for the HTTP server.
@@ -347,6 +356,7 @@
  * @property {StructureSqlConfiguration} [structureSql] - Structure SQL generation configuration.
  * @property {TenantResolverType} [tenantResolver] - Resolver for creating request-scoped tenant context objects.
  * @property {TenantDatabaseResolverType} [tenantDatabaseResolver] - Resolver for deriving tenant-specific database config overrides.
+ * @property {Record<string, TenantDatabaseProviderType>} [tenantDatabaseProviders] - Tenant database lifecycle providers keyed by database identifier.
  * @property {string} [testing] - Path to the testing configuration file.
  * @property {number | (() => number)} [timezoneOffsetMinutes] - Default timezone offset in minutes.
  * @property {number | (() => number)} [requestTimeoutMs] - Timeout in seconds for completing a HTTP request.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -70,7 +70,7 @@ export default class VelociousConfiguration {
   }
 
   /** @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments. */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, directory, environment, environmentHandler, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, directory, environment, environmentHandler, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -102,6 +102,7 @@ export default class VelociousConfiguration {
     this._timezoneOffsetMinutes = timezoneOffsetMinutes
     this._requestTimeoutMs = requestTimeoutMs
     this._structureSql = structureSql
+    this._tenantDatabaseProviders = tenantDatabaseProviders || {}
     this._tenantDatabaseResolver = tenantDatabaseResolver
     this._tenantResolver = tenantResolver
     this._websocketEvents = undefined
@@ -208,9 +209,8 @@ export default class VelociousConfiguration {
     return mergeDatabaseConfiguration(databaseConfiguration, overrideConfiguration)
   }
 
-  /** @returns {Array<string>} - The database identifiers.  */
-  getDatabaseIdentifiers() {
-    const identifiers = Object.keys(this.getDatabaseConfiguration())
+  /** @returns {Set<string>} - Disabled database identifiers from env flags. */
+  getDisabledDatabaseIdentifiers() {
     const disabledIdentifiers = new Set()
     const disabledIdentifiersRaw = process.env.VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS
 
@@ -226,9 +226,40 @@ export default class VelociousConfiguration {
       disabledIdentifiers.add("mssql")
     }
 
-    if (disabledIdentifiers.size === 0) return identifiers
+    return disabledIdentifiers
+  }
 
-    return identifiers.filter((identifier) => !disabledIdentifiers.has(identifier))
+  /**
+   * @param {string} identifier - Database identifier.
+   * @param {unknown} [tenant] - Tenant override.
+   * @returns {boolean} - Whether this database identifier is active in the current tenant context.
+   */
+  isDatabaseIdentifierActive(identifier, tenant = this.getCurrentTenant()) {
+    const databaseConfiguration = this.getDatabaseConfiguration()[identifier]
+
+    if (!databaseConfiguration) {
+      throw new Error(`No such database identifier configured: ${identifier}`)
+    }
+
+    if (!databaseConfiguration.tenantOnly) return true
+    if (tenant === undefined || !this._tenantDatabaseResolver) return false
+
+    const overrideConfiguration = this._tenantDatabaseResolver({
+      configuration: this,
+      databaseConfiguration,
+      identifier,
+      tenant
+    })
+
+    return Boolean(overrideConfiguration)
+  }
+
+  /** @returns {Array<string>} - The database identifiers.  */
+  getDatabaseIdentifiers() {
+    const identifiers = Object.keys(this.getDatabaseConfiguration())
+    const disabledIdentifiers = this.getDisabledDatabaseIdentifiers()
+
+    return identifiers.filter((identifier) => !disabledIdentifiers.has(identifier) && this.isDatabaseIdentifierActive(identifier))
   }
 
   /**
@@ -318,6 +349,23 @@ export default class VelociousConfiguration {
   /** @returns {import("./configuration-types.js").TenantDatabaseResolverType | undefined} - Tenant database resolver. */
   getTenantDatabaseResolver() { return this._tenantDatabaseResolver }
 
+  /** @returns {Record<string, import("./configuration-types.js").TenantDatabaseProviderType>} - Tenant database lifecycle providers. */
+  getTenantDatabaseProviders() { return this._tenantDatabaseProviders }
+
+  /**
+   * @param {string} identifier - Database identifier.
+   * @returns {import("./configuration-types.js").TenantDatabaseProviderType} - Tenant database lifecycle provider.
+   */
+  getTenantDatabaseProvider(identifier) {
+    const provider = this._tenantDatabaseProviders[identifier]
+
+    if (!provider) {
+      throw new Error(`No tenant database provider configured for database identifier: ${identifier}`)
+    }
+
+    return provider
+  }
+
   /** @returns {import("./configuration-types.js").AttachmentsConfiguration} - Attachments configuration. */
   getAttachmentsConfiguration() { return this._attachments || {} }
 
@@ -349,6 +397,12 @@ export default class VelociousConfiguration {
    * @returns {void} - No return value.
    */
   setTenantDatabaseResolver(resolver) { this._tenantDatabaseResolver = resolver }
+
+  /**
+   * @param {Record<string, import("./configuration-types.js").TenantDatabaseProviderType>} providers - Tenant database lifecycle providers.
+   * @returns {void} - No return value.
+   */
+  setTenantDatabaseProviders(providers) { this._tenantDatabaseProviders = providers }
 
   /**
    * @returns {string} - The environment.

--- a/src/database/migrator.js
+++ b/src/database/migrator.js
@@ -14,14 +14,26 @@ export default class VelociousDatabaseMigrator {
   /**
    * @param {object} args - Options object.
    * @param {import("../configuration.js").default} args.configuration - Configuration instance.
+   * @param {string[]} [args.databaseIdentifiers] - Optional database identifiers to migrate.
    */
-  constructor({configuration, ...restArgs}) {
+  constructor({configuration, databaseIdentifiers, ...restArgs}) {
     restArgsError(restArgs)
 
     if (!configuration) throw new Error("configuration argument is required")
 
     this.configuration = configuration
+    this.databaseIdentifiers = databaseIdentifiers
     this.logger = new Logger(this)
+  }
+
+  /**
+   * @param {string} dbIdentifier - Database identifier.
+   * @returns {boolean} - Whether this migrator should touch the database identifier.
+   */
+  handlesDatabaseIdentifier(dbIdentifier) {
+    if (!this.databaseIdentifiers) return true
+
+    return this.databaseIdentifiers.includes(dbIdentifier)
   }
 
 
@@ -36,6 +48,8 @@ export default class VelociousDatabaseMigrator {
     const dbs = await this.configuration.getCurrentConnections()
 
     for (const dbIdentifier in dbs) {
+      if (!this.handlesDatabaseIdentifier(dbIdentifier)) continue
+
       const db = dbs[dbIdentifier]
       const databaseConfiguration = this.configuration.getDatabaseIdentifier(dbIdentifier)
 
@@ -162,10 +176,13 @@ export default class VelociousDatabaseMigrator {
   async _afterMigrations() {
     const environmentHandler = this.configuration.getEnvironmentHandler()
     const dbs = await this.configuration.getCurrentConnections()
+    const filteredDbs = Object.fromEntries(
+      Object.entries(dbs).filter(([dbIdentifier]) => this.handlesDatabaseIdentifier(dbIdentifier))
+    )
 
-    if (!environmentHandler || !dbs || Object.keys(dbs).length == 0) return
+    if (!environmentHandler || Object.keys(filteredDbs).length == 0) return
 
-    await environmentHandler.afterMigrations({dbs})
+    await environmentHandler.afterMigrations({dbs: filteredDbs})
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
@@ -175,6 +192,8 @@ export default class VelociousDatabaseMigrator {
     const dbs = await this.configuration.getCurrentConnections()
 
     for (const dbIdentifier in dbs) {
+      if (!this.handlesDatabaseIdentifier(dbIdentifier)) continue
+
       const db = dbs[dbIdentifier]
       const databaseConfiguration = this.configuration.getDatabaseIdentifier(dbIdentifier)
 
@@ -257,6 +276,8 @@ export default class VelociousDatabaseMigrator {
     const dbs = await this.configuration.getCurrentConnections()
 
     for (const dbIdentifier in dbs) {
+      if (!this.handlesDatabaseIdentifier(dbIdentifier)) continue
+
       const db = dbs[dbIdentifier]
 
       await db.withDisabledForeignKeys(async () => {
@@ -360,6 +381,8 @@ export default class VelociousDatabaseMigrator {
     const migrationDatabaseIdentifiers = migrationClass.getDatabaseIdentifiers() || ["default"]
 
     for (const dbIdentifier in dbs) {
+      if (!this.handlesDatabaseIdentifier(dbIdentifier)) continue
+
       const databaseConfiguration = this.configuration.getDatabaseIdentifier(dbIdentifier)
 
       if (!databaseConfiguration.migrations) {


### PR DESCRIPTION
Adds tenant-only database identifiers and tenant lifecycle CLI commands for Apartment-style project/account databases.\n\nChanges:\n- Adds tenantOnly database identifiers that stay inactive outside resolved tenant contexts.\n- Adds tenantDatabaseProviders and db:tenants:create/check/migrate commands.\n- Scopes Migrator to optional database identifiers so tenant migrations do not run global migrations.\n- Documents tenant database configuration and targeted migrations.\n\nValidation:\n- npm run test -- spec/configuration/tenant-spec.js spec/cli/commands/db/tenants/migrate-spec.js\n- npm run typecheck\n- npm run lint (passes with existing warnings)