### PR TITLE
Add current translation relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Task.validates("name", {presence: true, uniqueness: true})
 export default Task
 ```
 
-Translated models also get a `currentTranslation` `hasOne` relationship scoped to the current locale. See [docs/translations.md](docs/translations.md) for preloading and frontend-model sorting behavior.
+Translated models also get a `currentTranslation` `hasOne` relationship scoped to the first available row in the current locale fallback order. See [docs/translations.md](docs/translations.md) for preloading and frontend-model sorting behavior.
 
 Async class APIs initialize record metadata on first use when a model has not
 already been initialized eagerly. See [docs/model-initialization.md](docs/model-initialization.md)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 * Per-row association counts via `.withCount(...)` on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)` on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
+* Translated model attributes with current-locale relationship sorting (see [docs/translations.md](docs/translations.md))
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon`, including forked background job runners (see [docs/beacon.md](docs/beacon.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 * Trusted reverse proxy handling for `request.remoteAddress()` (see [docs/trusted-proxies.md](docs/trusted-proxies.md))
@@ -639,6 +640,8 @@ Task.validates("name", {presence: true, uniqueness: true})
 
 export default Task
 ```
+
+Translated models also get a `currentTranslation` `hasOne` relationship scoped to the current locale. See [docs/translations.md](docs/translations.md) for preloading and frontend-model sorting behavior.
 
 Async class APIs initialize record metadata on first use when a model has not
 already been initialized eagerly. See [docs/model-initialization.md](docs/model-initialization.md)

--- a/changelog.d/20260522-current-translation.md
+++ b/changelog.d/20260522-current-translation.md
@@ -1,1 +1,1 @@
-- Add a `currentTranslation` relationship for translated records and use it for translated frontend-model sorting.
+- Add a fallback-aware `currentTranslation` relationship for translated records and use it for translated frontend-model sorting.

--- a/changelog.d/20260522-current-translation.md
+++ b/changelog.d/20260522-current-translation.md
@@ -1,0 +1,1 @@
+- Add a `currentTranslation` relationship for translated records and use it for translated frontend-model sorting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
+- `docs/translations.md`: Translated record attributes, `currentTranslation`, and translated frontend-model sorting.
 - `docs/routing-hooks-and-autoroutes.md`: Route hook support and frontend-model autoroute behavior.
 - `docs/authorization-and-current.md`: Ability usage, `Current`, and `accessible`/`accessibleBy` behavior.
 - `docs/relationships.md`: Relationship types, through (many-to-many) relationships, and preloading behavior.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -37,6 +37,7 @@
 - The `s` key applies sorting: `ransack({s: "name asc"})` sorts by name ascending.
 - Multiple sort columns can be specified: `ransack({s: "name asc, createdAt desc"})`.
 - Relationship paths are resolved automatically: `ransack({projectNameCont: "foo"})` filters through the `project` relationship.
