### PR TITLE
Emit background job failure events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 * Translated model attributes with current-locale relationship sorting (see [docs/translations.md](docs/translations.md))
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon`, including forked background job runners (see [docs/beacon.md](docs/beacon.md))
+* Background jobs with failure events for production reporting (see [docs/background-jobs.md](docs/background-jobs.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 * EJS-backed mailers with delivery, queueing, and payload rendering support (see [docs/mailers.md](docs/mailers.md))
 * Trusted reverse proxy handling for `request.remoteAddress()` (see [docs/trusted-proxies.md](docs/trusted-proxies.md))
@@ -1783,6 +1784,8 @@ Create the file `src/routes/testing/another-action.ejs` and so something like th
 # Background jobs
 
 Velocious includes a simple background jobs system inspired by Sidekiq.
+
+Production apps can listen for `background-job-failed` or its `all-error` mirror to report accepted failed attempts, including retry and terminal state metadata. See [docs/background-jobs.md](docs/background-jobs.md#failure-events).
 
 ## Setup
 

--- a/changelog.d/20260527143523-background-job-failure-events.md
+++ b/changelog.d/20260527143523-background-job-failure-events.md
@@ -1,0 +1,1 @@
+Background job failures now emit a structured `background-job-failed` error event after Velocious records an accepted failed attempt, including job id/name, args, attempts, retry/final status, worker handoff data, and the failure stack when available. Apps can subscribe to this event for bug reporting without wrapping every job class.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This folder contains implementation learnings and practical guidance discovered 
 
 ## Index
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
+- `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.
 - `docs/query-bulk-operations.md`: `updateAll` for efficient batch updates and `destroyAll` behavior.
 - `docs/logging.md`: Rails-style request and database query logging behavior.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -1,0 +1,48 @@
+# Background Jobs
+
+Velocious background jobs are documented in the main README. This page covers behavior that applications usually need when operating background jobs in production.
+
+## Failure Events
+
+`background-jobs-main` emits a `background-job-failed` error event after it accepts a worker failure report and records the updated job state. Duplicate or stale worker reports do not emit this event because they are rejected before the job row changes.
+
+The event fires for every accepted failed attempt, including attempts that are returned to the queue for retry and attempts that end the job.
+
+```js
+configuration.getErrorEvents().on("background-job-failed", ({error, context}) => {
+  console.error("Background job failed", {
+    error,
+    jobId: context.jobId,
+    jobName: context.jobName,
+    terminal: context.terminal,
+    willRetry: context.willRetry
+  })
+})
+```
+
+Applications that already listen to the aggregate error stream can handle the mirrored event there:
+
+```js
+configuration.getErrorEvents().on("all-error", ({error, errorType, context}) => {
+  if (errorType !== "background-job-failed") return
+
+  console.error("Background job failed", error, context)
+})
+```
+
+The `background-job-failed` payload has:
+
+- `error`: the job failure as an `Error`. String failure reports are normalized to an `Error`, with the original string preserved as `error.stack` when available.
+- `context.attempts`: the updated failed-attempt count after this report.
+- `context.handedOffAtMs`: the worker handoff timestamp included in the accepted report.
+- `context.jobArgs`: the serialized arguments for the job.
+- `context.jobId`: the background job id.
+- `context.jobName`: the job class name.
+- `context.maxRetries`: the job retry limit.
+- `context.stage`: always `"background-job-failed"`.
+- `context.status`: the persisted job status after failure handling, such as `"queued"` for a retry or `"failed"` for an exhausted job.
+- `context.terminal`: whether this failure ended the job.
+- `context.willRetry`: whether this failure returned the job to the queue.
+- `context.workerId`: the worker id included in the accepted report.
+
+The mirrored `all-error` payload includes the same `error` and `context` plus `errorType: "background-job-failed"`.

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -10,6 +10,7 @@ import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import AppendJob from "../dummy/src/jobs/append-job.js"
 import DelayedJob from "../dummy/src/jobs/delayed-job.js"
