### PR TITLE
Add opt-in parallel tenant migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2076,6 +2076,7 @@ For Apartment-style project/account databases, mark the logical per-tenant ident
 npx velocious db:tenants:create projectTenant
 npx velocious db:tenants:check projectTenant
 npx velocious db:tenants:migrate projectTenant
+npx velocious db:tenants:migrate projectTenant --parallel 20
 ```
 
 See [docs/tenant-databases.md](docs/tenant-databases.md) for the full configuration and migration pattern.

--- a/changelog.d/20260527153526-parallel-tenant-commands.md
+++ b/changelog.d/20260527153526-parallel-tenant-commands.md
@@ -1,0 +1,4 @@
+## Added
+
+- Added opt-in bounded parallel processing for tenant database CLI commands with `--parallel` / `--parallel <count>`.
+- Added an `afterMigrateTenant` tenant database provider hook that runs after generic tenant migrations for each tenant.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -42,6 +42,9 @@ export default new Configuration({
       },
       checkTenant: async ({databaseConfiguration, tenant}) => {
         // Optional preflight checks before generic connection validation.
+      },
+      afterMigrateTenant: async ({configuration, databaseConfiguration, tenant}) => {
+        // Optional app-owned schema or data work after generic migrations.
       }
     }
   }
@@ -54,6 +57,13 @@ Run tenant lifecycle commands by database identifier:
 npx velocious db:tenants:create projectTenant
 npx velocious db:tenants:check projectTenant
 npx velocious db:tenants:migrate projectTenant
+```
+
+Tenant lifecycle commands run one tenant at a time by default. Add `--parallel` to process up to 20 tenants at once, or pass a positive integer to choose a different concurrency:
+
+```sh
+npx velocious db:tenants:migrate projectTenant --parallel
+npx velocious db:tenants:migrate projectTenant --parallel 20
 ```
 
 Tenant migrations should explicitly target the tenant identifier:

