### PR TITLE
Keep tenant migrate hooks in connection scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2079,4 +2079,6 @@ npx velocious db:tenants:migrate projectTenant
 npx velocious db:tenants:migrate projectTenant --parallel 20
 ```
 
+`afterMigrateTenant` hooks run inside the active default and tenant database connection scope for the tenant being migrated.
+
 See [docs/tenant-databases.md](docs/tenant-databases.md) for the full configuration and migration pattern.

--- a/changelog.d/20260528050220-tenant-migrate-hook-connections.md
+++ b/changelog.d/20260528050220-tenant-migrate-hook-connections.md
@@ -1,0 +1,1 @@
+Tenant database `afterMigrateTenant` hooks now run inside the active migration connection scope, including when tenant commands use `--parallel`.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -66,6 +66,8 @@ npx velocious db:tenants:migrate projectTenant --parallel
 npx velocious db:tenants:migrate projectTenant --parallel 20
 ```
 
+`afterMigrateTenant` runs inside the tenant command's active connection scope after generic migrations finish for that tenant. Hooks can read `configuration.getCurrentConnections()` or run model/database queries against both the default database and the active tenant database without opening another connection scope.
+
 Tenant migrations should explicitly target the tenant identifier:
 
 ```js

--- a/spec/cli/commands/db/tenants/migrate-spec.js
+++ b/spec/cli/commands/db/tenants/migrate-spec.js
@@ -190,6 +190,113 @@ export default CreateTenantWidgets
     }
   })
 
+  it("keeps tenant connections active for after-migrate hooks during parallel tenant migrations", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-hook-connections-"))
+    const migrationsDirectory = path.join(directory, "src", "database", "migrations")
+    const migrationModuleUrl = new URL("../../../../../src/database/migration/index.js", import.meta.url).href
+    const migratedTenantSlugs = []
+    const migratedTenantDatabaseNames = []
+
+    await fs.mkdir(migrationsDirectory, {recursive: true})
+    await fs.writeFile(path.join(migrationsDirectory, "20260517000000-create-tenant-widgets.js"), `
+import Migration from ${JSON.stringify(migrationModuleUrl)}
+
+class CreateTenantWidgets extends Migration {
+  async change() {
+    await this.createTable("tenant_widgets", (table) => {
+      table.string("name", {null: false})
+    })
+  }
+}
+
+CreateTenantWidgets.onDatabases(["projectTenant"])
+
+export default CreateTenantWidgets
+`, "utf8")
+
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-hook-connections-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-hook-connections-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          afterMigrateTenant: async ({configuration, tenant}) => {
+            const tenantObject = /** @type {{slug?: string}} */ (tenant)
+            const dbs = configuration.getCurrentConnections()
+
+            expect(dbs.default).toBeTruthy()
+            expect(dbs.projectTenant).toBeTruthy()
+            expect(dbs.projectTenant.getArgs().name).toEqual(`velocious-cli-tenants-hook-connections-project-${tenantObject.slug}`)
+            expect(await dbs.projectTenant.getTableByName("tenant_widgets")).toBeTruthy()
+
+            migratedTenantSlugs.push(tenantObject.slug)
+            migratedTenantDatabaseNames.push(dbs.projectTenant.getArgs().name)
+          },
+          listTenants: async () => [
+            {slug: "alpha"},
+            {slug: "beta"},
+            {slug: "gamma"}
+          ]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-hook-connections-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      parsedProcessArgs: {parallel: "2"},
+      processArgs: ["db:tenants:migrate", "projectTenant", "--parallel", "2"],
+      testing: true
+    })
+
+    try {
+      expect(await cli.execute()).toEqual({
+        identifier: "projectTenant",
+        migrationCount: 1,
+        tenantCount: 3
+      })
+      expect(migratedTenantSlugs.sort()).toEqual(["alpha", "beta", "gamma"])
+      expect(migratedTenantDatabaseNames.sort()).toEqual([
+        "velocious-cli-tenants-hook-connections-project-alpha",
+        "velocious-cli-tenants-hook-connections-project-beta",
+        "velocious-cli-tenants-hook-connections-project-gamma"
+      ])
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
   it("runs tenant commands with opt-in bounded parallelism", async () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-parallel-"))
     let activeTenantCount = 0

--- a/src/cli/commands/db/tenants/migrate.js
+++ b/src/cli/commands/db/tenants/migrate.js
@@ -22,16 +22,16 @@ export default class DbTenantsMigrate extends BaseCommand {
       await this.getConfiguration().ensureConnections(async () => {
         await migrator.prepare()
         await migrator.migrateFiles(migrations, digg(this.getEnvironmentHandler(), "requireMigration"))
-      })
 
-      if (typeof helper.provider.afterMigrateTenant === "function") {
-        await helper.provider.afterMigrateTenant({
-          configuration: this.getConfiguration(),
-          databaseConfiguration,
-          identifier: helper.identifier,
-          tenant
-        })
-      }
+        if (typeof helper.provider.afterMigrateTenant === "function") {
+          await helper.provider.afterMigrateTenant({
+            configuration: this.getConfiguration(),
+            databaseConfiguration,
+            identifier: helper.identifier,
+            tenant
+          })
+        }
+      })
     })
 
     if (this.args.testing) {


### PR DESCRIPTION
## Summary
- keep tenant after-migrate hooks inside the active migration connection scope
- add parallel tenant migration regression coverage
- document the hook connection-scope guarantee

## Tests
- node scripts/run-tests.js spec/cli/commands/db/tenants/migrate-spec.js
- npm run lint
- npm run typecheck
- npm run build