### PR TITLE
Add lazy record initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,10 @@ Task.validates("name", {presence: true, uniqueness: true})
 export default Task
 ```
 
+Async class APIs initialize record metadata on first use when a model has not
+already been initialized eagerly. See [docs/model-initialization.md](docs/model-initialization.md)
+for the eager and lazy initialization behavior.
+
 ## Lifecycle callbacks
 
 Register lifecycle callbacks with either a function or an instance method name. Registrations run in order, so you can stack multiple callbacks on the same lifecycle hook.

--- a/changelog.d/20260518-lazy-record-initialization.md
+++ b/changelog.d/20260518-lazy-record-initialization.md
@@ -1,0 +1,1 @@
+Add lazy record initialization for async class APIs and initialize only the requested frontend-model resource class during frontend-model commands.

--- a/changelog.d/20260518-lazy-record-initialization.md
+++ b/changelog.d/20260518-lazy-record-initialization.md
@@ -1,1 +1,1 @@
-Add lazy record initialization for async class APIs and initialize only the requested frontend-model resource class during frontend-model commands.
+Add lazy record initialization for async class APIs and initialize only the requested frontend-model resource class and preload relationship targets during frontend-model commands.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.
 - `docs/query-bulk-operations.md`: `updateAll` for efficient batch updates and `destroyAll` behavior.
 - `docs/logging.md`: Rails-style request and database query logging behavior.
+- `docs/model-initialization.md`: Eager and lazy record/frontend-model initialization behavior.
 - `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.

--- a/docs/model-initialization.md
+++ b/docs/model-initialization.md
@@ -1,0 +1,37 @@
+# Model Initialization
+
+Velocious record classes can be initialized eagerly through the application
+configuration, or lazily the first time an async class API needs table metadata.
+
+## Lazy record APIs
+
+Async class methods such as `create`, `count`, `find`, `findBy`, `first`,
+`last`, `pluck`, `toArray`, `load`, `insertMultiple`, transactions, and
+advisory-lock helpers call `ensureInitialized()` before reading table metadata.
+This lets applications skip model initialization at boot for models whose tables
+may not exist in every deployed database.
+
+Lazy initialization still fails loudly when the model is actually used and the
+configured table is missing. Failed initialization attempts clear the in-flight
+promise so a later call can retry.
+
+```js
+class OptionalLegacyTable extends Record {}
+
+OptionalLegacyTable.setTableName("optional_legacy_table")
+
+// Initializes OptionalLegacyTable before querying optional_legacy_table.
+const rows = await OptionalLegacyTable.toArray()
+```
+
+## Frontend Model Requests
+
+Frontend-model command handling initializes only the requested resource model
+class. Other resources configured on the same backend project are not touched
+for that request, so an optional legacy resource does not block unrelated
+frontend-model commands at boot or request time.
+
+Use eager initialization when startup should validate every configured model and
+fail immediately on missing tables. Use lazy initialization when a model is an
+optional integration point and the missing-table error should surface only if
+that model path is used.

--- a/docs/model-initialization.md
+++ b/docs/model-initialization.md
@@ -31,6 +31,9 @@ class. Other resources configured on the same backend project are not touched
 for that request, so an optional legacy resource does not block unrelated
 frontend-model commands at boot or request time.
 
