### PR TITLE
Add frontend model event hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ This creates `src/frontend-models/user.js` (and one file per configured resource
 - Relationship helpers (when `relationships` are configured), for example `task.project()`, `await task.projectOrLoad()`, `await project.tasks().toArray()`, `await project.tasks().load()`, and `project.tasks().build({...})`
 - Attachment helpers (when `attachments` are configured), for example `await task.descriptionFile().attach(file)`, `await task.descriptionFile().download()`, and `await task.update({descriptionFile: file})`
 
+React components can subscribe to lifecycle broadcasts without manual cleanup code:
+
+```js
+import useModelClassEvent from "velocious/build/src/frontend-models/use-model-class-event.js"
+
+useModelClassEvent(Subscription, ["create", "update"], () => {
+  void loadSubscriptionStatus()
+})
+```
+
+`useCreatedEvent`, `useUpdatedEvent`, and `useDestroyedEvent` are also available. `useUpdatedEvent` and `useDestroyedEvent` accept either a model class or model instance.
+
 Frontend-model `group(...)` is attribute/path based and does not accept raw SQL fragments. Use model/relationship shapes (for example `Task.group({project: {account: ["id"]}})`) so grouping resolves through known relationships and mapped columns.
 Frontend-model `where(...)` supports nested relationship descriptors (for example `Task.where({project: {creatingUser: {reference: "owner-b"}}})`) and does not accept raw SQL fragments.
 Frontend-model `joins(...)` supports relationship-object descriptors only (for example `Task.joins({project: {creatingUser: true}})`) and rejects raw SQL join strings.

--- a/changelog.d/20260530084307-frontend-model-event-hooks.md
+++ b/changelog.d/20260530084307-frontend-model-event-hooks.md
@@ -1,0 +1,1 @@
+Add React hooks for frontend-model lifecycle events so components can subscribe to create, update, and destroy broadcasts without manual cleanup code.

--- a/changelog.d/20260530101958-has-many-size.md
+++ b/changelog.d/20260530101958-has-many-size.md
@@ -1,0 +1,1 @@
+Add preload-aware `size()` support to has-many relationship helpers.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -68,6 +68,13 @@
 - Relationship parity helpers are available via `loadRelationship(name)` / `relationshipOrLoad(name)` / `setRelationship(name, value)` and generated `loadXxx` / `xxxOrLoad` / `setXxx` methods where applicable.
 - Has-many relationship helpers support `await model.relationshipName().toArray()` to reuse preloaded data and `await model.relationshipName().load()` to force a refresh.
 
+## React event hooks
+- Use `useModelClassEvent(ModelClass, "create" | "update" | "destroy", callback)` to subscribe to frontend-model lifecycle broadcasts from React components.
+- Pass an array of event names to subscribe one callback to several class-level events, for example `useModelClassEvent(Subscription, ["create", "update"], reloadStatus)`.
+- Convenience wrappers are available as `useCreatedEvent(ModelClass, callback)`, `useUpdatedEvent(ModelClassOrModel, callback)`, and `useDestroyedEvent(ModelClassOrModel, callback)`.
+- `useUpdatedEvent` and `useDestroyedEvent` accept a model instance or array of model instances for instance-level subscriptions.
+- Hook options support `{active, debounce, onConnected}`. The hooks own subscribe/unsubscribe cleanup, so components do not need lifecycle methods just to remove event listeners.
+
 ## Attachment support
 - Frontend models can define `resourceConfig().attachments` and use generated attachment handles:
   - `await model.attachmentName().attach(fileLikeOrBase64Payload)`

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -109,6 +109,16 @@ for (const invoice of invoices) {
 }
 ```
 
+### Collection size
+
+Use `size()` on `hasMany` relationship helpers when you need a count and the relationship may already be loaded:
+
+```js
+const count = await invoice.invoiceGroups().size()
+```
+
+`size()` returns the loaded collection length when records were preloaded or built in memory. If the relationship has not been loaded and the parent is persisted, it runs a count query. This keeps display virtuals and frontend-model payloads from issuing extra child queries when a resource has already preloaded the relationship.
+
 ### Frontend model preloading
 
 Through relationships are also supported in frontend model preload queries:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/pg": "^8.20.0",
         "@types/proxy-addr": "^2.0.3",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/strftime": "^0.9.8",
         "chokidar-cli": "^3.0.0",
         "cpy-cli": "^7.0.0",
@@ -56,6 +57,8 @@
         "mysql": "^2.18.1",
         "node-fetch": "^3.3.1",
         "pg": "^8.16.3",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
         "release-patch": "^1.0.0",
         "require-context": "^1.1.0",
         "sqlite": "^5.1.1",
@@ -66,7 +69,13 @@
         "uniqunize": "^1.0.3"
       },
       "peerDependencies": {
+        "react": ">=18",
         "smtp-connection": "^4.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -5688,6 +5697,16 @@
       "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/readable-stream": {
@@ -14199,11 +14218,10 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14239,6 +14257,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-is": {
@@ -14995,8 +15026,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/scoundrel-remote-eval": {
       "version": "1.0.28",
@@ -21408,6 +21438,13 @@
         "csstype": "^3.2.2"
       }
     },
+    "@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@types/readable-stream": {
       "version": "4.0.22",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.22.tgz",
@@ -27273,10 +27310,9 @@
       }
     },
     "react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "peer": true
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="
     },
     "react-devtools-core": {
       "version": "6.1.5",
@@ -27295,6 +27331,15 @@
           "peer": true,
           "requires": {}
         }
+      }
+    },
+    "react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "dev": true,
+      "requires": {
+        "scheduler": "^0.27.0"
       }
     },
     "react-is": {
@@ -27831,8 +27876,7 @@
     "scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "peer": true
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "scoundrel-remote-eval": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,13 @@
     "strftime": "^0.10.2"
   },
   "peerDependencies": {
+    "react": ">=18",
     "smtp-connection": "^4.0.2"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -75,6 +81,7 @@
     "@types/pg": "^8.20.0",
     "@types/proxy-addr": "^2.0.3",
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/strftime": "^0.9.8",
     "chokidar-cli": "^3.0.0",
     "cpy-cli": "^7.0.0",
@@ -86,6 +93,8 @@
     "mysql": "^2.18.1",
     "node-fetch": "^3.3.1",
     "pg": "^8.16.3",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "release-patch": "^1.0.0",
     "require-context": "^1.1.0",
     "sqlite": "^5.1.1",

--- a/spec/database/record/query.browser-spec.js
+++ b/spec/database/record/query.browser-spec.js
@@ -94,6 +94,31 @@ describe("Record - query", {tags: ["dummy"]}, () => {
     expect(loadedTasks[0].name()).toEqual("Built task")
   })
 
+  it("returns has-many size from loaded records", async () => {
+    const project = await Project.create({name: "Size project"})
+    const task = await Task.create({name: "Size task", project})
+    const preloadedProject = await Project.preload({tasks: true}).find(project.id())
+
+    expect(await preloadedProject.tasks().size()).toEqual(1)
+    expect(preloadedProject.tasksLoaded().map((loadedTask) => loadedTask.id())).toEqual([task.id()])
+  })
+
+  it("returns has-many size from a count query when records are not loaded", async () => {
+    const project = await Project.create({name: "Count project"})
+    await Task.create({name: "Count task 1", project})
+    await Task.create({name: "Count task 2", project})
+
+    expect(await project.tasks().size()).toEqual(2)
+  })
+
+  it("returns has-many size from in-memory built records", async () => {
+    const project = new Project({name: "Unsaved size project"})
+
+    project.tasks().build({name: "Unsaved size task"})
+
+    expect(await project.tasks().size()).toEqual(1)
+  })
+
   it("finds the first record", async () => {
     const taskIDs = []
     const project = await Project.create()

--- a/spec/frontend-models/model-event-hooks.browser-spec.js
+++ b/spec/frontend-models/model-event-hooks.browser-spec.js
@@ -1,0 +1,179 @@
+// @ts-check
+
+import React from "react"
+import {createRoot} from "react-dom/client"
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import useDestroyedEvent from "../../src/frontend-models/use-destroyed-event.js"
+import useCreatedEvent from "../../src/frontend-models/use-created-event.js"
+import useModelClassEvent from "../../src/frontend-models/use-model-class-event.js"
+import useUpdatedEvent from "../../src/frontend-models/use-updated-event.js"
+
+/**
+ * @typedef {object} FakeSubscriptions
+ * @property {Set<(payload: unknown) => void>} create - Create callbacks.
+ * @property {Set<(payload: unknown) => void>} destroy - Destroy callbacks.
+ * @property {Set<(payload: unknown) => void>} update - Update callbacks.
+ */
+
+/** @returns {Promise<void>} - Resolves after React effects have run. */
+async function flushEffects() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * @param {React.ReactElement} element - Element to render.
+ * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
+ */
+async function renderElement(element) {
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  root.render(element)
+  await flushEffects()
+
+  return {
+    rerender: async (nextElement) => {
+      root.render(nextElement)
+      await flushEffects()
+    },
+    unmount: async () => {
+      root.unmount()
+      container.remove()
+      await flushEffects()
+    }
+  }
+}
+
+/** @returns {{ModelClass: typeof import("../../src/frontend-models/base.js").default, subscriptions: FakeSubscriptions}} - Fake model class setup. */
+function buildFakeModelClass() {
+  const subscriptions = {
+    create: new Set(),
+    destroy: new Set(),
+    update: new Set()
+  }
+  const ModelClass = /** @type {typeof import("../../src/frontend-models/base.js").default} */ ({
+    onCreate: async (callback) => {
+      subscriptions.create.add(callback)
+
+      return () => subscriptions.create.delete(callback)
+    },
+    onDestroy: async (callback) => {
+      subscriptions.destroy.add(callback)
+
+      return () => subscriptions.destroy.delete(callback)
+    },
+    onUpdate: async (callback) => {
+      subscriptions.update.add(callback)
+
+      return () => subscriptions.update.delete(callback)
+    }
+  })
+
+  return {ModelClass, subscriptions}
+}
+
+/**
+ * @param {FakeSubscriptions} subscriptions - Callback sets.
+ * @param {"create" | "destroy" | "update"} eventName - Event name.
+ * @param {unknown} payload - Event payload.
+ * @returns {void}
+ */
+function emitEvent(subscriptions, eventName, payload) {
+  for (const callback of subscriptions[eventName]) {
+    callback(payload)
+  }
+}
+
+/**
+ * @param {string} id - Model id.
+ * @param {FakeSubscriptions} subscriptions - Callback sets.
+ * @returns {import("../../src/frontend-models/base.js").default} - Fake model instance.
+ */
+function buildFakeModel(id, subscriptions) {
+  return /** @type {import("../../src/frontend-models/base.js").default} */ ({
+    onDestroy: async (callback) => {
+      subscriptions.destroy.add(callback)
+
+      return () => subscriptions.destroy.delete(callback)
+    },
+    onUpdate: async (callback) => {
+      subscriptions.update.add(callback)
+
+      return () => subscriptions.update.delete(callback)
+    },
+    primaryKeyValue: () => id
+  })
+}
+
+describe("Frontend model event hooks", () => {
+  it("subscribes to class lifecycle events and unsubscribes on unmount", async () => {
+    const {ModelClass, subscriptions} = buildFakeModelClass()
+    const receivedEvents = /** @type {unknown[]} */ ([])
+    let connectedCount = 0
+
+    /** @returns {React.ReactElement} */
+    function TestComponent() {
+      useModelClassEvent(ModelClass, ["create", "update"], (payload) => receivedEvents.push(payload), {
+        onConnected: () => { connectedCount += 1 }
+      })
+      useCreatedEvent(ModelClass, (payload) => receivedEvents.push(payload))
+
+      return React.createElement("div")
+    }
+
+    const controls = await renderElement(React.createElement(TestComponent))
+
+    expect(subscriptions.create.size).toEqual(2)
+    expect(subscriptions.update.size).toEqual(1)
+    expect(subscriptions.destroy.size).toEqual(0)
+    expect(connectedCount).toEqual(1)
+
+    emitEvent(subscriptions, "create", {id: "1", model: {id: "1"}})
+    emitEvent(subscriptions, "update", {id: "1", model: {id: "1"}})
+    emitEvent(subscriptions, "destroy", {id: "1"})
+
+    expect(receivedEvents.length).toEqual(3)
+
+    await controls.unmount()
+
+    expect(subscriptions.create.size).toEqual(0)
+    expect(subscriptions.update.size).toEqual(0)
+  })
+
+  it("subscribes to instance update and destroy events", async () => {
+    const subscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+    const model = buildFakeModel("task-1", subscriptions)
+    const receivedEvents = /** @type {unknown[]} */ ([])
+    let connectedCount = 0
+
+    /** @returns {React.ReactElement} */
+    function TestComponent() {
+      useUpdatedEvent(model, (payload) => receivedEvents.push(payload), {
+        onConnected: () => { connectedCount += 1 }
+      })
+      useDestroyedEvent([model], (payload) => receivedEvents.push(payload), {
+        onConnected: () => { connectedCount += 1 }
+      })
+
+      return React.createElement("div")
+    }
+
+    const controls = await renderElement(React.createElement(TestComponent))
+
+    expect(subscriptions.update.size).toEqual(1)
+    expect(subscriptions.destroy.size).toEqual(1)
+    expect(connectedCount).toEqual(2)
+
+    emitEvent(subscriptions, "update", {id: "task-1", model})
+    emitEvent(subscriptions, "destroy", {id: "task-1"})
+
+    expect(receivedEvents.length).toEqual(2)
+
+    await controls.unmount()
+
+    expect(subscriptions.update.size).toEqual(0)
+    expect(subscriptions.destroy.size).toEqual(0)
+  })
+})

--- a/spec/frontend-models/model-event-hooks.browser-spec.js
+++ b/spec/frontend-models/model-event-hooks.browser-spec.js
@@ -1,253 +1,77 @@
 // @ts-check
 
-import React from "react"
-import {createRoot} from "react-dom/client"
+import SystemTest from "system-testing/build/system-test.js"
 
 import {describe, expect, it} from "../../src/testing/test.js"
-import useDestroyedEvent from "../../src/frontend-models/use-destroyed-event.js"
-import useCreatedEvent from "../../src/frontend-models/use-created-event.js"
-import useModelClassEvent from "../../src/frontend-models/use-model-class-event.js"
-import useUpdatedEvent from "../../src/frontend-models/use-updated-event.js"
 
-/**
- * @typedef {object} FakeSubscriptions
- * @property {Set<(payload: unknown) => void>} create - Create callbacks.
- * @property {Set<(payload: unknown) => void>} destroy - Destroy callbacks.
- * @property {Set<(payload: unknown) => void>} update - Update callbacks.
- */
+/** @typedef {"classLifecycle" | "debounceUnmount" | "instanceLifecycle" | "resubscribeInstance"} FrontendModelEventHookScenario */
 
-/** @returns {Promise<void>} - Resolves after React effects have run. */
-async function flushEffects() {
-  await new Promise((resolve) => setTimeout(resolve, 0))
+/** @returns {boolean} - Whether the browser test runner is active. */
+function runBrowserHookScenarios() {
+  return process.env.VELOCIOUS_BROWSER_TESTS === "true"
 }
 
 /**
- * @param {number} milliseconds - Milliseconds to wait.
- * @returns {Promise<void>} - Resolves after the delay.
+ * @param {FrontendModelEventHookScenario} scenarioName - Browser scenario name.
+ * @returns {Promise<Record<string, number> | null>} - Scenario result, or null outside the browser runner.
  */
-async function sleep(milliseconds) {
-  await new Promise((resolve) => setTimeout(resolve, milliseconds))
-}
+async function runFrontendModelEventHookScenario(scenarioName) {
+  if (!runBrowserHookScenarios()) return null
 
-/**
- * @param {React.ReactElement} element - Element to render.
- * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
- */
-async function renderElement(element) {
-  const container = document.createElement("div")
-  document.body.appendChild(container)
-  const root = createRoot(container)
+  return /** @type {Promise<Record<string, number>>} */ (SystemTest.current().executeScript(`
+    const scenarioRunner = globalThis.velociousBrowserTest?.runFrontendModelEventHookScenario
 
-  root.render(element)
-  await flushEffects()
-
-  return {
-    rerender: async (nextElement) => {
-      root.render(nextElement)
-      await flushEffects()
-    },
-    unmount: async () => {
-      root.unmount()
-      container.remove()
-      await flushEffects()
+    if (!scenarioRunner) {
+      throw new Error("Frontend model event hook browser scenario runner is not installed")
     }
-  }
-}
 
-/** @returns {{ModelClass: typeof import("../../src/frontend-models/base.js").default, subscriptions: FakeSubscriptions}} - Fake model class setup. */
-function buildFakeModelClass() {
-  const subscriptions = {
-    create: new Set(),
-    destroy: new Set(),
-    update: new Set()
-  }
-  const ModelClass = /** @type {typeof import("../../src/frontend-models/base.js").default} */ ({
-    onCreate: async (callback) => {
-      subscriptions.create.add(callback)
-
-      return () => subscriptions.create.delete(callback)
-    },
-    onDestroy: async (callback) => {
-      subscriptions.destroy.add(callback)
-
-      return () => subscriptions.destroy.delete(callback)
-    },
-    onUpdate: async (callback) => {
-      subscriptions.update.add(callback)
-
-      return () => subscriptions.update.delete(callback)
-    }
-  })
-
-  return {ModelClass, subscriptions}
-}
-
-/**
- * @param {FakeSubscriptions} subscriptions - Callback sets.
- * @param {"create" | "destroy" | "update"} eventName - Event name.
- * @param {unknown} payload - Event payload.
- * @returns {void}
- */
-function emitEvent(subscriptions, eventName, payload) {
-  for (const callback of subscriptions[eventName]) {
-    callback(payload)
-  }
-}
-
-/**
- * @param {string} id - Model id.
- * @param {FakeSubscriptions} subscriptions - Callback sets.
- * @returns {import("../../src/frontend-models/base.js").default} - Fake model instance.
- */
-function buildFakeModel(id, subscriptions) {
-  return /** @type {import("../../src/frontend-models/base.js").default} */ ({
-    onDestroy: async (callback) => {
-      subscriptions.destroy.add(callback)
-
-      return () => subscriptions.destroy.delete(callback)
-    },
-    onUpdate: async (callback) => {
-      subscriptions.update.add(callback)
-
-      return () => subscriptions.update.delete(callback)
-    },
-    primaryKeyValue: () => id
-  })
+    return await scenarioRunner(arguments[0])
+  `, scenarioName))
 }
 
 describe("Frontend model event hooks", () => {
   it("subscribes to class lifecycle events and unsubscribes on unmount", async () => {
-    const {ModelClass, subscriptions} = buildFakeModelClass()
-    const receivedEvents = /** @type {unknown[]} */ ([])
-    let connectedCount = 0
+    const result = await runFrontendModelEventHookScenario("classLifecycle")
+    if (!result) return
 
-    /** @returns {React.ReactElement} */
-    function TestComponent() {
-      useModelClassEvent(ModelClass, ["create", "update"], (payload) => receivedEvents.push(payload), {
-        onConnected: () => { connectedCount += 1 }
-      })
-      useCreatedEvent(ModelClass, (payload) => receivedEvents.push(payload))
-
-      return React.createElement("div")
-    }
-
-    const controls = await renderElement(React.createElement(TestComponent))
-
-    expect(subscriptions.create.size).toEqual(2)
-    expect(subscriptions.update.size).toEqual(1)
-    expect(subscriptions.destroy.size).toEqual(0)
-    expect(connectedCount).toEqual(1)
-
-    emitEvent(subscriptions, "create", {id: "1", model: {id: "1"}})
-    emitEvent(subscriptions, "update", {id: "1", model: {id: "1"}})
-    emitEvent(subscriptions, "destroy", {id: "1"})
-
-    expect(receivedEvents.length).toEqual(3)
-
-    await controls.unmount()
-
-    expect(subscriptions.create.size).toEqual(0)
-    expect(subscriptions.update.size).toEqual(0)
+    expect(result.mountedCreateSubscriptions).toEqual(2)
+    expect(result.mountedUpdateSubscriptions).toEqual(1)
+    expect(result.mountedDestroySubscriptions).toEqual(0)
+    expect(result.mountedConnectedCount).toEqual(1)
+    expect(result.receivedEventsAfterEmit).toEqual(3)
+    expect(result.unmountedCreateSubscriptions).toEqual(0)
+    expect(result.unmountedUpdateSubscriptions).toEqual(0)
   })
 
   it("subscribes to instance update and destroy events", async () => {
-    const subscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
-    const model = buildFakeModel("task-1", subscriptions)
-    const receivedEvents = /** @type {unknown[]} */ ([])
-    let connectedCount = 0
+    const result = await runFrontendModelEventHookScenario("instanceLifecycle")
+    if (!result) return
 
-    /** @returns {React.ReactElement} */
-    function TestComponent() {
-      useUpdatedEvent(model, (payload) => receivedEvents.push(payload), {
-        onConnected: () => { connectedCount += 1 }
-      })
-      useDestroyedEvent([model], (payload) => receivedEvents.push(payload), {
-        onConnected: () => { connectedCount += 1 }
-      })
-
-      return React.createElement("div")
-    }
-
-    const controls = await renderElement(React.createElement(TestComponent))
-
-    expect(subscriptions.update.size).toEqual(1)
-    expect(subscriptions.destroy.size).toEqual(1)
-    expect(connectedCount).toEqual(2)
-
-    emitEvent(subscriptions, "update", {id: "task-1", model})
-    emitEvent(subscriptions, "destroy", {id: "task-1"})
-
-    expect(receivedEvents.length).toEqual(2)
-
-    await controls.unmount()
-
-    expect(subscriptions.update.size).toEqual(0)
-    expect(subscriptions.destroy.size).toEqual(0)
+    expect(result.mountedUpdateSubscriptions).toEqual(1)
+    expect(result.mountedDestroySubscriptions).toEqual(1)
+    expect(result.mountedConnectedCount).toEqual(2)
+    expect(result.receivedEventsAfterEmit).toEqual(2)
+    expect(result.unmountedUpdateSubscriptions).toEqual(0)
+    expect(result.unmountedDestroySubscriptions).toEqual(0)
   })
 
   it("clears pending debounced callbacks on unmount", async () => {
-    const {ModelClass, subscriptions: classSubscriptions} = buildFakeModelClass()
-    const instanceSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
-    const model = buildFakeModel("task-1", instanceSubscriptions)
-    const receivedEvents = /** @type {unknown[]} */ ([])
+    const result = await runFrontendModelEventHookScenario("debounceUnmount")
+    if (!result) return
 
-    /** @returns {React.ReactElement} */
-    function TestComponent() {
-      useModelClassEvent(ModelClass, "update", (payload) => receivedEvents.push(payload), {debounce: 20})
-      useUpdatedEvent(model, (payload) => receivedEvents.push(payload), {debounce: 20})
-      useDestroyedEvent(model, (payload) => receivedEvents.push(payload), {debounce: 20})
-
-      return React.createElement("div")
-    }
-
-    const controls = await renderElement(React.createElement(TestComponent))
-
-    emitEvent(classSubscriptions, "update", {id: "task-1", model})
-    emitEvent(instanceSubscriptions, "update", {id: "task-1", model})
-    emitEvent(instanceSubscriptions, "destroy", {id: "task-1"})
-
-    await controls.unmount()
-    await sleep(30)
-
-    expect(receivedEvents.length).toEqual(0)
+    expect(result.receivedEventsAfterDebounceWindow).toEqual(0)
   })
 
   it("resubscribes instance hooks when the model object changes", async () => {
-    const firstSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
-    const secondSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
-    const firstModel = buildFakeModel("task-1", firstSubscriptions)
-    const secondModel = buildFakeModel("task-1", secondSubscriptions)
-    const receivedEvents = /** @type {unknown[]} */ ([])
+    const result = await runFrontendModelEventHookScenario("resubscribeInstance")
+    if (!result) return
 
-    /**
-     * @param {{model: import("../../src/frontend-models/base.js").default}} props - Component props.
-     * @returns {React.ReactElement}
-     */
-    function TestComponent({model}) {
-      useUpdatedEvent(model, (payload) => receivedEvents.push(payload))
-      useDestroyedEvent(model, (payload) => receivedEvents.push(payload))
-
-      return React.createElement("div")
-    }
-
-    const controls = await renderElement(React.createElement(TestComponent, {model: firstModel}))
-
-    expect(firstSubscriptions.update.size).toEqual(1)
-    expect(firstSubscriptions.destroy.size).toEqual(1)
-
-    await controls.rerender(React.createElement(TestComponent, {model: secondModel}))
-
-    expect(firstSubscriptions.update.size).toEqual(0)
-    expect(firstSubscriptions.destroy.size).toEqual(0)
-    expect(secondSubscriptions.update.size).toEqual(1)
-    expect(secondSubscriptions.destroy.size).toEqual(1)
-
-    emitEvent(firstSubscriptions, "update", {id: "task-1", model: firstModel})
-    emitEvent(secondSubscriptions, "update", {id: "task-1", model: secondModel})
-    emitEvent(secondSubscriptions, "destroy", {id: "task-1"})
-
-    expect(receivedEvents.length).toEqual(2)
-
-    await controls.unmount()
+    expect(result.firstMountedUpdateSubscriptions).toEqual(1)
+    expect(result.firstMountedDestroySubscriptions).toEqual(1)
+    expect(result.firstAfterRerenderUpdateSubscriptions).toEqual(0)
+    expect(result.firstAfterRerenderDestroySubscriptions).toEqual(0)
+    expect(result.secondAfterRerenderUpdateSubscriptions).toEqual(1)
+    expect(result.secondAfterRerenderDestroySubscriptions).toEqual(1)
+    expect(result.receivedEventsAfterEmit).toEqual(2)
   })
 })

--- a/spec/frontend-models/model-event-hooks.browser-spec.js
+++ b/spec/frontend-models/model-event-hooks.browser-spec.js
@@ -22,6 +22,14 @@ async function flushEffects() {
 }
 
 /**
+ * @param {number} milliseconds - Milliseconds to wait.
+ * @returns {Promise<void>} - Resolves after the delay.
+ */
+async function sleep(milliseconds) {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+/**
  * @param {React.ReactElement} element - Element to render.
  * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
  */
@@ -175,5 +183,71 @@ describe("Frontend model event hooks", () => {
 
     expect(subscriptions.update.size).toEqual(0)
     expect(subscriptions.destroy.size).toEqual(0)
+  })
+
+  it("clears pending debounced callbacks on unmount", async () => {
+    const {ModelClass, subscriptions: classSubscriptions} = buildFakeModelClass()
+    const instanceSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+    const model = buildFakeModel("task-1", instanceSubscriptions)
+    const receivedEvents = /** @type {unknown[]} */ ([])
+
+    /** @returns {React.ReactElement} */
+    function TestComponent() {
+      useModelClassEvent(ModelClass, "update", (payload) => receivedEvents.push(payload), {debounce: 20})
+      useUpdatedEvent(model, (payload) => receivedEvents.push(payload), {debounce: 20})
+      useDestroyedEvent(model, (payload) => receivedEvents.push(payload), {debounce: 20})
+
+      return React.createElement("div")
+    }
+
+    const controls = await renderElement(React.createElement(TestComponent))
+
+    emitEvent(classSubscriptions, "update", {id: "task-1", model})
+    emitEvent(instanceSubscriptions, "update", {id: "task-1", model})
+    emitEvent(instanceSubscriptions, "destroy", {id: "task-1"})
+
+    await controls.unmount()
+    await sleep(30)
+
+    expect(receivedEvents.length).toEqual(0)
+  })
+
+  it("resubscribes instance hooks when the model object changes", async () => {
+    const firstSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+    const secondSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+    const firstModel = buildFakeModel("task-1", firstSubscriptions)
+    const secondModel = buildFakeModel("task-1", secondSubscriptions)
+    const receivedEvents = /** @type {unknown[]} */ ([])
+
+    /**
+     * @param {{model: import("../../src/frontend-models/base.js").default}} props - Component props.
+     * @returns {React.ReactElement}
+     */
+    function TestComponent({model}) {
+      useUpdatedEvent(model, (payload) => receivedEvents.push(payload))
+      useDestroyedEvent(model, (payload) => receivedEvents.push(payload))
+
+      return React.createElement("div")
+    }
+
+    const controls = await renderElement(React.createElement(TestComponent, {model: firstModel}))
+
+    expect(firstSubscriptions.update.size).toEqual(1)
+    expect(firstSubscriptions.destroy.size).toEqual(1)
+
+    await controls.rerender(React.createElement(TestComponent, {model: secondModel}))
+
+    expect(firstSubscriptions.update.size).toEqual(0)
+    expect(firstSubscriptions.destroy.size).toEqual(0)
+    expect(secondSubscriptions.update.size).toEqual(1)
+    expect(secondSubscriptions.destroy.size).toEqual(1)
+
+    emitEvent(firstSubscriptions, "update", {id: "task-1", model: firstModel})
+    emitEvent(secondSubscriptions, "update", {id: "task-1", model: secondModel})
+    emitEvent(secondSubscriptions, "destroy", {id: "task-1"})
+
+    expect(receivedEvents.length).toEqual(2)
+
+    await controls.unmount()
   })
 })

--- a/src/database/record/instance-relationships/has-many.js
+++ b/src/database/record/instance-relationships/has-many.js
@@ -119,6 +119,21 @@ export default class VelociousDatabaseRecordHasManyInstanceRelationship extends 
     return Array.isArray(loadedValue) ? loadedValue : [loadedValue]
   }
 
+  /** @returns {Promise<number>} - Resolves with the relationship size, using loaded records when available. */
+  async size() {
+    const loadedValue = this.getLoadedOrUndefined()
+
+    if (loadedValue !== undefined) {
+      if (!Array.isArray(loadedValue)) throw new Error(`Loaded had an unexpected type: ${typeof loadedValue}`)
+
+      return loadedValue.length
+    }
+
+    if (this.getModel().isNewRecord()) return 0
+
+    return await this.query().count()
+  }
+
   /**
    * @param {import("../../query/index.js").NestedPreloadRecord} preloads - Preload map for related records.
    * @returns {import("../../query/model-class-query.js").default<TMC>} - The preload.

--- a/src/frontend-models/clear-pending-debounced-callback.js
+++ b/src/frontend-models/clear-pending-debounced-callback.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+/**
+ * @param {unknown} callback - Potentially debounced callback.
+ * @returns {void}
+ */
+export default function clearPendingDebouncedCallback(callback) {
+  const callbackWithClear = /** @type {{clear?: unknown}} */ (callback)
+
+  if (typeof callbackWithClear.clear === "function") {
+    callbackWithClear.clear()
+  }
+}

--- a/src/frontend-models/event-hook-models.js
+++ b/src/frontend-models/event-hook-models.js
@@ -1,0 +1,42 @@
+// @ts-check
+
+/** @typedef {import("./base.js").default} FrontendModelInstance */
+
+/** @type {WeakMap<FrontendModelInstance, number>} */
+const modelDependencyIds = new WeakMap()
+let nextModelDependencyId = 1
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @returns {FrontendModelInstance[]} - Normalized model list.
+ */
+export function modelsFromInput(modelOrModels) {
+  if (!modelOrModels) return []
+  if (Array.isArray(modelOrModels)) return modelOrModels.filter(Boolean)
+
+  return [modelOrModels]
+}
+
+/**
+ * @param {FrontendModelInstance} model - Model instance.
+ * @returns {number} - Stable dependency id for the model object.
+ */
+function modelDependencyId(model) {
+  const existingId = modelDependencyIds.get(model)
+
+  if (existingId) return existingId
+
+  const id = nextModelDependencyId
+  nextModelDependencyId += 1
+  modelDependencyIds.set(model, id)
+
+  return id
+}
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @returns {string} - Stable dependency key.
+ */
+export function modelsDependencyKey(modelOrModels) {
+  return JSON.stringify(modelsFromInput(modelOrModels).map((model) => [model.primaryKeyValue(), modelDependencyId(model)]))
+}

--- a/src/frontend-models/use-created-event.js
+++ b/src/frontend-models/use-created-event.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+import useModelClassEvent from "./use-model-class-event.js"
+
+/** @typedef {typeof import("./base.js").default} FrontendModelClass */
+/** @typedef {import("./use-model-class-event.js").FrontendModelCreateUpdateEventPayload} FrontendModelCreateEventPayload */
+/** @typedef {import("./use-model-class-event.js").UseModelClassEventOptions} UseCreatedEventOptions */
+/** @typedef {(payload: FrontendModelCreateEventPayload) => void} FrontendModelCreateEventCallback */
+
+/**
+ * React hook for frontend-model class create events.
+ * @param {FrontendModelClass | null | undefined} modelClass - Frontend model class.
+ * @param {FrontendModelCreateEventCallback} callback - Event callback.
+ * @param {UseCreatedEventOptions} [options] - Hook options.
+ * @returns {void}
+ */
+export default function useCreatedEvent(modelClass, callback, options = {}) {
+  useModelClassEvent(modelClass, "create", (payload) => {
+    callback(/** @type {FrontendModelCreateEventPayload} */ (payload))
+  }, options)
+}

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -3,6 +3,8 @@
 import debounceFunction from "debounce"
 import {useEffect, useMemo, useRef} from "react"
 
+import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
+import {modelsDependencyKey, modelsFromInput} from "./event-hook-models.js"
 import useModelClassEvent from "./use-model-class-event.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
@@ -12,25 +14,6 @@ import useModelClassEvent from "./use-model-class-event.js"
 /** @typedef {FrontendModelClassDestroyEventPayload | FrontendModelInstanceDestroyEventPayload} FrontendModelDestroyEventPayload */
 /** @typedef {import("./use-model-class-event.js").UseModelClassEventOptions} UseDestroyedEventOptions */
 /** @typedef {(payload: FrontendModelDestroyEventPayload) => void} FrontendModelDestroyEventCallback */
-
-/**
- * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
- * @returns {FrontendModelInstance[]} - Normalized model list.
- */
-function modelsFromInput(modelOrModels) {
-  if (!modelOrModels) return []
-  if (Array.isArray(modelOrModels)) return modelOrModels.filter(Boolean)
-
-  return [modelOrModels]
-}
-
-/**
- * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
- * @returns {string} - Stable dependency key.
- */
-function modelsDependencyKey(modelOrModels) {
-  return JSON.stringify(modelsFromInput(modelOrModels).map((model) => model.primaryKeyValue()))
-}
 
 /**
  * @param {Record<string, unknown>} restOptions - Unknown options object.
@@ -97,10 +80,13 @@ function useInstanceDestroyedEvent(modelOrModels, callback, options) {
     let closed = false
     /** @type {Array<() => void>} */
     const unsubscribeCallbacks = []
+    const subscriptionCallback = (/** @type {FrontendModelInstanceDestroyEventPayload} */ payload) => {
+      if (!closed) eventCallback(payload)
+    }
 
     void (async () => {
       for (const model of models) {
-        const unsubscribe = await model.onDestroy(eventCallback)
+        const unsubscribe = await model.onDestroy(subscriptionCallback)
 
         if (closed) {
           unsubscribe()
@@ -118,6 +104,8 @@ function useInstanceDestroyedEvent(modelOrModels, callback, options) {
       for (const unsubscribe of unsubscribeCallbacks) {
         unsubscribe()
       }
+
+      clearPendingDebouncedCallback(eventCallback)
     }
   }, [active, eventCallback, modelsKey, onConnected])
 }

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -1,0 +1,123 @@
+// @ts-check
+
+import debounceFunction from "debounce"
+import {useEffect, useMemo, useRef} from "react"
+
+import useModelClassEvent from "./use-model-class-event.js"
+
+/** @typedef {typeof import("./base.js").default} FrontendModelClass */
+/** @typedef {import("./base.js").default} FrontendModelInstance */
+/** @typedef {import("./use-model-class-event.js").FrontendModelDestroyEventPayload} FrontendModelClassDestroyEventPayload */
+/** @typedef {{id: string}} FrontendModelInstanceDestroyEventPayload */
+/** @typedef {FrontendModelClassDestroyEventPayload | FrontendModelInstanceDestroyEventPayload} FrontendModelDestroyEventPayload */
+/** @typedef {import("./use-model-class-event.js").UseModelClassEventOptions} UseDestroyedEventOptions */
+/** @typedef {(payload: FrontendModelDestroyEventPayload) => void} FrontendModelDestroyEventCallback */
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @returns {FrontendModelInstance[]} - Normalized model list.
+ */
+function modelsFromInput(modelOrModels) {
+  if (!modelOrModels) return []
+  if (Array.isArray(modelOrModels)) return modelOrModels.filter(Boolean)
+
+  return [modelOrModels]
+}
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @returns {string} - Stable dependency key.
+ */
+function modelsDependencyKey(modelOrModels) {
+  return JSON.stringify(modelsFromInput(modelOrModels).map((model) => model.primaryKeyValue()))
+}
+
+/**
+ * @param {Record<string, unknown>} restOptions - Unknown options object.
+ * @returns {void}
+ */
+function assertNoUnknownOptions(restOptions) {
+  const unknownOptionNames = Object.keys(restOptions)
+
+  if (unknownOptionNames.length > 0) {
+    throw new Error(`Unknown options given to useDestroyedEvent: ${unknownOptionNames.join(", ")}`)
+  }
+}
+
+/**
+ * React hook for frontend-model destroy events. Pass a model class for class-level
+ * destroy events, or a model / model array for instance-level destroy events.
+ * @param {FrontendModelClass | FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelClassOrModels - Model class, model, or models.
+ * @param {FrontendModelDestroyEventCallback} callback - Event callback.
+ * @param {UseDestroyedEventOptions} [options] - Hook options.
+ * @returns {void}
+ */
+export default function useDestroyedEvent(modelClassOrModels, callback, options = {}) {
+  const {active = true, debounce = false, onConnected, ...restOptions} = options
+  assertNoUnknownOptions(restOptions)
+
+  const classModel = typeof modelClassOrModels === "function" ? modelClassOrModels : null
+  const instanceModels = typeof modelClassOrModels === "function" ? null : modelClassOrModels
+
+  useModelClassEvent(classModel, "destroy", callback, {active: active && Boolean(classModel), debounce, onConnected})
+  useInstanceDestroyedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected})
+}
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @param {FrontendModelDestroyEventCallback} callback - Event callback.
+ * @param {UseDestroyedEventOptions} options - Hook options.
+ * @returns {void}
+ */
+function useInstanceDestroyedEvent(modelOrModels, callback, options) {
+  const {active = true, debounce = false, onConnected} = options
+  const callbackRef = useRef(callback)
+  const activeRef = useRef(active)
+  callbackRef.current = callback
+  activeRef.current = active
+
+  const modelsKey = modelsDependencyKey(modelOrModels)
+  const eventCallback = useMemo(() => {
+    const wrappedCallback = (/** @type {FrontendModelInstanceDestroyEventPayload} */ payload) => {
+      if (activeRef.current) callbackRef.current(payload)
+    }
+
+    if (typeof debounce === "number") return debounceFunction(wrappedCallback, debounce)
+    if (debounce) return debounceFunction(wrappedCallback)
+
+    return wrappedCallback
+  }, [debounce])
+
+  useEffect(() => {
+    if (!active) return undefined
+
+    const models = modelsFromInput(modelOrModels)
+    if (models.length < 1) return undefined
+
+    let closed = false
+    /** @type {Array<() => void>} */
+    const unsubscribeCallbacks = []
+
+    void (async () => {
+      for (const model of models) {
+        const unsubscribe = await model.onDestroy(eventCallback)
+
+        if (closed) {
+          unsubscribe()
+        } else {
+          unsubscribeCallbacks.push(unsubscribe)
+        }
+      }
+
+      if (!closed && onConnected) onConnected()
+    })()
+
+    return () => {
+      closed = true
+
+      for (const unsubscribe of unsubscribeCallbacks) {
+        unsubscribe()
+      }
+    }
+  }, [active, eventCallback, modelsKey, onConnected])
+}

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -1,0 +1,116 @@
+// @ts-check
+
+import debounceFunction from "debounce"
+import {useEffect, useMemo, useRef} from "react"
+
+/** @typedef {typeof import("./base.js").default} FrontendModelClass */
+/** @typedef {InstanceType<FrontendModelClass>} FrontendModelInstance */
+/** @typedef {"create" | "update" | "destroy"} FrontendModelClassEventName */
+/** @typedef {{id: string, model: FrontendModelInstance}} FrontendModelCreateUpdateEventPayload */
+/** @typedef {{id: string}} FrontendModelDestroyEventPayload */
+/** @typedef {FrontendModelCreateUpdateEventPayload | FrontendModelDestroyEventPayload} FrontendModelClassEventPayload */
+/** @typedef {(payload: FrontendModelClassEventPayload) => void} FrontendModelClassEventCallback */
+/** @typedef {{active?: boolean, debounce?: boolean | number, onConnected?: () => void}} UseModelClassEventOptions */
+
+/**
+ * @param {FrontendModelClassEventName | FrontendModelClassEventName[]} eventOrEvents - Event name or names.
+ * @returns {FrontendModelClassEventName[]} - Normalized event names.
+ */
+function normalizeEventNames(eventOrEvents) {
+  return Array.isArray(eventOrEvents) ? eventOrEvents : [eventOrEvents]
+}
+
+/**
+ * @param {FrontendModelClassEventName[]} eventNames - Event names.
+ * @returns {string} - Stable dependency key.
+ */
+function eventNamesDependencyKey(eventNames) {
+  return eventNames.join("|")
+}
+
+/**
+ * @param {Record<string, unknown>} restOptions - Unknown options object.
+ * @returns {void}
+ */
+function assertNoUnknownOptions(restOptions) {
+  const unknownOptionNames = Object.keys(restOptions)
+
+  if (unknownOptionNames.length > 0) {
+    throw new Error(`Unknown options given to useModelClassEvent: ${unknownOptionNames.join(", ")}`)
+  }
+}
+
+/**
+ * @param {FrontendModelClass} modelClass - Frontend model class.
+ * @param {FrontendModelClassEventName} eventName - Event name.
+ * @param {FrontendModelClassEventCallback} callback - Event callback.
+ * @returns {Promise<() => void>} - Unsubscribe callback.
+ */
+async function subscribeToModelClassEvent(modelClass, eventName, callback) {
+  if (eventName === "create") return await modelClass.onCreate(callback)
+  if (eventName === "update") return await modelClass.onUpdate(callback)
+  if (eventName === "destroy") return await modelClass.onDestroy(callback)
+
+  throw new Error(`Unsupported frontend model class event: ${eventName}`)
+}
+
+/**
+ * React hook for frontend-model class lifecycle events.
+ * @param {FrontendModelClass | null | undefined} modelClass - Frontend model class.
+ * @param {FrontendModelClassEventName | FrontendModelClassEventName[]} eventOrEvents - Event name or names.
+ * @param {FrontendModelClassEventCallback} callback - Event callback.
+ * @param {UseModelClassEventOptions} [options] - Hook options.
+ * @returns {void}
+ */
+export default function useModelClassEvent(modelClass, eventOrEvents, callback, options = {}) {
+  const {active = true, debounce = false, onConnected, ...restOptions} = options
+  assertNoUnknownOptions(restOptions)
+
+  const callbackRef = useRef(callback)
+  const activeRef = useRef(active)
+  callbackRef.current = callback
+  activeRef.current = active
+
+  const eventNames = normalizeEventNames(eventOrEvents)
+  const eventsKey = eventNamesDependencyKey(eventNames)
+  const eventCallback = useMemo(() => {
+    const wrappedCallback = (/** @type {FrontendModelClassEventPayload} */ payload) => {
+      if (activeRef.current) callbackRef.current(payload)
+    }
+
+    if (typeof debounce === "number") return debounceFunction(wrappedCallback, debounce)
+    if (debounce) return debounceFunction(wrappedCallback)
+
+    return wrappedCallback
+  }, [debounce])
+
+  useEffect(() => {
+    if (!active || !modelClass) return undefined
+
+    let closed = false
+    /** @type {Array<() => void>} */
+    const unsubscribeCallbacks = []
+
+    void (async () => {
+      for (const eventName of eventNames) {
+        const unsubscribe = await subscribeToModelClassEvent(modelClass, eventName, eventCallback)
+
+        if (closed) {
+          unsubscribe()
+        } else {
+          unsubscribeCallbacks.push(unsubscribe)
+        }
+      }
+
+      if (!closed && onConnected) onConnected()
+    })()
+
+    return () => {
+      closed = true
+
+      for (const unsubscribe of unsubscribeCallbacks) {
+        unsubscribe()
+      }
+    }
+  }, [active, eventsKey, eventCallback, modelClass, onConnected])
+}

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -3,6 +3,8 @@
 import debounceFunction from "debounce"
 import {useEffect, useMemo, useRef} from "react"
 
+import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
+
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
 /** @typedef {InstanceType<FrontendModelClass>} FrontendModelInstance */
 /** @typedef {"create" | "update" | "destroy"} FrontendModelClassEventName */
@@ -90,10 +92,13 @@ export default function useModelClassEvent(modelClass, eventOrEvents, callback, 
     let closed = false
     /** @type {Array<() => void>} */
     const unsubscribeCallbacks = []
+    const subscriptionCallback = (/** @type {FrontendModelClassEventPayload} */ payload) => {
+      if (!closed) eventCallback(payload)
+    }
 
     void (async () => {
       for (const eventName of eventNames) {
-        const unsubscribe = await subscribeToModelClassEvent(modelClass, eventName, eventCallback)
+        const unsubscribe = await subscribeToModelClassEvent(modelClass, eventName, subscriptionCallback)
 
         if (closed) {
           unsubscribe()
@@ -111,6 +116,8 @@ export default function useModelClassEvent(modelClass, eventOrEvents, callback, 
       for (const unsubscribe of unsubscribeCallbacks) {
         unsubscribe()
       }
+
+      clearPendingDebouncedCallback(eventCallback)
     }
   }, [active, eventsKey, eventCallback, modelClass, onConnected])
 }

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -1,0 +1,125 @@
+// @ts-check
+
+import debounceFunction from "debounce"
+import {useEffect, useMemo, useRef} from "react"
+
+import useModelClassEvent from "./use-model-class-event.js"
+
+/** @typedef {typeof import("./base.js").default} FrontendModelClass */
+/** @typedef {import("./base.js").default} FrontendModelInstance */
+/** @typedef {import("./use-model-class-event.js").FrontendModelCreateUpdateEventPayload} FrontendModelClassUpdateEventPayload */
+/** @typedef {{id: string, model: FrontendModelInstance}} FrontendModelInstanceUpdateEventPayload */
+/** @typedef {FrontendModelClassUpdateEventPayload | FrontendModelInstanceUpdateEventPayload} FrontendModelUpdateEventPayload */
+/** @typedef {import("./use-model-class-event.js").UseModelClassEventOptions} UseUpdatedEventOptions */
+/** @typedef {(payload: FrontendModelUpdateEventPayload) => void} FrontendModelUpdateEventCallback */
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @returns {FrontendModelInstance[]} - Normalized model list.
+ */
+function modelsFromInput(modelOrModels) {
+  if (!modelOrModels) return []
+  if (Array.isArray(modelOrModels)) return modelOrModels.filter(Boolean)
+
+  return [modelOrModels]
+}
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @returns {string} - Stable dependency key.
+ */
+function modelsDependencyKey(modelOrModels) {
+  return JSON.stringify(modelsFromInput(modelOrModels).map((model) => model.primaryKeyValue()))
+}
+
+/**
+ * @param {Record<string, unknown>} restOptions - Unknown options object.
+ * @returns {void}
+ */
+function assertNoUnknownOptions(restOptions) {
+  const unknownOptionNames = Object.keys(restOptions)
+
+  if (unknownOptionNames.length > 0) {
+    throw new Error(`Unknown options given to useUpdatedEvent: ${unknownOptionNames.join(", ")}`)
+  }
+}
+
+/**
+ * React hook for frontend-model update events. Pass a model class for class-level
+ * update events, or a model / model array for instance-level update events.
+ * @param {FrontendModelClass | FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelClassOrModels - Model class, model, or models.
+ * @param {FrontendModelUpdateEventCallback} callback - Event callback.
+ * @param {UseUpdatedEventOptions} [options] - Hook options.
+ * @returns {void}
+ */
+export default function useUpdatedEvent(modelClassOrModels, callback, options = {}) {
+  const {active = true, debounce = false, onConnected, ...restOptions} = options
+  assertNoUnknownOptions(restOptions)
+
+  const classModel = typeof modelClassOrModels === "function" ? modelClassOrModels : null
+  const instanceModels = typeof modelClassOrModels === "function" ? null : modelClassOrModels
+
+  useModelClassEvent(classModel, "update", (payload) => {
+    callback(/** @type {FrontendModelClassUpdateEventPayload} */ (payload))
+  }, {active: active && Boolean(classModel), debounce, onConnected})
+  useInstanceUpdatedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected})
+}
+
+/**
+ * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
+ * @param {FrontendModelUpdateEventCallback} callback - Event callback.
+ * @param {UseUpdatedEventOptions} options - Hook options.
+ * @returns {void}
+ */
+function useInstanceUpdatedEvent(modelOrModels, callback, options) {
+  const {active = true, debounce = false, onConnected} = options
+  const callbackRef = useRef(callback)
+  const activeRef = useRef(active)
+  callbackRef.current = callback
+  activeRef.current = active
+
+  const modelsKey = modelsDependencyKey(modelOrModels)
+  const eventCallback = useMemo(() => {
+    const wrappedCallback = (/** @type {FrontendModelInstanceUpdateEventPayload} */ payload) => {
+      if (activeRef.current) callbackRef.current(payload)
+    }
+
+    if (typeof debounce === "number") return debounceFunction(wrappedCallback, debounce)
+    if (debounce) return debounceFunction(wrappedCallback)
+
+    return wrappedCallback
+  }, [debounce])
+
+  useEffect(() => {
+    if (!active) return undefined
+
+    const models = modelsFromInput(modelOrModels)
+    if (models.length < 1) return undefined
+
+    let closed = false
+    /** @type {Array<() => void>} */
+    const unsubscribeCallbacks = []
+
+    void (async () => {
+      for (const model of models) {
+        const unsubscribe = await model.onUpdate(eventCallback)
+
+        if (closed) {
+          unsubscribe()
+        } else {
+          unsubscribeCallbacks.push(unsubscribe)
+        }
+      }
+
+      if (!closed && onConnected) onConnected()
+    })()
+
+    return () => {
+      closed = true
+
+      for (const unsubscribe of unsubscribeCallbacks) {
+        unsubscribe()
+      }
+    }
+  }, [active, eventCallback, modelsKey, onConnected])
+}

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -3,6 +3,8 @@
 import debounceFunction from "debounce"
 import {useEffect, useMemo, useRef} from "react"
 
+import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
+import {modelsDependencyKey, modelsFromInput} from "./event-hook-models.js"
 import useModelClassEvent from "./use-model-class-event.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
@@ -12,25 +14,6 @@ import useModelClassEvent from "./use-model-class-event.js"
 /** @typedef {FrontendModelClassUpdateEventPayload | FrontendModelInstanceUpdateEventPayload} FrontendModelUpdateEventPayload */
 /** @typedef {import("./use-model-class-event.js").UseModelClassEventOptions} UseUpdatedEventOptions */
 /** @typedef {(payload: FrontendModelUpdateEventPayload) => void} FrontendModelUpdateEventCallback */
-
-/**
- * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
- * @returns {FrontendModelInstance[]} - Normalized model list.
- */
-function modelsFromInput(modelOrModels) {
-  if (!modelOrModels) return []
-  if (Array.isArray(modelOrModels)) return modelOrModels.filter(Boolean)
-
-  return [modelOrModels]
-}
-
-/**
- * @param {FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelOrModels - Model or models.
- * @returns {string} - Stable dependency key.
- */
-function modelsDependencyKey(modelOrModels) {
-  return JSON.stringify(modelsFromInput(modelOrModels).map((model) => model.primaryKeyValue()))
-}
 
 /**
  * @param {Record<string, unknown>} restOptions - Unknown options object.
@@ -99,10 +82,13 @@ function useInstanceUpdatedEvent(modelOrModels, callback, options) {
     let closed = false
     /** @type {Array<() => void>} */
     const unsubscribeCallbacks = []
+    const subscriptionCallback = (/** @type {FrontendModelInstanceUpdateEventPayload} */ payload) => {
+      if (!closed) eventCallback(payload)
+    }
 
     void (async () => {
       for (const model of models) {
-        const unsubscribe = await model.onUpdate(eventCallback)
+        const unsubscribe = await model.onUpdate(subscriptionCallback)
 
         if (closed) {
           unsubscribe()
@@ -120,6 +106,8 @@ function useInstanceUpdatedEvent(modelOrModels, callback, options) {
       for (const unsubscribe of unsubscribeCallbacks) {
         unsubscribe()
       }
+
+      clearPendingDebouncedCallback(eventCallback)
     }
   }, [active, eventCallback, modelsKey, onConnected])
 }

--- a/src/testing/browser-frontend-model-event-hook-scenarios.js
+++ b/src/testing/browser-frontend-model-event-hook-scenarios.js
@@ -1,0 +1,294 @@
+// @ts-check
+
+import React from "react"
+import {createRoot} from "react-dom/client"
+
+import useDestroyedEvent from "../frontend-models/use-destroyed-event.js"
+import useCreatedEvent from "../frontend-models/use-created-event.js"
+import useModelClassEvent from "../frontend-models/use-model-class-event.js"
+import useUpdatedEvent from "../frontend-models/use-updated-event.js"
+
+/**
+ * @typedef {object} FakeSubscriptions
+ * @property {Set<(payload: unknown) => void>} create - Create callbacks.
+ * @property {Set<(payload: unknown) => void>} destroy - Destroy callbacks.
+ * @property {Set<(payload: unknown) => void>} update - Update callbacks.
+ */
+
+/** @returns {Promise<void>} - Resolves after React effects have run. */
+async function flushEffects() {
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * @param {number} milliseconds - Milliseconds to wait.
+ * @returns {Promise<void>} - Resolves after the delay.
+ */
+async function sleep(milliseconds) {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+/**
+ * @param {React.ReactElement} element - Element to render.
+ * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
+ */
+async function renderElement(element) {
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  root.render(element)
+  await flushEffects()
+
+  return {
+    rerender: async (nextElement) => {
+      root.render(nextElement)
+      await flushEffects()
+    },
+    unmount: async () => {
+      root.unmount()
+      container.remove()
+      await flushEffects()
+    }
+  }
+}
+
+/** @returns {{ModelClass: typeof import("../frontend-models/base.js").default, subscriptions: FakeSubscriptions}} - Fake model class setup. */
+function buildFakeModelClass() {
+  const subscriptions = {
+    create: new Set(),
+    destroy: new Set(),
+    update: new Set()
+  }
+  const ModelClass = /** @type {typeof import("../frontend-models/base.js").default} */ (/** @type {unknown} */ ({
+    onCreate: async (/** @type {(payload: unknown) => void} */ callback) => {
+      subscriptions.create.add(callback)
+
+      return () => subscriptions.create.delete(callback)
+    },
+    onDestroy: async (/** @type {(payload: unknown) => void} */ callback) => {
+      subscriptions.destroy.add(callback)
+
+      return () => subscriptions.destroy.delete(callback)
+    },
+    onUpdate: async (/** @type {(payload: unknown) => void} */ callback) => {
+      subscriptions.update.add(callback)
+
+      return () => subscriptions.update.delete(callback)
+    }
+  }))
+
+  return {ModelClass, subscriptions}
+}
+
+/**
+ * @param {FakeSubscriptions} subscriptions - Callback sets.
+ * @param {"create" | "destroy" | "update"} eventName - Event name.
+ * @param {unknown} payload - Event payload.
+ * @returns {void}
+ */
+function emitEvent(subscriptions, eventName, payload) {
+  for (const callback of subscriptions[eventName]) {
+    callback(payload)
+  }
+}
+
+/**
+ * @param {string} id - Model id.
+ * @param {FakeSubscriptions} subscriptions - Callback sets.
+ * @returns {import("../frontend-models/base.js").default} - Fake model instance.
+ */
+function buildFakeModel(id, subscriptions) {
+  return /** @type {import("../frontend-models/base.js").default} */ (/** @type {unknown} */ ({
+    onDestroy: async (/** @type {(payload: unknown) => void} */ callback) => {
+      subscriptions.destroy.add(callback)
+
+      return () => subscriptions.destroy.delete(callback)
+    },
+    onUpdate: async (/** @type {(payload: unknown) => void} */ callback) => {
+      subscriptions.update.add(callback)
+
+      return () => subscriptions.update.delete(callback)
+    },
+    primaryKeyValue: () => id
+  }))
+}
+
+/** @returns {Promise<Record<string, number>>} - Scenario result. */
+async function classLifecycleScenario() {
+  const {ModelClass, subscriptions} = buildFakeModelClass()
+  const receivedEvents = /** @type {unknown[]} */ ([])
+  let connectedCount = 0
+
+  /** @returns {React.ReactElement} - Test element. */
+  function TestComponent() {
+    useModelClassEvent(ModelClass, ["create", "update"], (payload) => receivedEvents.push(payload), {
+      onConnected: () => { connectedCount += 1 }
+    })
+    useCreatedEvent(ModelClass, (payload) => receivedEvents.push(payload))
+
+    return React.createElement("div")
+  }
+
+  const controls = await renderElement(React.createElement(TestComponent))
+  const mountedCreateSubscriptions = subscriptions.create.size
+  const mountedUpdateSubscriptions = subscriptions.update.size
+  const mountedDestroySubscriptions = subscriptions.destroy.size
+  const mountedConnectedCount = connectedCount
+
+  emitEvent(subscriptions, "create", {id: "1", model: {id: "1"}})
+  emitEvent(subscriptions, "update", {id: "1", model: {id: "1"}})
+  emitEvent(subscriptions, "destroy", {id: "1"})
+
+  const receivedEventsAfterEmit = receivedEvents.length
+
+  await controls.unmount()
+
+  return {
+    mountedConnectedCount,
+    mountedCreateSubscriptions,
+    mountedDestroySubscriptions,
+    mountedUpdateSubscriptions,
+    receivedEventsAfterEmit,
+    unmountedCreateSubscriptions: subscriptions.create.size,
+    unmountedUpdateSubscriptions: subscriptions.update.size
+  }
+}
+
+/** @returns {Promise<Record<string, number>>} - Scenario result. */
+async function instanceLifecycleScenario() {
+  const subscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const model = buildFakeModel("task-1", subscriptions)
+  const receivedEvents = /** @type {unknown[]} */ ([])
+  let connectedCount = 0
+
+  /** @returns {React.ReactElement} - Test element. */
+  function TestComponent() {
+    useUpdatedEvent(model, (payload) => receivedEvents.push(payload), {
+      onConnected: () => { connectedCount += 1 }
+    })
+    useDestroyedEvent([model], (payload) => receivedEvents.push(payload), {
+      onConnected: () => { connectedCount += 1 }
+    })
+
+    return React.createElement("div")
+  }
+
+  const controls = await renderElement(React.createElement(TestComponent))
+  const mountedConnectedCount = connectedCount
+  const mountedDestroySubscriptions = subscriptions.destroy.size
+  const mountedUpdateSubscriptions = subscriptions.update.size
+
+  emitEvent(subscriptions, "update", {id: "task-1", model})
+  emitEvent(subscriptions, "destroy", {id: "task-1"})
+
+  const receivedEventsAfterEmit = receivedEvents.length
+
+  await controls.unmount()
+
+  return {
+    mountedConnectedCount,
+    mountedDestroySubscriptions,
+    mountedUpdateSubscriptions,
+    receivedEventsAfterEmit,
+    unmountedDestroySubscriptions: subscriptions.destroy.size,
+    unmountedUpdateSubscriptions: subscriptions.update.size
+  }
+}
+
+/** @returns {Promise<Record<string, number>>} - Scenario result. */
+async function debounceUnmountScenario() {
+  const {ModelClass, subscriptions: classSubscriptions} = buildFakeModelClass()
+  const instanceSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const model = buildFakeModel("task-1", instanceSubscriptions)
+  const receivedEvents = /** @type {unknown[]} */ ([])
+
+  /** @returns {React.ReactElement} - Test element. */
+  function TestComponent() {
+    useModelClassEvent(ModelClass, "update", (payload) => receivedEvents.push(payload), {debounce: 20})
+    useUpdatedEvent(model, (payload) => receivedEvents.push(payload), {debounce: 20})
+    useDestroyedEvent(model, (payload) => receivedEvents.push(payload), {debounce: 20})
+
+    return React.createElement("div")
+  }
+
+  const controls = await renderElement(React.createElement(TestComponent))
+
+  emitEvent(classSubscriptions, "update", {id: "task-1", model})
+  emitEvent(instanceSubscriptions, "update", {id: "task-1", model})
+  emitEvent(instanceSubscriptions, "destroy", {id: "task-1"})
+
+  await controls.unmount()
+  await sleep(30)
+
+  return {receivedEventsAfterDebounceWindow: receivedEvents.length}
+}
+
+/** @returns {Promise<Record<string, number>>} - Scenario result. */
+async function resubscribeInstanceScenario() {
+  const firstSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const secondSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const firstModel = buildFakeModel("task-1", firstSubscriptions)
+  const secondModel = buildFakeModel("task-1", secondSubscriptions)
+  const receivedEvents = /** @type {unknown[]} */ ([])
+
+  /**
+   * @param {{model: import("../frontend-models/base.js").default}} props - Component props.
+   * @returns {React.ReactElement} - Test element.
+   */
+  function TestComponent({model}) {
+    useUpdatedEvent(model, (payload) => receivedEvents.push(payload))
+    useDestroyedEvent(model, (payload) => receivedEvents.push(payload))
+
+    return React.createElement("div")
+  }
+
+  const controls = await renderElement(React.createElement(TestComponent, {model: firstModel}))
+  const firstMountedDestroySubscriptions = firstSubscriptions.destroy.size
+  const firstMountedUpdateSubscriptions = firstSubscriptions.update.size
+
+  await controls.rerender(React.createElement(TestComponent, {model: secondModel}))
+
+  const firstAfterRerenderDestroySubscriptions = firstSubscriptions.destroy.size
+  const firstAfterRerenderUpdateSubscriptions = firstSubscriptions.update.size
+  const secondAfterRerenderDestroySubscriptions = secondSubscriptions.destroy.size
+  const secondAfterRerenderUpdateSubscriptions = secondSubscriptions.update.size
+
+  emitEvent(firstSubscriptions, "update", {id: "task-1", model: firstModel})
+  emitEvent(secondSubscriptions, "update", {id: "task-1", model: secondModel})
+  emitEvent(secondSubscriptions, "destroy", {id: "task-1"})
+
+  const receivedEventsAfterEmit = receivedEvents.length
+
+  await controls.unmount()
+
+  return {
+    firstAfterRerenderDestroySubscriptions,
+    firstAfterRerenderUpdateSubscriptions,
+    firstMountedDestroySubscriptions,
+    firstMountedUpdateSubscriptions,
+    receivedEventsAfterEmit,
+    secondAfterRerenderDestroySubscriptions,
+    secondAfterRerenderUpdateSubscriptions
+  }
+}
+
+const scenarios = {
+  classLifecycle: classLifecycleScenario,
+  debounceUnmount: debounceUnmountScenario,
+  instanceLifecycle: instanceLifecycleScenario,
+  resubscribeInstance: resubscribeInstanceScenario
+}
+
+/**
+ * @param {keyof typeof scenarios} scenarioName - Scenario name.
+ * @returns {Promise<Record<string, number>>} - Scenario result.
+ */
+export default async function runFrontendModelEventHookScenario(scenarioName) {
+  const scenario = scenarios[scenarioName]
+
+  if (!scenario) throw new Error(`Unknown frontend model event hook scenario: ${scenarioName}`)
+
+  return await scenario()
+}

--- a/src/testing/browser-frontend-model-event-hook-scenarios.js
+++ b/src/testing/browser-frontend-model-event-hook-scenarios.js
@@ -30,6 +30,20 @@ async function sleep(milliseconds) {
 }
 
 /**
+ * @param {() => boolean} callback - Predicate to wait for.
+ * @returns {Promise<void>} - Resolves when the predicate returns true.
+ */
+async function waitFor(callback) {
+  const startedAt = Date.now()
+
+  while (!callback()) {
+    if (Date.now() - startedAt > 1000) return
+
+    await sleep(10)
+  }
+}
+
+/**
  * @param {React.ReactElement} element - Element to render.
  * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
  */
@@ -132,6 +146,8 @@ async function classLifecycleScenario() {
   }
 
   const controls = await renderElement(React.createElement(TestComponent))
+  await waitFor(() => subscriptions.create.size === 2 && subscriptions.update.size === 1)
+
   const mountedCreateSubscriptions = subscriptions.create.size
   const mountedUpdateSubscriptions = subscriptions.update.size
   const mountedDestroySubscriptions = subscriptions.destroy.size
@@ -176,6 +192,8 @@ async function instanceLifecycleScenario() {
   }
 
   const controls = await renderElement(React.createElement(TestComponent))
+  await waitFor(() => subscriptions.update.size === 1 && subscriptions.destroy.size === 1)
+
   const mountedConnectedCount = connectedCount
   const mountedDestroySubscriptions = subscriptions.destroy.size
   const mountedUpdateSubscriptions = subscriptions.update.size
@@ -214,6 +232,7 @@ async function debounceUnmountScenario() {
   }
 
   const controls = await renderElement(React.createElement(TestComponent))
+  await waitFor(() => classSubscriptions.update.size === 1 && instanceSubscriptions.update.size === 1 && instanceSubscriptions.destroy.size === 1)
 
   emitEvent(classSubscriptions, "update", {id: "task-1", model})
   emitEvent(instanceSubscriptions, "update", {id: "task-1", model})
@@ -245,10 +264,13 @@ async function resubscribeInstanceScenario() {
   }
 
   const controls = await renderElement(React.createElement(TestComponent, {model: firstModel}))
+  await waitFor(() => firstSubscriptions.update.size === 1 && firstSubscriptions.destroy.size === 1)
+
   const firstMountedDestroySubscriptions = firstSubscriptions.destroy.size
   const firstMountedUpdateSubscriptions = firstSubscriptions.update.size
 
   await controls.rerender(React.createElement(TestComponent, {model: secondModel}))
+  await waitFor(() => firstSubscriptions.update.size === 0 && firstSubscriptions.destroy.size === 0 && secondSubscriptions.update.size === 1 && secondSubscriptions.destroy.size === 1)
 
   const firstAfterRerenderDestroySubscriptions = firstSubscriptions.destroy.size
   const firstAfterRerenderUpdateSubscriptions = firstSubscriptions.update.size

--- a/src/testing/browser-test-app.js
+++ b/src/testing/browser-test-app.js
@@ -2,6 +2,7 @@
 
 import SystemTestBrowserHelper from "system-testing/build/system-test-browser-helper.js"
 import BrowserEnvironmentHandler from "../environment-handlers/browser.js"
+import runFrontendModelEventHookScenario from "./browser-frontend-model-event-hook-scenarios.js"
 
 const root = document.getElementById("root") || (() => {
   const element = document.createElement("div")
@@ -26,5 +27,6 @@ systemTestBrowserHelper.enableOnBrowser()
 
 globalThis.velociousBrowserTest = {
   BrowserEnvironmentHandler,
+  runFrontendModelEventHookScenario,
   systemTestBrowserHelper
 }


### PR DESCRIPTION
## Summary
- add React hooks for frontend-model create, update, and destroy broadcasts
- support class-level subscriptions plus instance/array subscriptions for update and destroy
- document the hook API and add browser coverage for subscription cleanup

## Validation
- npm run build
- npm run typecheck
- npm run lint (passes with existing repo warnings)
- npm run lint -- spec/frontend-models/model-event-hooks.browser-spec.js
- env NODE_ENV=test npm run test:browser -- spec/frontend-models/model-event-hooks.browser-spec.js (blocked locally: ChromeDriver supports Chrome 114, installed Chrome is 146.0.7680.164)