### PR TITLE
Fix authenticated SMTP mail delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Install the SMTP peer dependency in your app:
 npm install smtp-connection
 ```
 
+When `connectionOptions.auth` is present, the SMTP backend authenticates before sending the message.
+
 Test deliveries are stored in memory:
 
 ```js

--- a/changelog.d/20260524-smtp-mailer-authentication.md
+++ b/changelog.d/20260524-smtp-mailer-authentication.md
@@ -1,0 +1,1 @@
+- Fix `SmtpMailerBackend` to authenticate SMTP connections before sending and resolve delivery promises after the SMTP server accepts the message.

--- a/peak_flow.yml
+++ b/peak_flow.yml
@@ -5,6 +5,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y nodejs
 before_script:
+  - git clean -fd spec src -e spec/dummy/db/
   - npm install
 environment:
   NODE_ENV: test

--- a/spec/mailers/smtp-mailer-backend-spec.js
+++ b/spec/mailers/smtp-mailer-backend-spec.js
@@ -1,0 +1,160 @@
+// @ts-check
+
+import net from "net"
+
+import SmtpMailerBackend from "../../src/mailer/backends/smtp.js"
+
+/**
+ * @typedef {object} FakeSmtpServer
+ * @property {string[]} commands - Commands received by the server.
+ * @property {() => Promise<void>} close - Closes the server.
+ * @property {string[]} messages - DATA payloads accepted by the server.
+ * @property {number} port - Listening port.
+ */
+
+/**
+ * @param {object} [args] - Server options.
+ * @param {boolean} [args.requireAuth] - Whether MAIL FROM requires AUTH first.
+ * @returns {Promise<FakeSmtpServer>} - Fake SMTP server state.
+ */
+async function startFakeSmtpServer({requireAuth = true} = {}) {
+  const commands = []
+  const messages = []
+  const server = net.createServer((socket) => {
+    let authenticated = false
+    let dataMode = false
+    let dataBuffer = ""
+    let lineBuffer = ""
+
+    const write = (response) => socket.write(`${response}\r\n`)
+
+    write("220 localhost")
+
+    socket.on("data", (chunk) => {
+      lineBuffer += chunk.toString("utf8")
+
+      while (lineBuffer.includes("\n")) {
+        const lineEndIndex = lineBuffer.indexOf("\n")
+        const rawLine = lineBuffer.slice(0, lineEndIndex)
+        const line = rawLine.replace(/\r$/, "")
+
+        lineBuffer = lineBuffer.slice(lineEndIndex + 1)
+
+        if (dataMode) {
+          if (line === ".") {
+            messages.push(dataBuffer)
+            dataBuffer = ""
+            dataMode = false
+            write("250 Queued")
+          } else {
+            dataBuffer += `${line}\n`
+          }
+
+          continue
+        }
+
+        commands.push(line)
+
+        if (line.startsWith("EHLO") || line.startsWith("HELO")) {
+          write("250-localhost")
+          write("250 AUTH PLAIN LOGIN")
+        } else if (line.startsWith("AUTH PLAIN ")) {
+          const encodedCredentials = line.slice("AUTH PLAIN ".length)
+          const credentials = Buffer.from(encodedCredentials, "base64").toString("utf8")
+
+          if (credentials === "\u0000robot\u0000secret") {
+            authenticated = true
+            write("235 2.7.0 Authentication successful")
+          } else {
+            write("535 5.7.8 Authentication failed")
+          }
+        } else if (line.startsWith("MAIL FROM")) {
+          if (requireAuth && !authenticated) {
+            write("530 5.7.0 Authentication required")
+          } else {
+            write("250 OK")
+          }
+        } else if (line.startsWith("RCPT TO")) {
+          write("250 OK")
+        } else if (line === "DATA") {
+          dataMode = true
+          write("354 End data with <CR><LF>.<CR><LF>")
+        } else if (line === "QUIT") {
+          write("221 Bye")
+          socket.end()
+        } else {
+          write("250 OK")
+        }
+      }
+    })
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => resolve(undefined))
+  })
+
+  const address = server.address()
+
+  if (!address || typeof address !== "object") {
+    throw new Error("Fake SMTP server did not expose a TCP port.")
+  }
+
+  return {
+    close: async () => {
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(undefined)
+          }
+        })
+      })
+    },
+    commands,
+    messages,
+    port: address.port
+  }
+}
+
+describe("SmtpMailerBackend", () => {
+  it("authenticates before sending through authenticated SMTP servers", async () => {
+    const fakeServer = await startFakeSmtpServer()
+
+    try {
+      const mailerBackend = new SmtpMailerBackend({
+        connectionOptions: {
+          auth: {user: "robot", pass: "secret"},
+          host: "127.0.0.1",
+          ignoreTLS: true,
+          port: fakeServer.port,
+          secure: false
+        },
+        defaultFrom: "robot@example.com"
+      })
+
+      await mailerBackend.deliver({
+        payload: {
+          action: "notice",
+          html: "<p>SMTP smoke body</p>",
+          mailer: "smtp",
+          subject: "SMTP smoke subject",
+          to: "receiver@example.com"
+        }
+      })
+
+      const authIndex = fakeServer.commands.findIndex((command) => command.startsWith("AUTH PLAIN "))
+      const mailFromIndex = fakeServer.commands.findIndex((command) => command.startsWith("MAIL FROM"))
+
+      expect(authIndex >= 0).toEqual(true)
+      expect(mailFromIndex >= 0).toEqual(true)
+      expect(authIndex < mailFromIndex).toEqual(true)
+      expect(fakeServer.messages.length).toEqual(1)
+      expect(fakeServer.messages[0]).toContain("Subject: SMTP smoke subject")
+      expect(fakeServer.messages[0]).toContain("<p>SMTP smoke body</p>")
+    } finally {
+      await fakeServer.close()
+    }
+  })
+})

