### PR TITLE
Accept configuration in SMTP mail delivery

### DIFF
--- a/changelog.d/20260524-smtp-mailer-delivery-signature.md
+++ b/changelog.d/20260524-smtp-mailer-delivery-signature.md
@@ -1,0 +1,1 @@
+Fix SMTP mail delivery when Velocious passes the active configuration to the configured mailer backend.

--- a/spec/mailers/smtp-mailer-backend-spec.js
+++ b/spec/mailers/smtp-mailer-backend-spec.js
@@ -181,6 +181,7 @@ describe("SmtpMailerBackend", () => {
       })
 
       await mailerBackend.deliver({
+        configuration: /** @type {import("../../src/configuration.js").default} */ ({}),
         payload: {
           action: "notice",
           html: "<p>SMTP smoke body</p>",

--- a/src/mailer/backends/smtp.js
+++ b/src/mailer/backends/smtp.js
@@ -48,9 +48,10 @@ export default class SmtpMailerBackend {
   /**
    * @param {object} args - Delivery args.
    * @param {import("../index.js").MailerDeliveryPayload} args.payload - Mail delivery payload.
+   * @param {import("../../configuration.js").default} [args.configuration] - Active configuration.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async deliver({payload, ...restArgs}) {
+  async deliver({payload, configuration: _configuration, ...restArgs}) {
     restArgsError(restArgs)
 
     const from = payload.from || this.defaultFrom


### PR DESCRIPTION
## Summary
- allow `SmtpMailerBackend.deliver()` to accept the framework-provided `configuration` argument
- cover the production failure call shape in the SMTP backend spec
- add a changelog fragment

## Tests
- `npm run test -- spec/mailers/smtp-mailer-backend-spec.js`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`