### PR TITLE
Fix MySQL boolean create table SQL

### DIFF
--- a/changelog.d/20260518-mysql-boolean-ddl.md
+++ b/changelog.d/20260518-mysql-boolean-ddl.md
@@ -1,0 +1,1 @@
+Fix MySQL table creation SQL for boolean columns restored from schema metadata so they render as `TINYINT(1)` instead of invalid `BOOLEAN(1)`.

--- a/spec/database/drivers/mysql/sql/create-table-spec.js
+++ b/spec/database/drivers/mysql/sql/create-table-spec.js
@@ -1,0 +1,40 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../src/testing/test.js"
+import MysqlDriver from "../../../../../src/database/drivers/mysql/index.js"
+import TableData from "../../../../../src/database/table-data/index.js"
+
+/** @returns {MysqlDriver} */
+function buildDriver() {
+  return new MysqlDriver({type: "mysql"})
+}
+
+describe("database/drivers/mysql/sql/create-table", () => {
+  it("renders boolean columns as tinyint(1) with a boolean type hint", async () => {
+    const tableData = new TableData("feature_flags")
+
+    tableData.boolean("enabled", {null: false})
+
+    const sqls = await buildDriver().createTableSql(tableData)
+
+    expect(sqls).toEqual([
+      "CREATE TABLE `feature_flags` (`enabled` TINYINT(1) NOT NULL COMMENT 'velocious:type=boolean') DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    ])
+  })
+
+  it("renders cloned boolean metadata with maxLength as tinyint(1)", async () => {
+    const tableData = new TableData("auth_tokens")
+
+    tableData.addColumn("force_valid_domain", {
+      maxLength: 1,
+      null: false,
+      type: "boolean"
+    })
+
+    const sqls = await buildDriver().createTableSql(tableData)
+
+    expect(sqls).toEqual([
+      "CREATE TABLE `auth_tokens` (`force_valid_domain` TINYINT(1) NOT NULL COMMENT 'velocious:type=boolean') DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    ])
+  })
+})

--- a/src/database/table-data/table-column.js
+++ b/src/database/table-data/table-column.js
@@ -262,6 +262,10 @@ export default class TableColumn {
       type = databaseType == "mssql" ? "NVARCHAR" : "VARCHAR"
       maxlength ||= 255
     }
+    if (databaseType == "mysql" && type == "BOOLEAN") {
+      type = "TINYINT"
+      maxlength = 1
+    }
     if (databaseType == "pgsql" && type == "TINYINT") {
       type = "SMALLINT"
     }


### PR DESCRIPTION
## Summary
- render MySQL boolean table columns as TINYINT(1) instead of invalid BOOLEAN(1)
- add focused MySQL create-table SQL coverage for normal and cloned boolean metadata
- add changelog fragment

## Tests
- node scripts/run-tests.js spec/database/drivers/mysql/sql/create-table-spec.js
- node scripts/run-tests.js spec/database/drivers/mysql/sql/alter-table-spec.js
- npm run lint
- npm run typecheck