### PR TITLE
Enforce tenant database scopes for switched models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1989,6 +1989,8 @@ export default new Configuration({
 
 Use `configuration.runWithTenant(tenant, callback)` or `Current.tenant()` when custom model/database routing needs to read the active tenant manually.
 
+Tenant-switched model classes fail closed by default: if `switchesTenantDatabase(...)` cannot resolve a tenant database identifier for the current tenant, Velocious raises `TenantDatabaseScopeError` instead of running the query against the configured fallback database. Set `enforceTenantDatabaseScopes: false` only for legacy apps that still need the old fallback behavior during migration.
+
 For Apartment-style project/account databases, mark the logical per-tenant identifier with `tenantOnly: true`, provide `tenantDatabaseProviders`, and run tenant lifecycle commands explicitly. One logical identifier can resolve to any number of physical tenant databases at runtime; provider `listTenants` is queried for every command run so added/removed tenants do not require configuration changes or redeploys.
 
 ```sh

--- a/changelog.d/20260517-tenant-database-scope-guard.md
+++ b/changelog.d/20260517-tenant-database-scope-guard.md
@@ -1,0 +1,1 @@
+Velocious now raises `TenantDatabaseScopeError` when a model configured with `switchesTenantDatabase(...)` is queried without a resolved tenant database identifier. Set `enforceTenantDatabaseScopes: false` to keep the legacy fallback behavior temporarily.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -6,6 +6,8 @@ A tenant database identifier is a logical slot, not one physical database. For e
 
 Configure the tenant database as `tenantOnly: true`. Tenant-only identifiers are skipped by normal connection setup and `db:migrate` until a tenant context activates them through `tenantDatabaseResolver`.
 
+Model classes that call `switchesTenantDatabase(...)` require a tenant database identifier by default. If a model query or write runs without a current tenant, or with a tenant object that does not resolve the model's tenant database, Velocious raises `TenantDatabaseScopeError` instead of falling back to the global database. Legacy apps can temporarily set `enforceTenantDatabaseScopes: false` on the configuration while migrating to explicit tenant scopes.
+
 ```js
 export default new Configuration({
   database: {

--- a/spec/database/record/tenant-database-spec.js
+++ b/spec/database/record/tenant-database-spec.js
@@ -18,6 +18,10 @@ class StaticTenantAnalyticsRecord extends DatabaseRecord {}
 
 StaticTenantAnalyticsRecord.switchesTenantDatabase("analytics")
 
+class StaticProjectTenantRecord extends DatabaseRecord {}
+
+StaticProjectTenantRecord.switchesTenantDatabase("projectTenant")
+
 class GlobalRecord extends DatabaseRecord {}
 
 async function createTenantAnalyticsRecordTable(configuration, tenant) {
@@ -151,8 +155,46 @@ describe("DatabaseRecord tenant database switching", () => {
     }
   })
 
-  it("leaves static and non-tenant database identifiers unchanged", () => {
-    expect(StaticTenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("analytics")
-    expect(GlobalRecord.getDatabaseIdentifier()).toEqual("default")
+  it("leaves static and non-tenant database identifiers unchanged", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-static-active")
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      expect(StaticTenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("analytics")
+      expect(GlobalRecord.getDatabaseIdentifier()).toEqual("default")
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("throws when a static tenant-only database identifier is inactive", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-static-inactive")
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      await expect(async () => StaticProjectTenantRecord.getDatabaseIdentifier()).toThrow(TenantDatabaseScopeError)
+
+      await configuration.runWithTenant({}, async () => {
+        await expect(async () => StaticProjectTenantRecord.getDatabaseIdentifier()).toThrow(TenantDatabaseScopeError)
+      })
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
   })
 })

--- a/spec/database/record/tenant-database-spec.js
+++ b/spec/database/record/tenant-database-spec.js
@@ -1,11 +1,12 @@
 // @ts-check
 
 import Current from "../../../src/current.js"
-import DatabaseRecord from "../../../src/database/record/index.js"
+import DatabaseRecord, {TenantDatabaseScopeError} from "../../../src/database/record/index.js"
 import {describe, expect, it} from "../../../src/testing/test.js"
 import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.js"
 
 class TenantAnalyticsRecord extends DatabaseRecord {}
+TenantAnalyticsRecord.setTableName("tenant_analytics_records")
 
 TenantAnalyticsRecord.switchesTenantDatabase(({tenant}) => {
   if (tenant && typeof tenant === "object" && tenant.slug) {
@@ -13,8 +14,31 @@ TenantAnalyticsRecord.switchesTenantDatabase(({tenant}) => {
   }
 })
 
+class StaticTenantAnalyticsRecord extends DatabaseRecord {}
+
+StaticTenantAnalyticsRecord.switchesTenantDatabase("analytics")
+
+class GlobalRecord extends DatabaseRecord {}
+
+async function createTenantAnalyticsRecordTable(configuration, tenant) {
+  await configuration.runWithTenant(tenant, async () => {
+    await configuration.ensureConnections(async (dbs) => {
+      await dbs.analytics.query("CREATE TABLE IF NOT EXISTS tenant_analytics_records(id integer PRIMARY KEY AUTOINCREMENT, name varchar(255))")
+    })
+  })
+}
+
+async function initializeTenantAnalyticsRecord(configuration) {
+  await configuration.ensureConnections(async (dbs) => {
+    await dbs.default.query("CREATE TABLE IF NOT EXISTS tenant_analytics_records(id integer PRIMARY KEY AUTOINCREMENT, name varchar(255))")
+    await dbs.analytics.query("CREATE TABLE IF NOT EXISTS tenant_analytics_records(id integer PRIMARY KEY AUTOINCREMENT, name varchar(255))")
+
+    await TenantAnalyticsRecord.initializeRecord({configuration})
+  })
+}
+
 describe("DatabaseRecord tenant database switching", () => {
-  it("declares tenant-aware database identifiers on model classes", async () => {
+  it("throws before tenant-switched model queries fall back to the configured database", async () => {
     const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant")
     let previousConfiguration
 
@@ -26,18 +50,109 @@ describe("DatabaseRecord tenant database switching", () => {
       }
 
       configuration.setCurrent()
-      expect(TenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("default")
+      await initializeTenantAnalyticsRecord(configuration)
+
+      await expect(async () => TenantAnalyticsRecord.getDatabaseIdentifier()).toThrow(TenantDatabaseScopeError)
+
+      await configuration.ensureConnections(async () => {
+        await expect(async () => TenantAnalyticsRecord.count()).toThrow(TenantDatabaseScopeError)
+      })
 
       await configuration.runWithTenant({slug: "alpha"}, async () => {
         expect(Current.tenant()).toEqual({slug: "alpha"})
         expect(TenantAnalyticsRecord.getTenantDatabaseIdentifier()).toEqual("analytics")
         expect(TenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("analytics")
       })
-
-      expect(TenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("default")
     } finally {
       previousConfiguration?.setCurrent()
       await cleanup()
     }
+  })
+
+  it("uses resolved tenant database identifiers inside tenant scope", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-resolved")
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      await initializeTenantAnalyticsRecord(configuration)
+
+      await createTenantAnalyticsRecordTable(configuration, {slug: "alpha"})
+
+      await configuration.runWithTenant({slug: "alpha"}, async () => {
+        await configuration.ensureConnections(async () => {
+          await TenantAnalyticsRecord.create({name: "Tenant Alpha"})
+
+          expect(await TenantAnalyticsRecord.count()).toEqual(1)
+        })
+      })
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("throws when the current tenant does not resolve a database identifier", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-missing-scope")
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      await initializeTenantAnalyticsRecord(configuration)
+
+      await configuration.runWithTenant({}, async () => {
+        await configuration.ensureConnections(async () => {
+          await expect(async () => TenantAnalyticsRecord.count()).toThrow(TenantDatabaseScopeError)
+        })
+      })
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("allows legacy fallback when strict tenant database scopes are disabled", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration(
+      "velocious-record-tenant-legacy",
+      {enforceTenantDatabaseScopes: false}
+    )
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      await initializeTenantAnalyticsRecord(configuration)
+
+      expect(TenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("default")
+
+      await configuration.ensureConnections(async () => {
+        expect(await TenantAnalyticsRecord.count()).toEqual(0)
+      })
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("leaves static and non-tenant database identifiers unchanged", () => {
+    expect(StaticTenantAnalyticsRecord.getDatabaseIdentifier()).toEqual("analytics")
+    expect(GlobalRecord.getDatabaseIdentifier()).toEqual("default")
   })
 })

--- a/spec/dummy/src/config/configuration.peakflow.sqlite.js
+++ b/spec/dummy/src/config/configuration.peakflow.sqlite.js
@@ -129,7 +129,7 @@ const configuration = new Configuration({
 
         if (!modelClass?.initializeRecord) continue
 
-        if (typeof modelClass.getDatabaseIdentifier === "function" && modelClass.getDatabaseIdentifier() !== "default") {
+        if (typeof modelClass.getConfiguredDatabaseIdentifier === "function" && modelClass.getConfiguredDatabaseIdentifier() !== "default") {
           continue
         }
 

--- a/spec/helpers/tenant-test-helpers.js
+++ b/spec/helpers/tenant-test-helpers.js
@@ -14,9 +14,11 @@ import path from "path"
 
 /**
  * @param {string} prefix - Temp-path prefix.
+ * @param {object} [args] - Options.
+ * @param {boolean} [args.enforceTenantDatabaseScopes] - Whether tenant-switched model queries require a resolved tenant database.
  * @returns {Promise<{cleanup: () => Promise<void>, configuration: Configuration}>} - Test configuration and cleanup.
  */
-export async function createTenantTestConfiguration(prefix) {
+export async function createTenantTestConfiguration(prefix, {enforceTenantDatabaseScopes = true} = {}) {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`))
 
   const configuration = new Configuration({
@@ -47,6 +49,7 @@ export async function createTenantTestConfiguration(prefix) {
       }
     },
     directory,
+    enforceTenantDatabaseScopes,
     environment: "test",
     environmentHandler: new EnvironmentHandlerNode(),
     initializeModels: async () => {},

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -341,6 +341,7 @@
  * @property {{[key: string]: {[key: string]: DatabaseConfigurationType}}} database - Database configurations keyed by environment and identifier.
  * @property {boolean} [debug] - Enable debug logging.
  * @property {string} [directory] - Base directory for the project.
+ * @property {boolean} [enforceTenantDatabaseScopes] - Require tenant-switched model queries to resolve a tenant database identifier. Defaults to true.
  * @property {string} [environment] - Current environment name.
  * @property {import("./environment-handlers/base.js").default} environmentHandler - Environment handler instance.
  * @property {LoggingConfiguration} [logging] - Logging configuration.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -70,7 +70,7 @@ export default class VelociousConfiguration {
   }
 
   /** @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments. */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, directory, environment, environmentHandler, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -91,6 +91,7 @@ export default class VelociousConfiguration {
     this.debug = debug
     this._environment = environment || process.env.VELOCIOUS_ENV || process.env.NODE_ENV || "development"
     this._environmentHandler = environmentHandler
+    this._enforceTenantDatabaseScopes = enforceTenantDatabaseScopes
     this._directory = directory
     this._initializeModels = initializeModels
     this._isInitialized = false
@@ -349,6 +350,9 @@ export default class VelociousConfiguration {
   /** @returns {import("./configuration-types.js").TenantDatabaseResolverType | undefined} - Tenant database resolver. */
   getTenantDatabaseResolver() { return this._tenantDatabaseResolver }
 
+  /** @returns {boolean} - Whether tenant-switched models require a resolved tenant database identifier. */
+  getEnforceTenantDatabaseScopes() { return this._enforceTenantDatabaseScopes }
+
   /** @returns {Record<string, import("./configuration-types.js").TenantDatabaseProviderType>} - Tenant database lifecycle providers. */
   getTenantDatabaseProviders() { return this._tenantDatabaseProviders }
 
@@ -397,6 +401,12 @@ export default class VelociousConfiguration {
    * @returns {void} - No return value.
    */
   setTenantDatabaseResolver(resolver) { this._tenantDatabaseResolver = resolver }
+
+  /**
+   * @param {boolean} newValue - Whether tenant-switched models require a resolved tenant database identifier.
+   * @returns {void} - No return value.
+   */
+  setEnforceTenantDatabaseScopes(newValue) { this._enforceTenantDatabaseScopes = newValue }
 
   /**
    * @param {Record<string, import("./configuration-types.js").TenantDatabaseProviderType>} providers - Tenant database lifecycle providers.

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -1161,6 +1161,17 @@ class VelociousDatabaseRecord {
     const tenantDatabaseIdentifier = this.getTenantDatabaseIdentifier(tenant)
 
     if (tenantDatabaseIdentifier) {
+      if (
+        enforceTenantDatabaseScope &&
+        this._getConfiguration().getEnforceTenantDatabaseScopes() &&
+        !this._getConfiguration().isDatabaseIdentifierActive(tenantDatabaseIdentifier, tenant)
+      ) {
+        throw new TenantDatabaseScopeError(
+          `${this.getModelName()} resolved tenant database identifier ${JSON.stringify(tenantDatabaseIdentifier)} but that database identifier is not active for the current tenant. Wrap the model query in configuration.runWithTenant(...) or set enforceTenantDatabaseScopes: false to allow legacy fallback behavior.`,
+          {modelName: this.getModelName()}
+        )
+      }
+
       return tenantDatabaseIdentifier
     }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -96,6 +96,18 @@ class AdvisoryLockBusyError extends Error {
   }
 }
 
+class TenantDatabaseScopeError extends Error {
+  /**
+   * @param {string} message - Error message.
+   * @param {{modelName: string}} args - Context for the failed tenant-scoped model.
+   */
+  constructor(message, {modelName}) {
+    super(message)
+    this.name = "TenantDatabaseScopeError"
+    this.modelName = modelName
+  }
+}
+
 class VelociousDatabaseRecord {
   /** @type {string | undefined} */
   static modelName
@@ -787,10 +799,14 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * @param {object} [args] - Options.
+   * @param {boolean} [args.enforceTenantDatabaseScope] - Whether tenant-switched models must resolve a tenant database identifier.
    * @returns {import("../drivers/base.js").default} - The connection.
    */
-  static connection() {
-    const databasePool = this._getConfiguration().getDatabasePool(this.getDatabaseIdentifier())
+  static connection({enforceTenantDatabaseScope = true, ...restArgs} = {}) {
+    restArgsError(restArgs)
+
+    const databasePool = this._getConfiguration().getDatabasePool(this.getDatabaseIdentifier({enforceTenantDatabaseScope}))
     const connection = databasePool.getCurrentConnection()
 
     if (!connection) throw new Error("No connection?")
@@ -976,9 +992,11 @@ class VelociousDatabaseRecord {
 
     this._configuration = configuration
     this._configuration.registerModelClass(this)
-    this._databaseType = this.connection().getType()
+    const connection = this.connection({enforceTenantDatabaseScope: false})
 
-    this._table = await this.connection().getTableByName(this.tableName())
+    this._databaseType = connection.getType()
+
+    this._table = await connection.getTableByName(this.tableName())
     this._columns = await this._getTable().getColumns()
 
     /** @type {Record<string, import("../drivers/base-column.js").default>} */
@@ -1126,17 +1144,34 @@ class VelociousDatabaseRecord {
     }
   }
 
+  /** @returns {string} - The configured non-tenant database identifier. */
+  static getConfiguredDatabaseIdentifier() {
+    return this._databaseIdentifier || "default"
+  }
+
   /**
+   * @param {object} [args] - Options.
+   * @param {boolean} [args.enforceTenantDatabaseScope] - Whether tenant-switched models must resolve a tenant database identifier.
    * @returns {string} - The database identifier.
    */
-  static getDatabaseIdentifier() {
-    const tenantDatabaseIdentifier = this.getTenantDatabaseIdentifier()
+  static getDatabaseIdentifier({enforceTenantDatabaseScope = true, ...restArgs} = {}) {
+    restArgsError(restArgs)
+
+    const tenant = Current.tenant()
+    const tenantDatabaseIdentifier = this.getTenantDatabaseIdentifier(tenant)
 
     if (tenantDatabaseIdentifier) {
       return tenantDatabaseIdentifier
     }
 
-    return this._databaseIdentifier || "default"
+    if (enforceTenantDatabaseScope && this._tenantDatabaseIdentifierResolver && this._getConfiguration().getEnforceTenantDatabaseScopes()) {
+      throw new TenantDatabaseScopeError(
+        `${this.getModelName()} is configured with switchesTenantDatabase(...) but no tenant database identifier resolved for the current tenant. Wrap the model query in configuration.runWithTenant(...) or set enforceTenantDatabaseScopes: false to allow legacy fallback behavior.`,
+        {modelName: this.getModelName()}
+      )
+    }
+
+    return this.getConfiguredDatabaseIdentifier()
   }
 
   /**
@@ -3163,5 +3198,5 @@ VelociousDatabaseRecord.registerValidatorType("format", ValidatorsFormat)
 VelociousDatabaseRecord.registerValidatorType("presence", ValidatorsPresence)
 VelociousDatabaseRecord.registerValidatorType("uniqueness", ValidatorsUniqueness)
 
-export {AdvisoryLockBusyError, AdvisoryLockTimeoutError, ValidationError}
+export {AdvisoryLockBusyError, AdvisoryLockTimeoutError, TenantDatabaseScopeError, ValidationError}
 export default VelociousDatabaseRecord


### PR DESCRIPTION
## Summary
- add strict tenant-scope enforcement for models using switchesTenantDatabase(...)
- expose enforceTenantDatabaseScopes as the legacy opt-out flag
- document the new fail-closed behavior and add tenant database coverage

## Validation
- npm run test -- spec/database/record/tenant-database-spec.js
- npm run test -- spec/database/record/tenant-database-spec.js spec/configuration/tenant-spec.js spec/cli/commands/db/tenants/migrate-spec.js
- npm run typecheck
- npm run lint (warnings only, existing warning set)
- npm run build