+import FailingJob from "../dummy/src/jobs/failing-job.js"
 
 describe("Background jobs - queue", () => {
   it("processes inline jobs in order", async () => {
@@ -205,5 +206,60 @@ describe("Background jobs - queue", () => {
 
     await worker.stop()
     await main.stop()
+  })
+
+  it("emits background-job-failed after an accepted job failure report", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    await store.clearAll()
+
+    const main = new BackgroundJobsMain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+    await main.start()
+
+    dummyConfiguration.setBackgroundJobsConfig({
+      host: "127.0.0.1",
+      port: main.getPort()
+    })
+
+    const worker = new BackgroundJobsWorker({configuration: dummyConfiguration})
+    const failureEvents = []
+    const onFailure = (payload) => {
+      failureEvents.push(payload)
+    }
+
+    dummyConfiguration.getErrorEvents().on("background-job-failed", onFailure)
+
+    try {
+      await worker.start()
+
+      const jobId = await FailingJob.performLaterWithOptions({
+        args: ["planned failure"],
+        options: {forked: false, maxRetries: 0}
+      })
+
+      await timeout({timeout: 2000}, async () => {
+        while (true) {
+          const job = await store.getJob(jobId)
+
+          if (job?.status === "failed") break
+
+          await wait(0.05)
+        }
+      })
+
+      expect(failureEvents.length).toEqual(1)
+      expect(failureEvents[0].context.jobId).toEqual(jobId)
+      expect(failureEvents[0].context.jobName).toEqual("FailingJob")
+      expect(failureEvents[0].context.jobArgs).toEqual(["planned failure"])
+      expect(failureEvents[0].context.attempts).toEqual(1)
+      expect(failureEvents[0].context.terminal).toEqual(true)
+      expect(failureEvents[0].context.willRetry).toEqual(false)
+      expect(failureEvents[0].error.message).toEqual("Error: planned failure")
+      expect(String(failureEvents[0].error.stack)).toContain("planned failure")
+    } finally {
+      dummyConfiguration.getErrorEvents().off("background-job-failed", onFailure)
+      await worker.stop()
+      await main.stop()
+    }
   })
 })

--- a/spec/dummy/src/jobs/failing-job.js
+++ b/spec/dummy/src/jobs/failing-job.js
@@ -1,0 +1,7 @@
+import VelociousJob from "../../../../src/background-jobs/job.js"
+
+export default class FailingJob extends VelociousJob {
+  async perform(message = "background job failed") {
+    throw new Error(message)
+  }
+}

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -347,12 +347,22 @@ export default class BackgroundJobsMain {
    */
   async _handleJobFailed({jsonSocket, message}) {
     try {
-      await this.store.markFailed({
+      const failedJob = await this.store.markFailed({
         jobId: message.jobId,
         error: message.error,
         workerId: message.workerId,
         handedOffAtMs: message.handedOffAtMs
       })
+
+      if (failedJob) {
+        this._emitBackgroundJobFailed({
+          error: message.error,
+          handedOffAtMs: message.handedOffAtMs,
+          job: failedJob,
+          workerId: message.workerId
+        })
+      }
+
       jsonSocket.send({type: "job-updated", jobId: message.jobId})
       // A failed job may have been re-queued (with backoff) for retry —
       // poke the dispatcher so the retry timer is armed.
@@ -362,6 +372,53 @@ export default class BackgroundJobsMain {
       this.logger.error(() => ["Failed to update job failure:", error])
       jsonSocket.send({type: "job-update-error", jobId: message.jobId, error: "Failed to update job"})
     }
+  }
+
+  /**
+   * @param {{error: unknown, handedOffAtMs?: number, job: import("./types.js").BackgroundJobRow, workerId?: string}} args - Failure event data.
+   * @returns {void}
+   */
+  _emitBackgroundJobFailed({error, handedOffAtMs, job, workerId}) {
+    const normalizedError = this._normalizeFailureError(error)
+    const payload = {
+      context: {
+        attempts: job.attempts,
+        handedOffAtMs,
+        jobArgs: job.args,
+        jobId: job.id,
+        jobName: job.jobName,
+        maxRetries: job.maxRetries,
+        stage: "background-job-failed",
+        status: job.status,
+        terminal: job.status === "failed" || job.status === "orphaned",
+        willRetry: job.status === "queued",
+        workerId
+      },
+      error: normalizedError
+    }
+    const errorEvents = this.configuration.getErrorEvents()
+
+    errorEvents.emit("background-job-failed", payload)
+    errorEvents.emit("all-error", {...payload, errorType: "background-job-failed"})
+  }
+
+  /**
+   * @param {unknown} error - Reported failure value.
+   * @returns {Error} Normalized error.
+   */
+  _normalizeFailureError(error) {
+    if (error instanceof Error) return error
+
+    const message = typeof error === "string" && error.trim()
+      ? error.trim().split("\n")[0]
+      : String(error || "Background job failed")
+    const normalizedError = new Error(message)
+
+    if (typeof error === "string" && error.trim()) {
+      normalizedError.stack = error
+    }
+
+    return normalizedError
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -349,18 +349,18 @@ export default class BackgroundJobsStore {
    * @param {unknown} args.error - Error.
    * @param {string} [args.workerId] - Worker id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
-   * @returns {Promise<void>} - Resolves when updated.
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Updated job row when the report was accepted.
    */
   async markFailed({jobId, error, workerId, handedOffAtMs}) {
     await this.ensureReady()
 
-    await this._withDb(async (db) => {
+    return await this._withDb(async (db) => {
       const job = await this._getJobRowById(db, jobId)
 
-      if (!job) return
-      if (!this._shouldAcceptReport({job, workerId, handedOffAtMs})) return
+      if (!job) return null
+      if (!this._shouldAcceptReport({job, workerId, handedOffAtMs})) return null
 
-      await this._applyFailure({db, job, error, markOrphaned: false})
+      return await this._applyFailure({db, job, error, markOrphaned: false})
     })
   }
 
@@ -558,7 +558,7 @@ export default class BackgroundJobsStore {
    * @param {import("./types.js").BackgroundJobRow} args.job - Job row.
    * @param {unknown} args.error - Error.
    * @param {boolean} args.markOrphaned - Whether marking orphaned.
-   * @returns {Promise<void>} - Resolves when updated.
+   * @returns {Promise<import("./types.js").BackgroundJobRow>} - Updated job row.
    */
   async _applyFailure({db, job, error, markOrphaned}) {
     const now = Date.now()
@@ -595,6 +595,18 @@ export default class BackgroundJobsStore {
       data: update,
       conditions: {id: job.id}
     })
+
+    return {
+      ...job,
+      attempts: nextAttempt,
+      failedAtMs: update.failed_at_ms ?? job.failedAtMs,
+      handedOffAtMs: null,
+      lastError: failureMessage,
+      orphanedAtMs: update.orphaned_at_ms ?? job.orphanedAtMs,
+      scheduledAtMs: update.scheduled_at_ms ?? job.scheduledAtMs,
+      status: update.status,
+      workerId: null
+    }
   }
 
   /**

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -33,6 +33,16 @@
  * @property {string | null} lastError - Last failure message.
  */
 /**
+ * @typedef {object} BackgroundJobFailureEvent
+ * @property {BackgroundJobRow} job - Updated job row after failure handling.
+ * @property {unknown} error - Failure error.
+ * @property {number | null} attempts - Updated failure attempts count.
+ * @property {boolean} terminal - Whether this failure ended the job.
+ * @property {boolean} willRetry - Whether the job was returned to the queue.
+ * @property {number | undefined} handedOffAtMs - Handoff timestamp from the worker report.
+ * @property {string | undefined} workerId - Worker id from the worker report.
+ */
+/**
  * @typedef {"worker" | "client" | "reporter"} BackgroundJobSocketRole
  */
 /**


### PR DESCRIPTION
## Summary
- emit a structured background-job-failed event after accepted failed job reports
- include job id/name, args, attempts, retry/final status, worker data, and stack text when available
- add focused coverage for the emitted event

## Tests
- npm run test -- spec/background-jobs/queue-spec.js spec/background-jobs/store-spec.js
- npm run typecheck
- npm run lint (passes with existing warnings)