### PR TITLE
Capture test console output for failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,23 @@ it("retries a flaky check", {retry: 2}, async () => {})
 })
 ```
 
-During a failing run, Velocious captures all console output emitted while each test executes. At the end of a failed run, those logs are saved under `tmp/screenshots` next to failure screenshots/browser logs/HTML, and each failed test summary prints the saved console log path.
+Velocious captures console output emitted while each test executes, but does not print passing-test output by default. When a test fails, Velocious prints a truncated `Console output:` block for that failed test and saves the full captured log under `tmp/screenshots` next to failure screenshots/browser logs/HTML. Each failed test summary prints the saved console log path.
+
+Configure console output behavior in your testing config file.
+
+```js
+// src/config/testing.js
+import {configureTests} from "velocious/build/src/testing/test.js"
+
+export default async function configureTesting() {
+  configureTests({
+    consoleOutput: "failure", // default: print captured output only for failed tests
+    failedConsoleOutputMaxLines: 200 // default: print the last 200 lines inline
+  })
+}
+```
+
+Use `consoleOutput: "live"` to preserve the previous passthrough behavior where test console output is printed while tests run.
 
 Listen for attempt and retry events if you need to reset shared state after a failed attempt or log retry lifecycle details. `testAttemptFailed` fires after every failed attempt, including the final failed attempt when no retries remain. `testRetrying` only fires before a retry, and `testFailed` only fires after retries are exhausted.
 

--- a/changelog.d/20260518-failure-console-output.md
+++ b/changelog.d/20260518-failure-console-output.md
@@ -1,0 +1,1 @@
+Capture test console output quietly by default and print it only for failed tests, with configurable live passthrough and inline failure-log truncation.

--- a/spec/testing/test-runner-events-spec.js
+++ b/spec/testing/test-runner-events-spec.js
@@ -3,13 +3,66 @@
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import {format} from "node:util"
 import Configuration from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
-import {describe, expect, it, testEvents} from "../../src/testing/test.js"
+import {configureTests, describe, expect, it, testConfig, testEvents} from "../../src/testing/test.js"
 import TestRunner from "../../src/testing/test-runner.js"
 
 describe("TestRunner events", () => {
   const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+  const buildTestRunner = () => {
+    const environmentHandler = new EnvironmentHandlerNode()
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler,
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+
+    return new TestRunner({configuration, testFiles: []})
+  }
+  const runTestRunner = async (testRunner, tests) => {
+    await testRunner.runTests({
+      afterEaches: [],
+      beforeEaches: [],
+      tests,
+      descriptions: [],
+      indentLevel: 0
+    })
+  }
+  const captureConsole = async (callback) => {
+    /** @type {Array<{methodName: string, output: string}>} */
+    const entries = []
+    const originalConsoleMethods = {
+      debug: console.debug,
+      error: console.error,
+      info: console.info,
+      log: console.log,
+      warn: console.warn
+    }
+
+    for (const methodName of Object.keys(originalConsoleMethods)) {
+      console[methodName] = (...args) => {
+        entries.push({methodName, output: format(...args)})
+        originalConsoleMethods[methodName](...args)
+      }
+    }
+
+    try {
+      await callback()
+    } finally {
+      for (const methodName of Object.keys(originalConsoleMethods)) {
+        console[methodName] = originalConsoleMethods[methodName]
+      }
+    }
+
+    return entries
+  }
 
   it("emits testFailed with test details", async () => {
     const environmentHandler = new EnvironmentHandlerNode()
@@ -368,6 +421,206 @@ describe("TestRunner events", () => {
     expect(failedDetails[0].filePath).toBe("/tmp/sample-spec.js")
     expect(failedDetails[0].line).toBe(42)
     expect(failedDetails[0].consoleOutput).toContain("console output from failing test")
+  })
+
+  it("does not print passing test console output by default", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+
+    configureTests({consoleOutput: "failure"})
+
+    try {
+      const testRunner = buildTestRunner()
+      const tests = {
+        args: {},
+        afterEaches: [],
+        afterAlls: [],
+        beforeAlls: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "passes quietly": {
+            args: {},
+            function: async () => {
+              console.log("hidden passing console output")
+            }
+          }
+        }
+      }
+
+      const entries = await captureConsole(async () => {
+        await runTestRunner(testRunner, tests)
+      })
+      const output = entries.map((entry) => entry.output).join("\n")
+
+      expect(testRunner.getSuccessfulTests()).toBe(1)
+      expect(output).not.toContain("hidden passing console output")
+    } finally {
+      configureTests({consoleOutput: previousConsoleOutput})
+    }
+  })
+
+  it("prints failing test console output by default", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+
+    configureTests({consoleOutput: "failure"})
+
+    try {
+      const testRunner = buildTestRunner()
+      const tests = {
+        args: {},
+        afterEaches: [],
+        afterAlls: [],
+        beforeAlls: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "fails with output": {
+            args: {},
+            function: async () => {
+              console.info("visible failing console output")
+              throw new Error("boom")
+            }
+          }
+        }
+      }
+
+      const entries = await captureConsole(async () => {
+        await runTestRunner(testRunner, tests)
+      })
+      const output = entries.map((entry) => entry.output).join("\n")
+      const failedDetails = testRunner.getFailedTestDetails()
+
+      expect(output).toContain("Console output:")
+      expect(output).toContain("visible failing console output")
+      expect(failedDetails.length).toBe(1)
+      expect(failedDetails[0].consoleOutput).toContain("visible failing console output")
+    } finally {
+      configureTests({consoleOutput: previousConsoleOutput})
+    }
+  })
+
+  it("keeps live console passthrough available", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+
+    configureTests({consoleOutput: "live"})
+
+    try {
+      const testRunner = buildTestRunner()
+      const tests = {
+        args: {},
+        afterEaches: [],
+        afterAlls: [],
+        beforeAlls: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "passes live": {
+            args: {},
+            function: async () => {
+              console.log("live passing console output")
+            }
+          }
+        }
+      }
+
+      const entries = await captureConsole(async () => {
+        await runTestRunner(testRunner, tests)
+      })
+      const output = entries.map((entry) => entry.output).join("\n")
+
+      expect(testRunner.getSuccessfulTests()).toBe(1)
+      expect(output).toContain("live passing console output")
+    } finally {
+      configureTests({consoleOutput: previousConsoleOutput})
+    }
+  })
+
+  it("discards retry attempt console output when a retry passes", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+
+    configureTests({consoleOutput: "failure"})
+
+    try {
+      const testRunner = buildTestRunner()
+      let attempts = 0
+      const tests = {
+        args: {},
+        afterEaches: [],
+        afterAlls: [],
+        beforeAlls: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "retries into success": {
+            args: {retry: 1},
+            function: async () => {
+              attempts++
+              console.log(`hidden retry console output ${attempts}`)
+              if (attempts === 1) throw new Error("boom")
+            }
+          }
+        }
+      }
+
+      const entries = await captureConsole(async () => {
+        await runTestRunner(testRunner, tests)
+      })
+      const output = entries.map((entry) => entry.output).join("\n")
+
+      expect(testRunner.getSuccessfulTests()).toBe(1)
+      expect(testRunner.getFailedTestDetails().length).toBe(0)
+      expect(output).not.toContain("hidden retry console output")
+    } finally {
+      configureTests({consoleOutput: previousConsoleOutput})
+    }
+  })
+
+  it("truncates inline failed test console output", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+    const previousFailedConsoleOutputMaxLines = testConfig.failedConsoleOutputMaxLines
+
+    configureTests({consoleOutput: "failure", failedConsoleOutputMaxLines: 2})
+
+    try {
+      const testRunner = buildTestRunner()
+      const tests = {
+        args: {},
+        afterEaches: [],
+        afterAlls: [],
+        beforeAlls: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "fails with long output": {
+            args: {},
+            function: async () => {
+              console.log("console line 1")
+              console.log("console line 2")
+              console.log("console line 3")
+              console.log("console line 4")
+              throw new Error("boom")
+            }
+          }
+        }
+      }
+
+      const entries = await captureConsole(async () => {
+        await runTestRunner(testRunner, tests)
+      })
+      const output = entries.map((entry) => entry.output).join("\n")
+      const failedDetails = testRunner.getFailedTestDetails()
+
+      expect(output).toContain("2 console output lines omitted")
+      expect(output).toContain("console line 3")
+      expect(output).toContain("console line 4")
+      expect(output).not.toContain("console line 1")
+      expect(failedDetails[0].consoleOutput).toContain("console line 1")
+    } finally {
+      configureTests({
+        consoleOutput: previousConsoleOutput,
+        failedConsoleOutputMaxLines: previousFailedConsoleOutputMaxLines
+      })
+    }
   })
 
   it("persists failed test console output to an assets path", async () => {

--- a/spec/testing/test-runner-events-spec.js
+++ b/spec/testing/test-runner-events-spec.js
@@ -575,6 +575,52 @@ describe("TestRunner events", () => {
     }
   })
 
+  it("prints attempt failure listener console output when a retry passes", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+    const handler = (payload) => {
+      console.log(`retry lifecycle output attempt ${payload.attemptNumber} retry ${payload.willRetry}`)
+    }
+
+    configureTests({consoleOutput: "failure"})
+
+    try {
+      const testRunner = buildTestRunner()
+      let attempts = 0
+      const tests = {
+        args: {},
+        afterEaches: [],
+        afterAlls: [],
+        beforeAlls: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "retries after listener output": {
+            args: {retry: 1},
+            function: async () => {
+              attempts++
+              console.log(`hidden test attempt output ${attempts}`)
+              if (attempts === 1) throw new Error("boom")
+            }
+          }
+        }
+      }
+
+      testEvents.on("testAttemptFailed", handler)
+
+      const entries = await captureConsole(async () => {
+        await runTestRunner(testRunner, tests)
+      })
+      const output = entries.map((entry) => entry.output).join("\n")
+
+      expect(testRunner.getSuccessfulTests()).toBe(1)
+      expect(output).toContain("retry lifecycle output attempt 1 retry true")
+      expect(output).not.toContain("hidden test attempt output")
+    } finally {
+      testEvents.off("testAttemptFailed", handler)
+      configureTests({consoleOutput: previousConsoleOutput})
+    }
+  })
+
   it("truncates inline failed test console output", async () => {
     const previousConsoleOutput = testConfig.consoleOutput
     const previousFailedConsoleOutputMaxLines = testConfig.failedConsoleOutputMaxLines

--- a/spec/testing/test-runner-tags-spec.js
+++ b/spec/testing/test-runner-tags-spec.js
@@ -2,7 +2,7 @@
 
 import Configuration from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
-import {configureTests, describe, expect, it} from "../../src/testing/test.js"
+import {configureTests, describe, expect, it, testConfig} from "../../src/testing/test.js"
 import TestRunner from "../../src/testing/test-runner.js"
 
 /**
@@ -214,6 +214,49 @@ describe("TestRunner tags", () => {
       expect(testRunner.getSuccessfulTests()).toBe(1)
     } finally {
       configureTests({excludeTags: []})
+    }
+  })
+
+  it("keeps configured excluded tags when updating other test config", async () => {
+    const previousConsoleOutput = testConfig.consoleOutput
+
+    configureTests({excludeTags: ["mssql"]})
+    configureTests({consoleOutput: "live"})
+
+    try {
+      const testRunner = buildTestRunner()
+      const counts = {mssql: 0, untagged: 0}
+
+      const tests = {
+        args: {},
+        afterEaches: [],
+        beforeEaches: [],
+        subs: {},
+        tests: {
+          "mssql test": {
+            args: {tags: ["mssql"]},
+            function: async () => { counts.mssql++ }
+          },
+          "untagged test": {
+            args: {},
+            function: async () => { counts.untagged++ }
+          }
+        }
+      }
+
+      await testRunner.runTests({
+        afterEaches: [],
+        beforeEaches: [],
+        tests,
+        descriptions: [],
+        indentLevel: 0
+      })
+
+      expect(counts.mssql).toBe(0)
+      expect(counts.untagged).toBe(1)
+      expect(testRunner.getSuccessfulTests()).toBe(1)
+    } finally {
+      configureTests({consoleOutput: previousConsoleOutput, excludeTags: []})
     }
   })
 })

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -696,9 +696,12 @@ export default class TestRunner {
         while (true) {
           let shouldRetry = false
           /** @type {unknown} */
+          let caughtError
+          /** @type {unknown} */
           let failedError
           /** @type {unknown} */
           let lastError
+          let willRetry = false
           const stopConsoleCapture = this.startConsoleCapture({
             passthrough: testConfig.consoleOutput === "live"
           })
@@ -726,27 +729,13 @@ export default class TestRunner {
               }
             })
           } catch (error) {
+            caughtError = error
             lastError = error
-            const willRetry = retriesUsed < retryCount
+            willRetry = retriesUsed < retryCount
 
             if (willRetry) {
               retriesUsed++
             }
-
-            await this.emitEvent("testAttemptFailed", {
-              configuration: this.getConfiguration(),
-              descriptions,
-              error,
-              attemptNumber,
-              nextAttempt: willRetry ? attemptNumber + 1 : undefined,
-              retriesUsed,
-              retryCount,
-              testArgs,
-              testData,
-              testDescription,
-              testRunner: this,
-              willRetry
-            })
 
             if (willRetry) {
               shouldRetry = true
@@ -759,6 +748,23 @@ export default class TestRunner {
             if (consoleOutput) {
               attemptConsoleOutputs.push({attemptNumber, output: consoleOutput})
             }
+          }
+
+          if (caughtError !== undefined) {
+            await this.emitEvent("testAttemptFailed", {
+              configuration: this.getConfiguration(),
+              descriptions,
+              error: caughtError,
+              attemptNumber,
+              nextAttempt: willRetry ? attemptNumber + 1 : undefined,
+              retriesUsed,
+              retryCount,
+              testArgs,
+              testData,
+              testDescription,
+              testRunner: this,
+              willRetry
+            })
           }
 
           if (shouldRetry) {

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -42,6 +42,12 @@ function runWithTimeout(promise, timeoutMs, testDescription) {
 const CAPTURED_CONSOLE_METHODS = ["log", "info", "warn", "error", "debug"]
 
 /**
+ * @typedef {object} AttemptConsoleOutput
+ * @property {number} attemptNumber - Attempt number.
+ * @property {string} output - Captured console output.
+ */
+
+/**
  * @param {string} value - Value to sanitize.
  * @returns {string} - Slug-safe value.
  */
@@ -673,9 +679,6 @@ export default class TestRunner {
           testArgs.client = await this.requestClient()
         }
 
-        console.log(`${leftPadding}it ${testDescription}`)
-        const stopConsoleCapture = this.startConsoleCapture()
-
         const retryCount = typeof testArgs.retry === "number" && Number.isFinite(testArgs.retry)
           ? Math.max(0, Math.floor(testArgs.retry))
           : 0
@@ -685,143 +688,158 @@ export default class TestRunner {
         const timeoutMs = useTimeout ? timeoutSeconds * 1000 : undefined
         let retriesUsed = 0
         let attemptNumber = 1
+        /** @type {AttemptConsoleOutput[]} */
+        const attemptConsoleOutputs = []
 
-        try {
-          while (true) {
-            let shouldRetry = false
-            /** @type {unknown} */
-            let failedError
-            /** @type {unknown} */
-            let lastError
+        console.log(`${leftPadding}it ${testDescription}`)
 
-            try {
-              await this.runWithDummyIfNeeded(testArgs, async () => {
-                try {
-                  clearDeliveries()
-                  for (const beforeEachData of newBeforeEaches) {
-                    await beforeEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
-                  }
+        while (true) {
+          let shouldRetry = false
+          /** @type {unknown} */
+          let failedError
+          /** @type {unknown} */
+          let lastError
+          const stopConsoleCapture = this.startConsoleCapture({
+            passthrough: testConfig.consoleOutput === "live"
+          })
 
-                  const testPromise = testData.function(testArgs)
-
-                  if (useTimeout && timeoutMs !== undefined) {
-                    await runWithTimeout(testPromise, timeoutMs, testDescription)
-                  } else {
-                    await testPromise
-                  }
-                  this._successfulTests++
-                } finally {
-                  for (const afterEachData of newAfterEaches) {
-                    await afterEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
-                  }
+          try {
+            await this.runWithDummyIfNeeded(testArgs, async () => {
+              try {
+                clearDeliveries()
+                for (const beforeEachData of newBeforeEaches) {
+                  await beforeEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
                 }
-              })
-            } catch (error) {
-              lastError = error
-              const willRetry = retriesUsed < retryCount
 
-              if (willRetry) {
-                retriesUsed++
-              }
+                const testPromise = testData.function(testArgs)
 
-              await this.emitEvent("testAttemptFailed", {
-                configuration: this.getConfiguration(),
-                descriptions,
-                error,
-                attemptNumber,
-                nextAttempt: willRetry ? attemptNumber + 1 : undefined,
-                retriesUsed,
-                retryCount,
-                testArgs,
-                testData,
-                testDescription,
-                testRunner: this,
-                willRetry
-              })
-
-              if (willRetry) {
-                shouldRetry = true
-                console.warn(picocolors.red(`${leftPadding}  Retrying (${retriesUsed}/${retryCount}) after error: ${error instanceof Error ? error.message : String(error)}`))
-                await this.emitEvent("testRetrying", {
-                  configuration: this.getConfiguration(),
-                  descriptions,
-                  error,
-                  nextAttempt: attemptNumber + 1,
-                  retriesUsed,
-                  retryCount,
-                  testArgs,
-                  testData,
-                  testDescription,
-                  testRunner: this
-                })
-              } else {
-                failedError = error
-              }
-            }
-
-            if (attemptNumber > 1) {
-              await this.emitEvent("testRetried", {
-                configuration: this.getConfiguration(),
-                descriptions,
-                error: lastError,
-                attemptNumber,
-                retriesUsed,
-                retryCount,
-                testArgs,
-                testData,
-                testDescription,
-                testRunner: this
-              })
-            }
-
-            attemptNumber++
-
-            if (shouldRetry) continue
-
-            if (failedError) {
-              if (failedError instanceof Error) {
-                console.error(picocolors.red(`${leftPadding}  Test failed: ${failedError.message}`))
-                addTrackedStackToError(failedError)
-
-                const backtraceCleaner = new BacktraceCleaner(failedError)
-                const cleanedStack = backtraceCleaner.getCleanedStack()
-                const stackLines = cleanedStack?.split("\n")
-
-                if (stackLines) {
-                  for (const stackLine of stackLines) {
-                    console.error(picocolors.red(`${leftPadding}  ${stackLine}`))
-                  }
+                if (useTimeout && timeoutMs !== undefined) {
+                  await runWithTimeout(testPromise, timeoutMs, testDescription)
+                } else {
+                  await testPromise
                 }
-              } else {
-                console.error(picocolors.red(`${leftPadding}  Test failed with a ${typeof failedError}: ${String(failedError)}`))
+                this._successfulTests++
+              } finally {
+                for (const afterEachData of newAfterEaches) {
+                  await afterEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                }
               }
+            })
+          } catch (error) {
+            lastError = error
+            const willRetry = retriesUsed < retryCount
 
-              this._failedTests++
-              this._failedTestDetails.push({
-                fullDescription: this.buildFullDescription(descriptions, testDescription),
-                filePath: testData.filePath,
-                line: testData.line,
-                error: failedError,
-                consoleOutput: stopConsoleCapture()
-              })
-
-              await this.emitEvent("testFailed", {
-                configuration: this.getConfiguration(),
-                descriptions,
-                error: failedError,
-                testArgs,
-                testData,
-                testDescription,
-                testRunner: this
-              })
-
-              this.printRerunCommand({descriptions, testDescription, testData, leftPadding})
+            if (willRetry) {
+              retriesUsed++
             }
 
-            break
+            await this.emitEvent("testAttemptFailed", {
+              configuration: this.getConfiguration(),
+              descriptions,
+              error,
+              attemptNumber,
+              nextAttempt: willRetry ? attemptNumber + 1 : undefined,
+              retriesUsed,
+              retryCount,
+              testArgs,
+              testData,
+              testDescription,
+              testRunner: this,
+              willRetry
+            })
+
+            if (willRetry) {
+              shouldRetry = true
+            } else {
+              failedError = error
+            }
+          } finally {
+            const consoleOutput = stopConsoleCapture()
+
+            if (consoleOutput) {
+              attemptConsoleOutputs.push({attemptNumber, output: consoleOutput})
+            }
           }
-        } finally {
-          stopConsoleCapture()
+
+          if (shouldRetry) {
+            console.warn(picocolors.red(`${leftPadding}  Retrying (${retriesUsed}/${retryCount}) after error: ${lastError instanceof Error ? lastError.message : String(lastError)}`))
+            await this.emitEvent("testRetrying", {
+              configuration: this.getConfiguration(),
+              descriptions,
+              error: lastError,
+              nextAttempt: attemptNumber + 1,
+              retriesUsed,
+              retryCount,
+              testArgs,
+              testData,
+              testDescription,
+              testRunner: this
+            })
+          }
+
+          if (attemptNumber > 1) {
+            await this.emitEvent("testRetried", {
+              configuration: this.getConfiguration(),
+              descriptions,
+              error: lastError,
+              attemptNumber,
+              retriesUsed,
+              retryCount,
+              testArgs,
+              testData,
+              testDescription,
+              testRunner: this
+            })
+          }
+
+          attemptNumber++
+
+          if (shouldRetry) continue
+
+          if (failedError) {
+            const consoleOutput = this.buildConsoleOutput(attemptConsoleOutputs)
+
+            if (failedError instanceof Error) {
+              console.error(picocolors.red(`${leftPadding}  Test failed: ${failedError.message}`))
+              addTrackedStackToError(failedError)
+
+              const backtraceCleaner = new BacktraceCleaner(failedError)
+              const cleanedStack = backtraceCleaner.getCleanedStack()
+              const stackLines = cleanedStack?.split("\n")
+
+              if (stackLines) {
+                for (const stackLine of stackLines) {
+                  console.error(picocolors.red(`${leftPadding}  ${stackLine}`))
+                }
+              }
+            } else {
+              console.error(picocolors.red(`${leftPadding}  Test failed with a ${typeof failedError}: ${String(failedError)}`))
+            }
+
+            this.printFailedConsoleOutput({consoleOutput, leftPadding})
+            this._failedTests++
+            this._failedTestDetails.push({
+              fullDescription: this.buildFullDescription(descriptions, testDescription),
+              filePath: testData.filePath,
+              line: testData.line,
+              error: failedError,
+              consoleOutput: consoleOutput || undefined
+            })
+
+            await this.emitEvent("testFailed", {
+              configuration: this.getConfiguration(),
+              descriptions,
+              error: failedError,
+              testArgs,
+              testData,
+              testDescription,
+              testRunner: this
+            })
+
+            this.printRerunCommand({descriptions, testDescription, testData, leftPadding})
+          }
+
+          break
         }
       }
 
@@ -922,9 +940,76 @@ export default class TestRunner {
   }
 
   /**
+   * @param {AttemptConsoleOutput[]} attemptConsoleOutputs - Attempt output entries.
+   * @returns {string} - Combined console output.
+   */
+  buildConsoleOutput(attemptConsoleOutputs) {
+    if (attemptConsoleOutputs.length === 0) return ""
+    if (attemptConsoleOutputs.length === 1) return attemptConsoleOutputs[0].output
+
+    return attemptConsoleOutputs.map((attemptConsoleOutput) => {
+      return `--- Attempt ${attemptConsoleOutput.attemptNumber} ---\n${attemptConsoleOutput.output}`
+    }).join("\n")
+  }
+
+  /**
+   * @returns {number} - Maximum failed console lines.
+   */
+  getFailedConsoleOutputMaxLines() {
+    const maxLines = testConfig.failedConsoleOutputMaxLines
+
+    if (typeof maxLines !== "number" || !Number.isFinite(maxLines)) return 200
+
+    return Math.max(0, Math.floor(maxLines))
+  }
+
+  /**
+   * @param {string} consoleOutput - Console output.
+   * @returns {string[]} - Lines for inline output.
+   */
+  truncateFailedConsoleOutputLines(consoleOutput) {
+    const lines = consoleOutput.split("\n")
+    const maxLines = this.getFailedConsoleOutputMaxLines()
+
+    if (maxLines === 0) return []
+    if (lines.length <= maxLines) return lines
+
+    const omittedLines = lines.length - maxLines
+    const plural = omittedLines === 1 ? "" : "s"
+
+    return [
+      `... ${omittedLines} console output line${plural} omitted ...`,
+      ...lines.slice(-maxLines)
+    ]
+  }
+
+  /**
+   * @param {object} args - Options object.
+   * @param {string} args.consoleOutput - Console output.
+   * @param {string} args.leftPadding - Left padding.
+   * @returns {void} - No return value.
+   */
+  printFailedConsoleOutput({consoleOutput, leftPadding}) {
+    if (testConfig.consoleOutput !== "failure") return
+    if (!consoleOutput) return
+
+    const lines = this.truncateFailedConsoleOutputLines(consoleOutput)
+
+    if (lines.length === 0) return
+
+    console.error(picocolors.red(`${leftPadding}  Console output:`))
+
+    for (const line of lines) {
+      console.error(picocolors.red(`${leftPadding}    ${line}`))
+    }
+  }
+
+  /**
+   * @param {object} [args] - Options object.
+   * @param {boolean} [args.passthrough] - Whether to pass through to the original console.
    * @returns {() => string} - Stops the capture and returns captured text.
    */
-  startConsoleCapture() {
+  startConsoleCapture({passthrough = false} = {}) {
     /** @type {string[]} */
     const lines = []
     /** @type {Record<ConsoleMethodName, (...args: unknown[]) => void>} */
@@ -943,7 +1028,10 @@ export default class TestRunner {
     for (const methodName of CAPTURED_CONSOLE_METHODS) {
       consoleObject[methodName] = (...args) => {
         lines.push(`[${new Date().toISOString()}] [${methodName}] ${format(...args)}`)
-        originalConsoleMethods[methodName](...args)
+
+        if (passthrough) {
+          originalConsoleMethods[methodName](...args)
+        }
       }
     }
 

--- a/src/testing/test.js
+++ b/src/testing/test.js
@@ -102,7 +102,10 @@ const testConfig = {
  * @returns {void}
  */
 function configureTests({consoleOutput, excludeTags, defaultTimeoutSeconds, failedConsoleOutputMaxLines} = {}) {
-  testConfig.excludeTags = normalizeTags(excludeTags)
+  if (excludeTags !== undefined) {
+    testConfig.excludeTags = normalizeTags(excludeTags)
+  }
+
   if (consoleOutput !== undefined) {
     if (consoleOutput !== "failure" && consoleOutput !== "live") {
       throw new Error(`Invalid consoleOutput config: ${consoleOutput}`)

--- a/src/testing/test.js
+++ b/src/testing/test.js
@@ -87,20 +87,36 @@ function normalizeTags(tags) {
 
 /** @type {VelociousTestConfig} */
 const testConfig = {
+  consoleOutput: "failure",
+  failedConsoleOutputMaxLines: 200,
   excludeTags: [],
   defaultTimeoutSeconds: 60
 }
 
 /**
  * @param {object} args - Options.
+ * @param {"failure" | "live"} [args.consoleOutput] - Console output mode.
  * @param {string[] | string} [args.excludeTags] - Tags to exclude.
  * @param {number} [args.defaultTimeoutSeconds] - Default timeout in seconds.
+ * @param {number} [args.failedConsoleOutputMaxLines] - Maximum failed console lines to print inline.
  * @returns {void}
  */
-function configureTests({excludeTags, defaultTimeoutSeconds} = {}) {
+function configureTests({consoleOutput, excludeTags, defaultTimeoutSeconds, failedConsoleOutputMaxLines} = {}) {
   testConfig.excludeTags = normalizeTags(excludeTags)
+  if (consoleOutput !== undefined) {
+    if (consoleOutput !== "failure" && consoleOutput !== "live") {
+      throw new Error(`Invalid consoleOutput config: ${consoleOutput}`)
+    }
+
+    testConfig.consoleOutput = consoleOutput
+  }
+
   if (typeof defaultTimeoutSeconds === "number") {
     testConfig.defaultTimeoutSeconds = defaultTimeoutSeconds
+  }
+
+  if (typeof failedConsoleOutputMaxLines === "number") {
+    testConfig.failedConsoleOutputMaxLines = failedConsoleOutputMaxLines
   }
 }
 
@@ -301,6 +317,8 @@ globalThis.configureTests = configureTests
 export {afterAll, afterEach, beforeAll, beforeEach, configureTests, describe, expect, fit, it, arrayContaining, objectContaining, testConfig, testEvents, tests}
 /**
  * @typedef {object} VelociousTestConfig
+ * @property {"failure" | "live"} consoleOutput - Console output mode.
  * @property {string[]} excludeTags - Tags excluded by default.
  * @property {number} defaultTimeoutSeconds - Default timeout in seconds.
+ * @property {number} failedConsoleOutputMaxLines - Maximum failed console lines to print inline.
  */


### PR DESCRIPTION
## Summary
- Capture test console output quietly by default and print it only when an individual test fails.
- Add configurable `consoleOutput: "live"` passthrough and `failedConsoleOutputMaxLines` truncation.
- Document the testing config options and add a changelog fragment.

## Validation
- `npm run test -- spec/testing/test-runner-events-spec.js`
- `npm run lint`
- `npm run typecheck`
