### PR TITLE
Avoid leaking smtp-connection types

### DIFF
--- a/changelog.d/20260524-smtp-connection-types.md
+++ b/changelog.d/20260524-smtp-connection-types.md
@@ -1,0 +1,1 @@
+Fix SMTP mailer backend declarations so consumers do not need local smtp-connection module types.

--- a/src/mailer/backends/smtp.js
+++ b/src/mailer/backends/smtp.js
@@ -2,7 +2,7 @@
 
 import restArgsError from "../../utils/rest-args-error.js"
 
-/** @typedef {import("smtp-connection").SMTPConnectionOptions} SmtpConnectionOptions */
+/** @typedef {{auth?: Record<string, unknown>, [key: string]: unknown}} SmtpConnectionOptions */
 
 /**
  * @param {any} value - Recipient input.


### PR DESCRIPTION
## Summary
- replace the SMTP mailer backend's public smtp-connection import typedef with a structural options typedef
- add a changelog note for the consumer typecheck fix

## Tests
- npm run typecheck
- npm run lint
- npm run test -- spec/mailers/smtp-mailer-backend-spec.js