### PR TITLE
Expose opt-in frontend-model debug errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,16 @@ Frontend-model HTTP requests always use `credentials: "include"` so shared custo
 
 Unexpected frontend-model endpoint failures stay client-safe in production with `errorMessage: "Request failed."`.
 In `development` and `test`, Velocious also includes `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` fields so browser/system-test failures are easier to diagnose without exposing those details in production.
+Other non-production environments, such as `staging`, keep the same client-safe default unless you explicitly opt in with `exposeInternalErrorsToClients: true`:
+
+```js
+const configuration = new Configuration({
+  environment: "staging",
+  exposeInternalErrorsToClients: true
+})
+```
+
+This opt-in is ignored in `production`; production frontend-model responses never include internal exception details.
 
 For sqlite web databases, Velocious defaults to `https://sql.js.org/dist/<file>` for `sql.js` wasm loading. You can override wasm resolution per database config with `locateFile`:
 

--- a/changelog.d/20260524-client-debug-errors-config.md
+++ b/changelog.d/20260524-client-debug-errors-config.md
@@ -1,0 +1,1 @@
+Add `exposeInternalErrorsToClients` so non-production environments can opt into frontend-model debug error payloads while production remains client-safe.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -6,6 +6,12 @@
 - `FrontendModelBase.waitForIdle()` waits until queued, scheduled, and active frontend-model transport requests have resolved. Browser/system-test harnesses can call it during teardown before resetting app state.
 - Keep request execution centralized in Velocious instead of per-project endpoint overrides.
 
