### PR TITLE
Allow duplicate frontend models per output directory

### DIFF
--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -465,4 +465,50 @@ describe("Cli - generate - frontend-models", () => {
 
     await fs.rm(outputDirectory, {force: true, recursive: true})
   })
+
+  it("allows the same frontend model class name in different output directories", async () => {
+    const firstOutputDirectory = path.resolve(dummyDirectory(), "../tmp/frontend-model-output-one")
+    const secondOutputDirectory = path.resolve(dummyDirectory(), "../tmp/frontend-model-output-two")
+    await fs.rm(firstOutputDirectory, {force: true, recursive: true})
+    await fs.rm(secondOutputDirectory, {force: true, recursive: true})
+
+    const cli = new Cli({
+      configuration: buildConfiguration({
+        backendProjectsList: [
+          {
+            path: "/tmp/backend-one",
+            frontendModels: {
+              User: ReferenceUserFrontendResource
+            },
+            frontendModelsOutputPath: firstOutputDirectory
+          },
+          {
+            path: "/tmp/backend-two",
+            frontendModels: {
+              User: ReferenceUserFrontendResource
+            },
+            frontendModelsOutputPath: secondOutputDirectory
+          }
+        ],
+        initializeModels: async ({configuration}) => {
+          configuration.registerModelClass(User)
+        }
+      }),
+      directory: dummyDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["g:frontend-models"],
+      testing: true
+    })
+
+    await cli.execute()
+
+    const firstUserContents = await fs.readFile(`${firstOutputDirectory}/src/frontend-models/user.js`, "utf8")
+    const secondUserContents = await fs.readFile(`${secondOutputDirectory}/src/frontend-models/user.js`, "utf8")
+
+    expect(firstUserContents).toContain("class User extends FrontendModelBase")
+    expect(secondUserContents).toContain("class User extends FrontendModelBase")
+
+    await fs.rm(firstOutputDirectory, {force: true, recursive: true})
+    await fs.rm(secondOutputDirectory, {force: true, recursive: true})
+  })
 })

--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -511,4 +511,44 @@ describe("Cli - generate - frontend-models", () => {
     await fs.rm(firstOutputDirectory, {force: true, recursive: true})
     await fs.rm(secondOutputDirectory, {force: true, recursive: true})
   })
+
+  it("detects duplicate model names when two projects target the same directory spelled differently", async () => {
+    const outputDirectory = path.resolve(dummyDirectory(), "../tmp/frontend-model-output-canonical")
+    await fs.rm(outputDirectory, {force: true, recursive: true})
+
+    const cli = new Cli({
+      configuration: buildConfiguration({
+        backendProjectsList: [
+          {
+            path: "/tmp/backend-one",
+            frontendModels: {
+              User: ReferenceUserFrontendResource
+            },
+            frontendModelsOutputPath: outputDirectory
+          },
+          {
+            path: "/tmp/backend-two",
+            frontendModels: {
+              User: ReferenceUserFrontendResource
+            },
+            // Same directory as above, spelled with a redundant "." segment and a trailing slash.
+            frontendModelsOutputPath: `${outputDirectory}/./`
+          }
+        ],
+        initializeModels: async ({configuration}) => {
+          configuration.registerModelClass(User)
+        }
+      }),
+      directory: dummyDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["g:frontend-models"],
+      testing: true
+    })
+
+    await expect(async () => {
+      await cli.execute()
+    }).toThrow(/Duplicate frontend model definition for 'User'/)
+
+    await fs.rm(outputDirectory, {force: true, recursive: true})
+  })
 })

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -1,5 +1,6 @@
 import BaseCommand from "../../../../../cli/base-command.js"
 import fs from "fs/promises"
+import path from "node:path"
 import * as inflection from "inflection"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "../../../../../frontend-models/resource-definition.js"
 
@@ -31,7 +32,13 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     const generatedFilesByDirectory = new Map()
 
     for (const backendProject of backendProjects) {
-      const frontendModelsDir = this.frontendModelsDirectoryForBackendProject(backendProject)
+      // Canonicalize the output directory so equivalent spellings (a trailing
+      // slash, `.`/`..` segments, duplicate separators, relative vs absolute)
+      // resolve to a single key. Otherwise the per-directory maps below treat
+      // them as different directories, duplicate class names slip past detection,
+      // and the split buckets write incomplete index.js/setup.js for files that
+      // actually land in the same directory on disk.
+      const frontendModelsDir = path.resolve(this.frontendModelsDirectoryForBackendProject(backendProject))
       const importPath = this.importPathForFrontendModelsDirectory(frontendModelsDir)
 
       if (!ensuredDirectories.has(frontendModelsDir)) {

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -24,9 +24,9 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     }
 
     /** @type {Set<string>} */
-    const generatedModelNames = new Set()
-    /** @type {Set<string>} */
     const ensuredDirectories = new Set()
+    /** @type {Map<string, Set<string>>} */
+    const generatedModelNamesByDirectory = new Map()
     /** @type {Map<string, Array<{className: string, fileName: string}>>} */
     const generatedFilesByDirectory = new Map()
 
@@ -43,9 +43,15 @@ export default class DbGenerateFrontendModels extends BaseCommand {
         generatedFilesByDirectory.set(frontendModelsDir, [])
       }
 
+      if (!generatedModelNamesByDirectory.has(frontendModelsDir)) {
+        generatedModelNamesByDirectory.set(frontendModelsDir, new Set())
+      }
+
       const generatedFiles = generatedFilesByDirectory.get(frontendModelsDir)
+      const generatedModelNames = generatedModelNamesByDirectory.get(frontendModelsDir)
 
       if (!generatedFiles) throw new Error(`Generated files list missing for ${frontendModelsDir}`)
+      if (!generatedModelNames) throw new Error(`Generated model names set missing for ${frontendModelsDir}`)
       const resources = this.resourcesForBackendProject(backendProject)
       const availableFrontendModelClassNames = this.availableFrontendModelClassNames(resources)
 


### PR DESCRIPTION
## Summary
- Track duplicate generated frontend model class names per frontend output directory instead of globally.
- Add CLI generator coverage for using the same model class in two different app outputs.

## Tests
- npm run test -- spec/cli/commands/generate/frontend-models-spec.js
- npm run build
- npm run typecheck
- npm run lint (passes with existing warnings)