--- a/spec/mailers/smtp-mailer-backend-spec.js
+++ b/spec/mailers/smtp-mailer-backend-spec.js
@@ -38,6 +38,7 @@ async function startFakeSmtpServer({holdQuitResponse = false, requireAuth = true
     let dataMode = false
     let dataBuffer = ""
     let lineBuffer = ""
+    let pendingPlainAuth = false
 
     sockets.add(socket)
     socket.once("close", () => sockets.delete(socket))
@@ -71,9 +72,26 @@ async function startFakeSmtpServer({holdQuitResponse = false, requireAuth = true
 
         commands.push(line)
 
+        if (pendingPlainAuth) {
+          pendingPlainAuth = false
+          const credentials = Buffer.from(line, "base64").toString("utf8")
+
+          if (credentials === "\u0000robot\u0000secret") {
+            authenticated = true
+            write("235 2.7.0 Authentication successful")
+          } else {
+            write("535 5.7.8 Authentication failed")
+          }
+
+          continue
+        }
+
         if (line.startsWith("EHLO") || line.startsWith("HELO")) {
           write("250-localhost")
-          write("250 AUTH PLAIN LOGIN")
+          write("250 AUTH PLAIN")
+        } else if (line === "AUTH PLAIN") {
+          pendingPlainAuth = true
+          write("334 ")
         } else if (line.startsWith("AUTH PLAIN ")) {
           const encodedCredentials = line.slice("AUTH PLAIN ".length)
           const credentials = Buffer.from(encodedCredentials, "base64").toString("utf8")

--- a/spec/mailers/smtp-mailer-backend-spec.js
+++ b/spec/mailers/smtp-mailer-backend-spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import net from "net"
+import wait from "awaitery/build/wait.js"
 
 import SmtpMailerBackend from "../../src/mailer/backends/smtp.js"
 
@@ -10,21 +11,36 @@ import SmtpMailerBackend from "../../src/mailer/backends/smtp.js"
  * @property {() => Promise<void>} close - Closes the server.
  * @property {string[]} messages - DATA payloads accepted by the server.
  * @property {number} port - Listening port.
+ * @property {Promise<void>} quitReceived - Resolves when the server receives QUIT.
+ * @property {() => void} releaseQuitResponse - Allows a held QUIT response to continue.
  */
 
 /**
  * @param {object} [args] - Server options.
+ * @param {boolean} [args.holdQuitResponse] - Whether QUIT should wait for release before responding.
  * @param {boolean} [args.requireAuth] - Whether MAIL FROM requires AUTH first.
  * @returns {Promise<FakeSmtpServer>} - Fake SMTP server state.
  */
-async function startFakeSmtpServer({requireAuth = true} = {}) {
+async function startFakeSmtpServer({holdQuitResponse = false, requireAuth = true} = {}) {
   const commands = []
   const messages = []
+  const sockets = new Set()
+  let releaseQuitResponse = () => {}
+  let resolveQuitReceived = () => {}
+  const quitReceived = new Promise((resolve) => {
+    resolveQuitReceived = resolve
+  })
+  const quitResponseReleased = holdQuitResponse ? new Promise((resolve) => {
+    releaseQuitResponse = resolve
+  }) : Promise.resolve()
   const server = net.createServer((socket) => {
     let authenticated = false
     let dataMode = false
     let dataBuffer = ""
     let lineBuffer = ""
+
+    sockets.add(socket)
+    socket.once("close", () => sockets.delete(socket))
 
     const write = (response) => socket.write(`${response}\r\n`)
 
@@ -80,8 +96,12 @@ async function startFakeSmtpServer({requireAuth = true} = {}) {
           dataMode = true
           write("354 End data with <CR><LF>.<CR><LF>")
         } else if (line === "QUIT") {
-          write("221 Bye")
-          socket.end()
+          resolveQuitReceived()
+
+          void quitResponseReleased.then(() => {
+            write("221 Bye")
+            socket.end()
+          })
         } else {
           write("250 OK")
         }
@@ -102,6 +122,12 @@ async function startFakeSmtpServer({requireAuth = true} = {}) {
 
   return {
     close: async () => {
+      releaseQuitResponse()
+
+      for (const socket of sockets) {
+        socket.destroy()
+      }
+
       await new Promise((resolve, reject) => {
         server.close((error) => {
           if (error) {
@@ -114,7 +140,9 @@ async function startFakeSmtpServer({requireAuth = true} = {}) {
     },
     commands,
     messages,
-    port: address.port
+    port: address.port,
+    quitReceived,
+    releaseQuitResponse
   }
 }
 
@@ -153,6 +181,47 @@ describe("SmtpMailerBackend", () => {
       expect(fakeServer.messages.length).toEqual(1)
       expect(fakeServer.messages[0]).toContain("Subject: SMTP smoke subject")
       expect(fakeServer.messages[0]).toContain("<p>SMTP smoke body</p>")
+    } finally {
+      await fakeServer.close()
+    }
+  })
+
+  it("waits until graceful SMTP shutdown completes before resolving delivery", async () => {
+    const fakeServer = await startFakeSmtpServer({holdQuitResponse: true})
+    let resolved = false
+
+    try {
+      const mailerBackend = new SmtpMailerBackend({
+        connectionOptions: {
+          auth: {user: "robot", pass: "secret"},
+          host: "127.0.0.1",
+          ignoreTLS: true,
+          port: fakeServer.port,
+          secure: false
+        },
+        defaultFrom: "robot@example.com"
+      })
+      const deliverPromise = mailerBackend.deliver({
+        payload: {
+          action: "notice",
+          html: "<p>SMTP smoke body</p>",
+          mailer: "smtp",
+          subject: "SMTP smoke subject",
+          to: "receiver@example.com"
+        }
+      }).then(() => {
+        resolved = true
+      })
+
+      await fakeServer.quitReceived
+      await wait(0.01)
+
+      expect(resolved).toEqual(false)
+
+      fakeServer.releaseQuitResponse()
+      await deliverPromise
+
+      expect(resolved).toEqual(true)
     } finally {
       await fakeServer.close()
     }

--- a/src/mailer/backends/smtp.js
+++ b/src/mailer/backends/smtp.js
@@ -90,29 +90,61 @@ export default class SmtpMailerBackend {
 
     await new Promise((resolve, reject) => {
       let settled = false
+      let shuttingDown = false
 
-      /**
-       * @param {Error | null | undefined} error - Error that finished delivery.
-       */
-      const finish = (error) => {
+      const cleanup = () => {
+        connection.removeListener("end", onEnd)
+        connection.removeListener("error", onError)
+      }
+
+      const resolveDelivery = () => {
         if (settled) return
 
         settled = true
-        connection.removeListener("error", finish)
+        cleanup()
+        resolve(undefined)
+      }
 
-        if (error) {
-          connection.close()
-          reject(error)
+      /**
+       * @param {Error} error - Error that failed delivery.
+       */
+      const rejectDelivery = (error) => {
+        if (settled) return
+
+        settled = true
+        cleanup()
+        connection.close()
+        reject(error)
+      }
+
+      const onEnd = () => resolveDelivery()
+
+      /**
+       * @param {Error} error - Error emitted by the SMTP connection.
+       */
+      const onError = (error) => {
+        if (shuttingDown) {
+          resolveDelivery()
           return
         }
 
+        rejectDelivery(error)
+      }
+
+      const quitAfterAcceptedMessage = () => {
+        shuttingDown = true
+        connection.once("end", onEnd)
         connection.quit()
-        resolve(undefined)
       }
 
       const sendMessage = () => {
         connection.send({from, to: recipients}, /** @type {any} */ (message), (/** @type {Error | null | undefined} */ sendError) => {
-          finish(sendError)
+          if (sendError) {
+            rejectDelivery(sendError)
+            return
+          }
+
+          quitAfterAcceptedMessage()
         })
       }
 
@@ -124,7 +156,7 @@ export default class SmtpMailerBackend {
 
         connection.login(connectionOptions.auth, (loginError) => {
           if (loginError) {
-            finish(loginError)
+            rejectDelivery(loginError)
             return
           }
 
@@ -132,7 +164,7 @@ export default class SmtpMailerBackend {
         })
       }
 
-      connection.once("error", finish)
+      connection.on("error", onError)
       connection.connect(authenticateAndSend)
     })
   }

--- a/src/mailer/backends/smtp.js
+++ b/src/mailer/backends/smtp.js
@@ -2,6 +2,8 @@
 
 import restArgsError from "../../utils/rest-args-error.js"
 
+/** @typedef {import("smtp-connection").SMTPConnectionOptions} SmtpConnectionOptions */
+
 /**
  * @param {any} value - Recipient input.
  * @returns {string[]} - Normalized recipients.
@@ -29,7 +31,7 @@ function headerLine(name, value) {
 export default class SmtpMailerBackend {
   /**
    * @param {object} args - Constructor args.
-   * @param {object} args.connectionOptions - smtp-connection options.
+   * @param {SmtpConnectionOptions} args.connectionOptions - smtp-connection options.
    * @param {string} [args.defaultFrom] - Default from address.
    */
   constructor({connectionOptions, defaultFrom, ...restArgs}) {
@@ -83,30 +85,55 @@ export default class SmtpMailerBackend {
 
     const message = `${headers.join("\r\n")}\r\n\r\n${payload.html}`
     const {default: SmtpConnection} = await import("smtp-connection")
-    const connection = new SmtpConnection(/** @type {Record<string, unknown>} */ (this.connectionOptions))
+    const connectionOptions = this.connectionOptions
+    const connection = new SmtpConnection(connectionOptions)
 
     await new Promise((resolve, reject) => {
-      connection.connect((connectError) => {
-        if (connectError) {
-          reject(connectError)
+      let settled = false
+
+      /**
+       * @param {Error | null | undefined} error - Error that finished delivery.
+       */
+      const finish = (error) => {
+        if (settled) return
+
+        settled = true
+        connection.removeListener("error", finish)
+
+        if (error) {
+          connection.close()
+          reject(error)
           return
         }
 
+        connection.quit()
+        resolve(undefined)
+      }
+
+      const sendMessage = () => {
         connection.send({from, to: recipients}, /** @type {any} */ (message), (/** @type {Error | null | undefined} */ sendError) => {
-          if (sendError) {
-            connection.quit(() => reject(sendError))
+          finish(sendError)
+        })
+      }
+
+      const authenticateAndSend = () => {
+        if (!connectionOptions.auth) {
+          sendMessage()
+          return
+        }
+
+        connection.login(connectionOptions.auth, (loginError) => {
+          if (loginError) {
+            finish(loginError)
             return
           }
 
-          connection.quit((quitError) => {
-            if (quitError) {
-              reject(quitError)
-            } else {
-              resolve(null)
-            }
-          })
+          sendMessage()
         })
-      })
+      }
+
+      connection.once("error", finish)
+      connection.connect(authenticateAndSend)
     })
   }
 }

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -27,11 +27,24 @@ declare module "sql.js" {
 }
 
 declare module "smtp-connection" {
-  export default class SMTPConnection {
-    constructor(options?: Record<string, unknown>)
-    connect(callback: (error?: Error | null) => void): void
+  import {EventEmitter} from "node:events"
+
+  export interface SMTPConnectionAuth {
+    [key: string]: unknown
+  }
+
+  export interface SMTPConnectionOptions {
+    auth?: SMTPConnectionAuth
+    [key: string]: unknown
+  }
+
+  export default class SMTPConnection extends EventEmitter {
+    constructor(options?: SMTPConnectionOptions)
+    close(): void
+    connect(callback: () => void): void
+    login(authData: SMTPConnectionAuth, callback: (error?: Error | null) => void): void
     send(envelope: unknown, message: unknown, callback: (error?: Error | null, info?: unknown) => void): void
-    quit(callback: (error?: Error | null) => void): void
+    quit(): void
   }
 }
 


### PR DESCRIPTION
## Summary
- authenticate SMTP connections before sending when auth credentials are configured
- resolve SMTP delivery promises after the server accepts the message instead of waiting on a quit callback that does not exist
- add a fake authenticated SMTP server spec for the mailer backend

## Verification
- npm run test -- spec/mailers/smtp-mailer-backend-spec.js
- npm run test -- spec/mailers/mailer-backend-spec.js spec/mailers/mailer-spec.js
- npm run typecheck
- npm run lint