### PR TITLE
Fix worker websocket startup race

### DIFF
--- a/changelog.d/20260527-worker-websocket-startup.md
+++ b/changelog.d/20260527-worker-websocket-startup.md
@@ -1,0 +1,1 @@
+Fix HTTP worker startup so websocket broadcasts are not delivered to worker threads before their app configuration has finished initializing.

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -3,6 +3,7 @@
 import WorkerHandler from "../../src/http-server/worker-handler/index.js"
 import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
+import websocketEventsHost from "../../src/http-server/websocket-events-host.js"
 
 describe("HttpServer - worker handler", () => {
   it("closes client connections when the worker exits unexpectedly", () => {
@@ -43,6 +44,54 @@ describe("HttpServer - worker handler", () => {
     handler.unregisterFromEventsHost = () => {}
 
     expect(() => handler.dispatchWebsocketEvent({channel: "frontend-models:Task", payload: {action: "update"}})).not.toThrow()
+  })
+
+  it("only receives websocket broadcasts after the worker has started", async () => {
+    await websocketEventsHost.awaitPendingBroadcasts()
+
+    const originalHandlers = new Set(websocketEventsHost.handlers)
+    const sentMessages = []
+    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+
+    websocketEventsHost.handlers.clear()
+    handler.worker = {
+      postMessage: (message) => {
+        sentMessages.push(message)
+      }
+    }
+
+    try {
+      websocketEventsHost.broadcastV2({body: {action: "create", id: "1"}, broadcastParams: {model: "Build"}, channel: "frontend-models"})
+      await websocketEventsHost.awaitPendingBroadcasts()
+
+      expect(sentMessages).toEqual([])
+
+      handler.onWorkerMessage({command: "started"})
+      websocketEventsHost.broadcastV2({body: {action: "update", id: "1"}, broadcastParams: {model: "Build"}, channel: "frontend-models"})
+      await websocketEventsHost.awaitPendingBroadcasts()
+
+      expect(sentMessages).toEqual([{
+        body: {action: "update", id: "1"},
+        broadcastParams: {model: "Build"},
+        channel: "frontend-models",
+        command: "websocketV2Broadcast",
+        createdAt: undefined,
+        eventId: undefined
+      }])
+
+      handler.onWorkerExit(0)
+      websocketEventsHost.broadcastV2({body: {action: "destroy", id: "1"}, broadcastParams: {model: "Build"}, channel: "frontend-models"})
+      await websocketEventsHost.awaitPendingBroadcasts()
+
+      expect(sentMessages.length).toEqual(1)
+    } finally {
+      handler.unregisterFromEventsHostIfNeeded()
+      websocketEventsHost.handlers.clear()
+
+      for (const originalHandler of originalHandlers) {
+        websocketEventsHost.handlers.add(originalHandler)
+      }
+    }
   })
 
   it("recycles workers on development reload without restarting the process", async () => {

--- a/src/http-server/worker-handler/index.js
+++ b/src/http-server/worker-handler/index.js
@@ -47,7 +47,7 @@ export default class VelociousHttpServerWorker {
 
     this.logger = new Logger(this)
     this.workerCount = workerCount
-    this.unregisterFromEventsHost = websocketEventsHost.register(this)
+    this.workerStarted = false
     this._stopping = false
   }
 
@@ -107,6 +107,7 @@ export default class VelociousHttpServerWorker {
    */
   onWorkerExit = (code) => {
     this._hasExited = true
+    this.workerStarted = false
 
     if (code !== 0 && !this._stopping) {
       this.logger.error(`Velocious worker ${this.workerCount} exited unexpectedly with code ${code}`)
@@ -116,8 +117,10 @@ export default class VelociousHttpServerWorker {
       this.logger.debug(() => `Client worker stopped with exit code ${code}`)
     }
 
-    this.unregisterFromEventsHost?.()
-    this._stopResolve?.()
+    this.unregisterFromEventsHostIfNeeded()
+    if (this._stopResolve) {
+      this._stopResolve()
+    }
     this._stopResolve = null
   }
 
@@ -155,6 +158,9 @@ export default class VelociousHttpServerWorker {
 
 
     if (command == "started") {
+      this.workerStarted = true
+      this.registerWithEventsHost()
+
       if (this.onStartCallback) {
         this.onStartCallback(null)
       }
@@ -233,6 +239,8 @@ export default class VelociousHttpServerWorker {
     if (this._hasExited) return Promise.resolve()
 
     this._stopping = true
+    this.workerStarted = false
+    this.unregisterFromEventsHostIfNeeded()
     const worker = this.worker
 
     if (!worker) return Promise.resolve()
@@ -253,6 +261,7 @@ export default class VelociousHttpServerWorker {
    */
   dispatchWebsocketEvent({channel, createdAt, eventId, payload}) {
     // Test and shutdown paths can leave a registered handler without a live worker-thread transport.
+    if (!this.workerStarted) return
     if (!this.worker || typeof this.worker.postMessage !== "function") return
 
     this.worker.postMessage({channel, command: "websocketEvent", createdAt, eventId, payload})
@@ -261,7 +270,6 @@ export default class VelociousHttpServerWorker {
   /**
    * Forwards a V2 channel broadcast to this worker's thread so it can
    * dispatch to any locally-registered V2 subscriptions.
-   *
    * @param {object} args - Options object.
    * @param {string} args.channel - Channel name.
    * @param {Record<string, any>} args.broadcastParams - Routing filter params.
@@ -271,8 +279,24 @@ export default class VelociousHttpServerWorker {
    * @returns {void}
    */
   dispatchWebsocketV2Broadcast({body, broadcastParams, channel, eventId, createdAt}) {
+    if (!this.workerStarted) return
     if (!this.worker || typeof this.worker.postMessage !== "function") return
 
     this.worker.postMessage({body, broadcastParams, channel, command: "websocketV2Broadcast", eventId, createdAt})
+  }
+
+  /** @returns {void} */
+  registerWithEventsHost() {
+    if (this.unregisterFromEventsHost) return
+
+    this.unregisterFromEventsHost = websocketEventsHost.register(this)
+  }
+
+  /** @returns {void} */
+  unregisterFromEventsHostIfNeeded() {
+    if (!this.unregisterFromEventsHost) return
+
+    this.unregisterFromEventsHost()
+    this.unregisterFromEventsHost = null
   }
 }


### PR DESCRIPTION
Summary:
- Register HTTP worker handlers for websocket fan-out only after worker startup completes.
- Drop websocket fan-out registration during stop/exit.
- Add regression coverage for pre-start broadcasts.

Tests:
- node scripts/run-tests.js spec/http-server/worker-handler-spec.js
- npm run build
- npm run typecheck
- npm run lint (passes with existing warnings)