+When a request uses `preload`, Velocious initializes only the relationship
+target classes needed by that preload tree before building their queries.
+
 Use eager initialization when startup should validate every configured model and
 fail immediately on missing tables. Use lazy initialization when a model is an
 optional integration point and the missing-table error should surface only if

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -505,11 +505,20 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
 
   it("initializes relationship target classes before frontendIndex preload", async () => {
     await Dummy.run(async () => {
+      const configuration = Configuration.current()
+      const modelClasses = configuration.getModelClasses()
       const project = await Project.create({name: "Lazy relationship preload project"})
       const task = await Task.create({name: "Lazy relationship preload task", projectId: project.id()})
+      const comment = await Comment.create({body: "Lazy relationship preload comment", taskId: task.id()})
+      const previousTaskModelClass = modelClasses.Task
+      const previousCommentModelClass = modelClasses.Comment
 
+      delete modelClasses.Task
+      delete modelClasses.Comment
       Task._initialized = false
       Task._initializeRecordPromise = null
+      Comment._initialized = false
+      Comment._initializeRecordPromise = null
 
       try {
         const response = await postFrontendModel("/frontend-models", {
@@ -517,7 +526,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
             commandType: "index",
             model: "Project",
             payload: {
-              preload: {tasks: true},
+              preload: {tasks: ["comments"]},
               where: {id: project.id()}
             },
             requestId: "request-1"
@@ -527,11 +536,16 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
 
         expect(payload.status).toEqual("success")
         expect(Task.isInitialized()).toEqual(true)
+        expect(Comment.isInitialized()).toEqual(true)
         expect(payload.models.length).toEqual(1)
         expect(payload.models[0].__preloadedRelationships?.tasks.length).toEqual(1)
         expect(payload.models[0].__preloadedRelationships.tasks[0].id).toEqual(task.id())
+        expect(payload.models[0].__preloadedRelationships.tasks[0].__preloadedRelationships.comments[0].id).toEqual(comment.id())
       } finally {
-        await Task.ensureInitialized()
+        modelClasses.Task = previousTaskModelClass
+        modelClasses.Comment = previousCommentModelClass
+        await Task.ensureInitialized({configuration})
+        await Comment.ensureInitialized({configuration})
       }
     })
   })

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -503,6 +503,39 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     })
   })
 
