### PR TITLE
Fail HTTP server startup on listen errors

### DIFF
--- a/changelog.d/20260520-server-listen-errors.md
+++ b/changelog.d/20260520-server-listen-errors.md
@@ -1,0 +1,1 @@
+Fix HTTP server startup so port binding errors reject startup instead of leaving a non-serving process alive.

--- a/changelog.d/20260520-server-listen-errors.md
+++ b/changelog.d/20260520-server-listen-errors.md
@@ -1,1 +1,1 @@
-Fix HTTP server startup so port binding errors reject startup instead of leaving a non-serving process alive.
+Fix HTTP server startup so port binding errors reject startup instead of leaving a non-serving process alive. Preserve explicit port `0` so tests and callers can ask the OS for a random free port.

--- a/spec/http-server/listen-error-spec.js
+++ b/spec/http-server/listen-error-spec.js
@@ -5,6 +5,48 @@ import Net from "node:net"
 import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 
+class TestWorkerHandler {
+  /** @type {import("../../src/http-server/server-client.js").default | undefined} */
+  client
+
+  /**
+   * @param {object} args - Options object.
+   * @param {Array<string>} args.stoppedWorkers - Stopped workers.
+   * @param {number} args.workerCount - Worker count.
+   */
+  constructor({stoppedWorkers, workerCount}) {
+    this.started = false
+    this.stoppedWorkers = stoppedWorkers
+    this.workerCount = workerCount
+  }
+
+  /** @returns {Promise<void>} - Resolves when started. */
+  async start() {
+    this.started = true
+  }
+
+  /**
+   * @param {import("../../src/http-server/server-client.js").default} client - Server client.
+   * @returns {void} - No return value.
+   */
+  addSocketConnection(client) {
+    this.client = client
+  }
+
+  /** @returns {Promise<void>} - Resolves when stopped. */
+  async stop() {
+    this.stoppedWorkers.push(`worker-${this.workerCount}`)
+  }
+}
+
+/** @returns {{debug: boolean, getEnvironment: () => string}} - Test configuration. */
+function buildConfiguration() {
+  return {
+    debug: false,
+    getEnvironment: () => "test"
+  }
+}
+
 /**
  * @param {Net.Server} server - Server to bind.
  * @returns {Promise<number>} - Bound port.
@@ -28,21 +70,11 @@ describe("HttpServer - listen errors", () => {
     const stoppedWorkers = []
 
     const server = new HttpServer({
-      configuration: {debug: false},
+      configuration: buildConfiguration(),
       host: "127.0.0.1",
-      port
+      port,
+      workerHandlerFactory: ({workerCount}) => new TestWorkerHandler({stoppedWorkers, workerCount})
     })
-
-    server._ensureAtLeastOneWorker = async () => {
-      server.workerHandlers = [
-        {
-          stop: async () => {
-            stoppedWorkers.push("worker")
-          }
-        }
-      ]
-    }
-    server._startDevelopmentReloader = async () => {}
 
     let startupError
     try {
@@ -62,7 +94,34 @@ describe("HttpServer - listen errors", () => {
     })
 
     expect(startupError.code).toEqual("EADDRINUSE")
-    expect(stoppedWorkers).toEqual(["worker"])
+    expect(stoppedWorkers).toEqual(["worker-0"])
     expect(server.isActive()).toBeFalse()
+  })
+
+  it("rejects repeated starts without tearing down the active server", async () => {
+    const stoppedWorkers = []
+    const server = new HttpServer({
+      configuration: buildConfiguration(),
+      host: "127.0.0.1",
+      port: 0,
+      workerHandlerFactory: ({workerCount}) => new TestWorkerHandler({stoppedWorkers, workerCount})
+    })
+
+    await server.start()
+
+    let startupError
+    try {
+      await server.start()
+    } catch (error) {
+      startupError = error
+    }
+
+    expect(startupError.message).toEqual("Velocious HTTP server is already running")
+    expect(stoppedWorkers).toEqual([])
+    expect(server.isActive()).toBeTrue()
+
+    await server.stop()
+
+    expect(stoppedWorkers).toEqual(["worker-0"])
   })
 })

--- a/spec/http-server/listen-error-spec.js
+++ b/spec/http-server/listen-error-spec.js
@@ -124,4 +124,13 @@ describe("HttpServer - listen errors", () => {
 
     expect(stoppedWorkers).toEqual(["worker-0"])
   })
+
+  it("preserves explicit port zero for random-port test servers", () => {
+    const server = new HttpServer({
+      configuration: buildConfiguration(),
+      port: 0
+    })
+
+    expect(server.port).toEqual(0)
+  })
 })

--- a/spec/http-server/listen-error-spec.js
+++ b/spec/http-server/listen-error-spec.js
@@ -1,0 +1,68 @@
+// @ts-check
+
+import Net from "node:net"
+
+import HttpServer from "../../src/http-server/index.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/**
+ * @param {Net.Server} server - Server to bind.
+ * @returns {Promise<number>} - Bound port.
+ */
+async function listenOnRandomPort(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error(`Unexpected server address: ${address}`)
+
+  return address.port
+}
+
+describe("HttpServer - listen errors", () => {
+  it("rejects startup and stops workers when the port is already in use", async () => {
+    const occupiedServer = Net.createServer()
+    const port = await listenOnRandomPort(occupiedServer)
+    const stoppedWorkers = []
+
+    const server = new HttpServer({
+      configuration: {debug: false},
+      host: "127.0.0.1",
+      port
+    })
+
+    server._ensureAtLeastOneWorker = async () => {
+      server.workerHandlers = [
+        {
+          stop: async () => {
+            stoppedWorkers.push("worker")
+          }
+        }
+      ]
+    }
+    server._startDevelopmentReloader = async () => {}
+
+    let startupError
+    try {
+      await server.start()
+    } catch (error) {
+      startupError = error
+    }
+
+    await new Promise((resolve, reject) => {
+      occupiedServer.close((error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(undefined)
+        }
+      })
+    })
+
+    expect(startupError.code).toEqual("EADDRINUSE")
+    expect(stoppedWorkers).toEqual(["worker"])
+    expect(server.isActive()).toBeFalse()
+  })
+})

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -45,13 +45,18 @@ export default class VelociousHttpServer {
 
   /** @returns {Promise<void>} - Resolves when complete.  */
   async start() {
-    await this._ensureAtLeastOneWorker()
-    await this._startDevelopmentReloader()
-    this.netServer = new Net.Server()
-    this.netServer.on("close", this.onClose)
-    this.netServer.on("connection", this.onConnection)
-    this.netServer.on("error", this.onServerError)
-    await this._netServerListen()
+    try {
+      await this._ensureAtLeastOneWorker()
+      await this._startDevelopmentReloader()
+      this.netServer = new Net.Server()
+      this.netServer.on("close", this.onClose)
+      this.netServer.on("connection", this.onConnection)
+      this.netServer.on("error", this.onServerError)
+      await this._netServerListen()
+    } catch (error) {
+      await this.stop()
+      throw error
+    }
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
@@ -59,8 +64,16 @@ export default class VelociousHttpServer {
     return new Promise((resolve, reject) => {
       if (!this.netServer) throw new Error("No netServer")
 
+      /** @param {Error} error - Listen error. */
+      const onListenError = (error) => {
+        this.netServer?.off("error", onListenError)
+        reject(error)
+      }
+
       try {
+        this.netServer.once("error", onListenError)
         this.netServer.listen(this.port, this.host, () => {
+          this.netServer?.off("error", onListenError)
           this.logger.debug(`Velocious listening on ${this.host}:${this.port}`)
           resolve(undefined)
         })

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -9,8 +9,21 @@ import Net from "net"
 import ServerClient from "./server-client.js"
 import WorkerHandler from "./worker-handler/index.js"
 
+/** @typedef {{start: () => Promise<void>, stop: () => Promise<void>}} DevelopmentReloaderLike */
+/** @typedef {function({configuration: import("../configuration.js").default, workerCount: number}) : (WorkerHandler | InProcessHandler)} WorkerHandlerFactory */
+
 export default class VelociousHttpServer {
   clientCount = 0
+  _starting = false
+
+  /** @type {DevelopmentReloader | DevelopmentReloaderLike | undefined} */
+  developmentReloader
+
+  /** @type {import("net").Server | undefined} */
+  netServer
+
+  /** @type {WorkerHandlerFactory | undefined} */
+  workerHandlerFactory
 
   /** @type {Record<string, ServerClient>}  */
   clients = {}
@@ -32,10 +45,12 @@ export default class VelociousHttpServer {
    * @param {number} [args.port] - Port.
    * @param {number} [args.maxWorkers] - Max workers.
    * @param {function({configuration: import("../configuration.js").default, onReload: function({changedPath: string}) : Promise<void>}) : {start: () => Promise<void>, stop: () => Promise<void>}} [args.developmentReloaderFactory] - Development reloader factory.
+   * @param {WorkerHandlerFactory} [args.workerHandlerFactory] - Worker handler factory.
    */
-  constructor({configuration, developmentReloaderFactory, host, inProcess, maxWorkers, port}) {
+  constructor({configuration, developmentReloaderFactory, host, inProcess, maxWorkers, port, workerHandlerFactory}) {
     this.configuration = configuration
     this.developmentReloaderFactory = developmentReloaderFactory
+    this.workerHandlerFactory = workerHandlerFactory
     this.inProcess = inProcess || false
     this.logger = new Logger(this)
     this.host = host || "0.0.0.0"
@@ -45,18 +60,62 @@ export default class VelociousHttpServer {
 
   /** @returns {Promise<void>} - Resolves when complete.  */
   async start() {
+    if (this._starting) throw new Error("Velocious HTTP server is already starting")
+    if (this.isActive()) throw new Error("Velocious HTTP server is already running")
+
+    this._starting = true
+    const startupState = this._captureStartupState()
+
     try {
       await this._ensureAtLeastOneWorker()
       await this._startDevelopmentReloader()
-      this.netServer = new Net.Server()
-      this.netServer.on("close", this.onClose)
-      this.netServer.on("connection", this.onConnection)
-      this.netServer.on("error", this.onServerError)
+      /** @type {import("net").Server} */
+      const netServer = new Net.Server()
+      this.netServer = netServer
+      netServer.on("close", this.onClose)
+      netServer.on("connection", this.onConnection)
+      netServer.on("error", this.onServerError)
       await this._netServerListen()
     } catch (error) {
-      await this.stop()
+      await this._stopStartupResources(startupState)
       throw error
+    } finally {
+      this._starting = false
     }
+  }
+
+  /** @returns {{developmentReloader: DevelopmentReloader | DevelopmentReloaderLike | undefined, netServer: import("net").Server | undefined, workerHandlers: Array<WorkerHandler | InProcessHandler>}} - Startup state. */
+  _captureStartupState() {
+    return {
+      developmentReloader: this.developmentReloader,
+      netServer: this.netServer,
+      workerHandlers: [...this.workerHandlers]
+    }
+  }
+
+  /**
+   * @param {ReturnType<VelociousHttpServer["_captureStartupState"]>} startupState - State captured before startup.
+   * @returns {Promise<void>} - Resolves when cleanup is complete.
+   */
+  async _stopStartupResources(startupState) {
+    /** @type {import("net").Server | undefined} */
+    const startupNetServer = this.netServer
+
+    if (this.developmentReloader && this.developmentReloader !== startupState.developmentReloader) {
+      await this.developmentReloader.stop()
+    }
+
+    if (startupNetServer && startupNetServer !== startupState.netServer) {
+      await this.stopServer(startupNetServer)
+    }
+
+    const startupWorkerHandlers = this.workerHandlers.filter((workerHandler) => !startupState.workerHandlers.includes(workerHandler))
+
+    await Promise.all(startupWorkerHandlers.map((handler) => handler.stop()))
+
+    this.developmentReloader = startupState.developmentReloader
+    this.netServer = startupState.netServer
+    this.workerHandlers = startupState.workerHandlers
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
@@ -112,24 +171,29 @@ export default class VelociousHttpServer {
     await Promise.all(promises)
   }
 
-  /** @returns {Promise<void>} - Resolves when complete.  */
-  stopServer() {
+  /**
+   * @param {import("net").Server | undefined} [netServer] - Server to stop.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  stopServer(netServer = this.netServer) {
     return new Promise((resolve, reject) => {
-      if (!this.netServer || !this.netServer.listening) {
+      if (!netServer || !netServer.listening) {
         resolve(undefined)
         return
       }
 
-      // Force-close lingering sockets (e.g. WebSocket upgrade
-      // connections mid-close-handshake) so the port is released
-      // immediately instead of waiting for graceful drain.
-      for (const socket of this._activeSockets) {
-        socket.destroy()
+      if (netServer === this.netServer) {
+        // Force-close lingering sockets (e.g. WebSocket upgrade
+        // connections mid-close-handshake) so the port is released
+        // immediately instead of waiting for graceful drain.
+        for (const socket of this._activeSockets) {
+          socket.destroy()
+        }
+
+        this._activeSockets.clear()
       }
 
-      this._activeSockets.clear()
-
-      this.netServer.close((error) => {
+      netServer.close((error) => {
         if (error) {
           reject(error)
         } else {
@@ -233,10 +297,12 @@ export default class VelociousHttpServer {
     this.workerCount++
 
     const Handler = this.inProcess ? InProcessHandler : WorkerHandler
-    const workerHandler = new Handler({
-      configuration: this.configuration,
-      workerCount
-    })
+    const workerHandler = this.workerHandlerFactory
+      ? this.workerHandlerFactory({configuration: this.configuration, workerCount})
+      : new Handler({
+        configuration: this.configuration,
+        workerCount
+      })
 
     await workerHandler.start()
 

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -53,9 +53,9 @@ export default class VelociousHttpServer {
     this.workerHandlerFactory = workerHandlerFactory
     this.inProcess = inProcess || false
     this.logger = new Logger(this)
-    this.host = host || "0.0.0.0"
-    this.port = port || 3006
-    this.maxWorkers = maxWorkers || 16
+    this.host = host ?? "0.0.0.0"
+    this.port = port ?? 3006
+    this.maxWorkers = maxWorkers ?? 16
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */


### PR DESCRIPTION
Summary:
- Reject Velocious HTTP server startup when the listen socket emits an async error such as EADDRINUSE.
- Stop started workers/reloader after startup failure so a replacement process does not stay alive without serving traffic.
- Add a port collision regression test.

Tests:
- ./run-tests.sh spec/http-server/listen-error-spec.js
- npm run lint
- npm run typecheck
- npx eslint src/http-server/index.js spec/http-server/listen-error-spec.js