+## Unexpected error payloads
+- Unexpected frontend-model endpoint failures return `errorMessage: "Request failed."` by default so internal exception details are not exposed to clients.
+- `development` and `test` responses also include `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` for faster browser/system-test diagnosis.
+- Other non-production environments, such as `staging`, can opt into the same debug fields with `exposeInternalErrorsToClients: true` on the app `Configuration`.
+- `production` always keeps the generic response, even if `exposeInternalErrorsToClients` is set.
+
 ## Frontend vs backend model API differences
 - Frontend models expose a narrower query surface (mainly `find`, `findBy`, `findByOrFail`, `findOrInitializeBy`, `findOrCreateBy`, `toArray`, `where`, `joins`, `sort`, `order`, `group`, `distinct`, `pluck`, `count`, `limit`, `offset`, `page`, `perPage`) and do not expose the full backend query API (raw SQL joins, etc.).
 - Frontend model commands are resource-mapped; `toArray()` calls the configured `index` command, which may map to a backend command name like `list` instead of literal `index`.

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -68,9 +68,10 @@ async function postSharedTaskFrontendModelCommand(commandType, payload) {
 
 /**
  * @param {string} environment - Environment.
+ * @param {{exposeInternalErrorsToClients?: boolean}} [options] - Configuration options.
  * @returns {Configuration} - Test configuration.
  */
-function buildFrontendModelControllerConfiguration(environment) {
+function buildFrontendModelControllerConfiguration(environment, options = {}) {
   return new Configuration({
     backendProjects,
     cookieSecret: "dummy-cookie-secret",
@@ -78,6 +79,7 @@ function buildFrontendModelControllerConfiguration(environment) {
     directory: dummyDirectory(),
     environment,
     environmentHandler: new EnvironmentHandlerNode(),
+    exposeInternalErrorsToClients: options.exposeInternalErrorsToClients === true,
     initializeModels: async () => {},
     locale: "en",
     localeFallbacks: {en: ["en"]},
@@ -154,6 +156,18 @@ function expectDebugFrontendModelError(payload, messagePattern) {
   expect(payload.debugErrorMessage).toMatch(messagePattern)
   expect(Array.isArray(payload.debugBacktrace)).toEqual(true)
   expect(payload.debugBacktrace[0]).toMatch(messagePattern)
+}
+
+/**
+ * @param {Record<string, any>} payload - Error payload.
+ * @returns {void}
+ */
+function expectGenericFrontendModelError(payload) {
+  expect(payload.status).toEqual("error")
+  expect(payload.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
+  expect(payload.debugErrorClass).toEqual(undefined)
+  expect(payload.debugErrorMessage).toEqual(undefined)
+  expect(payload.debugBacktrace).toEqual(undefined)
 }
 
 /**
@@ -480,11 +494,64 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
 
     expect(payload.status).toEqual("success")
     expect(payload.responses.length).toEqual(1)
-    expect(payload.responses[0].response.status).toEqual("error")
-    expect(payload.responses[0].response.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
-    expect(payload.responses[0].response.debugErrorClass).toEqual(undefined)
-    expect(payload.responses[0].response.debugErrorMessage).toEqual(undefined)
-    expect(payload.responses[0].response.debugBacktrace).toEqual(undefined)
+    expectGenericFrontendModelError(payload.responses[0].response)
+  })
+
+  it("keeps unexpected shared frontend-model failures generic in staging by default", async () => {
+    const configuration = buildFrontendModelControllerConfiguration("staging")
+    const payload = await runFrontendApi({
+      configuration,
+      params: {
+        requests: [{
+          commandType: "index",
+          model: "UnknownModel",
+          payload: {},
+          requestId: "request-1"
+        }]
+      }
+    })
+
+    expect(payload.status).toEqual("success")
+    expect(payload.responses.length).toEqual(1)
+    expectGenericFrontendModelError(payload.responses[0].response)
+  })
+
+  it("returns debug details for unexpected shared frontend-model failures when staging opts in", async () => {
+    const configuration = buildFrontendModelControllerConfiguration("staging", {exposeInternalErrorsToClients: true})
+    const payload = await runFrontendApi({
+      configuration,
+      params: {
+        requests: [{
+          commandType: "index",
+          model: "UnknownModel",
+          payload: {},
+          requestId: "request-1"
+        }]
+      }
+    })
+
+    expect(payload.status).toEqual("success")
+    expect(payload.responses.length).toEqual(1)
+    expectDebugFrontendModelError(payload.responses[0].response, /No frontend model resource configuration/)
+  })
+
+  it("keeps unexpected shared frontend-model failures generic in production when debug details are enabled", async () => {
+    const configuration = buildFrontendModelControllerConfiguration("production", {exposeInternalErrorsToClients: true})
+    const payload = await runFrontendApi({
+      configuration,
+      params: {
+        requests: [{
+          commandType: "index",
+          model: "UnknownModel",
+          payload: {},
+          requestId: "request-1"
+        }]
+      }
+    })
+
+    expect(payload.status).toEqual("success")
+    expect(payload.responses.length).toEqual(1)
+    expectGenericFrontendModelError(payload.responses[0].response)
   })
 
   it("applies preload params to frontendIndex query", async () => {

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -362,6 +362,7 @@
  * @property {boolean} [enforceTenantDatabaseScopes] - Require tenant-switched model queries to resolve a tenant database identifier. Defaults to true.
  * @property {string} [environment] - Current environment name.
  * @property {import("./environment-handlers/base.js").default} environmentHandler - Environment handler instance.
+ * @property {boolean} [exposeInternalErrorsToClients] - Return unexpected internal error details in client API payloads outside production. Defaults to false.
  * @property {LoggingConfiguration} [logging] - Logging configuration.
  * @property {BackgroundJobsConfiguration} [backgroundJobs] - Background jobs configuration.
  * @property {BeaconConfiguration} [beacon] - Beacon broadcast bus configuration.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -70,7 +70,7 @@ export default class VelociousConfiguration {
   }
 
   /** @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments. */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -92,6 +92,7 @@ export default class VelociousConfiguration {
     this._environment = environment || process.env.VELOCIOUS_ENV || process.env.NODE_ENV || "development"
     this._environmentHandler = environmentHandler
     this._enforceTenantDatabaseScopes = enforceTenantDatabaseScopes
+    this._exposeInternalErrorsToClients = exposeInternalErrorsToClients
     this._directory = directory
     this._initializeModels = initializeModels
     this._isInitialized = false
@@ -160,6 +161,9 @@ export default class VelociousConfiguration {
 
   /** @returns {boolean} Whether auto-batch-preload of relationships on lazy access is enabled globally. */
   getAutoload() { return this._autoload }
+
+  /** @returns {boolean} Whether unexpected internal error details may be returned to API clients. */
+  getExposeInternalErrorsToClients() { return this._exposeInternalErrorsToClients === true }
 
   /**
    * @param {boolean} newValue - Whether auto-batch-preload of relationships is enabled.

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -379,12 +379,15 @@ function frontendModelClientMessageForError(error) {
 
 /**
  * @param {object} args - Arguments.
+ * @param {import("./configuration.js").default} args.configuration - Current configuration.
  * @param {string} args.environment - Current environment.
  * @param {unknown} args.error - Caught error.
  * @returns {Record<string, any>} - Optional debug payload for non-production environments.
  */
-function frontendModelDebugPayloadForError({environment, error}) {
-  if (!frontendModelDebugErrorEnvironments.has(environment)) {
+function frontendModelDebugPayloadForError({configuration, environment, error}) {
+  const debugAllowed = frontendModelDebugErrorEnvironments.has(environment) || environment !== "production" && configuration.getExposeInternalErrorsToClients()
+
+  if (!debugAllowed) {
     return {}
   }
 
@@ -3049,6 +3052,7 @@ export default class FrontendModelController extends Controller {
     return {
       ...this.frontendModelErrorPayload(frontendModelClientMessageForError(error)),
       ...frontendModelDebugPayloadForError({
+        configuration: this.getConfiguration(),
         environment: this.getConfiguration().getEnvironment(),
         error
       }),


### PR DESCRIPTION
## Summary
- add an opt-in Velocious config flag for returning unexpected frontend-model debug details to clients outside production
- keep production responses generic even when the flag is enabled
- cover production, staging default, and staging opt-in behavior in focused controller specs

## Tests
- npm run test -- spec/controller/frontend-model-actions-spec.js
- npm run typecheck
- npm run lint (passes with existing warnings)