--- a/spec/cli/commands/db/tenants/migrate-spec.js
+++ b/spec/cli/commands/db/tenants/migrate-spec.js
@@ -77,6 +77,7 @@ describe("Cli - Commands - db:tenants:migrate", () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-migrate-"))
     const migrationsDirectory = path.join(directory, "src", "database", "migrations")
     const migrationModuleUrl = new URL("../../../../../src/database/migration/index.js", import.meta.url).href
+    const migratedTenantSlugs = []
 
     await fs.mkdir(migrationsDirectory, {recursive: true})
     await fs.writeFile(path.join(migrationsDirectory, "20260517000000-create-tenant-widgets.js"), `
@@ -124,6 +125,15 @@ export default CreateTenantWidgets
       locales: ["en"],
       tenantDatabaseProviders: {
         projectTenant: {
+          afterMigrateTenant: async ({configuration, tenant}) => {
+            const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+            await configuration.ensureConnections(async (dbs) => {
+              expect(await dbs.projectTenant.getTableByName("tenant_widgets")).toBeTruthy()
+            })
+
+            migratedTenantSlugs.push(tenantObject.slug)
+          },
           listTenants: async () => [{slug: "alpha"}, {slug: "beta"}]
         }
       },
@@ -153,6 +163,7 @@ export default CreateTenantWidgets
         migrationCount: 1,
         tenantCount: 2
       })
+      expect(migratedTenantSlugs.sort()).toEqual(["alpha", "beta"])
 
       await configuration.runWithTenant({slug: "alpha"}, async () => {
         await configuration.ensureConnections(async (dbs) => {
@@ -173,6 +184,150 @@ export default CreateTenantWidgets
           expect(table?.getName()).toEqual("tenant_widgets")
         })
       })
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("runs tenant commands with opt-in bounded parallelism", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-parallel-"))
+    let activeTenantCount = 0
+    let maximumActiveTenantCount = 0
+    const checkedTenantSlugs = []
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-parallel-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-parallel-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          checkTenant: async ({tenant}) => {
+            const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+            activeTenantCount++
+            maximumActiveTenantCount = Math.max(maximumActiveTenantCount, activeTenantCount)
+
+            await new Promise((resolve) => setTimeout(resolve, 25))
+
+            checkedTenantSlugs.push(tenantObject.slug)
+            activeTenantCount--
+          },
+          listTenants: async () => [
+            {slug: "alpha"},
+            {slug: "beta"},
+            {slug: "gamma"},
+            {slug: "delta"}
+          ]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-parallel-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      parsedProcessArgs: {parallel: "2"},
+      processArgs: ["db:tenants:check", "projectTenant", "--parallel", "2"],
+      testing: true
+    })
+
+    try {
+      expect(await cli.execute()).toEqual({
+        identifier: "projectTenant",
+        tenantCount: 4
+      })
+      expect(maximumActiveTenantCount).toEqual(2)
+      expect(checkedTenantSlugs.sort()).toEqual(["alpha", "beta", "delta", "gamma"])
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("rejects invalid parallel tenant command counts", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-parallel-invalid-"))
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-parallel-invalid-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-parallel-invalid-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          listTenants: async () => [{slug: "alpha"}]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-parallel-invalid-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      parsedProcessArgs: {parallel: "zero"},
+      processArgs: ["db:tenants:check", "projectTenant", "--parallel", "zero"],
+      testing: true
+    })
+
+    try {
+      await expect(async () => {
+        await cli.execute()
+      }).toThrow(/--parallel must be a positive integer/)
     } finally {
       await configuration.closeDatabaseConnections()
       await fs.rm(directory, {force: true, recursive: true})

--- a/src/cli/commands/db/tenants/migrate.js
+++ b/src/cli/commands/db/tenants/migrate.js
@@ -13,7 +13,7 @@ export default class DbTenantsMigrate extends BaseCommand {
       identifier: this.processArgs?.[1]
     })
     const migrations = await this.getEnvironmentHandler().findMigrations()
-    const tenantCount = await helper.eachTenant(async () => {
+    const tenantCount = await helper.eachTenant(async ({databaseConfiguration, tenant}) => {
       const migrator = new Migrator({
         configuration: this.getConfiguration(),
         databaseIdentifiers: [helper.identifier]
@@ -23,6 +23,15 @@ export default class DbTenantsMigrate extends BaseCommand {
         await migrator.prepare()
         await migrator.migrateFiles(migrations, digg(this.getEnvironmentHandler(), "requireMigration"))
       })
+
+      if (typeof helper.provider.afterMigrateTenant === "function") {
+        await helper.provider.afterMigrateTenant({
+          configuration: this.getConfiguration(),
+          databaseConfiguration,
+          identifier: helper.identifier,
+          tenant
+        })
+      }
     })
 
     if (this.args.testing) {

--- a/src/cli/tenant-database-command-helper.js
+++ b/src/cli/tenant-database-command-helper.js
@@ -66,21 +66,99 @@ export default class TenantDatabaseCommandHelper {
    */
   async eachTenant(callback) {
     const tenants = await this.listTenants()
+    const parallelCount = this.parallelCount()
 
-    for (const tenant of tenants) {
-      await this.configuration.runWithTenant(tenant, async () => {
-        if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
-          throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${this.tenantLabel(tenant)}`)
+    if (parallelCount <= 1) {
+      for (const tenant of tenants) {
+        await this.runTenantCallback({callback, tenant})
+      }
+
+      return tenants.length
+    }
+
+    /** @type {Array<{error: Error, tenant: unknown}>} */
+    const failures = []
+    const workers = []
+    let tenantIndex = 0
+    const workerCount = Math.min(parallelCount, tenants.length)
+
+    for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+      workers.push((async () => {
+        while (tenantIndex < tenants.length) {
+          const tenant = tenants[tenantIndex]
+
+          tenantIndex++
+
+          try {
+            await this.runTenantCallback({callback, tenant})
+          } catch (error) {
+            failures.push({
+              error: error instanceof Error ? error : new Error(String(error)),
+              tenant
+            })
+          }
         }
+      })())
+    }
 
-        await callback({
-          databaseConfiguration: this.configuration.resolveDatabaseConfiguration(this.identifier),
-          tenant
-        })
-      })
+    await Promise.all(workers)
+
+    if (failures.length > 0) {
+      const failedTenantLabels = failures.map((failure) => this.tenantLabel(failure.tenant)).join(", ")
+
+      throw new AggregateError(
+        failures.map((failure) => failure.error),
+        `Failed tenant database command for tenant(s): ${failedTenantLabels}`
+      )
     }
 
     return tenants.length
