### PR TITLE
Add model metadata eager-load opt-out

### DIFF
--- a/changelog.d/20260520-model-eager-metadata-opt-out.md
+++ b/changelog.d/20260520-model-eager-metadata-opt-out.md
@@ -1,0 +1,3 @@
+## Model metadata eager-load opt-out
+
+- Added `Record.setEagerLoadRecordMetadata(false)` so individual model classes can be registered during require-context initialization without loading table and column metadata until first use.

--- a/spec/database/initializer-from-require-context-spec.js
+++ b/spec/database/initializer-from-require-context-spec.js
@@ -94,6 +94,50 @@ describe("Database - initializer from require context", () => {
     expect(configuration.getModelClasses().LazyMetadataRecord).toEqual(LazyMetadataRecord)
   })
 
+  it("clears stale metadata when an opted-out model is re-registered", async () => {
+    class ReRegisteredLazyMetadataRecord extends DatabaseRecord {
+      /**
+       * @param {object} args - Options object.
+       * @param {Configuration} args.configuration - Configuration instance.
+       * @returns {Promise<void>} - Resolves when complete.
+       */
+      static async initializeRecord({configuration}) {
+        this.registerRecordClass({configuration})
+        this._databaseType = "sqlite"
+        this._columns = []
+        this._columnsAsHash = {}
+        this._initialized = true
+      }
+    }
+
+    ReRegisteredLazyMetadataRecord.setEagerLoadRecordMetadata(false)
+    ReRegisteredLazyMetadataRecord._databaseType = "mysql"
+    ReRegisteredLazyMetadataRecord._table = /** @type {any} */ ({})
+    ReRegisteredLazyMetadataRecord._columns = [/** @type {any} */ ({})]
+    ReRegisteredLazyMetadataRecord._columnsAsHash = {id: /** @type {any} */ ({})}
+    ReRegisteredLazyMetadataRecord._columnNames = ["id"]
+    ReRegisteredLazyMetadataRecord._columnTypeByName = {id: "integer"}
+    ReRegisteredLazyMetadataRecord._attributeNameToColumnName = {id: "id"}
+    ReRegisteredLazyMetadataRecord._columnNameToAttributeName = {id: "id"}
+    ReRegisteredLazyMetadataRecord._initialized = true
+
+    const configuration = buildConfiguration()
+    const initializer = new InitializerFromRequireContext({
+      requireContext: buildRequireContext({"./re-registered-lazy-metadata-record.js": {default: ReRegisteredLazyMetadataRecord}})
+    })
+
+    await initializer.initialize({configuration})
+
+    expect(ReRegisteredLazyMetadataRecord.isInitialized()).toEqual(false)
+    expect(() => ReRegisteredLazyMetadataRecord.getDatabaseType()).toThrow("Database type hasn't been set")
+    expect(() => ReRegisteredLazyMetadataRecord.getColumns()).toThrow(/used before initialization/)
+
+    await ReRegisteredLazyMetadataRecord.ensureInitialized()
+
+    expect(ReRegisteredLazyMetadataRecord.getDatabaseType()).toEqual("sqlite")
+    expect(ReRegisteredLazyMetadataRecord.isInitialized()).toEqual(true)
+  })
+
   it("initializes opted-out models on first use", async () => {
     class FirstUseLazyMetadataRecord extends DatabaseRecord {
       static initializeRecordCalls = 0

--- a/spec/database/initializer-from-require-context-spec.js
+++ b/spec/database/initializer-from-require-context-spec.js
@@ -1,0 +1,129 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Configuration from "../../src/configuration.js"
+import DatabaseRecord from "../../src/database/record/index.js"
+import dummyDirectory from "../dummy/dummy-directory.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import InitializerFromRequireContext from "../../src/database/initializer-from-require-context.js"
+
+/**
+ * @param {Record<string, {default: typeof DatabaseRecord}>} models - Models keyed by require-context path.
+ * @returns {import("../../src/database/initializer-from-require-context.js").ModelClassRequireContextType} - Require context.
+ */
+function buildRequireContext(models) {
+  const requireContext = /** @type {import("../../src/database/initializer-from-require-context.js").ModelClassRequireContextType} */ ((fileName) => models[fileName])
+
+  requireContext.keys = () => Object.keys(models)
+  requireContext.id = "initializer-from-require-context-spec"
+
+  return requireContext
+}
+
+/** @returns {Configuration} - Test configuration. */
+function buildConfiguration() {
+  return new Configuration({
+    database: {test: {}},
+    directory: dummyDirectory(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+}
+
+describe("Database - initializer from require context", () => {
+  it("eager-loads record metadata by default", async () => {
+    class EagerMetadataRecord extends DatabaseRecord {
+      static initializeRecordCalls = 0
+
+      /**
+       * @param {object} args - Options object.
+       * @param {Configuration} args.configuration - Configuration instance.
+       * @returns {Promise<void>} - Resolves when complete.
+       */
+      static async initializeRecord({configuration}) {
+        this.initializeRecordCalls += 1
+        this.registerRecordClass({configuration})
+        this._initialized = true
+      }
+
+      /** @returns {Promise<boolean>} - Whether the model has a translations table. */
+      static async hasTranslationsTable() {
+        return false
+      }
+    }
+
+    const configuration = buildConfiguration()
+    const initializer = new InitializerFromRequireContext({
+      requireContext: buildRequireContext({"./eager-metadata-record.js": {default: EagerMetadataRecord}})
+    })
+
+    await initializer.initialize({configuration})
+
+    expect(EagerMetadataRecord.initializeRecordCalls).toEqual(1)
+    expect(EagerMetadataRecord.isInitialized()).toEqual(true)
+    expect(configuration.getModelClasses().EagerMetadataRecord).toEqual(EagerMetadataRecord)
+  })
+
+  it("registers opted-out models without loading record metadata", async () => {
+    class LazyMetadataRecord extends DatabaseRecord {
+      /** @returns {Promise<void>} - Never resolves because lazy registration must not call this. */
+      static async initializeRecord() {
+        throw new Error("Lazy metadata record should not initialize during require-context registration")
+      }
+
+      /** @returns {Promise<boolean>} - Never resolves because lazy registration must not check translations. */
+      static async hasTranslationsTable() {
+        throw new Error("Lazy metadata record should not check translations during require-context registration")
+      }
+    }
+
+    LazyMetadataRecord.setEagerLoadRecordMetadata(false)
+
+    const configuration = buildConfiguration()
+    const initializer = new InitializerFromRequireContext({
+      requireContext: buildRequireContext({"./lazy-metadata-record.js": {default: LazyMetadataRecord}})
+    })
+
+    await initializer.initialize({configuration})
+
+    expect(LazyMetadataRecord.isInitialized()).toEqual(false)
+    expect(configuration.getModelClasses().LazyMetadataRecord).toEqual(LazyMetadataRecord)
+  })
+
+  it("initializes opted-out models on first use", async () => {
+    class FirstUseLazyMetadataRecord extends DatabaseRecord {
+      static initializeRecordCalls = 0
+
+      /**
+       * @param {object} args - Options object.
+       * @param {Configuration} args.configuration - Configuration instance.
+       * @returns {Promise<void>} - Resolves when complete.
+       */
+      static async initializeRecord({configuration}) {
+        this.initializeRecordCalls += 1
+        this.registerRecordClass({configuration})
+        this._initialized = true
+      }
+    }
+
+    FirstUseLazyMetadataRecord.setEagerLoadRecordMetadata(false)
+
+    const configuration = buildConfiguration()
+    const initializer = new InitializerFromRequireContext({
+      requireContext: buildRequireContext({"./first-use-lazy-metadata-record.js": {default: FirstUseLazyMetadataRecord}})
+    })
+
+    await initializer.initialize({configuration})
+
+    expect(FirstUseLazyMetadataRecord.initializeRecordCalls).toEqual(0)
+
+    await FirstUseLazyMetadataRecord.ensureInitialized()
+
+    expect(FirstUseLazyMetadataRecord.initializeRecordCalls).toEqual(1)
+    expect(FirstUseLazyMetadataRecord.isInitialized()).toEqual(true)
+  })
+})

--- a/src/database/initializer-from-require-context.js
+++ b/src/database/initializer-from-require-context.js
@@ -38,6 +38,11 @@ export default class VelociousDatabaseInitializerFromRequireContext {
 
       if (!modelClass) throw new Error(`Model wasn't exported from: ${fileName}`)
 
+      if (!modelClass.getEagerLoadRecordMetadata()) {
+        modelClass.registerRecordClass({configuration})
+        continue
+      }
+
       await modelClass.initializeRecord({configuration})
 
       if (await modelClass.hasTranslationsTable()) {

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -1003,6 +1003,20 @@ class VelociousDatabaseRecord {
     return this._eagerLoadRecordMetadata
   }
 
+  /** @returns {void} - No return value. */
+  static resetRecordMetadata() {
+    this._initialized = false
+    this._initializeRecordPromise = null
+    this._databaseType = undefined
+    this._table = undefined
+    this._columns = undefined
+    this._columnsAsHash = undefined
+    this._columnNames = undefined
+    this._columnTypeByName = undefined
+    this._attributeNameToColumnName = undefined
+    this._columnNameToAttributeName = undefined
+  }
+
   /**
    * Registers the model class with a configuration without loading table metadata.
    * @param {object} args - Options object.
@@ -1014,6 +1028,7 @@ class VelociousDatabaseRecord {
 
     if (!configuration) throw new Error(`No configuration given for ${this.name}`)
 
+    this.resetRecordMetadata()
     this._configuration = configuration
     this._configuration.registerModelClass(this)
   }

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -115,6 +115,9 @@ class VelociousDatabaseRecord {
   /** @type {Promise<void> | null | undefined} */
   static _initializeRecordPromise
 
+  /** @type {boolean | undefined} */
+  static _eagerLoadRecordMetadata
+
   /**
    * Returns the model name, preferring an explicit `static modelName` declaration
    * over the JavaScript class `.name` property. This allows minified builds to
@@ -986,6 +989,36 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * @param {boolean} eagerLoadRecordMetadata - Whether require-context initialization should load table metadata for this model.
+   * @returns {void} - No return value.
+   */
+  static setEagerLoadRecordMetadata(eagerLoadRecordMetadata) {
+    this._eagerLoadRecordMetadata = eagerLoadRecordMetadata
+  }
+
+  /** @returns {boolean} - Whether require-context initialization should load table metadata for this model. */
+  static getEagerLoadRecordMetadata() {
+    if (this._eagerLoadRecordMetadata === undefined) return true
+
+    return this._eagerLoadRecordMetadata
+  }
+
+  /**
+   * Registers the model class with a configuration without loading table metadata.
+   * @param {object} args - Options object.
+   * @param {import("../../configuration.js").default} args.configuration - Configuration instance.
+   * @returns {void} - No return value.
+   */
+  static registerRecordClass({configuration, ...restArgs}) {
+    restArgsError(restArgs)
+
+    if (!configuration) throw new Error(`No configuration given for ${this.name}`)
+
+    this._configuration = configuration
+    this._configuration.registerModelClass(this)
+  }
+
+  /**
    * @param {object} args - Options object.
    * @param {import("../../configuration.js").default} args.configuration - Configuration instance.
    * @returns {Promise<void>} - Resolves when complete.
@@ -995,8 +1028,7 @@ class VelociousDatabaseRecord {
 
     if (!configuration) throw new Error(`No configuration given for ${this.name}`)
 
-    this._configuration = configuration
-    this._configuration.registerModelClass(this)
+    this.registerRecordClass({configuration})
     const connection = this.connection({enforceTenantDatabaseScope: false})
 
     this._databaseType = connection.getType()


### PR DESCRIPTION
## Summary
- add per-model eager metadata loading control to DatabaseRecord
- register opted-out models during require-context initialization without loading table columns
- cover default eager behavior and lazy first-use initialization

## Tests
- ./run-tests.sh spec/database/initializer-from-require-context-spec.js
- ./run-tests.sh spec/database/record/lazy-initialization.browser-spec.js
- npm run typecheck
- npm run lint -- src/database/record/index.js src/database/initializer-from-require-context.js spec/database/initializer-from-require-context-spec.js