### PR TITLE
Reap idle DB connections and cap forked jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,23 @@ To prime *all* configured pools at once, call `configuration.ensureGlobalConnect
 
 When an async context exists, that connection is still preferred over the global one.
 
+Checked-in `AsyncTrackedMultiConnection` connections are closed after 5 seconds of idle time by default. This keeps tenant-scoped and short-lived background-job connections from accumulating in long-running processes while still allowing immediate reuse by nearby async work. Configure `database.<environment>.<identifier>.pool.idleTimeoutMillis` to change the timeout, or set it to `null` to disable idle reaping for that pool:
+
+```js
+database: {
+  production: {
+    default: {
+      driver: MysqlDriver,
+      poolType: AsyncTrackedMultiConnection,
+      type: "mysql",
+      pool: {
+        idleTimeoutMillis: 10000
+      }
+    }
+  }
+}
+```
+
 # Websockets
 
 Velocious includes a lightweight websocket entry point for API-style calls and server-side events.
@@ -1818,6 +1835,7 @@ export default new Configuration({
     host: "127.0.0.1",
     port: 7331,
     databaseIdentifier: "default",
+    maxConcurrentForkedJobs: 4,
     maxConcurrentInlineJobs: 4,
     dispatchStrategy: "beacon"
   }
@@ -1830,12 +1848,15 @@ Or via env vars:
 VELOCIOUS_BACKGROUND_JOBS_HOST=127.0.0.1
 VELOCIOUS_BACKGROUND_JOBS_PORT=7331
 VELOCIOUS_BACKGROUND_JOBS_DATABASE_IDENTIFIER=default
+VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_FORKED_JOBS=4
 VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS=4
 VELOCIOUS_BACKGROUND_JOBS_DISPATCH_STRATEGY=beacon
 VELOCIOUS_BACKGROUND_JOBS_POLL_INTERVAL_MS=1000
 ```
 
 `maxConcurrentInlineJobs` (default: `4`) caps how many `forked: false` jobs a single `background-jobs-worker` process runs in parallel. Concurrency is at the JS event-loop level: every job in flight shares the worker's process and DB connection pool, so the cap should fit the pool, not the CPU count. Forking remains the right tool when you need memory isolation across long-running jobs or want to use more cores.
+
+`maxConcurrentForkedJobs` (default: `4`) caps how many detached `background-jobs-runner` child processes one worker may keep in flight. Forked jobs still run in separate Node processes, but the worker withholds forked-job capacity until an existing runner exits so bursts cannot spawn unbounded database-using children.
 
 ### Dispatch strategy
 

--- a/changelog.d/20260530074056-background-job-connection-caps.md
+++ b/changelog.d/20260530074056-background-job-connection-caps.md
@@ -1,0 +1,1 @@
+Async-tracked database pools now reap checked-in idle connections after 5 seconds by default, configurable with `pool.idleTimeoutMillis`. Background job workers also cap detached forked runners with `maxConcurrentForkedJobs` so forked job bursts cannot spawn unbounded database-using child processes.

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -11,6 +11,7 @@ import dummyConfiguration from "../dummy/src/config/configuration.js"
 import AppendJob from "../dummy/src/jobs/append-job.js"
 import DelayedJob from "../dummy/src/jobs/delayed-job.js"
 import FailingJob from "../dummy/src/jobs/failing-job.js"