+  }
+
+  /** @returns {number} - Number of tenants to process concurrently. */
+  parallelCount() {
+    const parsedProcessArgs = this.command.args?.parsedProcessArgs || {}
+    let parallelArg = parsedProcessArgs.parallel
+
+    if (parallelArg === undefined) {
+      const parallelArgIndex = this.command.processArgs?.indexOf("--parallel") ?? -1
+
+      if (parallelArgIndex >= 0) {
+        const nextArg = this.command.processArgs?.[parallelArgIndex + 1]
+
+        parallelArg = nextArg && !nextArg.startsWith("-") ? nextArg : true
+      }
+    }
+
+    if (parallelArg === undefined || parallelArg === false) return 1
+    if (parallelArg === true) return 20
+
+    const parallelCount = Number(parallelArg)
+
+    if (!Number.isInteger(parallelCount) || parallelCount < 1) {
+      throw new Error(`--parallel must be a positive integer when a value is provided: ${parallelArg}`)
+    }
+
+    return parallelCount
+  }
+
+  /**
+   * @param {object} args - Tenant callback args.
+   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: unknown}) : Promise<void>} args.callback - Callback.
+   * @param {unknown} args.tenant - Tenant.
+   * @returns {Promise<void>}
+   */
+  async runTenantCallback({callback, tenant}) {
+    await this.configuration.runWithTenant(tenant, async () => {
+      if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
+        throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${this.tenantLabel(tenant)}`)
+      }
+
+      await callback({
+        databaseConfiguration: this.configuration.resolveDatabaseConfiguration(this.identifier),
+        tenant
+      })
+    })
   }
 
   /**

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -345,6 +345,7 @@
  * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [createDatabase] - Creates the tenant database/schema for one tenant.
  * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [dropDatabase] - Drops the tenant database/schema for one tenant.
  * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [checkTenant] - Checks one tenant database before generic connection validation.
+ * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: unknown}) : void | Promise<void>} [afterMigrateTenant] - Runs app-owned tenant work after generic migrations for one tenant.
  */
 
 /**

--- a/src/database/drivers/mysql/columns-index.js
+++ b/src/database/drivers/mysql/columns-index.js
@@ -1,6 +1,22 @@
 // @ts-check
 
 import BaseColumnsIndex from "../base-columns-index.js"
+import {digg} from "diggerize"
+import TableIndex from "../../table-data/table-index.js"
 
 export default class VelociousDatabaseDriversMysqlColumnsIndex extends BaseColumnsIndex {
+  getColumnNames() {
+    const columnNames = digg(this, "data", "column_names")
+
+    if (columnNames) return columnNames
+
+    return [digg(this, "data", "COLUMN_NAME")]
+  }
+
+  getTableDataIndex() {
+    return new TableIndex(this.getColumnNames(), {
+      name: this.getName(),
+      unique: this.isUnique()
+    })
+  }
 }

--- a/src/database/drivers/mysql/table.js
+++ b/src/database/drivers/mysql/table.js
@@ -70,9 +70,13 @@ export default class VelociousDatabaseDriversMysqlTable extends BaseTable {
         WHERE
           TABLE_SCHEMA = DATABASE() AND
           TABLE_NAME = ${options.quote(this.getName())}
+        ORDER BY
+          INDEX_NAME,
+          SEQ_IN_INDEX
       `
       const indexesRows = await this.getDriver().query(sql)
       const indexes = []
+      const indexRowsByName = new Map()
 
       for (const indexRow of indexesRows) {
         if (indexRow.NON_UNIQUE == 1) {
@@ -87,9 +91,19 @@ export default class VelociousDatabaseDriversMysqlTable extends BaseTable {
           indexRow.is_primary_key = false
         }
 
-        const index = new ColumnsIndex(this, indexRow)
+        const existingIndexRow = indexRowsByName.get(indexRow.index_name)
 
-        indexes.push(index)
+        if (existingIndexRow) {
+          existingIndexRow.column_names.push(indexRow.COLUMN_NAME)
+        } else {
+          const groupedIndexRow = Object.assign({}, indexRow, {
+            column_names: [indexRow.COLUMN_NAME]
+          })
+          const index = new ColumnsIndex(this, groupedIndexRow)
+
+          indexRowsByName.set(indexRow.index_name, groupedIndexRow)
+          indexes.push(index)
+        }
       }
 
       return indexes


### PR DESCRIPTION
## Summary
- add opt-in --parallel support to tenant database CLI commands
- add afterMigrateTenant provider hook after generic tenant migrations
- expose grouped MySQL index metadata for tenant schema consumers

## Tests
- node scripts/run-tests.js spec/cli/commands/db/tenants/migrate-spec.js
- npm run typecheck
- npm run lint
- npm run build