### PR TITLE
Connect forked job runners to Beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * Per-row association counts via `.withCount(...)` on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)` on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
-* Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon` (see [docs/beacon.md](docs/beacon.md))
+* Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon`, including forked background job runners (see [docs/beacon.md](docs/beacon.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 * In-process driver schema metadata caching (see [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md))
 

--- a/changelog.d/20260517-background-runner-beacon-ready.md
+++ b/changelog.d/20260517-background-runner-beacon-ready.md
@@ -1,0 +1,1 @@
+Forked background job runners now connect to Beacon and wait for daemon acknowledgement before performing jobs, so their websocket broadcasts can reach subscribers in other processes.

--- a/changelog.d/20260517-background-runner-beacon-ready.md
+++ b/changelog.d/20260517-background-runner-beacon-ready.md
@@ -1,1 +1,1 @@
-Forked background job runners now connect to Beacon and wait for daemon acknowledgement before performing jobs, so their websocket broadcasts can reach subscribers in other processes.
+Forked background job runners now inherit the resolved Velocious environment, connect to Beacon, and wait for daemon acknowledgement before performing jobs, so their websocket broadcasts can reach subscribers in other processes.

--- a/docs/beacon.md
+++ b/docs/beacon.md
@@ -25,6 +25,10 @@ sender, so all peers follow a single delivery path).
                        ┌──────────────┐
                        │  jobs-main   │
                        └──────────────┘
+                              ↑↓
+                       ┌──────────────┐
+                       │ jobs-runner  │
+                       └──────────────┘
 ```
 
 Every peer with a `Configuration` calls `connectBeacon()` once during
@@ -69,6 +73,7 @@ Peers shipped by Velocious connect automatically:
 - `application.startHttpServer()` calls `connectBeacon({peerType: "server"})`.
 - `BackgroundJobsMain.start()` calls `connectBeacon({peerType: "background-jobs-main"})`.
 - `BackgroundJobsWorker.start()` calls `connectBeacon({peerType: "background-jobs-worker"})`.
+- Forked `background-jobs-runner` processes call `connectBeacon({peerType: "background-jobs-runner"})` before performing their job.
 
 Custom processes that maintain their own `Configuration` lifecycle
 should call `connectBeacon` themselves:
@@ -89,12 +94,13 @@ OS TCP connect timeout (tens of seconds), defeating the documented
 "fall back to local-only and reconnect in the background" contract.
 Initial-connect failures surface asynchronously on the framework-error
 channel (see *Error reporting* below); the BeaconClient's reconnect
-loop keeps trying. If a caller needs to wait for connectivity, poll
-`configuration.getBeaconClient()?.isConnected()`.
+loop keeps trying. If a caller needs a deterministic publish-readiness
+boundary, use `await configuration.getBeaconClient()?.waitForReady({timeoutMs: 1000})`.
 
 In-process mode (`beacon: {inProcess: true}`) **does** await `connect()`
 — that path is synchronous, cannot fail, and gives callers predictable
-readiness on the very next line.
+readiness on the very next line. `waitForReady()` resolves immediately
+in this mode.
 
 ## In-process mode
 
@@ -187,6 +193,10 @@ Stages emitted today:
   drops. The `error` is the underlying socket error if there was one,
   or `Error("Beacon broker disconnected")` otherwise. Explicit
   `disconnectBeacon()` calls do **not** fire this event.
+- `"beacon-ready"` — fired by forked background job runners when the
+  daemon does not acknowledge peer registration before the runner's
+  readiness timeout. The job still runs, but broadcasts fall back to
+  local-only delivery until the client reconnects and becomes ready.
 
 A parallel `"all-error"` event mirrors the framework-error channel
 with `errorType: "framework-error"` for apps that prefer one
@@ -225,6 +235,7 @@ await server.start()
 
 const client = new BeaconClient({host: "127.0.0.1", port: server.getPort(), peerType: "test"})
 await client.connect()
+await client.waitForReady({timeoutMs: 1000})
 
 client.onBroadcast((message) => console.log("received:", message))
 client.publish({channel: "frontend-models", broadcastParams: {model: "Build"}, body: {action: "create", id: "1"}})