+  it("initializes relationship target classes before frontendIndex preload", async () => {
+    await Dummy.run(async () => {
+      const project = await Project.create({name: "Lazy relationship preload project"})
+      const task = await Task.create({name: "Lazy relationship preload task", projectId: project.id()})
+
+      Task._initialized = false
+      Task._initializeRecordPromise = null
+
+      try {
+        const response = await postFrontendModel("/frontend-models", {
+          requests: [{
+            commandType: "index",
+            model: "Project",
+            payload: {
+              preload: {tasks: true},
+              where: {id: project.id()}
+            },
+            requestId: "request-1"
+          }]
+        })
+        const payload = response.responses[0].response
+
+        expect(payload.status).toEqual("success")
+        expect(Task.isInitialized()).toEqual(true)
+        expect(payload.models.length).toEqual(1)
+        expect(payload.models[0].__preloadedRelationships?.tasks.length).toEqual(1)
+        expect(payload.models[0].__preloadedRelationships.tasks[0].id).toEqual(task.id())
+      } finally {
+        await Task.ensureInitialized()
+      }
+    })
+  })
+
   it("merges nested preload entries from array shorthand", async () => {
     await Dummy.run(async () => {
       const task = await createTask("Merged preload task")

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -8,8 +8,10 @@ import Comment from "../dummy/src/models/comment.js"
 import backendProjects from "../dummy/src/config/backend-projects.js"
 import dummyDirectory from "../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
 import FrontendModelController from "../../src/frontend-model-controller.js"
 import Project from "../dummy/src/models/project.js"
+import Record from "../../src/database/record/index.js"
 import Request from "../../src/http-server/client/request.js"
 import Response from "../../src/http-server/client/response.js"
 import Task from "../dummy/src/models/task.js"
@@ -380,6 +382,86 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     expect(response.headers["Set-Cookie"]).toEqual([
       "frontend_model_session=frontend-model-shared-cookie; Path=/; HttpOnly; SameSite=Lax"
     ])
+  })
+
+  it("only initializes the requested frontend-model class", async () => {
+    class RequestedLazyFrontendModel extends Record {
+      /** @returns {Promise<void>} */
+      static async initializeRecord() {
+        this._initialized = true
+      }
+    }
+
+    class UnrequestedLazyFrontendModel extends Record {
+      /** @returns {Promise<void>} */
+      static async initializeRecord() {
+        throw new Error("Unrequested lazy frontend model should not initialize")
+      }
+    }
+
+    class RequestedLazyFrontendResource extends FrontendModelBaseResource {
+      static ModelClass = RequestedLazyFrontendModel
+
+      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
+      static resourceConfig() {
+        return {
+          abilities: ["read"],
+          attributes: ["id"],
+          builtInCollectionCommands: ["index"]
+        }
+      }
+    }
+
+    class UnrequestedLazyFrontendResource extends FrontendModelBaseResource {
+      static ModelClass = UnrequestedLazyFrontendModel
+
+      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
+      static resourceConfig() {
+        return {
+          abilities: ["read"],
+          attributes: ["id"],
+          builtInCollectionCommands: ["index"]
+        }
+      }
+    }
+
+    const configuration = new Configuration({
+      backendProjects: [{
+        frontendModels: {
+          RequestedLazyFrontendModel: RequestedLazyFrontendResource,
+          UnrequestedLazyFrontendModel: UnrequestedLazyFrontendResource
+        },
+        path: dummyDirectory()
+      }],
+      cookieSecret: "dummy-cookie-secret",
+      database: {test: {}},
+      directory: dummyDirectory(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const client = {remoteAddress: "127.0.0.1"}
+    const request = new Request({client, configuration})
+    const response = new Response({configuration})
+    const controller = new FrontendModelController({
+      action: "frontendApi",
+      configuration,
+      controller: "frontend-models",
+      params: {model: "RequestedLazyFrontendModel"},
+      request,
+      response,
+      viewPath: `${dummyDirectory()}/src/routes/frontend-models`
+    })
+
+    await controller.withFrontendModelParams({model: "RequestedLazyFrontendModel"}, async () => {
+      await controller.ensureFrontendModelClassInitialized()
+    })
+
+    expect(RequestedLazyFrontendModel.isInitialized()).toEqual(true)
+    expect(UnrequestedLazyFrontendModel.isInitialized()).toEqual(false)
   })
 
   it("keeps unexpected shared frontend-model failures generic in production", async () => {

--- a/spec/database/record/lazy-initialization.browser-spec.js
+++ b/spec/database/record/lazy-initialization.browser-spec.js
@@ -1,0 +1,43 @@
+// @ts-check
+
+import Dummy from "../../dummy/index.js"
+import Record from "../../../src/database/record/index.js"
+
+describe("Record - lazy initialization", {tags: ["dummy"]}, () => {
+  it("initializes an uninitialized model on first async class API use", async () => {
+    await Dummy.run(async () => {
+      class LazyProject extends Record {}
+
+      LazyProject.setTableName("projects")
+
+      expect(LazyProject.isInitialized()).toEqual(false)
+
+      const count = await LazyProject.count()
+
+      expect(typeof count).toEqual("number")
+      expect(LazyProject.isInitialized()).toEqual(true)
+    })
+  })
+
+  it("allows a later lazy initialization retry after an earlier failure", async () => {
+    await Dummy.run(async () => {
+      class LazyRetryProject extends Record {}
+
+      LazyRetryProject.setTableName("missing_lazy_retry_projects")
+
+      try {
+        await LazyRetryProject.count()
+        throw new Error("Didn't expect missing table lookup to succeed")
+      } catch (error) {
+        expect(error.message).toMatch(/missing_lazy_retry_projects/)
+      }
+
+      LazyRetryProject.setTableName("projects")
+
+      const count = await LazyRetryProject.count()
+
+      expect(typeof count).toEqual("number")
+      expect(LazyRetryProject.isInitialized()).toEqual(true)
+    })
+  })
+})

--- a/spec/database/record/lazy-initialization.browser-spec.js
+++ b/spec/database/record/lazy-initialization.browser-spec.js
@@ -1,43 +1,38 @@
 // @ts-check
 
-import Dummy from "../../dummy/index.js"
 import Record from "../../../src/database/record/index.js"
 
 describe("Record - lazy initialization", {tags: ["dummy"]}, () => {
   it("initializes an uninitialized model on first async class API use", async () => {
-    await Dummy.run(async () => {
-      class LazyProject extends Record {}
+    class LazyProject extends Record {}
 
-      LazyProject.setTableName("projects")
+    LazyProject.setTableName("projects")
 
-      expect(LazyProject.isInitialized()).toEqual(false)
+    expect(LazyProject.isInitialized()).toEqual(false)
 
-      const count = await LazyProject.count()
+    const count = await LazyProject.count()
 
-      expect(typeof count).toEqual("number")
-      expect(LazyProject.isInitialized()).toEqual(true)
-    })
+    expect(typeof count).toEqual("number")
+    expect(LazyProject.isInitialized()).toEqual(true)
   })
 
   it("allows a later lazy initialization retry after an earlier failure", async () => {
-    await Dummy.run(async () => {
-      class LazyRetryProject extends Record {}
+    class LazyRetryProject extends Record {}
 
-      LazyRetryProject.setTableName("missing_lazy_retry_projects")
+    LazyRetryProject.setTableName("missing_lazy_retry_projects")
 
-      try {
-        await LazyRetryProject.count()
-        throw new Error("Didn't expect missing table lookup to succeed")
-      } catch (error) {
-        expect(error.message).toMatch(/missing_lazy_retry_projects/)
-      }
+    try {
+      await LazyRetryProject.count()
+      throw new Error("Didn't expect missing table lookup to succeed")
+    } catch (error) {
+      expect(error.message).toMatch(/missing_lazy_retry_projects/)
+    }
 
-      LazyRetryProject.setTableName("projects")
+    LazyRetryProject.setTableName("projects")
 
-      const count = await LazyRetryProject.count()
+    const count = await LazyRetryProject.count()
 
-      expect(typeof count).toEqual("number")
-      expect(LazyRetryProject.isInitialized()).toEqual(true)
-    })
+    expect(typeof count).toEqual("number")
+    expect(LazyRetryProject.isInitialized()).toEqual(true)
   })
 })

--- a/spec/database/record/read-only.browser-spec.js
+++ b/spec/database/record/read-only.browser-spec.js
@@ -1,10 +1,12 @@
 import Task from "../../dummy/src/models/task.js"
 import Configuration from "../../../src/configuration.js"
+import Project from "../../dummy/src/models/project.js"
 
 describe("Record - read only", {tags: ["dummy"]}, () => {
   it("prevents writes when database is read only", async () => {
     const databaseConfig = Configuration.current().getDatabaseIdentifier("default")
     const previousReadOnly = databaseConfig.readOnly
+    const project = await Project.create({name: "Read-only project"})
 
     databaseConfig.readOnly = true
 
@@ -12,7 +14,7 @@ describe("Record - read only", {tags: ["dummy"]}, () => {
       let error
 
       try {
-        await Task.create({name: "Blocked task"})
+        await Task.create({name: "Blocked task", projectId: project.id()})
       } catch (caughtError) {
         error = caughtError
       }

--- a/src/database/query/preloader/belongs-to.js
+++ b/src/database/query/preloader/belongs-to.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
 export default class VelociousDatabaseQueryPreloaderBelongsTo {
@@ -57,6 +58,8 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
       for (const targetType in foreignKeyValuesByType) {
         const targetModelClass = configuration.getModelClass(targetType)
 
+        await ensureModelClassInitialized(targetModelClass, configuration)
+
         /** @type {Record<string, string | number | Array<string | number>>} */
         const whereArgs = {}
 
@@ -109,6 +112,8 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
     const targetModelClass = this.relationship.getTargetModelClass()
 
     if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
+
+    await ensureModelClassInitialized(targetModelClass, this.relationship.getConfiguration())
 
     // Load target models to be preloaded on the given models
     let query = targetModelClass.where(whereArgs)

--- a/src/database/query/preloader/ensure-model-class-initialized.js
+++ b/src/database/query/preloader/ensure-model-class-initialized.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+/**
+ * @param {typeof import("../../record/index.js").default} modelClass - Model class to initialize.
+ * @param {import("../../../configuration.js").default} configuration - Current configuration.
+ * @returns {Promise<void>} - Resolves when the model class is initialized.
+ */
+export default async function ensureModelClassInitialized(modelClass, configuration) {
+  if (modelClass.isInitialized()) return
+
+  if (typeof modelClass.ensureInitialized === "function") {
+    await modelClass.ensureInitialized({configuration})
+    return
+  }
+
+  await modelClass.initializeRecord({configuration})
+}

--- a/src/database/query/preloader/has-many.js
+++ b/src/database/query/preloader/has-many.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
 export default class VelociousDatabaseQueryPreloaderHasMany {
@@ -46,6 +47,11 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
     const targetModelClass = this.relationship.getTargetModelClass()
 
     if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
+
+    const configuration = this.relationship.getConfiguration()
+
+    await ensureModelClassInitialized(throughModelClass, configuration)
+    await ensureModelClassInitialized(targetModelClass, configuration)
 
     const throughForeignKey = throughRelationship.getForeignKey()
 
@@ -196,6 +202,8 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
     const targetModelClass = this.relationship.getTargetModelClass()
 
     if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
+
+    await ensureModelClassInitialized(targetModelClass, this.relationship.getConfiguration())
 
     let query = targetModelClass.where(whereArgs)
 

--- a/src/database/query/preloader/has-one.js
+++ b/src/database/query/preloader/has-one.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
 export default class VelociousDatabaseQueryPreloaderHasOne {
@@ -53,6 +54,8 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
     const targetModelClass = this.relationship.getTargetModelClass()
 
     if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
+
+    await ensureModelClassInitialized(targetModelClass, this.relationship.getConfiguration())
 
     // Load target models to be preloaded on the given models
     let query = targetModelClass.where(whereArgs)

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -1067,13 +1067,16 @@ class VelociousDatabaseRecord {
 
     const resolvedConfiguration = configuration || this._configuration || Configuration.current()
 
-    this._initializeRecordPromise = this.initializeRecord({configuration: resolvedConfiguration})
+    const initializeRecordPromise = this.initializeRecord({configuration: resolvedConfiguration})
+
+    this._initializeRecordPromise = initializeRecordPromise
 
     try {
-      await this._initializeRecordPromise
-    } catch (error) {
-      this._initializeRecordPromise = null
-      throw error
+      await initializeRecordPromise
+    } finally {
+      if (this._initializeRecordPromise === initializeRecordPromise) {
+        this._initializeRecordPromise = null
+      }
     }
   }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -112,6 +112,9 @@ class VelociousDatabaseRecord {
   /** @type {string | undefined} */
   static modelName
 
+  /** @type {Promise<void> | null | undefined} */
+  static _initializeRecordPromise
+
   /**
    * Returns the model name, preferring an explicit `static modelName` declaration
    * over the JavaScript class `.name` property. This allows minified builds to
@@ -821,6 +824,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the create.
    */
   static async create(attributes) {
+    await this.ensureInitialized()
+
     const record = /** @type {InstanceType<MC>} */ (new this(attributes))
 
     await record.save()
@@ -1039,6 +1044,37 @@ class VelociousDatabaseRecord {
 
     await this._defineTranslationMethods()
     this._initialized = true
+  }
+
+  /**
+   * Initializes the model class the first time an async record API needs table
+   * metadata. Concurrent callers share the same initialization promise, and a
+   * failed initialization can be retried by a later call.
+   * @param {{configuration?: import("../../configuration.js").default}} [args] - Optional configuration override.
+   * @returns {Promise<void>} - Resolves when the model class is initialized.
+   */
+  static async ensureInitialized(args = {}) {
+    const {configuration, ...restArgs} = args
+
+    restArgsError(restArgs)
+
+    if (this._initialized) return
+
+    if (this._initializeRecordPromise) {
+      await this._initializeRecordPromise
+      return
+    }
+
+    const resolvedConfiguration = configuration || this._configuration || Configuration.current()
+
+    this._initializeRecordPromise = this.initializeRecord({configuration: resolvedConfiguration})
+
+    try {
+      await this._initializeRecordPromise
+    } catch (error) {
+      this._initializeRecordPromise = null
+      throw error
+    }
   }
 
   /**
@@ -1411,6 +1447,7 @@ class VelociousDatabaseRecord {
     const {cast = true, retryIndividuallyOnFailure = false, returnResults = false, ...restArgs} = args
 
     restArgsError(restArgs)
+    await this.ensureInitialized()
 
     const normalizedRows = cast
       ? this._normalizeInsertMultipleRows({columns, rows})
@@ -1653,6 +1690,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<number>} - Resolves with the next primary key.
    */
   static async nextPrimaryKey() {
+    await this.ensureInitialized()
+
     const primaryKey = this.primaryKey()
     const tableName = this.tableName()
     const connection = this.connection()
@@ -1894,6 +1933,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<unknown>} - Resolves with the transaction.
    */
   static async transaction(callback) {
+    await this.ensureInitialized()
+
     const useTransactions = this.connection().getArgs().record?.transactions
 
     if (useTransactions !== false) {
@@ -1920,6 +1961,8 @@ class VelociousDatabaseRecord {
    * @throws {AdvisoryLockTimeoutError} - If `timeoutMs` elapses before the lock is granted.
    */
   static async withAdvisoryLock(name, callback, args = {}) {
+    await this.ensureInitialized()
+
     const connection = this.connection()
     const acquired = await connection.acquireAdvisoryLock(name, args)
 
@@ -1947,6 +1990,8 @@ class VelociousDatabaseRecord {
    * @throws {AdvisoryLockBusyError} - If the lock is already held.
    */
   static async withAdvisoryLockOrFail(name, callback) {
+    await this.ensureInitialized()
+
     const connection = this.connection()
     const acquired = await connection.tryAcquireAdvisoryLock(name)
 
@@ -1970,6 +2015,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<boolean>} - Whether the advisory lock is currently held.
    */
   static async hasAdvisoryLock(name) {
+    await this.ensureInitialized()
+
     return await this.connection().isAdvisoryLockHeld(name)
   }
 
@@ -2240,6 +2287,8 @@ class VelociousDatabaseRecord {
 
   /** @returns {Promise<number>} - Resolves with the count.  */
   static async count() {
+    await this.ensureInitialized()
+
     return await this._newQuery().count()
   }
 
@@ -2254,6 +2303,8 @@ class VelociousDatabaseRecord {
   }
 
   static async destroyAll() {
+    await this.ensureInitialized()
+
     return await this._newQuery().destroyAll()
   }
 
@@ -2264,6 +2315,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<any[]>} - Resolves with the pluck.
    */
   static async pluck(...columns) {
+    await this.ensureInitialized()
+
     return await this._newQuery().pluck(...columns)
   }
 
@@ -2274,6 +2327,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the find.
    */
   static async find(recordId) {
+    await this.ensureInitialized()
+
     return await this._newQuery().find(recordId)
   }
 
@@ -2284,6 +2339,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC> | null>} - Resolves with the by.
    */
   static async findBy(conditions) {
+    await this.ensureInitialized()
+
     return await this._newQuery().findBy(conditions)
   }
 
@@ -2294,6 +2351,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the by or fail.
    */
   static async findByOrFail(conditions) {
+    await this.ensureInitialized()
+
     return await this._newQuery().findByOrFail(conditions)
   }
 
@@ -2305,6 +2364,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the or create by.
    */
   static async findOrCreateBy(conditions, callback) {
+    await this.ensureInitialized()
+
     return await this._newQuery().findOrCreateBy(conditions, callback)
   }
 
@@ -2316,6 +2377,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the or initialize by.
    */
   static async findOrInitializeBy(conditions, callback) {
+    await this.ensureInitialized()
+
     return await this._newQuery().findOrInitializeBy(conditions, callback)
   }
 
@@ -2325,6 +2388,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the first.
    */
   static async first() {
+    await this.ensureInitialized()
+
     const result = await this._newQuery().first()
 
     if (!result) throw new Error(`${this.name}.first() returned no records`)
@@ -2348,6 +2413,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>>} - Resolves with the last.
    */
   static async last() {
+    await this.ensureInitialized()
+
     const result = await this._newQuery().last()
 
     if (!result) throw new Error(`${this.name}.last() returned no records`)
@@ -2413,6 +2480,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>[]>} - Resolves with the array.
    */
   static async toArray() {
+    await this.ensureInitialized()
+
     return await this._newQuery().toArray()
   }
 
@@ -2422,6 +2491,8 @@ class VelociousDatabaseRecord {
    * @returns {Promise<InstanceType<MC>[]>} - Resolves with the array.
    */
   static async load() {
+    await this.ensureInitialized()
+
     return await this._newQuery().load()
   }
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -1192,26 +1192,55 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
-   * @param {typeof import("./database/record/index.js").default} modelClass - Model class.
-   * @returns {{modelName: string, resourceClass: import("./configuration-types.js").FrontendModelResourceClassType, resourceConfiguration: import("./configuration-types.js").NormalizedFrontendModelResourceConfiguration} | null} - Frontend model resource configuration for model class.
+   * @param {object} args - Arguments.
+   * @param {import("./configuration-types.js").BackendProjectConfiguration} args.backendProject - Backend project configuration.
+   * @param {string} args.modelName - Model name.
+   * @returns {{backendProject: import("./configuration-types.js").BackendProjectConfiguration, modelName: string, resourceClass: import("./configuration-types.js").FrontendModelResourceClassType, resourceConfiguration: import("./configuration-types.js").NormalizedFrontendModelResourceConfiguration} | null} - Frontend model resource configuration for model name.
    */
-  frontendModelResourceConfigurationForModelClass(modelClass) {
-    const frontendModelResource = this.frontendModelResourceConfiguration()
+  frontendModelResourceConfigurationForBackendProjectModelName({backendProject, modelName}) {
+    const resources = frontendModelResourcesForBackendProject(backendProject)
+    const resourceDefinition = resources[modelName]
 
-    if (!frontendModelResource) return null
+    if (!resourceDefinition) return null
 
-    const resources = frontendModelResourcesForBackendProject(frontendModelResource.backendProject)
-    const resourceDefinition = resources[modelClass.getModelName()]
     const resourceConfiguration = frontendModelResourceConfigurationFromDefinition(resourceDefinition)
     const resourceClass = frontendModelResourceClassFromDefinition(resourceDefinition)
 
     if (!resourceConfiguration || !resourceClass) return null
 
     return {
-      modelName: modelClass.getModelName(),
+      backendProject,
+      modelName,
       resourceClass,
       resourceConfiguration
     }
+  }
+
+  /**
+   * @param {typeof import("./database/record/index.js").default} modelClass - Model class.
+   * @returns {{backendProject: import("./configuration-types.js").BackendProjectConfiguration, modelName: string, resourceClass: import("./configuration-types.js").FrontendModelResourceClassType, resourceConfiguration: import("./configuration-types.js").NormalizedFrontendModelResourceConfiguration} | null} - Frontend model resource configuration for model class.
+   */
+  frontendModelResourceConfigurationForModelClass(modelClass) {
+    const frontendModelResource = this.frontendModelResourceConfiguration()
+
+    if (!frontendModelResource) return null
+
+    return this.frontendModelResourceConfigurationForBackendProjectModelName({
+      backendProject: frontendModelResource.backendProject,
+      modelName: modelClass.getModelName()
+    })
+  }
+
+  /**
+   * @param {{modelName: string, resourceClass: import("./configuration-types.js").FrontendModelResourceClassType}} frontendModelResource - Frontend model resource configuration.
+   * @returns {typeof import("./database/record/index.js").default | null} - Backing record class, when available.
+   */
+  frontendModelResourceModelClass(frontendModelResource) {
+    const resourceModelClass = frontendModelResource.resourceClass.ModelClass
+
+    if (resourceModelClass) return resourceModelClass
+
+    return this.getConfiguration().getModelClasses()[frontendModelResource.modelName] || null
   }
 
   /**
@@ -1222,7 +1251,7 @@ export default class FrontendModelController extends Controller {
 
     if (!frontendModelResource) return null
 
-    const resourceModelClass = frontendModelResource.resourceClass?.ModelClass
+    const resourceModelClass = this.frontendModelResourceModelClass(frontendModelResource)
 
     if (resourceModelClass) return resourceModelClass
 
@@ -1237,14 +1266,33 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
-   * Ensures the frontend model class is initialized (has columns, table name, etc.).
+   * Ensures the frontend model class and requested preload target classes are initialized.
    * This handles the case where model initialization was skipped at startup (e.g., browser tests).
    * @returns {Promise<void>} - Resolves when the model class is ready.
    */
   async ensureFrontendModelClassInitialized() {
+    const frontendModelResource = this.frontendModelResourceConfiguration()
     const modelClass = this.frontendModelClassFromConfiguration()
 
-    if (!modelClass || modelClass._initialized) return
+    if (!modelClass) return
+
+    await this.ensureFrontendModelRecordClassInitialized(modelClass)
+
+    if (!frontendModelResource) return
+
+    await this.ensureFrontendModelPreloadClassesInitialized({
+      backendProject: frontendModelResource.backendProject,
+      modelClass,
+      preload: this.frontendModelPreload()
+    })
+  }
+
+  /**
+   * @param {typeof import("./database/record/index.js").default} modelClass - Model class to initialize.
+   * @returns {Promise<void>} - Resolves when the model class is ready.
+   */
+  async ensureFrontendModelRecordClassInitialized(modelClass) {
+    if (!modelClass || modelClass.isInitialized()) return
 
     const configuration = this.getConfiguration()
 
@@ -1253,6 +1301,92 @@ export default class FrontendModelController extends Controller {
     } else if (typeof modelClass.initializeRecord === "function") {
       await modelClass.initializeRecord({configuration})
     }
+  }
+
+  /**
+   * @param {object} args - Arguments.
+   * @param {import("./configuration-types.js").BackendProjectConfiguration} args.backendProject - Backend project configuration.
+   * @param {typeof import("./database/record/index.js").default} args.modelClass - Model class whose preload tree is being resolved.
+   * @param {import("./database/query/index.js").NestedPreloadRecord | null} args.preload - Normalized preload tree.
+   * @returns {Promise<void>} - Resolves when preload target classes are initialized.
+   */
+  async ensureFrontendModelPreloadClassesInitialized({backendProject, modelClass, preload}) {
+    if (!preload) return
+
+    for (const [relationshipName, relationshipPreload] of Object.entries(preload)) {
+      if (relationshipPreload === false) continue
+
+      const relationship = modelClass.getRelationshipByName(relationshipName)
+      const targetModelClass = await this.ensureFrontendModelRelationshipTargetClassInitialized({
+        backendProject,
+        relationship
+      })
+
+      if (!targetModelClass || !isPlainObject(relationshipPreload)) continue
+
+      await this.ensureFrontendModelPreloadClassesInitialized({
+        backendProject,
+        modelClass: targetModelClass,
+        preload: /** @type {import("./database/query/index.js").NestedPreloadRecord} */ (relationshipPreload)
+      })
+    }
+  }
+
+  /**
+   * @param {object} args - Arguments.
+   * @param {import("./configuration-types.js").BackendProjectConfiguration} args.backendProject - Backend project configuration.
+   * @param {import("./database/record/relationships/base.js").default} args.relationship - Relationship definition.
+   * @returns {Promise<typeof import("./database/record/index.js").default | null>} - Target model class, when available.
+   */
+  async ensureFrontendModelRelationshipTargetClassInitialized({backendProject, relationship}) {
+    if (relationship.through) {
+      const throughRelationship = relationship.getModelClass().getRelationshipByName(relationship.through)
+      await this.ensureFrontendModelRelationshipTargetClassInitialized({
+        backendProject,
+        relationship: throughRelationship
+      })
+    }
+
+    const targetModelClass = this.frontendModelRelationshipTargetModelClass({
+      backendProject,
+      relationship
+    })
+
+    if (!targetModelClass) return null
+
+    await this.ensureFrontendModelRecordClassInitialized(targetModelClass)
+
+    return targetModelClass
+  }
+
+  /**
+   * @param {object} args - Arguments.
+   * @param {import("./configuration-types.js").BackendProjectConfiguration} args.backendProject - Backend project configuration.
+   * @param {import("./database/record/relationships/base.js").default} args.relationship - Relationship definition.
+   * @returns {typeof import("./database/record/index.js").default | null} - Target model class, when available.
+   */
+  frontendModelRelationshipTargetModelClass({backendProject, relationship}) {
+    if (relationship.getPolymorphic() && relationship.getType() === "belongsTo") return null
+
+    if (relationship.klass) return relationship.klass
+
+    if (relationship.className) {
+      const frontendModelResource = this.frontendModelResourceConfigurationForBackendProjectModelName({
+        backendProject,
+        modelName: relationship.className
+      })
+      const resourceModelClass = frontendModelResource ? this.frontendModelResourceModelClass(frontendModelResource) : null
+
+      if (resourceModelClass) return resourceModelClass
+
+      const registeredModelClass = this.getConfiguration().getModelClasses()[relationship.className]
+
+      if (registeredModelClass) return registeredModelClass
+    }
+
+    const targetModelClass = relationship.getTargetModelClass()
+
+    return targetModelClass || null
   }
 
   /**

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -1247,20 +1247,11 @@ export default class FrontendModelController extends Controller {
     if (!modelClass || modelClass._initialized) return
 
     const configuration = this.getConfiguration()
-    const backendProjects = configuration.getBackendProjects()
 
-    for (const backendProject of backendProjects) {
-      const resources = frontendModelResourcesForBackendProject(backendProject)
-
-      for (const resourceModelName in resources) {
-        const resourceDefinition = resources[resourceModelName]
-        const resourceClass = frontendModelResourceClassFromDefinition(resourceDefinition)
-        const resourceModelClass = resourceClass?.ModelClass
-
-        if (resourceModelClass && !resourceModelClass._initialized && typeof resourceModelClass.initializeRecord === "function") {
-          await resourceModelClass.initializeRecord({configuration})
-        }
-      }
+    if (typeof modelClass.ensureInitialized === "function") {
+      await modelClass.ensureInitialized({configuration})
+    } else if (typeof modelClass.initializeRecord === "function") {
+      await modelClass.initializeRecord({configuration})
     }
   }
 


### PR DESCRIPTION
Summary
- add Record.ensureInitialized and call it from async class APIs that need table metadata
- initialize only the requested frontend-model resource model during frontend-model commands
- document lazy/eager initialization behavior and add changelog coverage

Validation
- ./run-tests.sh database/record/lazy-initialization.browser-spec.js controller/frontend-model-actions-spec.js
- npm run typecheck
- npm run lint (passes with existing warnings)