### PR TITLE
Add mountable background-jobs dashboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,6 +1926,24 @@ await MyJob.performLaterWithOptions({
 
 If a handed-off job does not report back within 2 hours, it is marked orphaned and re-queued if retries remain.
 
+## Dashboard
+
+Velocious ships a mountable read-only HTTP API for inspecting jobs (queued, running, completed, failed, orphaned and scheduled), similar in spirit to `sidekiq-web`. Mount it in your routes file the way `Sidekiq::Web` is mounted in Rails:
+
+```js
+import VelociousBackgroundJobsApi from "velocious/build/src/background-jobs/web/index.js"
+
+routes.draw((route) => {
+  route.mount(VelociousBackgroundJobsApi, {
+    at: "/velocious/jobs",
+    authorize: async ({request, ability}) => Boolean(ability?.can("manage", "BackgroundJobs")),
+    accessTokens: [process.env.VELOCIOUS_JOBS_TOKEN]
+  })
+})
+```
+
+It exposes `GET /api/stats`, `/api/jobs`, `/api/jobs/:id`, `/api/schedule` and `/api/health` under the mount path, gated by a bearer token and/or an `authorize` callback (loopback-only when neither is configured). The dashboard UI is a separate Expo app. See [docs/background-jobs-dashboard.md](docs/background-jobs-dashboard.md).
+
 # Running a server
 
 ```bash

--- a/changelog.d/20260522-background-jobs-dashboard-api.md
+++ b/changelog.d/20260522-background-jobs-dashboard-api.md
@@ -1,0 +1,7 @@
+Added a mountable read-only HTTP API for a background-jobs dashboard (sidekiq-web style).
+
+- `route.mount(VelociousBackgroundJobsApi, {at: "/velocious/jobs", ...})` mounts a read-only jobs API in the routes file, the way `Sidekiq::Web` is mounted in Rails
+- exposes `GET /api/stats`, `/api/jobs` (filter by `status`/`jobName`, paginated, sortable), `/api/jobs/:id`, `/api/schedule` and `/api/health`
+- access is gated by a bearer token (`accessTokens`) and/or an `authorize({request, ability, token})` callback, falling back to loopback-only when neither is configured
+- adds a generic `route.mount(mountable, {at})` helper to the routes DSL backed by route-resolver hooks
+- the dashboard UI ships separately as its own Expo app/package; management actions (retry/delete/kill/enqueue) are planned (see docs/background-jobs-dashboard.md)

--- a/docs/background-jobs-dashboard.md
+++ b/docs/background-jobs-dashboard.md
@@ -1,0 +1,146 @@
+# Background jobs dashboard
+
+A dashboard for inspecting Velocious [background jobs](../README.md#background-jobs) —
+what's queued, running, completed, failed, orphaned and scheduled — similar in
+spirit to `sidekiq-web`.
+
+The feature is split in two:
+
+| Piece | Where it lives | What it is |
+| --- | --- | --- |
+| **Jobs API** | `velocious` core (this repo) | A mountable read-only REST/JSON API you add to your routes file the way `Sidekiq::Web` is mounted in Rails. |
+| **Dashboard UI** | Its own repo + npm package (`velocious-jobs`, an Expo app) | A multi-connection UI for iOS / Android / web. Talks only to the Jobs API, so it can point at any backend that has mounted it. |
+
+This document covers the **Jobs API** that ships in core, plus the overall
+design so the UI app can be built against a stable contract.
+
+## Mounting the API
+
+Mount it in your routes file, like Sidekiq::Web:
+
+```js
+import Routes from "velocious/build/src/routes/index.js"
+import VelociousBackgroundJobsApi from "velocious/build/src/background-jobs/web/index.js"
+
+const routes = new Routes()
+
+routes.draw((route) => {
+  route.mount(VelociousBackgroundJobsApi, {
+    at: "/velocious/jobs",
+    authorize: async ({request, ability}) => {
+      // Reuse your app's session/ability for the embedded/same-origin dashboard.
+      return Boolean(ability?.can("manage", "BackgroundJobs"))
+    },
+    accessTokens: [process.env.VELOCIOUS_JOBS_TOKEN], // for the standalone app (cross-origin/native)
+    allowedOrigins: ["https://jobs.example.com"],     // CORS allow-list for the browser UI
+    redactArgs: false                                 // omit job args from responses when true
+  })
+})
+
+export default {routes}
+```
+
+`route.mount(mountable, {at, ...})` records the mount; the configuration applies
+it when the routes are set, registering a route-resolver hook so the controller
+can ship inside the `velocious` package (the same mechanism the `sql.js` asset
+route uses).
+
+## Endpoints
+
+All paths are relative to the mount prefix (`at`). Responses are JSON.
+
+| Method & path | Purpose |
+| --- | --- |
+| `GET /api/health` | Connection check. Returns `{ok: true}`. The UI uses this to validate a connection. |
+| `GET /api/stats` | Counts per status (`queued`, `handed_off`, `completed`, `failed`, `orphaned`) and `total`. |
+| `GET /api/jobs` | Paginated job list. Query: `status`, `jobName`, `page`, `perPage` (max 100), `sort`. |
+| `GET /api/jobs/:id` | A single job with args, error, attempts and timestamps. `404` when missing. |
+| `GET /api/schedule` | The configured recurring/`scheduledBackgroundJobs` entries. |
+
+`sort` accepts a sortable key, optionally prefixed with `-` for descending:
+`createdAtMs` (default, descending), `scheduledAtMs`, `completedAtMs`,
+`failedAtMs`, `handedOffAtMs`, `attempts`. Unknown keys fall back to
+`createdAtMs`.
+
+Example list response:
+
+```json
+{
+  "jobs": [
+    {
+      "id": "…",
+      "jobName": "FailingJob",
+      "status": "failed",
+      "attempts": 1,
+      "maxRetries": 0,
+      "forked": false,
+      "args": ["b"],
+      "argsRedacted": false,
+      "workerId": "worker-1",
+      "lastError": "Error: boom\n  at …",
+      "scheduledAtMs": 1700000000000,
+      "createdAtMs": 1700000000000,
+      "handedOffAtMs": null,
+      "completedAtMs": null,
+      "failedAtMs": 1700000000123,
+      "orphanedAtMs": null
+    }
+  ],
+  "pagination": {"page": 1, "perPage": 25, "total": 1, "totalPages": 1}
+}
+```
+
+Velocious jobs don't have Sidekiq-style named queues; they have a `job_name`
+(the job class) and a `status`. The dashboard groups and filters by those.
+
+## Authorization
+
+Every request is authorized before any job data is read, in this order:
+
+1. **Bearer token** — if `accessTokens` is set and the request carries a matching
+   `Authorization: Bearer <token>` (constant-time compared), it's allowed. Use
+   this for the standalone app, which connects cross-origin/native and can't rely
+   on cookie sessions.
+2. **`authorize` callback** — called with `{request, ability, token, configuration}`.
+   Return `true` to allow. Use this for the embedded/same-origin dashboard to
+   reuse your app's session and ability.
+3. **Loopback fallback** — if neither `accessTokens` nor `authorize` is configured,
+   access is allowed only from loopback addresses (`127.0.0.1`, `::1`). This keeps
+   a freshly mounted dashboard reachable on the same host during development
+   without silently exposing jobs to the network. **Configure auth before
+   exposing the API.**
+
+### CORS
+
+When `allowedOrigins` is set and the request `Origin` matches (or the list
+contains `"*"`), the API adds `Access-Control-Allow-Origin`/`-Headers`/`-Methods`
+to responses so a browser dashboard can read it cross-origin. Cross-origin
+browser requests that carry an `Authorization` header trigger a preflight
+`OPTIONS`; that is handled by Velocious's standard `cors` configuration, so
+configure `cors` on the host app for cross-origin browser access. Native apps
+and same-origin/embedded use don't need this.
+
+## The UI app (separate repo)
+
+The dashboard UI is a separate Expo app + npm package + GitHub repo
+(`velocious-jobs`), modeled on the existing Velocious-backed Expo apps. It:
+
+- runs on iOS, Android and web from one codebase;
+- lets you register multiple "connections" (name + base URL + token) and switch
+  between backends — the multi-app overview;
+- can also be served by a host backend through the mount (`serveUi`, planned) so
+  the same UI works embedded (single same-origin app) or standalone;
+- talks only to the Jobs API above, polling `GET /api/stats` and the active list
+  on an interval.
+
+## Roadmap
+
+This is delivered in phases against the stable API contract above.
+
+- **Phase 1 (done):** mountable read-only API — `health`, `stats`, `jobs`,
+  `jobs/:id`, `schedule`; authorize-hook + token auth; CORS headers.
+- **Phase 2:** management actions — `retry` (re-queue failed/orphaned), `delete`,
+  `kill` (stop a handed-off job) and manual enqueue, routed through the
+  background-jobs main process to avoid racing the dispatcher.
+- **Phase 3+:** the standalone Expo UI app (connections, overview, list, detail),
+  serving the prebuilt web bundle via the mount, and EAS native builds.

--- a/spec/background-jobs/web/api-spec.js
+++ b/spec/background-jobs/web/api-spec.js
@@ -1,0 +1,211 @@
+// @ts-check
+
+import BackgroundJobsStore from "../../../src/background-jobs/store.js"
+import Configuration from "../../../src/configuration.js"
+import Dummy from "../../dummy/index.js"
+import dummyConfiguration from "../../dummy/src/config/configuration.js"
+import dummyDirectory from "../../dummy/dummy-directory.js"
+import EnvironmentHandlerNode from "../../../src/environment-handlers/node.js"
+import fetch from "node-fetch"
+import Request from "../../../src/http-server/client/request.js"
+import Response from "../../../src/http-server/client/response.js"
+import RoutesResolver from "../../../src/routes/resolver.js"
+import VelociousBackgroundJobsApi from "../../../src/background-jobs/web/index.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+
+const API_BASE = "http://localhost:3006/velocious/jobs/api"
+const TOKEN = "test-jobs-token"
+
+/**
+ * Seeds a known set of jobs (2 queued + 1 failed) for assertions.
+ * @returns {Promise<{failedId: string}>} - Seeded ids.
+ */
+async function seedJobs() {
+  dummyConfiguration.setCurrent()
+
+  const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+  await store.clearAll()
+  await store.enqueue({jobName: "TestJob", args: ["alpha"], options: {forked: false}})
+  await store.enqueue({jobName: "TestJob", args: ["beta"], options: {forked: false}})
+
+  const failedId = await store.enqueue({jobName: "FailingJob", args: ["b"], options: {forked: false, maxRetries: 0}})
+  const handedOffAtMs = await store.markHandedOff({jobId: failedId, workerId: "worker-1"})
+
+  await store.markFailed({error: "boom", handedOffAtMs, jobId: failedId, workerId: "worker-1"})
+
+  return {failedId}
+}
+
+/**
+ * @param {object} args - Options.
+ * @param {string} args.at - Mount prefix.
+ * @returns {Configuration} - A throwaway configuration for resolver-level tests.
+ */
+function buildResolverConfiguration({at}) {
+  const configuration = new Configuration({
+    database: {test: {}},
+    directory: dummyDirectory(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    logging: {console: true, file: false, levels: ["info", "warn", "error"]}
+  })
+
+  VelociousBackgroundJobsApi.mountInto({at, configuration})
+
+  return configuration
+}
+
+/**
+ * Resolves a single GET request through the routes resolver and returns the response.
+ * @param {object} args - Options.
+ * @param {Configuration} args.configuration - Configuration.
+ * @param {string} args.path - Request path.
+ * @param {string} args.remoteAddress - Client remote address.
+ * @returns {Promise<Response>} - The populated response.
+ */
+async function resolveGet({configuration, path, remoteAddress}) {
+  const client = {remoteAddress}
+  const request = new Request({client, configuration})
+  const response = new Response({configuration})
+  const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+  const requestLines = [`GET ${path} HTTP/1.1`, "Host: example.com", "", ""].join("\r\n")
+
+  let previousConfiguration
+
+  try {
+    previousConfiguration = Configuration.current()
+  } catch {
+    // No current configuration yet.
+  }
+
+  configuration.setCurrent()
+
+  try {
+    request.feed(Buffer.from(requestLines, "utf8"))
+    await donePromise
+
+    const resolver = new RoutesResolver({configuration, request, response})
+
+    await resolver.resolve()
+  } finally {
+    if (previousConfiguration) previousConfiguration.setCurrent()
+  }
+
+  return response
+}
+
+describe("Background jobs - web API", () => {
+  it("requires authentication", async () => {
+    await Dummy.run(async () => {
+      await seedJobs()
+
+      const response = await fetch(`${API_BASE}/stats`)
+
+      expect(response.status).toEqual(401)
+    })
+  })
+
+  it("returns status counts when given a valid token", async () => {
+    await Dummy.run(async () => {
+      await seedJobs()
+
+      const response = await fetch(`${API_BASE}/stats`, {headers: {Authorization: `Bearer ${TOKEN}`}})
+      const body = await response.json()
+
+      expect(response.status).toEqual(200)
+      expect(body.counts.queued).toEqual(2)
+      expect(body.counts.failed).toEqual(1)
+      expect(body.counts.handed_off).toEqual(0)
+      expect(body.total).toEqual(3)
+    })
+  })
+
+  it("authorizes through the host-supplied authorize callback", async () => {
+    await Dummy.run(async () => {
+      await seedJobs()
+
+      const response = await fetch(`${API_BASE}/stats`, {headers: {"x-jobs-allow": "yes"}})
+
+      expect(response.status).toEqual(200)
+    })
+  })
+
+  it("rejects an invalid token", async () => {
+    await Dummy.run(async () => {
+      await seedJobs()
+
+      const response = await fetch(`${API_BASE}/stats`, {headers: {Authorization: "Bearer wrong-token"}})
+
+      expect(response.status).toEqual(401)
+    })
+  })
+
+  it("lists jobs filtered by status", async () => {
+    await Dummy.run(async () => {
+      await seedJobs()
+
+      const response = await fetch(`${API_BASE}/jobs?status=failed`, {headers: {Authorization: `Bearer ${TOKEN}`}})
+      const body = await response.json()
+
+      expect(response.status).toEqual(200)
+      expect(body.jobs.length).toEqual(1)
+      expect(body.jobs[0].jobName).toEqual("FailingJob")
+      expect(body.jobs[0].status).toEqual("failed")
+      expect(body.pagination.total).toEqual(1)
+    })
+  })
+
+  it("returns a single job with its error detail", async () => {
+    await Dummy.run(async () => {
+      const {failedId} = await seedJobs()
+
+      const response = await fetch(`${API_BASE}/jobs/${failedId}`, {headers: {Authorization: `Bearer ${TOKEN}`}})
+      const body = await response.json()
+
+      expect(response.status).toEqual(200)
+      expect(body.job.id).toEqual(failedId)
+      expect(body.job.status).toEqual("failed")
+      expect(body.job.attempts).toEqual(1)
+      expect(body.job.args).toEqual(["b"])
+      expect(body.job.lastError.includes("boom")).toEqual(true)
+    })
+  })
+
+  it("returns 404 for a missing job", async () => {
+    await Dummy.run(async () => {
+      await seedJobs()
+
+      const response = await fetch(`${API_BASE}/jobs/does-not-exist`, {headers: {Authorization: `Bearer ${TOKEN}`}})
+
+      expect(response.status).toEqual(404)
+    })
+  })
+
+  it("exposes a health check", async () => {
+    await Dummy.run(async () => {
+      const response = await fetch(`${API_BASE}/health`, {headers: {Authorization: `Bearer ${TOKEN}`}})
+      const body = await response.json()
+
+      expect(response.status).toEqual(200)
+      expect(body.ok).toEqual(true)
+    })
+  })
+
+  it("falls back to loopback-only access when no auth is configured", async () => {
+    const configuration = buildResolverConfiguration({at: "/velocious/jobs-open"})
+
+    const loopbackResponse = await resolveGet({configuration, path: "/velocious/jobs-open/api/health", remoteAddress: "127.0.0.1"})
+
+    expect(loopbackResponse.getStatusCode()).toEqual(200)
+    expect(JSON.parse(loopbackResponse.getBody()).ok).toEqual(true)
+
+    const remoteResponse = await resolveGet({configuration, path: "/velocious/jobs-open/api/health", remoteAddress: "203.0.113.5"})
+
+    expect(remoteResponse.getStatusCode()).toEqual(401)
+  })
+})

--- a/spec/background-jobs/web/path-matcher-spec.js
+++ b/spec/background-jobs/web/path-matcher-spec.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+import {matchJobsApiPath, normalizeMountPrefix} from "../../../src/background-jobs/web/path-matcher.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+
+describe("Background jobs - web path matcher", () => {
+  it("matches API paths under a normal mount prefix", () => {
+    expect(matchJobsApiPath({method: "GET", path: "/velocious/jobs/api/stats", prefix: "/velocious/jobs"})).toEqual({action: "stats", params: {}})
+    expect(matchJobsApiPath({method: "GET", path: "/velocious/jobs/api/jobs/abc-123", prefix: "/velocious/jobs"})).toEqual({action: "show", params: {id: "abc-123"}})
+  })
+
+  it("matches API paths under a root mount", () => {
+    const prefix = normalizeMountPrefix("/")
+
+    expect(prefix).toEqual("/")
+    expect(matchJobsApiPath({method: "GET", path: "/api/health", prefix})).toEqual({action: "health", params: {}})
+    expect(matchJobsApiPath({method: "GET", path: "/api/jobs", prefix})).toEqual({action: "index", params: {}})
+  })
+
+  it("ignores paths outside the mount and the bare mount root", () => {
+    expect(matchJobsApiPath({method: "GET", path: "/something-else/api/stats", prefix: "/velocious/jobs"})).toEqual(null)
+    expect(matchJobsApiPath({method: "GET", path: "/velocious/jobs", prefix: "/velocious/jobs"})).toEqual(null)
+    expect(matchJobsApiPath({method: "POST", path: "/velocious/jobs/api/stats", prefix: "/velocious/jobs"})).toEqual(null)
+  })
+})

--- a/spec/dummy/src/config/routes.js
+++ b/spec/dummy/src/config/routes.js
@@ -1,8 +1,15 @@
 import Routes from "../../../../src/routes/index.js"
+import VelociousBackgroundJobsApi from "../../../../src/background-jobs/web/index.js"
 
 const routes = new Routes()
 
 routes.draw((route) => {
+  route.mount(VelociousBackgroundJobsApi, {
+    accessTokens: ["test-jobs-token"],
+    at: "/velocious/jobs",
+    authorize: async ({request}) => request.header("x-jobs-allow") === "yes"
+  })
+
   route.namespace("api", (route) => {
     route.post("broadcast-event")
     route.post("metadata")

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -12,6 +12,21 @@ const JOBS_TABLE = "background_jobs"
 const DEFAULT_MAX_RETRIES = 10
 const ORPHANED_AFTER_MS = 2 * 60 * 60 * 1000
 
+/**
+ * Columns the dashboard is allowed to sort job listings by, mapped to their
+ * database column names. Restricting to this set keeps the sort parameter
+ * (which originates from untrusted query strings) from reaching raw SQL.
+ * @type {Record<string, string>}
+ */
+const SORTABLE_COLUMNS = {
+  attempts: "attempts",
+  completedAtMs: "completed_at_ms",
+  createdAtMs: "created_at_ms",
+  failedAtMs: "failed_at_ms",
+  handedOffAtMs: "handed_off_at_ms",
+  scheduledAtMs: "scheduled_at_ms"
+}
+
 export default class BackgroundJobsStore {
   /**
    * @param {object} args - Options.
@@ -166,6 +181,92 @@ export default class BackgroundJobsStore {
       if (!row) return null
 
       return this._normalizeJobRow(row)
+    })
+  }
+
+  /**
+   * Counts jobs grouped by status. Used by the dashboard overview.
+   * @returns {Promise<Record<string, number>>} - Counts keyed by status.
+   */
+  async countsByStatus() {
+    await this.ensureReady()
+
+    return await this._withDb(async (db) => {
+      const rows = await db
+        .newQuery()
+        .from(JOBS_TABLE)
+        .select("status")
+        .select("COUNT(*) AS count")
+        .group("status")
+        .results()
+
+      /** @type {Record<string, number>} */
+      const counts = {}
+
+      for (const row of rows) {
+        const typedRow = /** @type {Record<string, any>} */ (row)
+
+        counts[String(typedRow.status)] = this._normalizeNumber(typedRow.count) || 0
+      }
+
+      return counts
+    })
+  }
+
+  /**
+   * Counts jobs matching the given filters.
+   * @param {object} [args] - Options.
+   * @param {string} [args.status] - Filter by status.
+   * @param {string} [args.jobName] - Filter by job name.
+   * @returns {Promise<number>} - Matching job count.
+   */
+  async countJobs({status, jobName} = {}) {
+    await this.ensureReady()
+
+    return await this._withDb(async (db) => {
+      let query = db.newQuery().from(JOBS_TABLE).select("COUNT(*) AS count")
+
+      if (status) query = query.where({status})
+      if (jobName) query = query.where({job_name: jobName})
+
+      const rows = await query.results()
+      const countRow = /** @type {Record<string, any>} */ (rows[0] || {})
+
+      return this._normalizeNumber(countRow.count) || 0
+    })
+  }
+
+  /**
+   * Lists jobs for the dashboard, filtered, sorted and paginated.
+   * @param {object} [args] - Options.
+   * @param {string} [args.status] - Filter by status.
+   * @param {string} [args.jobName] - Filter by job name.
+   * @param {number} [args.limit] - Maximum rows to return.
+   * @param {number} [args.offset] - Rows to skip.
+   * @param {string} [args.sortColumn] - Camel-cased column to sort by (see SORTABLE_COLUMNS).
+   * @param {"ASC" | "DESC"} [args.sortDirection] - Sort direction.
+   * @returns {Promise<import("./types.js").BackgroundJobRow[]>} - Normalized job rows.
+   */
+  async listJobs({status, jobName, limit = 25, offset = 0, sortColumn = "createdAtMs", sortDirection = "DESC"} = {}) {
+    await this.ensureReady()
+
+    const column = SORTABLE_COLUMNS[sortColumn] || SORTABLE_COLUMNS.createdAtMs
+    const direction = sortDirection === "ASC" ? "ASC" : "DESC"
+
+    return await this._withDb(async (db) => {
+      let query = db.newQuery().from(JOBS_TABLE)
+
+      if (status) query = query.where({status})
+      if (jobName) query = query.where({job_name: jobName})
+
+      const rows = await query
+        .order(`${column} ${direction}`)
+        .order("created_at_ms DESC")
+        .limit(limit)
+        .offset(offset)
+        .results()
+
+      return rows.map((row) => this._normalizeJobRow(row))
     })
   }
 

--- a/src/background-jobs/web/authorization.js
+++ b/src/background-jobs/web/authorization.js
@@ -1,0 +1,87 @@
+// @ts-check
+
+import crypto from "node:crypto"
+
+/**
+ * Constant-time comparison so token checks don't leak length/contents through
+ * timing. Returns false for differing lengths before the timing-safe compare.
+ * @param {string} a - First value.
+ * @param {string} b - Second value.
+ * @returns {boolean} - Whether the values are equal.
+ */
+function safeEqual(a, b) {
+  const bufferA = Buffer.from(String(a))
+  const bufferB = Buffer.from(String(b))
+
+  if (bufferA.length !== bufferB.length) return false
+
+  return crypto.timingSafeEqual(bufferA, bufferB)
+}
+
+/**
+ * @param {import("../../http-server/client/request.js").default} request - Request object.
+ * @returns {string | null} - Bearer token from the Authorization header, if any.
+ */
+function bearerToken(request) {
+  const header = request.header("authorization")
+
+  if (typeof header !== "string") return null
+
+  const match = header.match(/^Bearer\s+(.+)$/i)
+
+  return match ? match[1].trim() : null
+}
+
+/**
+ * @param {string | undefined} remoteAddress - Remote address.
+ * @returns {boolean} - Whether the address is loopback.
+ */
+function isLoopback(remoteAddress) {
+  if (!remoteAddress) return false
+
+  return (
+    remoteAddress === "127.0.0.1" ||
+    remoteAddress === "::1" ||
+    remoteAddress === "::ffff:127.0.0.1" ||
+    remoteAddress.startsWith("127.")
+  )
+}
+
+/**
+ * Decides whether a jobs-dashboard request is authorized. Order of precedence:
+ * a matching bearer token, then the host-supplied `authorize` callback. When
+ * neither tokens nor an authorize callback are configured, access falls back to
+ * loopback-only so a freshly mounted dashboard is reachable on the same host
+ * during development without being exposed to the network.
+ * @param {object} args - Options.
+ * @param {import("./registry.js").JobsMountOptions} args.options - Mount options.
+ * @param {import("../../http-server/client/request.js").default} args.request - Request object.
+ * @param {import("../../configuration.js").default} args.configuration - Configuration instance.
+ * @param {import("../../authorization/ability.js").default | undefined} args.ability - Current ability.
+ * @returns {Promise<boolean>} - Whether the request is authorized.
+ */
+export async function authorizeJobsRequest({ability, configuration, options, request}) {
+  const accessTokens = Array.isArray(options.accessTokens)
+    ? options.accessTokens.filter((token) => typeof token === "string" && token.length > 0)
+    : []
+  const authorize = typeof options.authorize === "function" ? options.authorize : null
+  const token = bearerToken(request)
+
+  if (accessTokens.length > 0 && token) {
+    for (const accessToken of accessTokens) {
+      if (safeEqual(token, accessToken)) return true
+    }
+  }
+
+  if (authorize) {
+    const result = await authorize({ability, configuration, request, token})
+
+    if (result === true) return true
+  }
+
+  if (accessTokens.length === 0 && !authorize) {
+    return isLoopback(request.remoteAddress())
+  }
+
+  return false
+}

--- a/src/background-jobs/web/controller.js
+++ b/src/background-jobs/web/controller.js
@@ -1,0 +1,249 @@
+// @ts-check
+
+import Controller from "../../controller.js"
+import BackgroundJobsStore from "../store.js"
+import {authorizeJobsRequest} from "./authorization.js"
+import {getJobsMount} from "./registry.js"
+
+const DASHBOARD_STATUSES = ["queued", "handed_off", "completed", "failed", "orphaned"]
+const SORTABLE_KEYS = ["attempts", "completedAtMs", "createdAtMs", "failedAtMs", "handedOffAtMs", "scheduledAtMs"]
+const DEFAULT_PER_PAGE = 25
+const MAX_PER_PAGE = 100
+
+/**
+ * Read-only HTTP API backing the background-jobs dashboard. Mounted by
+ * {@link import("./index.js").default} as a route-resolver hook so it can ship
+ * inside the velocious package. Every action is gated by {@link authorizeJobsRequest}.
+ */
+export default class VelociousBackgroundJobsWebController extends Controller {
+  /** @returns {import("./registry.js").JobsMountOptions} - Options for the mount that matched this request. */
+  _mountOptions() {
+    const at = this.params().velociousJobsMountAt
+
+    return getJobsMount(this.getConfiguration(), at) || {}
+  }
+
+  /** @returns {BackgroundJobsStore} - Jobs store scoped to the mount's database. */
+  _store() {
+    if (!this._jobsStore) {
+      this._jobsStore = new BackgroundJobsStore({
+        configuration: this.getConfiguration(),
+        databaseIdentifier: this._mountOptions().databaseIdentifier
+      })
+    }
+
+    return this._jobsStore
+  }
+
+  /**
+   * Adds CORS headers when the request origin is allowed, so the standalone
+   * browser dashboard can read the API cross-origin.
+   * @param {import("./registry.js").JobsMountOptions} options - Mount options.
+   * @returns {void} - No return value.
+   */
+  _applyCorsHeaders(options) {
+    const allowedOrigins = Array.isArray(options.allowedOrigins) ? options.allowedOrigins : []
+
+    if (allowedOrigins.length === 0) return
+
+    const origin = this.request().origin()
+    const allowAll = allowedOrigins.includes("*")
+
+    if (!origin) return
+    if (!allowAll && !allowedOrigins.includes(origin)) return
+
+    const response = this.response()
+
+    response.setHeader("Access-Control-Allow-Origin", allowAll ? "*" : origin)
+    response.setHeader("Vary", "Origin")
+    response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
+    response.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+  }
+
+  /**
+   * Applies CORS headers, authorizes the request, and runs the action body only
+   * when authorized. Renders a 401 otherwise. The base controller has no
+   * before-action halting, so authorization is enforced here per action.
+   * @param {() => Promise<void>} actionFn - Action body.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _respond(actionFn) {
+    const options = this._mountOptions()
+
+    this._applyCorsHeaders(options)
+
+    const authorized = await authorizeJobsRequest({
+      ability: this.currentAbility(),
+      configuration: this.getConfiguration(),
+      options,
+      request: this.request()
+    })
+
+    if (!authorized) {
+      await this.render({json: {error: "unauthorized"}, status: 401})
+      return
+    }
+
+    await actionFn()
+  }
+
+  /** @returns {Promise<void>} - Resolves when complete. */
+  async health() {
+    await this._respond(async () => {
+      await this.render({json: {ok: true, service: "velocious-background-jobs"}})
+    })
+  }
+
+  /** @returns {Promise<void>} - Resolves when complete. */
+  async stats() {
+    await this._respond(async () => {
+      const counts = await this._store().countsByStatus()
+      /** @type {Record<string, number>} */
+      const byStatus = {}
+      let total = 0
+
+      for (const status of DASHBOARD_STATUSES) {
+        byStatus[status] = counts[status] || 0
+      }
+
+      for (const value of Object.values(counts)) {
+        total += value
+      }
+
+      await this.render({json: {counts: byStatus, generatedAtMs: Date.now(), total}})
+    })
+  }
+
+  /** @returns {Promise<void>} - Resolves when complete. */
+  async index() {
+    await this._respond(async () => {
+      const params = this.params()
+      const status = this._sanitizeStatus(params.status)
+      const jobName = typeof params.jobName === "string" && params.jobName.length > 0 ? params.jobName : undefined
+      const page = this._positiveInt(params.page, 1)
+      const perPage = Math.min(this._positiveInt(params.perPage, DEFAULT_PER_PAGE), MAX_PER_PAGE)
+      const {sortColumn, sortDirection} = this._sanitizeSort(params.sort)
+      const store = this._store()
+      const jobs = await store.listJobs({jobName, limit: perPage, offset: (page - 1) * perPage, sortColumn, sortDirection, status})
+      const total = await store.countJobs({jobName, status})
+
+      await this.render({json: {
+        jobs: jobs.map((job) => this._serializeJob(job)),
+        pagination: {page, perPage, total, totalPages: perPage > 0 ? Math.ceil(total / perPage) : 0}
+      }})
+    })
+  }
+
+  /** @returns {Promise<void>} - Resolves when complete. */
+  async show() {
+    await this._respond(async () => {
+      const job = await this._store().getJob(this.params().id)
+
+      if (!job) {
+        await this.render({json: {error: "not_found"}, status: 404})
+        return
+      }
+
+      await this.render({json: {job: this._serializeJob(job)}})
+    })
+  }
+
+  /** @returns {Promise<void>} - Resolves when complete. */
+  async schedule() {
+    await this._respond(async () => {
+      const scheduled = await this.getConfiguration().getScheduledBackgroundJobsConfig()
+
+      await this.render({json: {schedule: this._serializeSchedule(scheduled)}})
+    })
+  }
+
+  /**
+   * @param {import("../types.js").BackgroundJobRow} job - Job row.
+   * @returns {Record<string, any>} - Serialized job for the API.
+   */
+  _serializeJob(job) {
+    const redactArgs = Boolean(this._mountOptions().redactArgs)
+
+    return {
+      args: redactArgs ? undefined : job.args,
+      argsRedacted: redactArgs,
+      attempts: job.attempts,
+      completedAtMs: job.completedAtMs,
+      createdAtMs: job.createdAtMs,
+      failedAtMs: job.failedAtMs,
+      forked: job.forked,
+      handedOffAtMs: job.handedOffAtMs,
+      id: job.id,
+      jobName: job.jobName,
+      lastError: job.lastError,
+      maxRetries: job.maxRetries,
+      orphanedAtMs: job.orphanedAtMs,
+      scheduledAtMs: job.scheduledAtMs,
+      status: job.status,
+      workerId: job.workerId
+    }
+  }
+
+  /**
+   * @param {import("../../configuration-types.js").ScheduledBackgroundJobsConfiguration | undefined} scheduled - Scheduled jobs config.
+   * @returns {Array<Record<string, any>>} - Serialized recurring jobs.
+   */
+  _serializeSchedule(scheduled) {
+    const jobs = scheduled?.jobs
+
+    if (!jobs || typeof jobs !== "object") return []
+
+    const redactArgs = Boolean(this._mountOptions().redactArgs)
+
+    return Object.keys(jobs).map((name) => {
+      const entry = jobs[name] || /** @type {any} */ ({})
+
+      return {
+        args: redactArgs ? undefined : (entry.args || []),
+        cron: entry.cron,
+        enabled: entry.enabled !== false,
+        every: entry.every,
+        jobName: typeof entry.class === "function" ? entry.class.name : undefined,
+        name,
+        options: entry.options || {}
+      }
+    })
+  }
+
+  /**
+   * @param {unknown} value - Raw status param.
+   * @returns {string | undefined} - Valid status or undefined.
+   */
+  _sanitizeStatus(value) {
+    return typeof value === "string" && DASHBOARD_STATUSES.includes(value) ? value : undefined
+  }
+
+  /**
+   * @param {unknown} value - Raw sort param (e.g. "createdAtMs" or "-failedAtMs").
+   * @returns {{sortColumn: string, sortDirection: "ASC" | "DESC"}} - Normalized sort.
+   */
+  _sanitizeSort(value) {
+    if (typeof value !== "string" || value.length === 0) {
+      return {sortColumn: "createdAtMs", sortDirection: "DESC"}
+    }
+
+    const descending = value.startsWith("-")
+    const key = descending ? value.slice(1) : value
+    const sortColumn = SORTABLE_KEYS.includes(key) ? key : "createdAtMs"
+
+    return {sortColumn, sortDirection: descending ? "DESC" : "ASC"}
+  }
+
+  /**
+   * @param {unknown} value - Raw numeric param.
+   * @param {number} fallback - Fallback when invalid.
+   * @returns {number} - Positive integer.
+   */
+  _positiveInt(value, fallback) {
+    const numeric = Number(Array.isArray(value) ? value[0] : value)
+
+    if (!Number.isFinite(numeric) || numeric < 1) return fallback
+
+    return Math.floor(numeric)
+  }
+}

--- a/src/background-jobs/web/index.js
+++ b/src/background-jobs/web/index.js
@@ -1,0 +1,57 @@
+// @ts-check
+
+import VelociousBackgroundJobsWebController from "./controller.js"
+import {matchJobsApiPath, normalizeMountPrefix} from "./path-matcher.js"
+import {registerJobsMount} from "./registry.js"
+
+/**
+ * Mountable read-only background-jobs dashboard API. Include it in a routes file
+ * the way Sidekiq::Web is mounted in Rails:
+ *
+ * ```js
+ * routes.draw((route) => {
+ *   route.mount(VelociousBackgroundJobsApi, {
+ *     at: "/velocious/jobs",
+ *     authorize: async ({request, ability}) => { ... },
+ *     accessTokens: [process.env.VELOCIOUS_JOBS_TOKEN]
+ *   })
+ * })
+ * ```
+ */
+export default class VelociousBackgroundJobsApi {
+  /**
+   * Registers the jobs API under `at`. Implemented as a route-resolver hook so
+   * the controller can live inside the velocious package rather than the host
+   * app's `src/routes` directory. Invoked by the routing layer for each
+   * `route.mount(...)` registration.
+   * @param {object} args - Options.
+   * @param {import("../../configuration.js").default} args.configuration - Configuration instance.
+   * @param {string} args.at - Mount path prefix (e.g. "/velocious/jobs").
+   * @param {import("./registry.js").JobsMountOptions["authorize"]} [args.authorize] - Authorization callback.
+   * @param {string[]} [args.accessTokens] - Accepted bearer tokens for cross-origin/native access.
+   * @param {string[]} [args.allowedOrigins] - Allowed CORS origins for browser access.
+   * @param {boolean} [args.redactArgs] - When true, job arguments are omitted from responses.
+   * @param {string} [args.databaseIdentifier] - Database identifier the jobs store reads from.
+   * @returns {void} - No return value.
+   */
+  static mountInto({accessTokens, allowedOrigins, at, authorize, configuration, databaseIdentifier, redactArgs}) {
+    if (!configuration) throw new Error("No configuration given")
+
+    const prefix = normalizeMountPrefix(at)
+
+    registerJobsMount(configuration, prefix, {accessTokens, allowedOrigins, authorize, databaseIdentifier, redactArgs})
+
+    configuration.addRouteResolverHook(({currentPath, request}) => {
+      const match = matchJobsApiPath({method: request.httpMethod(), path: currentPath, prefix})
+
+      if (!match) return null
+
+      return {
+        action: match.action,
+        controller: "velociousBackgroundJobsWeb",
+        controllerClass: VelociousBackgroundJobsWebController,
+        params: {...match.params, velociousJobsMountAt: prefix}
+      }
+    })
+  }
+}

--- a/src/background-jobs/web/path-matcher.js
+++ b/src/background-jobs/web/path-matcher.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+/**
+ * @typedef {object} JobsApiMatch
+ * @property {string} action - Controller action to run.
+ * @property {Record<string, string>} params - Extra params extracted from the path.
+ */
+
+/**
+ * Normalizes a mount prefix: ensures a leading slash and strips any trailing
+ * slash so `/velocious/jobs/` and `/velocious/jobs` behave identically.
+ * @param {string} at - Raw mount prefix.
+ * @returns {string} - Normalized prefix.
+ */
+export function normalizeMountPrefix(at) {
+  if (typeof at !== "string" || !at.startsWith("/")) {
+    throw new Error(`mount requires an 'at' path starting with '/', got: ${String(at)}`)
+  }
+
+  if (at.length > 1 && at.endsWith("/")) {
+    return at.slice(0, -1)
+  }
+
+  return at
+}
+
+/**
+ * Matches an incoming request against the read-only jobs API routes that live
+ * under the mount prefix. Returns the controller action plus any extracted
+ * params, or null when the path/method isn't part of the jobs API.
+ * @param {object} args - Options.
+ * @param {string} args.prefix - Normalized mount prefix.
+ * @param {string} args.path - Request path without query string.
+ * @param {string} args.method - HTTP method.
+ * @returns {JobsApiMatch | null} - Matched action or null.
+ */
+export function matchJobsApiPath({prefix, path, method}) {
+  if (path !== prefix && !path.startsWith(`${prefix}/`)) return null
+
+  const subPath = path.slice(prefix.length) || "/"
+
+  if (method === "GET" && subPath === "/api/health") return {action: "health", params: {}}
+  if (method === "GET" && subPath === "/api/stats") return {action: "stats", params: {}}
+  if (method === "GET" && subPath === "/api/schedule") return {action: "schedule", params: {}}
+  if (method === "GET" && subPath === "/api/jobs") return {action: "index", params: {}}
+
+  if (method === "GET") {
+    const jobMatch = subPath.match(/^\/api\/jobs\/([^/]+)$/)
+
+    if (jobMatch) {
+      let id
+
+      try {
+        id = decodeURIComponent(jobMatch[1])
+      } catch {
+        return null
+      }
+
+      return {action: "show", params: {id}}
+    }
+  }
+
+  return null
+}

--- a/src/background-jobs/web/path-matcher.js
+++ b/src/background-jobs/web/path-matcher.js
@@ -35,9 +35,19 @@ export function normalizeMountPrefix(at) {
  * @returns {JobsApiMatch | null} - Matched action or null.
  */
 export function matchJobsApiPath({prefix, path, method}) {
-  if (path !== prefix && !path.startsWith(`${prefix}/`)) return null
+  /** @type {string} */
+  let subPath
 
-  const subPath = path.slice(prefix.length) || "/"
+  if (prefix === "/") {
+    // Root mount: the whole path is the sub-path (avoid building a "//" guard).
+    subPath = path
+  } else if (path === prefix) {
+    subPath = "/"
+  } else if (path.startsWith(`${prefix}/`)) {
+    subPath = path.slice(prefix.length)
+  } else {
+    return null
+  }
 
   if (method === "GET" && subPath === "/api/health") return {action: "health", params: {}}
   if (method === "GET" && subPath === "/api/stats") return {action: "stats", params: {}}

--- a/src/background-jobs/web/registry.js
+++ b/src/background-jobs/web/registry.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+/**
+ * @typedef {object} JobsMountOptions
+ * @property {(args: {request: import("../../http-server/client/request.js").default, ability: (import("../../authorization/ability.js").default | undefined), token: (string | null), configuration: import("../../configuration.js").default}) => (boolean | void | Promise<boolean | void>)} [authorize] - Authorization callback. Return true to allow the request.
+ * @property {string[]} [accessTokens] - Bearer tokens accepted for cross-origin/native access.
+ * @property {string[]} [allowedOrigins] - Origins allowed for cross-origin browser access.
+ * @property {boolean} [redactArgs] - When true, job arguments are omitted from API responses.
+ * @property {string} [databaseIdentifier] - Database identifier the jobs store reads from.
+ */
+
+/**
+ * Mount options are keyed by configuration so multiple configurations (e.g.
+ * across tests) never share state, and by mount path so a single configuration
+ * can mount the dashboard at more than one prefix. Functions in the options
+ * (the `authorize` callback) can't travel through route params, so the
+ * controller looks them up here using the plain `at` string it receives.
+ * @type {WeakMap<import("../../configuration.js").default, Map<string, JobsMountOptions>>}
+ */
+const registry = new WeakMap()
+
+/**
+ * @param {import("../../configuration.js").default} configuration - Configuration instance.
+ * @param {string} at - Normalized mount path.
+ * @param {JobsMountOptions} options - Mount options.
+ * @returns {void} - No return value.
+ */
+export function registerJobsMount(configuration, at, options) {
+  let byPath = registry.get(configuration)
+
+  if (!byPath) {
+    byPath = new Map()
+    registry.set(configuration, byPath)
+  }
+
+  byPath.set(at, options)
+}
+
+/**
+ * @param {import("../../configuration.js").default} configuration - Configuration instance.
+ * @param {string} at - Normalized mount path.
+ * @returns {JobsMountOptions | undefined} - Mount options if registered.
+ */
+export function getJobsMount(configuration, at) {
+  return registry.get(configuration)?.get(at)
+}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -144,6 +144,9 @@ export default class VelociousConfiguration {
     this._logging = logging
     this._mailerBackend = mailerBackend
     this._routeResolverHooks = [...(routeResolverHooks || [])]
+
+    /** @type {WeakSet<object>} */
+    this._appliedRouteMounts = new WeakSet()
     this._errorEvents = new EventEmitter()
 
     /** @type {{[key: string]: import("./database/pool/base.js").default}} */
@@ -1112,7 +1115,29 @@ export default class VelociousConfiguration {
    * @param {import("./routes/index.js").default} newRoutes - New routes.
    * @returns {void} - No return value.
    */
-  setRoutes(newRoutes) { this._routes = newRoutes }
+  setRoutes(newRoutes) {
+    this._routes = newRoutes
+    this._applyRouteMounts(newRoutes)
+  }
+
+  /**
+   * Applies any `route.mount(...)` registrations from the routes file by letting
+   * each mountable register its routes (typically route-resolver hooks) against
+   * this configuration. Guarded so repeated setRoutes calls with the same routes
+   * don't register a mount more than once.
+   * @param {import("./routes/index.js").default} newRoutes - Routes instance.
+   * @returns {void} - No return value.
+   */
+  _applyRouteMounts(newRoutes) {
+    if (!newRoutes || typeof newRoutes.getMounts !== "function") return
+
+    for (const mount of newRoutes.getMounts()) {
+      if (this._appliedRouteMounts.has(mount)) continue
+
+      this._appliedRouteMounts.add(mount)
+      mount.mountable.mountInto({configuration: this, ...mount.options})
+    }
+  }
 
   /**
    * Adds plugin/library routes using a lightweight route DSL backed by route resolver hooks.

--- a/src/routes/base-route.js
+++ b/src/routes/base-route.js
@@ -36,9 +36,15 @@ export default class VelociousBaseRoute {
   /** @type {Array<VelociousBaseRoute>} */
   routes = []
 
+  /** @type {Array<{mountable: {mountInto: (args: object) => void}, options: Record<string, any>}>} */
+  mounts = []
+
   constructor() {
     // Nothing
   }
+
+  /** @returns {Array<{mountable: {mountInto: (args: object) => void}, options: Record<string, any>}>} - Mounts declared on this route. */
+  getMounts() { return this.mounts }
 
   /**
    * @abstract

--- a/src/routes/basic-route.js
+++ b/src/routes/basic-route.js
@@ -23,6 +23,29 @@ export default class VelociousBasicRoute extends BaseRoute {
   }
 
   /**
+   * Mounts a sub-application (e.g. the background-jobs dashboard API) at a path
+   * prefix, similar to mounting Sidekiq::Web in a Rails routes file. The
+   * mountable's `mountInto({configuration, ...options})` is invoked when the
+   * configuration receives the routes.
+   * @param {{mountInto: (args: object) => void}} mountable - Mountable with a static `mountInto` method.
+   * @param {object} [options] - Mount options. Must include an `at` path prefix starting with "/".
+   * @returns {void} - No return value.
+   */
+  mount(mountable, options = {}) {
+    if (!mountable || typeof mountable.mountInto !== "function") {
+      throw new Error("mount expects a mountable with a 'mountInto' method")
+    }
+
+    const at = /** @type {Record<string, any>} */ (options).at
+
+    if (typeof at !== "string" || !at.startsWith("/")) {
+      throw new Error(`mount requires an 'at' option starting with '/', got: ${String(at)}`)
+    }
+
+    this.mounts.push({mountable, options})
+  }
+
+  /**
    * @param {string} name - Name.
    * @param {function(import("./namespace-route.js").default) : void} callback - Callback function.
    * @returns {void} - No return value.

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -16,4 +16,29 @@ export default class VelociousRoutes {
   draw(callback) {
     callback(this.rootRoute)
   }
+
+  /**
+   * Collects all `route.mount(...)` registrations across the route tree so the
+   * configuration can apply them when the routes are set.
+   * @returns {Array<{mountable: {mountInto: (args: object) => void}, options: Record<string, any>}>} - Declared mounts.
+   */
+  getMounts() {
+    /** @type {Array<{mountable: {mountInto: (args: object) => void}, options: Record<string, any>}>} */
+    const collected = []
+
+    /** @param {import("./base-route.js").default} route - Route to visit. */
+    const visit = (route) => {
+      if (typeof route.getMounts === "function") {
+        collected.push(...route.getMounts())
+      }
+
+      for (const subRoute of route.getSubRoutes()) {
+        visit(subRoute)
+      }
+    }
+
+    visit(this.rootRoute)
+
+    return collected
+  }
 }


### PR DESCRIPTION
## What

Phase 1 of the background-jobs dashboard: a **read-only HTTP API in Velocious core**, mountable in the routes file the way `Sidekiq::Web` is mounted in Rails. The dashboard **UI** is a separate Expo app/package/repo (`velocious-jobs`) and is not part of this PR.

This implements the design agreed in [docs/background-jobs-dashboard.md](https://github.com/kaspernj/velocious/blob/background-jobs-dashboard-api/docs/background-jobs-dashboard.md): REST/JSON API, authorize-hook + per-connection token auth.

## Mounting

```js
import VelociousBackgroundJobsApi from "velocious/build/src/background-jobs/web/index.js"

routes.draw((route) => {
  route.mount(VelociousBackgroundJobsApi, {
    at: "/velocious/jobs",
    authorize: async ({request, ability}) => Boolean(ability?.can("manage", "BackgroundJobs")),
    accessTokens: [process.env.VELOCIOUS_JOBS_TOKEN]
  })
})
```

## Endpoints (under the mount prefix)

- `GET /api/health` — connection check
- `GET /api/stats` — counts per status + total
- `GET /api/jobs` — list, filter by `status`/`jobName`, paginated, sortable
- `GET /api/jobs/:id` — job detail (args, error, attempts, timestamps); `404` when missing
- `GET /api/schedule` — configured recurring jobs

## How it works

- New generic `route.mount(mountable, {at})` helper on the routes DSL. `configuration.setRoutes` applies declared mounts by registering route-resolver hooks (the same mechanism the `sql.js` asset route uses), so the controller ships inside the `velocious` package rather than the host app's `src/routes`.
- Reads go through new `BackgroundJobsStore` helpers (`countsByStatus`, `countJobs`, `listJobs`); the sort column is whitelisted before reaching SQL.
- Auth precedence: matching bearer token → `authorize` callback → loopback-only fallback when neither is configured. Optional CORS headers via `allowedOrigins`.

## Auth choices (from planning)

REST/JSON API · v1 includes management actions (planned as Phase 2 follow-up: retry/delete/kill/enqueue via the main process) · authorize-hook + per-connection token.

## Tests

`spec/background-jobs/web/api-spec.js` — 9 tests: auth required / token accepted / authorize callback / invalid token rejected, list filtered by status, single job detail, 404, health, and the loopback-only fallback (resolver-level). Existing `plugin-routes`, `sqljs`, `store` and `http-server` specs re-run green (they exercise the shared `setRoutes` path).

`npm run typecheck` and `eslint` on touched files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)