+import SlowTestJob from "../dummy/src/jobs/slow-test-job.js"
 
 describe("Background jobs - queue", () => {
   it("processes inline jobs in order", async () => {
@@ -136,6 +137,89 @@ describe("Background jobs - queue", () => {
     })
 
     expect(forkedResult).toEqual({value: "forked"})
+
+    await worker.stop()
+    await main.stop()
+  })
+
+  it("limits forked runner concurrency without blocking inline job capacity", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    await store.clearAll()
+
+    const main = new BackgroundJobsMain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+    await main.start()
+
+    dummyConfiguration.setBackgroundJobsConfig({
+      host: "127.0.0.1",
+      port: main.getPort()
+    })
+
+    const worker = new BackgroundJobsWorker({
+      configuration: dummyConfiguration,
+      maxConcurrentForkedJobs: 1,
+      maxConcurrentInlineJobs: 4
+    })
+    await worker.start()
+
+    const tmpDir = path.join(dummyConfiguration.getDirectory(), "tmp")
+    await fs.mkdir(tmpDir, {recursive: true})
+    const firstForkedPath = path.join(tmpDir, `forked-limit-first-${Date.now()}.json`)
+    const secondForkedPath = path.join(tmpDir, `forked-limit-second-${Date.now()}.json`)
+    const inlinePath = path.join(tmpDir, `forked-limit-inline-${Date.now()}.json`)
+
+    await SlowTestJob.performLater("first", firstForkedPath, 1)
+    await SlowTestJob.performLater("second", secondForkedPath, 0.01)
+    await AppendJob.performLaterWithOptions({
+      args: ["inline", inlinePath],
+      options: {forked: false}
+    })
+
+    await timeout({timeout: 2000}, async () => {
+      while (true) {
+        try {
+          const contents = await fs.readFile(inlinePath, "utf8")
+          if (JSON.parse(contents).length === 1) break
+        } catch {
+          // Ignore missing file.
+        }
+
+        await wait(0.05)
+      }
+    })
+
+    let secondForkedExists = true
+
+    try {
+      await fs.readFile(secondForkedPath, "utf8")
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+
+      secondForkedExists = false
+    }
+
+    expect(secondForkedExists).toBeFalse()
+
+    await timeout({timeout: 5000}, async () => {
+      while (true) {
+        try {
+          const [firstContents, secondContents] = await Promise.all([
+            fs.readFile(firstForkedPath, "utf8"),
+            fs.readFile(secondForkedPath, "utf8")
+          ])
+
+          if (firstContents && secondContents) break
+        } catch {
+          // Ignore missing files.
+        }
+
+        await wait(0.05)
+      }
+    })
+
+    expect(JSON.parse(await fs.readFile(inlinePath, "utf8"))).toEqual(["inline"])
+    expect(JSON.parse(await fs.readFile(firstForkedPath, "utf8"))).toEqual({message: "first"})
+    expect(JSON.parse(await fs.readFile(secondForkedPath, "utf8"))).toEqual({message: "second"})
 
     await worker.stop()
     await main.stop()

--- a/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+import AsyncTrackedMultiConnection from "../../../src/database/pool/async-tracked-multi-connection.js"
+import wait from "awaitery/build/wait.js"
+import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+
+describe("database - pool - async tracked multi connection idle reaper", () => {
+  it("closes checked-in idle connections after the configured idle timeout", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-reaper")
+
+    try {
+      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 1}
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      /** @type {(import("../../../src/database/drivers/base.js").default & {connection?: unknown}) | undefined} */
+      let checkedInConnection
+
+      await pool.withConnection(async (connection) => {
+        checkedInConnection = connection
+        await connection.query("CREATE TABLE IF NOT EXISTS idle_reaper_values(value varchar(255))")
+      })
+
+      if (!checkedInConnection) throw new Error("Expected checked-in connection")
+
+      expect(pool.connections.includes(checkedInConnection)).toBe(true)
+
+      pool.clearIdleConnectionReaperTimer()
+      await wait(0.02)
+      await pool.reapIdleConnections()
+
+      expect(checkedInConnection.connection).toEqual(undefined)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("keeps checked-in transaction connections so callers can check them out and roll back", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-transaction")
+
+    try {
+      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 1}
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      /** @type {import("../../../src/database/drivers/base.js").default | undefined} */
+      let transactionConnection
+
+      await pool.withConnection(async (connection) => {
+        transactionConnection = connection
+        await connection.startTransaction()
+      })
+
+      await wait(0.02)
+      await pool.reapIdleConnections()
+
+      if (!transactionConnection) throw new Error("Expected transaction connection")
+
+      expect(pool.connections.includes(transactionConnection)).toBe(true)
+
+      await pool.withConnection(async (connection) => {
+        expect(connection).toBe(transactionConnection)
+        await connection.rollbackTransaction()
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -93,6 +93,10 @@ export default async function runJobPayload(payload) {
       throw error
     }
   } finally {
-    await configuration.disconnectBeacon()
+    try {
+      await configuration.disconnectBeacon()
+    } finally {
+      await configuration.closeDatabaseConnections()
+    }
   }
 }

--- a/src/background-jobs/json-socket.js
+++ b/src/background-jobs/json-socket.js
@@ -11,6 +11,10 @@ export default class JsonSocket extends EventEmitter {
     this.socket = socket
     /** @type {string | undefined} */
     this.workerId = undefined
+    /** @type {boolean} */
+    this.acceptsForkedJobs = true
+    /** @type {boolean} */
+    this.acceptsInlineJobs = true
     this.buffer = ""
     this.socket.setEncoding("utf8")
     this.socket.on("data", (chunk) => this._onData(String(chunk)))

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -559,7 +559,7 @@ export default class BackgroundJobsMain {
   /** @returns {boolean} - Whether any ready worker can accept forked jobs. */
   readyWorkersAcceptForkedJobs() {
     for (const worker of this.readyWorkers) {
-      if (worker.acceptsForkedJobs) return true
+      if (worker.acceptsForkedJobs !== false) return true
     }
 
     return false
@@ -568,7 +568,7 @@ export default class BackgroundJobsMain {
   /** @returns {boolean} - Whether any ready worker can accept inline jobs. */
   readyWorkersAcceptInlineJobs() {
     for (const worker of this.readyWorkers) {
-      if (worker.acceptsInlineJobs) return true
+      if (worker.acceptsInlineJobs !== false) return true
     }
 
     return false
@@ -580,8 +580,8 @@ export default class BackgroundJobsMain {
    */
   readyWorkerForJob(job) {
     for (const worker of this.readyWorkers) {
-      if (job.forked && worker.acceptsForkedJobs) return worker
-      if (!job.forked && worker.acceptsInlineJobs) return worker
+      if (job.forked && worker.acceptsForkedJobs !== false) return worker
+      if (!job.forked && worker.acceptsInlineJobs !== false) return worker
     }
   }
 

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -259,8 +259,6 @@ export default class BackgroundJobsMain {
         if (role === "worker") {
           jsonSocket.workerId = message.workerId
           this.workers.add(jsonSocket)
-          this.readyWorkers.add(jsonSocket)
-          void this._drain()
         }
 
         return
@@ -272,6 +270,8 @@ export default class BackgroundJobsMain {
       }
 
       if (role === "worker" && message?.type === "ready") {
+        jsonSocket.acceptsForkedJobs = message.acceptsForked !== false
+        jsonSocket.acceptsInlineJobs = message.acceptsInline !== false
         this.readyWorkers.add(jsonSocket)
         void this._drain()
         return
@@ -510,10 +510,10 @@ export default class BackgroundJobsMain {
    */
   async _drainOnce() {
     while (this.readyWorkers.size > 0 && !this._stopped) {
-      const job = await this.store.nextAvailableJob()
+      const job = await this.nextAvailableJobForReadyWorkers()
       if (!job) return
 
-      const [worker] = this.readyWorkers
+      const worker = this.readyWorkerForJob(job)
       if (!worker) return
 
       this.readyWorkers.delete(worker)
@@ -539,6 +539,49 @@ export default class BackgroundJobsMain {
         await this.store.markReturnedToQueue({jobId: job.id})
         this.readyWorkers.add(worker)
       }
+    }
+  }
+
+  /**
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Next queued job matching ready worker capacity.
+   */
+  async nextAvailableJobForReadyWorkers() {
+    const acceptsForked = this.readyWorkersAcceptForkedJobs()
+    const acceptsInline = this.readyWorkersAcceptInlineJobs()
+
+    if (!acceptsForked && !acceptsInline) return null
+    if (acceptsForked && acceptsInline) return await this.store.nextAvailableJob()
+    if (acceptsForked) return await this.store.nextAvailableJob({forked: true})
+
+    return await this.store.nextAvailableJob({forked: false})
+  }
+
+  /** @returns {boolean} - Whether any ready worker can accept forked jobs. */
+  readyWorkersAcceptForkedJobs() {
+    for (const worker of this.readyWorkers) {
+      if (worker.acceptsForkedJobs) return true
+    }
+
+    return false
+  }
+
+  /** @returns {boolean} - Whether any ready worker can accept inline jobs. */
+  readyWorkersAcceptInlineJobs() {
+    for (const worker of this.readyWorkers) {
+      if (worker.acceptsInlineJobs) return true
+    }
+
+    return false
+  }
+
+  /**
+   * @param {import("./types.js").BackgroundJobRow} job - Job being handed off.
+   * @returns {JsonSocket | undefined} - Ready worker for the job type.
+   */
+  readyWorkerForJob(job) {
+    for (const worker of this.readyWorkers) {
+      if (job.forked && worker.acceptsForkedJobs) return worker
+      if (!job.forked && worker.acceptsInlineJobs) return worker
     }
   }
 

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -105,18 +105,26 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * @param {object} [args] - Options.
+   * @param {boolean} [args.forked] - When set, only return jobs with this forked value.
    * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Next job.
    */
-  async nextAvailableJob() {
+  async nextAvailableJob(args = {}) {
     await this.ensureReady()
 
     return await this._withDb(async (db) => {
       const now = Date.now()
-      const query = db
+      let query = db
         .newQuery()
         .from(JOBS_TABLE)
         .where({status: "queued"})
         .where(`scheduled_at_ms <= ${db.quote(now)}`)
+
+      if (typeof args.forked === "boolean") {
+        query = query.where({forked: args.forked})
+      }
+
+      query = query
         .order("scheduled_at_ms ASC")
         .order("created_at_ms ASC")
         .limit(1)

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -47,7 +47,7 @@
  */
 /**
  * @typedef {{type: "hello", role: BackgroundJobSocketRole, workerId?: string}} BackgroundJobHelloMessage
- * @typedef {{type: "ready"}} BackgroundJobReadyMessage
+ * @typedef {{type: "ready", acceptsForked?: boolean, acceptsInline?: boolean}} BackgroundJobReadyMessage
  * @typedef {{type: "draining"}} BackgroundJobDrainingMessage
  * @typedef {{type: "enqueue", jobName: string, args?: any[], options?: BackgroundJobOptions}} BackgroundJobEnqueueMessage
  * @typedef {{type: "job", payload: BackgroundJobPayload}} BackgroundJobJobMessage

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -14,11 +14,10 @@ export default class BackgroundJobsWorker {
    * @param {import("../configuration.js").default} [args.configuration] - Configuration.
    * @param {string} [args.host] - Hostname.
    * @param {number} [args.port] - Port.
-   * @param {number} [args.maxConcurrentInlineJobs] - Override the
-   *   concurrency cap from `configuration.getBackgroundJobsConfig()`.
-   *   See `BackgroundJobsConfiguration` for what the value means.
+   * @param {number} [args.maxConcurrentForkedJobs] - Override the forked runner concurrency cap from `configuration.getBackgroundJobsConfig()`.
+   * @param {number} [args.maxConcurrentInlineJobs] - Override the inline-job concurrency cap from `configuration.getBackgroundJobsConfig()`.
    */
-  constructor({configuration, host, port, maxConcurrentInlineJobs} = {}) {
+  constructor({configuration, host, port, maxConcurrentForkedJobs, maxConcurrentInlineJobs} = {}) {
     /** @type {Promise<import("../configuration.js").default>} */
     this.configurationPromise = configuration ? Promise.resolve(configuration) : configurationResolver()
     /** @type {import("../configuration.js").default | undefined} */
@@ -34,12 +33,18 @@ export default class BackgroundJobsWorker {
     this.maxConcurrentInlineJobsOverride = typeof maxConcurrentInlineJobs === "number" && maxConcurrentInlineJobs >= 1
       ? maxConcurrentInlineJobs
       : undefined
+    /** @type {number | undefined} */
+    this.maxConcurrentForkedJobsOverride = typeof maxConcurrentForkedJobs === "number" && maxConcurrentForkedJobs >= 1
+      ? maxConcurrentForkedJobs
+      : undefined
     /**
      * Resolved cap for inline-job concurrency. Set in `start()`; defaults to
      * 4 if no configuration value is available.
      * @type {number}
      */
     this.maxConcurrentInlineJobs = this.maxConcurrentInlineJobsOverride || 4
+    /** @type {number} */
+    this.maxConcurrentForkedJobs = this.maxConcurrentForkedJobsOverride || 4
     this.shouldStop = false
     this.workerId = randomUUID()
     /** @type {JsonSocket | undefined} */
@@ -47,10 +52,6 @@ export default class BackgroundJobsWorker {
     /** @type {BackgroundJobsStatusReporter | undefined} */
     this.statusReporter = undefined
     /**
-     * In-flight inline jobs the worker is currently running. Forked jobs run
-     * in detached child processes so they don't appear here; the worker
-     * doesn't need to wait for them on shutdown — they survive on their own.
-     *
      * Up to `this.maxConcurrentInlineJobs` of these run in parallel. They
      * share the worker's process and DB connection pool, so concurrency is
      * about overlapping I/O waits — use forking for memory isolation across
@@ -58,6 +59,13 @@ export default class BackgroundJobsWorker {
      * @type {Set<Promise<void>>}
      */
     this.inflightInlineJobs = new Set()
+    /**
+     * In-flight detached runner processes. The worker does not wait for
+     * them during shutdown, but it does track exits while running so
+     * forked job handoff stays bounded.
+     * @type {Set<Promise<void>>}
+     */
+    this.inflightForkedJobs = new Set()
   }
 
   /**
@@ -69,11 +77,16 @@ export default class BackgroundJobsWorker {
     await this.configuration.initialize({type: "background-jobs-worker"})
     await this.configuration.connectBeacon({peerType: "background-jobs-worker"})
 
-    // Constructor override wins; otherwise pick up the configured cap.
+    // Constructor overrides win; otherwise pick up the configured caps.
     if (typeof this.maxConcurrentInlineJobsOverride !== "number") {
       const config = this.configuration.getBackgroundJobsConfig()
 
       this.maxConcurrentInlineJobs = config.maxConcurrentInlineJobs || this.maxConcurrentInlineJobs
+    }
+    if (typeof this.maxConcurrentForkedJobsOverride !== "number") {
+      const config = this.configuration.getBackgroundJobsConfig()
+
+      this.maxConcurrentForkedJobs = config.maxConcurrentForkedJobs || this.maxConcurrentForkedJobs
     }
 
     this.statusReporter = new BackgroundJobsStatusReporter({
@@ -156,7 +169,7 @@ export default class BackgroundJobsWorker {
 
     socket.on("connect", () => {
       jsonSocket.send({type: "hello", role: "worker", workerId: this.workerId})
-      jsonSocket.send({type: "ready"})
+      this._sendReadyIfRunning()
     })
   }
 
@@ -173,7 +186,18 @@ export default class BackgroundJobsWorker {
     const shouldFork = options.forked !== false
 
     if (shouldFork) {
-      await this._spawnDetachedJob(identifiedPayload)
+      /** @type {Promise<void>} */
+      let inflight
+
+      inflight = this._spawnDetachedJob(identifiedPayload).finally(() => {
+        this.inflightForkedJobs.delete(inflight)
+
+        if (!this.shouldStop && this.inflightForkedJobs.size === this.maxConcurrentForkedJobs - 1) {
+          this._sendReadyIfRunning()
+        }
+      })
+
+      this.inflightForkedJobs.add(inflight)
       this._sendReadyIfRunning()
       return
     }
@@ -239,7 +263,18 @@ export default class BackgroundJobsWorker {
    */
   _sendReadyIfRunning() {
     if (this.shouldStop) return
-    this.jsonSocket?.send({type: "ready"})
+    if (!this.jsonSocket) return
+
+    const acceptsForked = this.inflightForkedJobs.size < this.maxConcurrentForkedJobs
+    const acceptsInline = this.inflightInlineJobs.size < this.maxConcurrentInlineJobs
+
+    if (!acceptsForked && !acceptsInline) return
+
+    this.jsonSocket.send({
+      type: "ready",
+      acceptsForked,
+      acceptsInline
+    })
   }
 
   /**
@@ -264,9 +299,9 @@ export default class BackgroundJobsWorker {
 
   /**
    * @param {import("./types.js").BackgroundJobPayload} payload - Payload.
-   * @returns {Promise<void>} - Resolves when spawned.
+   * @returns {Promise<void>} - Resolves when the detached runner exits or spawn fails.
    */
-  async _spawnDetachedJob(payload) {
+  _spawnDetachedJob(payload) {
     const configuration = this.configuration
     if (!configuration) throw new Error("Background jobs worker configuration not initialized")
 
@@ -286,8 +321,17 @@ export default class BackgroundJobsWorker {
         VELOCIOUS_JOB_PAYLOAD: encodedPayload
       })
     })
+    const finished = new Promise((resolve) => {
+      child.once("exit", () => resolve(undefined))
+      child.once("error", (error) => {
+        console.error("Background jobs forked runner spawn error:", error)
+        resolve(undefined)
+      })
+    })
 
     child.unref()
+
+    return finished
   }
 
   /**

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -52,6 +52,11 @@
  */
 
 /**
+ * @typedef {object} DatabasePoolConfiguration
+ * @property {number | null} [idleTimeoutMillis] - Idle timeout before closing a checked-in async-tracked connection. Set null to disable idle reaping. Default: 5000.
+ */
+
+/**
  * @typedef {object} DatabaseConfigurationType
  * @property {string} [databaseCharset] - Default character set applied by `db:create` via mysql/mariadb `CREATE DATABASE ... CHARACTER SET`. Distinct from `charset`, which is the client connection charset forwarded to the mysql2 driver.
  * @property {string} [databaseCollation] - Default collation applied by `db:create` via mysql/mariadb `CREATE DATABASE ... COLLATE`.
@@ -63,6 +68,7 @@
  * @property {boolean} [migrations] - Whether migrations are enabled for this database.
  * @property {string} [password] - Password for the database user.
  * @property {number} [port] - Database port.
+ * @property {DatabasePoolConfiguration} [pool] - Velocious database pool lifecycle configuration.
  * @property {string} [name] - Friendly name for the configuration.
  * @property {(file: string) => string} [locateFile] - Optional sqlite-web sql.js wasm resolver (`initSqlJs({locateFile})`).
  * @property {boolean} [readOnly] - Whether writes should be blocked for this database.
@@ -149,6 +155,9 @@
  *   process and DB connection pool, so this should fit the pool size, not the
  *   CPU count. Forking remains the right tool for memory isolation across
  *   long-running jobs and for using more cores. Default: `4`.
+ * @property {number} [maxConcurrentForkedJobs] - How many forked detached runner
+ *   processes a single `background-jobs-worker` is allowed to keep in flight.
+ *   Default: `4`.
  * @property {BackgroundJobsDispatchStrategy} [dispatchStrategy] - How the main process
  *   detects new work. Defaults to `"beacon"` (event-driven). Set to `"polling"`
  *   to restore the legacy fixed-interval poll.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -532,10 +532,12 @@ export default class VelociousConfiguration {
     const envHost = process.env.VELOCIOUS_BACKGROUND_JOBS_HOST
     const envPortRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_PORT
     const envDatabaseIdentifier = process.env.VELOCIOUS_BACKGROUND_JOBS_DATABASE_IDENTIFIER
+    const envMaxConcurrentForkedRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_FORKED_JOBS
     const envMaxConcurrentRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS
     const envDispatchStrategy = process.env.VELOCIOUS_BACKGROUND_JOBS_DISPATCH_STRATEGY
     const envPollIntervalRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POLL_INTERVAL_MS
     const envPort = envPortRaw ? Number(envPortRaw) : undefined
+    const envMaxConcurrentForked = envMaxConcurrentForkedRaw ? Number(envMaxConcurrentForkedRaw) : undefined
     const envMaxConcurrent = envMaxConcurrentRaw ? Number(envMaxConcurrentRaw) : undefined
     const envPollInterval = envPollIntervalRaw ? Number(envPollIntervalRaw) : undefined
     const configured = this._backgroundJobs || {}
@@ -547,13 +549,16 @@ export default class VelociousConfiguration {
     const maxConcurrentInlineJobs = typeof configured.maxConcurrentInlineJobs === "number" && configured.maxConcurrentInlineJobs >= 1
       ? configured.maxConcurrentInlineJobs
       : (typeof envMaxConcurrent === "number" && Number.isFinite(envMaxConcurrent) && envMaxConcurrent >= 1 ? envMaxConcurrent : 4)
+    const maxConcurrentForkedJobs = typeof configured.maxConcurrentForkedJobs === "number" && configured.maxConcurrentForkedJobs >= 1
+      ? configured.maxConcurrentForkedJobs
+      : (typeof envMaxConcurrentForked === "number" && Number.isFinite(envMaxConcurrentForked) && envMaxConcurrentForked >= 1 ? envMaxConcurrentForked : 4)
     const dispatchStrategyRaw = configured.dispatchStrategy || envDispatchStrategy
     const dispatchStrategy = dispatchStrategyRaw === "polling" ? "polling" : "beacon"
     const pollIntervalMs = typeof configured.pollIntervalMs === "number" && configured.pollIntervalMs >= 1
       ? configured.pollIntervalMs
       : (typeof envPollInterval === "number" && Number.isFinite(envPollInterval) && envPollInterval >= 1 ? envPollInterval : 1000)
 
-    return {host, port, databaseIdentifier, maxConcurrentInlineJobs, dispatchStrategy, pollIntervalMs}
+    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, dispatchStrategy, pollIntervalMs}
   }
 
   /**

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -4,6 +4,8 @@ import {AsyncLocalStorage} from "async_hooks"
 import BasePool from "./base.js"
 
 export const CLOSED_CONNECTION = Symbol("velociousClosedConnection")
+const IDLE_CONNECTION_CHECKED_IN_AT = Symbol("velociousIdleConnectionCheckedInAt")
+const DEFAULT_IDLE_TIMEOUT_MILLIS = 5000
 
 export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends BasePool {
   /**
@@ -27,6 +29,9 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
   /** @type {Record<number, import("../drivers/base.js").default>} */
   connectionsInUse = {}
+
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  idleConnectionReaperTimer = undefined
 
   idSeq = 0
 
@@ -53,16 +58,20 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     connection.setIdSeq(undefined)
 
-    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean}} */ (connection)
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
 
     if (trackedConnection[CLOSED_CONNECTION]) return
 
+    trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT] = Date.now()
     this.connections.push(connection)
+    this.scheduleIdleConnectionReaper()
 
   }
 
   /** @returns {Promise<import("../drivers/base.js").default>} - Resolves with the checkout.  */
   async checkout() {
+    await this.reapIdleConnections()
+
     const connectionIndex = this.connections.findIndex((queuedConnection) => this.connectionMatchesCurrentConfiguration(queuedConnection))
     let connection = connectionIndex === -1 ? undefined : this.connections.splice(connectionIndex, 1)[0]
 
@@ -73,6 +82,9 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (connection.getIdSeq() !== undefined) throw new Error(`Connection already has an ID-seq - is it in use? ${connection.getIdSeq()}`)
 
     const id = this.idSeq++
+
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+    delete trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
 
     connection.setIdSeq(id)
     this.connectionsInUse[id] = connection
@@ -219,11 +231,148 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     }
   }
 
+  /** @returns {number | null} - Idle timeout in milliseconds, or null when disabled. */
+  idleTimeoutMillis() {
+    const value = this.getConfiguration().pool?.idleTimeoutMillis
+
+    if (value === null) return null
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value
+
+    return DEFAULT_IDLE_TIMEOUT_MILLIS
+  }
+
+  /** @returns {void} */
+  scheduleIdleConnectionReaper() {
+    if (this.idleConnectionReaperTimer) return
+    if (this.connections.length === 0) return
+
+    const idleTimeoutMillis = this.idleTimeoutMillis()
+
+    if (idleTimeoutMillis === null) return
+
+    const delay = this.nextIdleConnectionReapDelay(idleTimeoutMillis)
+
+    this.idleConnectionReaperTimer = setTimeout(() => {
+      this.idleConnectionReaperTimer = undefined
+      void this.reapIdleConnections().catch((error) => {
+        this.logger.warn(() => ["Failed to reap idle database connections:", error])
+      })
+    }, delay)
+
+    if (typeof this.idleConnectionReaperTimer.unref === "function") {
+      this.idleConnectionReaperTimer.unref()
+    }
+  }
+
+  /**
+   * @param {number} idleTimeoutMillis - Idle timeout in milliseconds.
+   * @returns {number} - Delay before the next reap.
+   */
+  nextIdleConnectionReapDelay(idleTimeoutMillis) {
+    let delay = idleTimeoutMillis
+    const now = Date.now()
+
+    for (const connection of this.connections) {
+      if (this.connectionHasOpenTransaction(connection)) continue
+
+      const trackedConnection = /** @type {import("../drivers/base.js").default & {[IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+      const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
+
+      if (typeof checkedInAt !== "number") continue
+
+      delay = Math.min(delay, Math.max(0, idleTimeoutMillis - (now - checkedInAt)))
+    }
+
+    return delay
+  }
+
+  /**
+   * Closes idle checked-in connections that have exceeded the configured timeout.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async reapIdleConnections() {
+    if (this.connections.length === 0) return
+
+    const idleTimeoutMillis = this.idleTimeoutMillis()
+
+    if (idleTimeoutMillis === null) return
+
+    const now = Date.now()
+    /** @type {import("../drivers/base.js").default[]} */
+    const keptConnections = []
+    /** @type {import("../drivers/base.js").default[]} */
+    const expiredConnections = []
+
+    for (const connection of this.connections) {
+      const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+
+      if (trackedConnection[CLOSED_CONNECTION]) continue
+      if (this.connectionHasOpenTransaction(connection)) {
+        keptConnections.push(connection)
+        continue
+      }
+
+      const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
+      const expired = typeof checkedInAt === "number" && now - checkedInAt >= idleTimeoutMillis
+
+      if (expired) {
+        expiredConnections.push(connection)
+      } else {
+        keptConnections.push(connection)
+      }
+    }
+
+    this.connections = keptConnections
+
+    for (const connection of expiredConnections) {
+      await this.closeConnection(connection)
+    }
+
+    if (this.connections.length > 0) {
+      this.scheduleIdleConnectionReaper()
+    }
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection to inspect.
+   * @returns {boolean} - Whether the connection has an open transaction.
+   */
+  connectionHasOpenTransaction(connection) {
+    return connection._transactionsCount > 0
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection to close.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async closeConnection(connection) {
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+
+    trackedConnection[CLOSED_CONNECTION] = true
+    delete trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
+
+    if (typeof trackedConnection.close === "function") {
+      await trackedConnection.close()
+    } else if (typeof trackedConnection.disconnect === "function") {
+      await trackedConnection.disconnect()
+    }
+  }
+
+  /** @returns {void} */
+  clearIdleConnectionReaperTimer() {
+    if (!this.idleConnectionReaperTimer) return
+
+    clearTimeout(this.idleConnectionReaperTimer)
+    this.idleConnectionReaperTimer = undefined
+  }
+
   /**
    * Closes all active and cached connections for this pool.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async closeAll() {
+    this.clearIdleConnectionReaperTimer()
+
     const connections = new Set([
       ...this.connections,
       ...Object.values(this.connectionsInUse),
@@ -236,14 +385,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     for (const connection of connections) {
       if (!connection) continue
 
-      const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean}} */ (connection)
-      trackedConnection[CLOSED_CONNECTION] = true
-
-      if (typeof trackedConnection.close === "function") {
-        await trackedConnection.close()
-      } else if (typeof trackedConnection.disconnect === "function") {
-        await trackedConnection.disconnect()
-      }
+      await this.closeConnection(connection)
     }
 
   }


### PR DESCRIPTION
Summary:
- Reap checked-in AsyncTrackedMultiConnection DB connections after a configurable idle timeout.
- Cap forked background-job runner handoff so one worker cannot spawn unbounded detached jobs.
- Close database pools at the end of forked runner payloads and document the new configuration knobs.

Tests:
- npm run typecheck
- npm run lint
- npm run test -- spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
- npm run test -- spec/background-jobs/queue-spec.js