--- a/spec/background-jobs/job-runner-beacon-spec.js
+++ b/spec/background-jobs/job-runner-beacon-spec.js
@@ -1,0 +1,168 @@
+// @ts-check
+
+import fs from "fs/promises"
+import path from "path"
+import {fileURLToPath, pathToFileURL} from "url"
+import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
+
+import BeaconServer from "../../src/beacon/server.js"
+import Configuration, {CurrentConfigurationNotSetError} from "../../src/configuration.js"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import SingleMultiUsePool from "../../src/database/pool/single-multi-use.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import runJobPayload from "../../src/background-jobs/job-runner.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/**
+ * @returns {string} - Repository root.
+ */
+function repoRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+}
+
+/**
+ * @returns {Promise<{cleanup: () => Promise<void>, directory: string}>} - Temporary project.
+ */
+async function createTempProjectDir() {
+  const directory = path.join(repoRoot(), "tmp", `job-runner-beacon-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  await fs.mkdir(path.join(directory, "src", "jobs"), {recursive: true})
+  await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+
+  return {
+    cleanup: async () => {
+      await fs.rm(directory, {recursive: true, force: true})
+    },
+    directory
+  }
+}
+
+/**
+ * @param {string} directory - Temporary project directory.
+ * @returns {Promise<void>}
+ */
+async function writeBroadcastJob(directory) {
+  const jobPath = pathToFileURL(path.join(repoRoot(), "src", "background-jobs", "job.js")).href
+  const configurationPath = pathToFileURL(path.join(repoRoot(), "src", "configuration.js")).href
+  const contents = `import VelociousJob from ${JSON.stringify(jobPath)}
+import Configuration from ${JSON.stringify(configurationPath)}
+
+export default class BroadcastBuildLogJob extends VelociousJob {
+  async perform() {
+    Configuration.current().broadcastToChannel("frontend-models", {model: "BuildLog"}, {action: "create", id: "runner-log"})
+  }
+}
+`
+
+  await fs.writeFile(path.join(directory, "src", "jobs", "broadcast-build-log-job.js"), contents)
+}
+
+/**
+ * @param {object} args - Options.
+ * @param {import("../../src/configuration-types.js").BeaconConfiguration} args.beacon - Beacon configuration.
+ * @param {string} args.directory - App directory.
+ * @param {string} args.name - Database name.
+ * @returns {Configuration}
+ */
+function createConfiguration({beacon, directory, name}) {
+  return new Configuration({
+    beacon,
+    database: {
+      test: {
+        default: {
+          driver: SqliteDriver,
+          poolType: SingleMultiUsePool,
+          type: "sqlite",
+          name,
+          migrations: false
+        }
+      }
+    },
+    directory,
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+}
+
+/**
+ * @returns {{matches: (broadcastParams: Record<string, unknown>) => boolean, sendMessage: (body: unknown) => void, isClosed: () => boolean, received: Array<unknown>, subscriptionId: string}}
+ */
+function makeSubscription() {
+  /** @type {Array<unknown>} */
+  const received = []
+
+  return {
+    isClosed: () => false,
+    matches: (broadcastParams) => broadcastParams.model === "BuildLog",
+    received,
+    sendMessage: (body) => received.push(body),
+    subscriptionId: `s-${Math.random().toString(36).slice(2)}`
+  }
+}
+
+describe("Background jobs - runner Beacon", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("connects forked job runners to Beacon before performing jobs", async () => {
+    const {cleanup, directory} = await createTempProjectDir()
+    await writeBroadcastJob(directory)
+
+    /** @type {Configuration | undefined} */
+    let previousConfiguration
+
+    try {
+      previousConfiguration = Configuration.current()
+    } catch (error) {
+      if (!(error instanceof CurrentConfigurationNotSetError)) throw error
+    }
+
+    const beacon = new BeaconServer({
+      configuration: createConfiguration({
+        beacon: {host: "127.0.0.1", port: 0},
+        directory,
+        name: "job-runner-beacon-server"
+      }),
+      host: "127.0.0.1",
+      port: 0
+    })
+    await beacon.start()
+
+    const port = beacon.getPort()
+    const subscriberConfiguration = createConfiguration({
+      beacon: {host: "127.0.0.1", port},
+      directory,
+      name: "job-runner-beacon-subscriber"
+    })
+    const runnerConfiguration = createConfiguration({
+      beacon: {host: "127.0.0.1", port},
+      directory,
+      name: "job-runner-beacon-runner"
+    })
+    const subscription = makeSubscription()
+
+    try {
+      subscriberConfiguration._registerWebsocketChannelSubscription("frontend-models", /** @type {any} */ (subscription))
+      const subscriberClient = await subscriberConfiguration.connectBeacon({peerType: "subscriber"})
+      await subscriberClient?.waitForReady({timeoutMs: 1000})
+
+      runnerConfiguration.setCurrent()
+      await runJobPayload({jobName: "BroadcastBuildLogJob", args: []})
+
+      await timeout({timeout: 1000}, async () => {
+        while (subscription.received.length === 0) await wait(0.01)
+      })
+
+      expect(subscription.received[0]).toEqual({action: "create", id: "runner-log"})
+    } finally {
+      previousConfiguration?.setCurrent()
+      await runnerConfiguration.disconnectBeacon()
+      await runnerConfiguration.closeDatabaseConnections()
+      await subscriberConfiguration.disconnectBeacon()
+      await subscriberConfiguration.closeDatabaseConnections()
+      await beacon.stop()
+      await cleanup()
+    }
+  })
+})

--- a/spec/background-jobs/job-runner-beacon-spec.js
+++ b/spec/background-jobs/job-runner-beacon-spec.js
@@ -4,7 +4,6 @@ import fs from "fs/promises"
 import path from "path"
 import {fileURLToPath, pathToFileURL} from "url"
 import timeout from "awaitery/build/timeout.js"
-import wait from "awaitery/build/wait.js"
 
 import BeaconServer from "../../src/beacon/server.js"
 import Configuration, {CurrentConfigurationNotSetError} from "../../src/configuration.js"
@@ -89,17 +88,20 @@ function createConfiguration({beacon, directory, name}) {
 }
 
 /**
- * @returns {{matches: (broadcastParams: Record<string, unknown>) => boolean, sendMessage: (body: unknown) => void, isClosed: () => boolean, received: Array<unknown>, subscriptionId: string}}
+ * @returns {{matches: (broadcastParams: Record<string, unknown>) => boolean, sendMessage: (body: unknown) => void, isClosed: () => boolean, nextMessage: Promise<unknown>, subscriptionId: string}}
  */
 function makeSubscription() {
-  /** @type {Array<unknown>} */
-  const received = []
+  /** @type {(body: unknown) => void} */
+  let resolveNextMessage = () => {}
+  const nextMessage = new Promise((resolve) => {
+    resolveNextMessage = resolve
+  })
 
   return {
     isClosed: () => false,
     matches: (broadcastParams) => broadcastParams.model === "BuildLog",
-    received,
-    sendMessage: (body) => received.push(body),
+    nextMessage,
+    sendMessage: (body) => resolveNextMessage(body),
     subscriptionId: `s-${Math.random().toString(36).slice(2)}`
   }
 }
@@ -145,16 +147,14 @@ describe("Background jobs - runner Beacon", {databaseCleaning: {transaction: fal
     try {
       subscriberConfiguration._registerWebsocketChannelSubscription("frontend-models", /** @type {any} */ (subscription))
       const subscriberClient = await subscriberConfiguration.connectBeacon({peerType: "subscriber"})
-      await subscriberClient?.waitForReady({timeoutMs: 1000})
+      await subscriberClient?.waitForReady({timeoutMs: 5000})
 
       runnerConfiguration.setCurrent()
       await runJobPayload({jobName: "BroadcastBuildLogJob", args: []})
 
-      await timeout({timeout: 1000}, async () => {
-        while (subscription.received.length === 0) await wait(0.01)
-      })
+      const received = await timeout({timeout: 5000}, async () => await subscription.nextMessage)
 
-      expect(subscription.received[0]).toEqual({action: "create", id: "runner-log"})
+      expect(received).toEqual({action: "create", id: "runner-log"})
     } finally {
       previousConfiguration?.setCurrent()
       await runnerConfiguration.disconnectBeacon()

--- a/spec/beacon/client-spec.js
+++ b/spec/beacon/client-spec.js
@@ -37,6 +37,8 @@ describe("BeaconClient", {databaseCleaning: {transaction: false, truncate: false
     await client.connect()
 
     expect(client.isConnected()).toBe(true)
+    await client.waitForReady({timeoutMs: 1000})
+    expect(client.isReady()).toBe(true)
     expect(client.publish({channel: "c", broadcastParams: {}, body: {}})).toBe(true)
 
     await client.close()

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -4,6 +4,47 @@ import configurationResolver from "../configuration-resolver.js"
 import BackgroundJobRegistry from "./job-registry.js"
 import BackgroundJobsStatusReporter from "./status-reporter.js"
 
+const BEACON_READY_TIMEOUT_MS = 5000
+
+/**
+ * @param {import("../configuration.js").default} configuration - Configuration.
+ * @param {unknown} error - Beacon readiness error.
+ * @returns {void}
+ */
+function reportBeaconReadyError(configuration, error) {
+  const errorEvents = configuration.getErrorEvents()
+  const normalizedError = error instanceof Error ? error : new Error(String(error))
+  const payload = {
+    context: {peerType: "background-jobs-runner", stage: "beacon-ready"},
+    error: normalizedError
+  }
+  const hasListener = errorEvents.listenerCount("framework-error") > 0
+    || errorEvents.listenerCount("all-error") > 0
+
+  errorEvents.emit("framework-error", payload)
+  errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
+
+  if (!hasListener) {
+    console.error(`[velocious framework-error stage=beacon-ready] ${normalizedError.message}`)
+  }
+}
+
+/**
+ * @param {import("../configuration.js").default} configuration - Configuration.
+ * @returns {Promise<void>}
+ */
+async function connectBeacon(configuration) {
+  const beaconClient = await configuration.connectBeacon({peerType: "background-jobs-runner"})
+
+  if (!beaconClient) return
+
+  try {
+    await beaconClient.waitForReady({timeoutMs: BEACON_READY_TIMEOUT_MS})
+  } catch (error) {
+    reportBeaconReadyError(configuration, error)
+  }
+}
+
 /**
  * @param {import("./types.js").BackgroundJobPayload} payload - Payload.
  * @returns {Promise<void>} - Resolves when complete.
@@ -12,6 +53,7 @@ export default async function runJobPayload(payload) {
   const configuration = await configurationResolver()
   configuration.setCurrent()
   await configuration.initialize({type: "background-jobs-runner"})
+  await connectBeacon(configuration)
   const reporter = new BackgroundJobsStatusReporter({configuration})
 
   const registry = new BackgroundJobRegistry({configuration})
@@ -22,31 +64,35 @@ export default async function runJobPayload(payload) {
   const perform = jobInstance.perform
 
   try {
-    await configuration.withConnections(async () => {
-      await perform.apply(jobInstance, payload.args || [])
-    })
-
-    if (payload.id) {
-      await reporter.reportWithRetry({
-        jobId: payload.id,
-        status: "completed",
-        workerId: payload.workerId,
-        handedOffAtMs: payload.handedOffAtMs,
-        maxDurationMs: 30000
+    try {
+      await configuration.withConnections(async () => {
+        await perform.apply(jobInstance, payload.args || [])
       })
-    }
-  } catch (error) {
-    if (payload.id) {
-      await reporter.reportWithRetry({
-        jobId: payload.id,
-        status: "failed",
-        error,
-        workerId: payload.workerId,
-        handedOffAtMs: payload.handedOffAtMs,
-        maxDurationMs: 30000
-      })
-    }
 
-    throw error
+      if (payload.id) {
+        await reporter.reportWithRetry({
+          jobId: payload.id,
+          status: "completed",
+          workerId: payload.workerId,
+          handedOffAtMs: payload.handedOffAtMs,
+          maxDurationMs: 30000
+        })
+      }
+    } catch (error) {
+      if (payload.id) {
+        await reporter.reportWithRetry({
+          jobId: payload.id,
+          status: "failed",
+          error,
+          workerId: payload.workerId,
+          handedOffAtMs: payload.handedOffAtMs,
+          maxDurationMs: 30000
+        })
+      }
+
+      throw error
+    }
+  } finally {
+    await configuration.disconnectBeacon()
   }
 }

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -280,6 +280,7 @@ export default class BackgroundJobsWorker {
       detached: true,
       stdio: "ignore",
       env: Object.assign({}, process.env, {
+        VELOCIOUS_ENV: configuration.getEnvironment(),
         VELOCIOUS_BACKGROUND_JOBS_HOST: backgroundJobsConfig.host,
         VELOCIOUS_BACKGROUND_JOBS_PORT: `${backgroundJobsConfig.port}`,
         VELOCIOUS_JOB_PAYLOAD: encodedPayload

--- a/src/beacon/client.js
+++ b/src/beacon/client.js
@@ -2,6 +2,7 @@
 
 import {randomUUID} from "node:crypto"
 import net from "node:net"
+import timeout from "awaitery/build/timeout.js"
 
 import JsonSocket from "../background-jobs/json-socket.js"
 import EventEmitter from "../utils/event-emitter.js"
@@ -20,6 +21,7 @@ const MAX_RECONNECT_DELAY_MS = 30_000
  * Lifecycle:
  *   const client = new BeaconClient({host, port, peerType: "server"})
  *   await client.connect()                         // resolves on first successful connect
+ *   await client.waitForReady({timeoutMs: 1000})   // resolves after the daemon hello-ack
  *   client.onBroadcast((message) => { ... })       // every fan-out
  *   client.publish({channel, broadcastParams, body})
  *   await client.close()
@@ -54,6 +56,7 @@ export default class BeaconClient extends EventEmitter {
     /** @type {net.Socket | undefined} */
     this._socket = undefined
     this._connected = false
+    this._ready = false
     this._closed = false
     /** @type {NodeJS.Timeout | undefined} */
     this._reconnectTimer = undefined
@@ -71,6 +74,9 @@ export default class BeaconClient extends EventEmitter {
 
   /** @returns {boolean} - Whether the underlying socket is currently connected. */
   isConnected() { return this._connected }
+
+  /** @returns {boolean} - Whether the daemon has acknowledged this peer registration. */
+  isReady() { return this._ready }
 
   /**
    * Resolves on the first successful connect. Subsequent calls return
@@ -104,6 +110,43 @@ export default class BeaconClient extends EventEmitter {
     this._openSocket()
 
     return await this._connectPromise
+  }
+
+  /**
+   * Resolves after the Beacon daemon has acknowledged this peer's
+   * hello handshake. This is stronger than `isConnected()`: connected
+   * means the TCP socket is open, ready means the daemon has registered
+   * the peer and broadcasts can be routed through the bus.
+   * @param {object} [args] - Options.
+   * @param {number} [args.timeoutMs] - Optional timeout in milliseconds.
+   * @returns {Promise<void>}
+   */
+  async waitForReady({timeoutMs} = {}) {
+    if (this._ready) return
+
+    /** @type {() => void} */
+    let cleanup = () => {}
+    const readyPromise = new Promise((resolve) => {
+      const onReady = () => {
+        cleanup()
+        resolve(undefined)
+      }
+
+      cleanup = () => this.off("ready", onReady)
+      this.on("ready", onReady)
+    })
+
+    try {
+      if (typeof timeoutMs === "number") {
+        await timeout({timeout: timeoutMs}, async () => {
+          await readyPromise
+        })
+      } else {
+        await readyPromise
+      }
+    } finally {
+      cleanup()
+    }
   }
 
   /**
@@ -179,6 +222,7 @@ export default class BeaconClient extends EventEmitter {
 
     socket.on("connect", () => {
       this._connected = true
+      this._ready = false
       this._reconnectDelayMs = this._initialReconnectDelayMs
 
       jsonSocket.send({
@@ -192,7 +236,10 @@ export default class BeaconClient extends EventEmitter {
     })
 
     jsonSocket.on("message", (/** @type {import("./types.js").BeaconSocketMessage} */ message) => {
-      if (message?.type === "broadcast") {
+      if (message?.type === "hello-ack" && message.peerId === this.peerId) {
+        this._ready = true
+        this.emit("ready")
+      } else if (message?.type === "broadcast") {
         this.emit("broadcast", message)
       }
     })
@@ -215,6 +262,7 @@ export default class BeaconClient extends EventEmitter {
       const wasConnected = this._connected
 
       this._connected = false
+      this._ready = false
       this._jsonSocket = undefined
       this._socket = undefined
 

--- a/src/beacon/in-process-client.js
+++ b/src/beacon/in-process-client.js
@@ -18,7 +18,7 @@ import {publishToInProcessPeers, registerInProcessPeer} from "./in-process-broke
  * `Configuration` can use either client interchangeably.
  *
  * Lifecycle differs from `BeaconClient` in two intentional ways:
- *   - `connect()` resolves immediately; there is no broker to wait for.
+ *   - `connect()` and `waitForReady()` resolve immediately; there is no broker to wait for.
  *   - There is no reconnect loop and no `connect-error` / `disconnect`
  *     event surface, because nothing can fail.
  */
@@ -43,6 +43,9 @@ export default class InProcessBeaconClient extends EventEmitter {
   /** @returns {boolean} - Whether the peer is registered with the broker. */
   isConnected() { return this._connected }
 
+  /** @returns {boolean} - Whether the peer is ready to publish through the broker. */
+  isReady() { return this._connected }
+
   /**
    * Registers with the in-process broker. Idempotent.
    * @returns {Promise<void>}
@@ -53,6 +56,14 @@ export default class InProcessBeaconClient extends EventEmitter {
     this._unregister = registerInProcessPeer(this)
     this._connected = true
     this.emit("connect")
+  }
+
+  /**
+   * In-process peers are ready as soon as they are connected.
+   * @returns {Promise<void>}
+   */
+  async waitForReady() {
+    if (!this._connected) await this.connect()
   }
 
   /**

--- a/src/beacon/server.js
+++ b/src/beacon/server.js
@@ -106,6 +106,7 @@ export default class BeaconServer {
       if (!peerId && message?.type === "hello") {
         peerId = message.peerId
         this.peers.add(jsonSocket)
+        jsonSocket.send({type: "hello-ack", peerId})
         return
       }
 

--- a/src/beacon/types.js
+++ b/src/beacon/types.js
@@ -29,6 +29,14 @@
  */
 
 /**
+ * @typedef {{type: "hello-ack", peerId: string}} BeaconHelloAckMessage
+ *
+ * Sent by the daemon after it has registered the peer. Clients can use
+ * this as a deterministic readiness boundary before publishing events
+ * that must not fall back to local-only delivery.
+ */
+
+/**
  * @typedef {{type: "broadcast", channel: string, broadcastParams: Record<string, any>, body: any, originPeerId?: string}} BeaconBroadcastMessage
  *
  * `channel`, `broadcastParams`, and `body` mirror the
@@ -41,7 +49,7 @@
  */
 
 /**
- * @typedef {BeaconHelloMessage | BeaconBroadcastMessage} BeaconSocketMessage
+ * @typedef {BeaconHelloMessage | BeaconHelloAckMessage | BeaconBroadcastMessage} BeaconSocketMessage
  */
 
 export const nothing = {}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -607,8 +607,9 @@ export default class VelociousConfiguration {
    * documented "fall back to local-only and reconnect in the
    * background" contract. Initial-connect failures surface
    * asynchronously on the framework-error channel via the
-   * `connect-error` listener registered here. Callers that need to
-   * wait for connectivity should poll `getBeaconClient()?.isConnected()`.
+   * `connect-error` listener registered here. Callers that need a
+   * deterministic publish-readiness boundary should call
+   * `getBeaconClient()?.waitForReady({timeoutMs})`.
    *
    * **In-process mode** awaits `connect()` — that path is synchronous,
    * cannot fail, and gives callers predictable readiness.


### PR DESCRIPTION
## Summary
- add Beacon hello-ack readiness and waitForReady
- connect background-jobs-runner processes to Beacon before job perform
- cover runner BuildLog-style broadcasts through Beacon

## Tests
- npm run test -- spec/beacon/client-spec.js spec/background-jobs/job-runner-beacon-spec.js
- npm run test -- spec/beacon/client-spec.js spec/beacon/server-spec.js spec/beacon/configuration-integration-spec.js spec/beacon/in-process-spec.js spec/beacon/error-reporting-spec.js spec/background-jobs/job-runner-beacon-spec.js
- npm run lint
- npm run typecheck
- npm run build