+- Translated sort attributes use the translated model's `currentTranslation` relationship so the sort follows the current locale without duplicating records. See [translations.md](translations.md).
 - Example combining filter and sort: `User.ransack({emailCont: "john", s: "name asc"}).toArray()`.
 
 ## Query parity helpers

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -11,7 +11,7 @@ class TaskType extends Record {
 TaskType.translates("name")
 ```
 
-`translates(...)` defines the `translations` collection and a `currentTranslation` `hasOne` relationship. `currentTranslation` is scoped to the configuration's current locale and can be used anywhere normal relationships can be joined or preloaded:
+`translates(...)` defines the `translations` collection and a `currentTranslation` `hasOne` relationship. `currentTranslation` picks the first available row from the configuration's current locale fallback order and can be used anywhere normal relationships can be joined or preloaded:
 
 ```js
 const taskTypes = await TaskType
@@ -21,6 +21,6 @@ const taskTypes = await TaskType
   .toArray()
 ```
 
-Frontend-model index requests that sort by a translated attribute use `currentTranslation` internally. This keeps `TaskType.order("name")` or `TaskType.ransack({s: "name asc"})` ordered by the current locale without joining every translation row.
+Frontend-model index requests that sort by a translated attribute use `currentTranslation` internally. This keeps `TaskType.order("name")` or `TaskType.ransack({s: "name asc"})` ordered by the visible fallback-aware value without joining every translation row.
 
 Translated attribute serialization still preloads `translations` when the selected payload needs the translated value, so model methods such as `name()` can use the configured locale fallbacks.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,26 @@
+# Translations
+
+Backend records can declare translated attributes with `translates(...)`:
+
+```js
+import Record from "velocious/build/src/database/record/index.js"
+
+class TaskType extends Record {
+}
+
+TaskType.translates("name")
+```
+
+`translates(...)` defines the `translations` collection and a `currentTranslation` `hasOne` relationship. `currentTranslation` is scoped to the configuration's current locale and can be used anywhere normal relationships can be joined or preloaded:
+
+```js
+const taskTypes = await TaskType
+  .preload("currentTranslation")
+  .joins("currentTranslation")
+  .order({currentTranslation: [["name", "asc"]]})
+  .toArray()
+```
+
+Frontend-model index requests that sort by a translated attribute use `currentTranslation` internally. This keeps `TaskType.order("name")` or `TaskType.ransack({s: "name asc"})` ordered by the current locale without joining every translation row.
+
+Translated attribute serialization still preloads `translations` when the selected payload needs the translated value, so model methods such as `name()` can use the configured locale fallbacks.

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -1300,6 +1300,23 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     })
   })
 
+  it("orders translated attributes through the current translation", async () => {
+    await Dummy.run(async () => {
+      const laterProject = await Project.create({nameDe: "Aardvark fallback", nameEn: "Zeta current"})
+      const earlierProject = await Project.create({nameDe: "Zulu fallback", nameEn: "Alpha current"})
+
+      const payload = await postSharedProjectFrontendModelCommand("index", {
+        select: {Project: ["id", "name"]},
+        sort: "name asc",
+        where: {id: [laterProject.id(), earlierProject.id()]}
+      })
+
+      expect(payload.status).toEqual("success")
+      expect(payload.models.map((project) => project.id)).toEqual([earlierProject.id(), laterProject.id()])
+      expect(payload.models.map((project) => project.name)).toEqual(["Alpha current", "Zeta current"])
+    })
+  })
+
   it("excludes name from default serialization when selectedByDefault is false", async () => {
     await Dummy.run(async () => {
       const project = await Project.create({name: "Hidden name project"})

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -1300,20 +1300,21 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     })
   })
 
-  it("orders translated attributes through the current translation", async () => {
+  it("orders translated attributes through current translation fallbacks", async () => {
     await Dummy.run(async () => {
-      const laterProject = await Project.create({nameDe: "Aardvark fallback", nameEn: "Zeta current"})
-      const earlierProject = await Project.create({nameDe: "Zulu fallback", nameEn: "Alpha current"})
+      const fallbackProject = await Project.create({nameDe: "Zulu fallback"})
+      const middleProject = await Project.create({nameDe: "Should not sort first", nameEn: "Beta current"})
+      const lastProject = await Project.create({nameEn: "Alpha current"})
 
       const payload = await postSharedProjectFrontendModelCommand("index", {
         select: {Project: ["id", "name"]},
-        sort: "name asc",
-        where: {id: [laterProject.id(), earlierProject.id()]}
+        sort: "name desc",
+        where: {id: [fallbackProject.id(), middleProject.id(), lastProject.id()]}
       })
 
       expect(payload.status).toEqual("success")
-      expect(payload.models.map((project) => project.id)).toEqual([earlierProject.id(), laterProject.id()])
-      expect(payload.models.map((project) => project.name)).toEqual(["Alpha current", "Zeta current"])
+      expect(payload.models.map((project) => project.id)).toEqual([fallbackProject.id(), middleProject.id(), lastProject.id()])
+      expect(payload.models.map((project) => project.name)).toEqual(["Zulu fallback", "Beta current", "Alpha current"])
     })
   })
 

--- a/spec/database/record/translation-fallbacks.browser-spec.js
+++ b/spec/database/record/translation-fallbacks.browser-spec.js
@@ -23,13 +23,20 @@ describe("Record - translation fallbacks", {tags: ["dummy"]}, () => {
   it("preloads the current translation for translated records", async () => {
     const task = new Task({name: "Test task"})
     const project = task.buildProject({nameDe: "Test projekt", nameEn: "Test project"})
+    const fallbackTask = new Task({name: "Fallback task"})
+    const fallbackProject = fallbackTask.buildProject({nameDe: "Fallback projekt"})
 
     await task.save()
+    await fallbackTask.save()
 
     const sameProject = await Project.preload("currentTranslation").find(project.id())
     const currentTranslation = sameProject.currentTranslation()
+    const sameFallbackProject = await Project.preload("currentTranslation").find(fallbackProject.id())
+    const fallbackTranslation = sameFallbackProject.currentTranslation()
 
     expect(currentTranslation.locale()).toEqual("en")
     expect(currentTranslation.name()).toEqual("Test project")
+    expect(fallbackTranslation.locale()).toEqual("de")
+    expect(fallbackTranslation.name()).toEqual("Fallback projekt")
   })
 })

--- a/spec/database/record/translation-fallbacks.browser-spec.js
+++ b/spec/database/record/translation-fallbacks.browser-spec.js
@@ -1,3 +1,4 @@
+import Project from "../../dummy/src/models/project.js"
 import Task from "../../dummy/src/models/task.js"
 
 describe("Record - translation fallbacks", {tags: ["dummy"]}, () => {
@@ -17,5 +18,18 @@ describe("Record - translation fallbacks", {tags: ["dummy"]}, () => {
     expect(sameProject.name()).toEqual("Test projekt")
     expect(sameProject.nameEn()).toEqual(undefined)
     expect(sameProject.nameDe()).toEqual("Test projekt")
+  })
+
+  it("preloads the current translation for translated records", async () => {
+    const task = new Task({name: "Test task"})
+    const project = task.buildProject({nameDe: "Test projekt", nameEn: "Test project"})
+
+    await task.save()
+
+    const sameProject = await Project.preload("currentTranslation").find(project.id())
+    const currentTranslation = sameProject.currentTranslation()
+
+    expect(currentTranslation.locale()).toEqual("en")
+    expect(currentTranslation.name()).toEqual("Test project")
   })
 })

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2089,15 +2089,48 @@ class VelociousDatabaseRecord {
       if (!this._relationshipExists("currentTranslation")) {
         this._defineRelationship("currentTranslation", {
           klass: this.getTranslationClass(),
-          scope: (query) => {
-            const locale = this._getConfiguration().getLocale()
-
-            return locale ? query.where({locale}) : query.where("1=0")
-          },
+          scope: (query) => this.currentTranslationScope(query),
           type: "hasOne"
         })
       }
     }
+  }
+
+  /**
+   * @param {ModelClassQuery} query - Translation query.
+   * @returns {ModelClassQuery} - Scoped query.
+   */
+  static currentTranslationScope(query) {
+    const configuration = this._getConfiguration()
+    const locale = configuration.getLocale()
+    const fallbacks = configuration.getLocaleFallbacks()
+    const locales = locale ? (fallbacks?.[locale] || [locale]) : []
+
+    if (locales.length === 0) return query.where("1=0")
+
+    const driver = query.driver
+    const translationClass = this.getTranslationClass()
+    const relationship = this.getRelationshipByName("currentTranslation")
+    const tableName = translationClass.tableName()
+    const scopeTableReference = `${tableName}_current_translation_scope`
+    const targetTableSql = driver.quoteTable(query.getTableReferenceForJoin())
+    const scopeTableSql = driver.quoteTable(scopeTableReference)
+    const scopeTableFromSql = `${driver.quoteTable(tableName)} AS ${scopeTableSql}`
+    const primaryKeyColumn = translationClass.primaryKey()
+    const foreignKeyColumn = relationship.getForeignKey()
+    const targetPrimaryKeySql = `${targetTableSql}.${driver.quoteColumn(primaryKeyColumn)}`
+    const targetForeignKeySql = `${targetTableSql}.${driver.quoteColumn(foreignKeyColumn)}`
+    const scopePrimaryKeySql = `${scopeTableSql}.${driver.quoteColumn(primaryKeyColumn)}`
+    const scopeForeignKeySql = `${scopeTableSql}.${driver.quoteColumn(foreignKeyColumn)}`
+    const scopeLocaleSql = `${scopeTableSql}.${driver.quoteColumn("locale")}`
+    const localeListSql = locales.map((fallbackLocale) => driver.quote(fallbackLocale)).join(", ")
+    const localeOrderSql = locales.map((fallbackLocale, index) => `WHEN ${scopeLocaleSql} = ${driver.quote(fallbackLocale)} THEN ${driver.quote(index)}`).join(" ")
+    const fallbackOrderSql = `CASE ${localeOrderSql} ELSE ${driver.quote(locales.length)} END`
+    const selectedTranslationSql = driver.getType() == "mssql"
+      ? `SELECT TOP 1 ${scopePrimaryKeySql} FROM ${scopeTableFromSql} WHERE ${scopeForeignKeySql} = ${targetForeignKeySql} AND ${scopeLocaleSql} IN (${localeListSql}) ORDER BY ${fallbackOrderSql}, ${scopePrimaryKeySql} ASC`
+      : `SELECT ${scopePrimaryKeySql} FROM ${scopeTableFromSql} WHERE ${scopeForeignKeySql} = ${targetForeignKeySql} AND ${scopeLocaleSql} IN (${localeListSql}) ORDER BY ${fallbackOrderSql}, ${scopePrimaryKeySql} ASC LIMIT 1`
+
+    return query.where(`${targetPrimaryKeySql} = (${selectedTranslationSql})`)
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2085,6 +2085,18 @@ class VelociousDatabaseRecord {
       if (!this._relationshipExists("translations")) {
         this._defineRelationship("translations", {dependent: "destroy", klass: this.getTranslationClass(), type: "hasMany"})
       }
+
+      if (!this._relationshipExists("currentTranslation")) {
+        this._defineRelationship("currentTranslation", {
+          klass: this.getTranslationClass(),
+          scope: (query) => {
+            const locale = this._getConfiguration().getLocale()
+
+            return locale ? query.where({locale}) : query.where("1=0")
+          },
+          type: "hasOne"
+        })
+      }
     }
   }
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -2520,7 +2520,7 @@ export default class FrontendModelController extends Controller {
       const translationModelClass = targetModelClass.getTranslationClass()
       const translationAttributeNameToColumnNameMap = translationModelClass.getAttributeNameToColumnNameMap()
       const translationColumnName = translationAttributeNameToColumnNameMap[sort.column]
-      const translationPath = sort.path.concat(["translations"])
+      const translationPath = sort.path.concat(["currentTranslation"])
 
       if (!translationColumnName) {
         throw new Error(`Unknown translated sort column "${sort.column}" for ${targetModelClass.name}`)


### PR DESCRIPTION
Adds a generated `currentTranslation` relationship for translated records and uses it for translated frontend-model sorting so current-locale order does not join every translation row.

Validation:
- `./run-tests.sh spec/controller/frontend-model-actions-spec.js`
- `VELOCIOUS_ENV=test npm run test:browser -- spec/database/record/translation-fallbacks.browser-spec.js`
- `npm run lint`
- `npm run typecheck`