### PR TITLE
Add frontend-model event projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ useModelClassEvent(Subscription, ["create", "update"], () => {
 })
 ```
 
-`useCreatedEvent`, `useUpdatedEvent`, and `useDestroyedEvent` are also available. `useUpdatedEvent` and `useDestroyedEvent` accept either a model class or model instance.
+`useCreatedEvent`, `useUpdatedEvent`, and `useDestroyedEvent` are also available. `useUpdatedEvent` and `useDestroyedEvent` accept either a model class or model instance. Lifecycle subscriptions accept the same projection options as frontend-model queries for event records, including `select`, `preload`, `withCount`, `abilities`, and `queryData`.
 
 Frontend-model `group(...)` is attribute/path based and does not accept raw SQL fragments. Use model/relationship shapes (for example `Task.group({project: {account: ["id"]}})`) so grouping resolves through known relationships and mapped columns.
 Frontend-model `where(...)` supports nested relationship descriptors (for example `Task.where({project: {creatingUser: {reference: "owner-b"}}})`) and does not accept raw SQL fragments.

--- a/changelog.d/20260530134146-frontend-model-event-projections.md
+++ b/changelog.d/20260530134146-frontend-model-event-projections.md
@@ -1,0 +1,1 @@
+Frontend-model lifecycle subscriptions can now request event record projections with `select`, `preload`, `withCount`, `abilities`, and `queryData`, including through the React event hooks.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -73,7 +73,14 @@
 - Pass an array of event names to subscribe one callback to several class-level events, for example `useModelClassEvent(Subscription, ["create", "update"], reloadStatus)`.
 - Convenience wrappers are available as `useCreatedEvent(ModelClass, callback)`, `useUpdatedEvent(ModelClassOrModel, callback)`, and `useDestroyedEvent(ModelClassOrModel, callback)`.
 - `useUpdatedEvent` and `useDestroyedEvent` accept a model instance or array of model instances for instance-level subscriptions.
-- Hook options support `{active, debounce, onConnected}`. The hooks own subscribe/unsubscribe cleanup, so components do not need lifecycle methods just to remove event listeners.
+- Hook options support `{active, debounce, onConnected}` plus event record projection options: `select`, `preload`, `withCount`, `abilities`, and `queryData`. The hooks own subscribe/unsubscribe cleanup, so components do not need lifecycle methods just to remove event listeners.
+
+```js
+useUpdatedEvent(BuildGroup, onBuildGroupUpdated, {
+  select: {BuildGroup: ["id", "status", "rebuildableBuildsCount"]},
+  withCount: "builds"
+})
+```
 
 ## Attachment support
 - Frontend models can define `resourceConfig().attachments` and use generated attachment handles:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,28 @@ export default defineConfig([
     }
   }),
   {
+    files: [
+      "src/frontend-models/use-model-class-event.js",
+      "src/frontend-models/use-created-event.js",
+      "src/frontend-models/use-updated-event.js",
+      "src/frontend-models/use-destroyed-event.js",
+      "src/frontend-models/websocket-channel.js",
+      "src/http-server/websocket-channel.js",
+      "src/testing/browser-frontend-model-event-hook-scenarios.js"
+    ],
+    settings: {
+      jsdoc: {
+        preferredTypes: {
+          unknown: false
+        }
+      }
+    },
+    rules: {
+      "jsdoc/check-types": "error",
+      "jsdoc/reject-any-type": "error"
+    }
+  },
+  {
     files: ["spec/**/*.js"],
     rules: {
       "no-undef": "off"

--- a/spec/beacon/configuration-integration-spec.js
+++ b/spec/beacon/configuration-integration-spec.js
@@ -25,6 +25,7 @@ function makeSubscription({matches} = {}) {
     subscriptionId: `s-${Math.random().toString(36).slice(2)}`,
     received,
     matches: matches || (() => true),
+    deliverBroadcast: (body) => received.push(body),
     sendMessage: (body) => received.push(body),
     isClosed: () => false
   }
@@ -186,6 +187,28 @@ describe("Beacon configuration integration", {databaseCleaning: {transaction: fa
 
     configuration.broadcastToChannel("frontend-models", {}, {hello: "world"})
 
+    await wait(0.01)
+
     expect(subscription.received).toEqual([{hello: "world"}])
+  })
+
+  it("continues broadcasting when one subscriber throws synchronously during delivery", async () => {
+    const configuration = buildConfiguration()
+    const throwingSubscription = {
+      ...makeSubscription(),
+      deliverBroadcast: () => {
+        throw new Error("sync delivery failed")
+      }
+    }
+    const receivingSubscription = makeSubscription()
+
+    configuration._registerWebsocketChannelSubscription("frontend-models", /** @type {import("../../src/http-server/websocket-channel.js").default} */ (throwingSubscription))
+    configuration._registerWebsocketChannelSubscription("frontend-models", /** @type {import("../../src/http-server/websocket-channel.js").default} */ (receivingSubscription))
+
+    configuration.broadcastToChannel("frontend-models", {}, {hello: "after throw"})
+
+    await wait(0.01)
+
+    expect(receivingSubscription.received).toEqual([{hello: "after throw"}])
   })
 })

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -469,6 +469,51 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
     })
   })
 
+  it("serializes projected model lifecycle events for websocket subscribers", async () => {
+    await Dummy.run(async () => {
+      const websocketClient = new WebsocketClient()
+      const project = await ProjectRecord.create({name: "Projected event project"})
+      const task = await TaskRecord.create({name: "Projected original", project})
+      await CommentRecord.create({body: "Projected comment", task})
+
+      configureWebsocketSharedTransport(websocketClient)
+
+      /** @type {Array<{id: string, model: Task}>} */
+      const updates = []
+      const offUpdate = await Task.onUpdate((event) => {
+        updates.push({id: event.id, model: /** @type {Task} */ (event.model)})
+      }, {
+        preload: "project",
+        select: {
+          Project: ["id"],
+          Task: ["id", "nameUppercase"]
+        },
+        withCount: "comments"
+      })
+
+      try {
+        task.setName("Projected renamed")
+        await task.save()
+
+        await waitFor(() => {
+          if (updates.length < 1) throw new Error(`Expected projected onUpdate but got ${updates.length}`)
+        })
+
+        const projectedTask = updates[0].model
+        const projectedProject = projectedTask.getRelationshipByName("project").loaded()
+
+        expect(projectedTask.readAttribute("nameUppercase")).toEqual("PROJECTED RENAMED")
+        expect(projectedTask.readCount("commentsCount")).toEqual(1)
+        expect(projectedProject.id()).toEqual(project.id())
+        expect(() => projectedTask.name()).toThrow(/Task#name was not selected/)
+      } finally {
+        offUpdate()
+        resetFrontendModelTransport()
+        await websocketClient.close()
+      }
+    })
+  })
+
   it("auto-merges attributes on instance-level onUpdate and fires onDestroy once", async () => {
     await Dummy.run(async () => {
       const websocketClient = new WebsocketClient()

--- a/spec/frontend-models/model-event-hooks.browser-spec.js
+++ b/spec/frontend-models/model-event-hooks.browser-spec.js
@@ -4,7 +4,7 @@ import SystemTest from "system-testing/build/system-test.js"
 
 import {describe, expect, it} from "../../src/testing/test.js"
 
-/** @typedef {"classLifecycle" | "debounceUnmount" | "instanceLifecycle" | "resubscribeInstance"} FrontendModelEventHookScenario */
+/** @typedef {"classLifecycle" | "debounceUnmount" | "instanceLifecycle" | "projectionOptions" | "resubscribeInstance"} FrontendModelEventHookScenario */
 
 /** @returns {boolean} - Whether the browser test runner is active. */
 function runBrowserHookScenarios() {
@@ -60,6 +60,18 @@ describe("Frontend model event hooks", () => {
     if (!result) return
 
     expect(result.receivedEventsAfterDebounceWindow).toEqual(0)
+  })
+
+  it("passes projection options through class and instance hooks", async () => {
+    const result = await runFrontendModelEventHookScenario("projectionOptions")
+    if (!result) return
+
+    expect(result.classCreatePreloadProject).toEqual(1)
+    expect(result.classCreateSelectCount).toEqual(2)
+    expect(result.instanceUpdateSelectCount).toEqual(1)
+    expect(result.instanceUpdateWithCountComments).toEqual(1)
+    expect(result.instanceDestroyPreloadProject).toEqual(1)
+    expect(result.instanceDestroySelectCount).toEqual(1)
   })
 
   it("resubscribes instance hooks when the model object changes", async () => {

--- a/spec/frontend-models/websocket-channel-spec.js
+++ b/spec/frontend-models/websocket-channel-spec.js
@@ -66,4 +66,27 @@ describe("FrontendModelWebsocketChannel", () => {
     expect(request.header("x-session-token")).toEqual(undefined)
     expect(request.metadata("X-Session-Token")).toEqual("metadata-token")
   })
+
+  it("skips projected lifecycle events when the record cannot be reloaded", async () => {
+    /** @type {Array<{body?: object, type?: string}>} */
+    const sentFrames = []
+    const channel = new FrontendModelWebsocketChannel({
+      params: {model: "Task", select: {Task: ["id", "name"]}},
+      // @ts-expect-error Minimal sendJson-only session stub for direct channel delivery.
+      session: {
+        sendJson: (/** @type {{body?: object, type?: string}} */ frame) => sentFrames.push(frame)
+      },
+      subscriptionId: "projected-missing-record"
+    })
+
+    channel._projectedRecordForEventId = async () => null
+
+    await channel.deliverBroadcast({
+      action: "update",
+      id: "missing-task",
+      record: {id: "missing-task", name: "Raw fallback"}
+    })
+
+    expect(sentFrames).toEqual([])
+  })
 })

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1608,7 +1608,8 @@ export default class VelociousConfiguration {
       if (!matches) continue
 
       void Promise
-        .resolve(subscription.deliverBroadcast(body, {eventId: meta?.eventId}))
+        .resolve()
+        .then(() => subscription.deliverBroadcast(body, {eventId: meta?.eventId}))
         .catch((error) => {
           console.error(`broadcastToChannel: ${name} subscription ${subscription.subscriptionId} deliverBroadcast threw`, error)
         })

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1609,11 +1609,25 @@ export default class VelociousConfiguration {
 
       void Promise
         .resolve()
-        .then(() => subscription.deliverBroadcast(body, {eventId: meta?.eventId}))
+        .then(() => this._deliverWebsocketChannelBroadcast(subscription, body, {eventId: meta?.eventId}))
         .catch((error) => {
           console.error(`broadcastToChannel: ${name} subscription ${subscription.subscriptionId} deliverBroadcast threw`, error)
         })
     }
+  }
+
+  /**
+   * @param {import("./http-server/websocket-channel.js").default} subscription - Channel subscription.
+   * @param {import("./http-server/websocket-channel.js").WebsocketJsonValue} body - Broadcast body.
+   * @param {{eventId?: string}} meta - Broadcast metadata.
+   * @returns {void | Promise<void>} Broadcast delivery result.
+   */
+  _deliverWebsocketChannelBroadcast(subscription, body, meta) {
+    if (typeof subscription.deliverBroadcast === "function") {
+      return subscription.deliverBroadcast(body, meta)
+    }
+
+    return subscription.sendMessage(body, meta)
   }
 
   /** @returns {import("./configuration-types.js").WebsocketMessageHandlerResolverType | undefined} - The websocket message handler resolver. */

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1607,11 +1607,11 @@ export default class VelociousConfiguration {
 
       if (!matches) continue
 
-      try {
-        subscription.sendMessage(body, {eventId: meta?.eventId})
-      } catch (error) {
-        console.error(`broadcastToChannel: ${name} subscription ${subscription.subscriptionId} sendMessage threw`, error)
-      }
+      void Promise
+        .resolve(subscription.deliverBroadcast(body, {eventId: meta?.eventId}))
+        .catch((error) => {
+          console.error(`broadcastToChannel: ${name} subscription ${subscription.subscriptionId} deliverBroadcast threw`, error)
+        })
     }
   }
 

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -2,7 +2,7 @@
 
 import * as inflection from "inflection"
 import timeout from "awaitery/build/timeout.js"
-import FrontendModelQuery from "./query.js"
+import FrontendModelQuery, {frontendModelProjectionPayload} from "./query.js"
 import {registerFrontendModel, resolveFrontendModelClass} from "./model-registry.js"
 import {validateFrontendModelResourceCommandName, validateFrontendModelResourcePath} from "./resource-config-validation.js"
 import {deserializeFrontendModelTransportValue, serializeFrontendModelTransportValue} from "./transport-serialization.js"
@@ -726,6 +726,112 @@ function cloneFrontendModelAttributes(value) {
 const FRONTEND_MODELS_CHANNEL_NAME = "frontend-models"
 
 /**
+ * @typedef {{callback: (payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void, projectionPayload: import("./query.js").FrontendModelProjectionPayload}} FrontendModelModelEventCallbackEntry
+ */
+/**
+ * @typedef {{callback: (payload: {id: string}) => void}} FrontendModelDestroyEventCallbackEntry
+ */
+
+/**
+ * @param {Record<string, import("./query.js").FrontendModelTransportValue>} target - Target preload payload.
+ * @param {Record<string, import("./query.js").FrontendModelTransportValue>} source - Source preload payload.
+ * @returns {void}
+ */
+function mergeFrontendModelEventPreload(target, source) {
+  for (const [relationshipName, value] of Object.entries(source)) {
+    const existingValue = target[relationshipName]
+
+    if (value === true || value === false) {
+      if (existingValue === undefined) target[relationshipName] = value
+      continue
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      target[relationshipName] = value
+      continue
+    }
+
+    if (!existingValue || typeof existingValue !== "object" || Array.isArray(existingValue)) {
+      target[relationshipName] = {}
+    }
+
+    mergeFrontendModelEventPreload(
+      /** @type {Record<string, import("./query.js").FrontendModelTransportValue>} */ (target[relationshipName]),
+      /** @type {Record<string, import("./query.js").FrontendModelTransportValue>} */ (value)
+    )
+  }
+}
+
+/**
+ * @param {Record<string, string[]>} target - Target select map.
+ * @param {Record<string, string[]>} source - Source select map.
+ * @returns {void}
+ */
+function mergeFrontendModelEventSelect(target, source) {
+  for (const [modelName, attributes] of Object.entries(source)) {
+    const existingAttributes = target[modelName] || []
+
+    target[modelName] = Array.from(new Set(existingAttributes.concat(attributes)))
+  }
+}
+
+/**
+ * @param {Array<import("./query.js").FrontendModelWithCountPayloadEntry | import("./query.js").FrontendModelAbilitiesPayloadEntry>} target - Target array.
+ * @param {Array<import("./query.js").FrontendModelWithCountPayloadEntry | import("./query.js").FrontendModelAbilitiesPayloadEntry>} source - Source array.
+ * @returns {void}
+ */
+function mergeUniqueFrontendModelEventEntries(target, source) {
+  const existingKeys = new Set(target.map((entry) => JSON.stringify(entry)))
+
+  for (const entry of source) {
+    const key = JSON.stringify(entry)
+
+    if (existingKeys.has(key)) continue
+
+    target.push(entry)
+    existingKeys.add(key)
+  }
+}
+
+/**
+ * @param {import("./query.js").FrontendModelProjectionPayload} target - Target payload.
+ * @param {import("./query.js").FrontendModelProjectionPayload} source - Source payload.
+ * @returns {void}
+ */
+function mergeFrontendModelEventProjectionPayload(target, source) {
+  if (source.preload) {
+    if (!target.preload) target.preload = {}
+    mergeFrontendModelEventPreload(target.preload, source.preload)
+  }
+
+  if (source.select) {
+    if (!target.select) target.select = {}
+    mergeFrontendModelEventSelect(target.select, source.select)
+  }
+
+  if (source.withCount) {
+    if (!target.withCount) target.withCount = []
+    mergeUniqueFrontendModelEventEntries(target.withCount, source.withCount)
+  }
+
+  if (source.abilities) {
+    if (!target.abilities) target.abilities = []
+    mergeUniqueFrontendModelEventEntries(target.abilities, source.abilities)
+  }
+
+  if (source.queryData !== undefined) {
+    const targetQueryData = Array.isArray(target.queryData) ? target.queryData : []
+
+    target.queryData = targetQueryData
+    const queryDataEntries = Array.isArray(source.queryData) ? source.queryData : [source.queryData]
+
+    for (const entry of queryDataEntries) {
+      targetQueryData.push(entry)
+    }
+  }
+}
+
+/**
  * Per-model class singleton that multiplexes all registered onCreate /
  * onUpdate / onDestroy callbacks — class-level + instance-level —
  * over one WebsocketChannelV2 subscription. Subscription opens on the
@@ -740,25 +846,65 @@ class FrontendModelEventSubscription {
   /** @param {typeof FrontendModelBase} ModelClass - Frontend model class for this subscription bucket. */
   constructor(ModelClass) {
     this.ModelClass = ModelClass
-    /** @type {Set<(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void>} */
+    /** @type {Set<FrontendModelModelEventCallbackEntry>} */
     this.classCreateCallbacks = new Set()
-    /** @type {Set<(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void>} */
+    /** @type {Set<FrontendModelModelEventCallbackEntry>} */
     this.classUpdateCallbacks = new Set()
-    /** @type {Set<(payload: {id: string}) => void>} */
+    /** @type {Set<FrontendModelDestroyEventCallbackEntry>} */
     this.classDestroyCallbacks = new Set()
-    /** @type {Map<string, {instance: InstanceType<typeof FrontendModelBase>, updateCallbacks: Set<(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void>, destroyCallbacks: Set<(payload: {id: string}) => void>}>} */
+    /** @type {Map<string, {instance: InstanceType<typeof FrontendModelBase>, updateCallbacks: Set<FrontendModelModelEventCallbackEntry>, destroyCallbacks: Set<FrontendModelDestroyEventCallbackEntry>}>} */
     this.instanceListeners = new Map()
     /** @type {any} */
     this.channelHandle = null
     /** @type {Promise<void> | null} */
     this.readyPromise = null
+    /** @type {string | null} */
+    this.subscriptionParamsKey = null
+  }
+
+  /**
+   * @returns {{model: string} & import("./query.js").FrontendModelProjectionPayload} - Current websocket subscription params.
+   */
+  subscriptionParams() {
+    /** @type {import("./query.js").FrontendModelProjectionPayload} */
+    const projectionPayload = {}
+    const projectionEntries = []
+
+    for (const entry of this.classCreateCallbacks) projectionEntries.push(entry)
+    for (const entry of this.classUpdateCallbacks) projectionEntries.push(entry)
+
+    for (const listener of this.instanceListeners.values()) {
+      for (const entry of listener.updateCallbacks) projectionEntries.push(entry)
+    }
+
+    for (const entry of projectionEntries) {
+      mergeFrontendModelEventProjectionPayload(projectionPayload, entry.projectionPayload)
+    }
+
+    return {
+      model: this.ModelClass.getModelName(),
+      ...projectionPayload
+    }
+  }
+
+  /** @returns {string} - Stable key for current subscription params. */
+  subscriptionParamsJson() {
+    return JSON.stringify(this.subscriptionParams())
   }
 
   /** @returns {Promise<void>} */
   async ensureSubscribed() {
+    const paramsJson = this.subscriptionParamsJson()
+
     if (this.channelHandle && !this.channelHandle.isClosed()) {
-      if (this.readyPromise) await this.readyPromise
-      return
+      if (this.subscriptionParamsKey !== paramsJson) {
+        this.channelHandle.close()
+        this.channelHandle = null
+        this.readyPromise = null
+      } else {
+        if (this.readyPromise) await this.readyPromise
+        return
+      }
     }
 
     // Serialize parallel calls (e.g. Promise.all([onCreate, onUpdate,
@@ -778,12 +924,16 @@ class FrontendModelEventSubscription {
     this.readyPromise = (async () => {
       if (typeof client.connect === "function") await client.connect()
 
+      const params = this.subscriptionParams()
+
+      this.subscriptionParamsKey = JSON.stringify(params)
       this.channelHandle = client.subscribeChannel(FRONTEND_MODELS_CHANNEL_NAME, {
-        params: {model: this.ModelClass.getModelName()},
+        params,
         onMessage: (/** @type {any} */ body) => this._dispatchEvent(body),
         onClose: () => {
           this.channelHandle = null
           this.readyPromise = null
+          this.subscriptionParamsKey = null
           this.instanceListeners.clear()
 
           const hasCallbacks = this.classCreateCallbacks.size > 0
@@ -817,13 +967,13 @@ class FrontendModelEventSubscription {
       const listener = this.instanceListeners.get(id)
 
       if (listener) {
-        for (const cb of listener.destroyCallbacks) {
-          try { cb({id}) } catch (error) { console.error(error) }
+        for (const entry of listener.destroyCallbacks) {
+          try { entry.callback({id}) } catch (error) { console.error(error) }
         }
         this.instanceListeners.delete(id)
       }
-      for (const cb of this.classDestroyCallbacks) {
-        try { cb({id}) } catch (error) { console.error(error) }
+      for (const entry of this.classDestroyCallbacks) {
+        try { entry.callback({id}) } catch (error) { console.error(error) }
       }
       return
     }
@@ -842,15 +992,15 @@ class FrontendModelEventSubscription {
       instanceAny.assignAttributes(freshModel.attributes())
       instanceAny._persistedAttributes = cloneFrontendModelAttributes(listener.instance.attributes())
 
-      for (const cb of listener.updateCallbacks) {
-        try { cb({id, model: listener.instance}) } catch (error) { console.error(error) }
+      for (const entry of listener.updateCallbacks) {
+        try { entry.callback({id, model: listener.instance}) } catch (error) { console.error(error) }
       }
     }
 
     const classCallbacks = action === "create" ? this.classCreateCallbacks : this.classUpdateCallbacks
 
-    for (const cb of classCallbacks) {
-      try { cb({id, model: freshModel}) } catch (error) { console.error(error) }
+    for (const entry of classCallbacks) {
+      try { entry.callback({id, model: freshModel}) } catch (error) { console.error(error) }
     }
   }
 
@@ -872,6 +1022,7 @@ class FrontendModelEventSubscription {
 
     this.channelHandle = null
     this.readyPromise = null
+    this.subscriptionParamsKey = null
   }
 }
 
@@ -2496,16 +2647,18 @@ export default class FrontendModelBase {
    * without re-checking per-record visibility.
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
+   * @param {import("./query.js").FrontendModelProjectionOptions} [options] - Event record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  static async onCreate(callback) {
+  static async onCreate(callback, options = {}) {
     const sub = ensureFrontendModelEventSubscription(this)
+    const entry = {callback, projectionPayload: frontendModelProjectionPayload(this, options)}
 
-    sub.classCreateCallbacks.add(callback)
+    sub.classCreateCallbacks.add(entry)
     await sub.ensureSubscribed()
 
     return () => {
-      sub.classCreateCallbacks.delete(callback)
+      sub.classCreateCallbacks.delete(entry)
       sub.maybeTeardown()
     }
   }
@@ -2514,16 +2667,18 @@ export default class FrontendModelBase {
    * Class-level hook fired when any record of this model is updated.
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
+   * @param {import("./query.js").FrontendModelProjectionOptions} [options] - Event record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  static async onUpdate(callback) {
+  static async onUpdate(callback, options = {}) {
     const sub = ensureFrontendModelEventSubscription(this)
+    const entry = {callback, projectionPayload: frontendModelProjectionPayload(this, options)}
 
-    sub.classUpdateCallbacks.add(callback)
+    sub.classUpdateCallbacks.add(entry)
     await sub.ensureSubscribed()
 
     return () => {
-      sub.classUpdateCallbacks.delete(callback)
+      sub.classUpdateCallbacks.delete(entry)
       sub.maybeTeardown()
     }
   }
@@ -2532,16 +2687,18 @@ export default class FrontendModelBase {
    * Class-level hook fired when any record of this model is destroyed.
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string}) => void} callback - Event callback.
+   * @param {import("./query.js").FrontendModelProjectionOptions} [_options] - Accepted for API symmetry; destroy events carry ids only.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  static async onDestroy(callback) {
+  static async onDestroy(callback, _options = {}) {
     const sub = ensureFrontendModelEventSubscription(this)
+    const entry = {callback}
 
-    sub.classDestroyCallbacks.add(callback)
+    sub.classDestroyCallbacks.add(entry)
     await sub.ensureSubscribed()
 
     return () => {
-      sub.classDestroyCallbacks.delete(callback)
+      sub.classDestroyCallbacks.delete(entry)
       sub.maybeTeardown()
     }
   }
@@ -2552,13 +2709,15 @@ export default class FrontendModelBase {
    * before the callback runs, so callers can read fresh values via
    * `this.someAttr()` without re-fetching.
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
+   * @param {import("./query.js").FrontendModelProjectionOptions} [options] - Event record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  async onUpdate(callback) {
+  async onUpdate(callback, options = {}) {
     const self = /** @type {any} */ (this)
     const ModelClass = /** @type {typeof FrontendModelBase} */ (this.constructor)
     const sub = ensureFrontendModelEventSubscription(ModelClass)
     const id = String(self.id())
+    const entry = {callback, projectionPayload: frontendModelProjectionPayload(ModelClass, options)}
     let listener = sub.instanceListeners.get(id)
 
     if (!listener) {
@@ -2568,14 +2727,14 @@ export default class FrontendModelBase {
       listener.instance = this
     }
 
-    listener.updateCallbacks.add(callback)
+    listener.updateCallbacks.add(entry)
     await sub.ensureSubscribed()
 
     return () => {
       const current = sub.instanceListeners.get(id)
 
       if (!current) return
-      current.updateCallbacks.delete(callback)
+      current.updateCallbacks.delete(entry)
 
       if (current.updateCallbacks.size === 0 && current.destroyCallbacks.size === 0) {
         sub.instanceListeners.delete(id)
@@ -2587,13 +2746,15 @@ export default class FrontendModelBase {
   /**
    * Instance-level hook fired when THIS record is destroyed.
    * @param {(payload: {id: string}) => void} callback - Event callback.
+   * @param {import("./query.js").FrontendModelProjectionOptions} [_options] - Accepted for API symmetry; destroy events carry ids only.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  async onDestroy(callback) {
+  async onDestroy(callback, _options = {}) {
     const self = /** @type {any} */ (this)
     const ModelClass = /** @type {typeof FrontendModelBase} */ (this.constructor)
     const sub = ensureFrontendModelEventSubscription(ModelClass)
     const id = String(self.id())
+    const entry = {callback}
     let listener = sub.instanceListeners.get(id)
 
     if (!listener) {
@@ -2603,14 +2764,14 @@ export default class FrontendModelBase {
       listener.instance = this
     }
 
-    listener.destroyCallbacks.add(callback)
+    listener.destroyCallbacks.add(entry)
     await sub.ensureSubscribed()
 
     return () => {
       const current = sub.instanceListeners.get(id)
 
       if (!current) return
-      current.destroyCallbacks.delete(callback)
+      current.destroyCallbacks.delete(entry)
 
       if (current.updateCallbacks.size === 0 && current.destroyCallbacks.size === 0) {
         sub.instanceListeners.delete(id)

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -11,6 +11,31 @@ import {isModelScopeDescriptor} from "../utils/model-scope.js"
  * @property {string[]} path - Relationship path from root model.
  * @property {unknown} value - Search value.
  */
+/**
+ * @typedef {null | boolean | number | string | object} FrontendModelTransportValue
+ */
+/**
+ * @typedef {{attributeName: string, relationshipName: string, where?: Record<string, FrontendModelTransportValue>}} FrontendModelWithCountPayloadEntry
+ */
+/**
+ * @typedef {{modelName: string, actions: string[]}} FrontendModelAbilitiesPayloadEntry
+ */
+/**
+ * @typedef {object} FrontendModelProjectionOptions
+ * @property {Record<string, string[] | string> | string | string[]} [select] - Model-aware attribute select map or root-model shorthand.
+ * @property {import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} [preload] - Relationship preload tree.
+ * @property {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, FrontendModelTransportValue>}>} [withCount] - Association count spec.
+ * @property {string[] | Record<string, string[]>} [abilities] - Ability actions to compute per record.
+ * @property {string | Array<string | Record<string, FrontendModelTransportValue>> | Record<string, FrontendModelTransportValue>} [queryData] - Backend query data names/spec.
+ */
+/**
+ * @typedef {object} FrontendModelProjectionPayload
+ * @property {Record<string, string[]>} [select] - Normalized select map.
+ * @property {import("../database/query/index.js").NestedPreloadRecord} [preload] - Normalized preload tree.
+ * @property {FrontendModelWithCountPayloadEntry[]} [withCount] - Normalized count specs.
+ * @property {FrontendModelAbilitiesPayloadEntry[]} [abilities] - Normalized ability specs.
+ * @property {FrontendModelTransportValue} [queryData] - Normalized queryData spec.
+ */
 
 /**
  * @param {unknown} value - Candidate value.
@@ -1860,6 +1885,29 @@ export default class FrontendModelQuery {
     this.modelClass.assertFindByConditions(conditions)
 
     return normalizeFindConditions(conditions)
+  }
+}
+
+/**
+ * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {FrontendModelProjectionOptions} [options] - Projection options.
+ * @returns {FrontendModelProjectionPayload} - Normalized frontend-model projection payload.
+ */
+export function frontendModelProjectionPayload(modelClass, options = {}) {
+  const query = new FrontendModelQuery({modelClass})
+
+  if (options.select !== undefined) query.select(options.select)
+  if (options.preload !== undefined) query.preload(options.preload)
+  if (options.withCount !== undefined) query.withCount(options.withCount)
+  if (options.abilities !== undefined) query.abilities(options.abilities)
+  if (options.queryData !== undefined) query.queryData(options.queryData)
+
+  return {
+    ...query.preloadPayload(),
+    ...query.selectPayload(),
+    ...query.withCountPayload(),
+    ...query.abilitiesPayload(),
+    ...query.queryDataPayload()
   }
 }
 

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -16,7 +16,7 @@ import useModelClassEvent from "./use-model-class-event.js"
 /** @typedef {(payload: FrontendModelDestroyEventPayload) => void} FrontendModelDestroyEventCallback */
 
 /**
- * @param {Record<string, unknown>} restOptions - Unknown options object.
+ * @param {Record<string, import("./query.js").FrontendModelTransportValue | (() => void) | undefined>} restOptions - Unknown options object.
  * @returns {void}
  */
 function assertNoUnknownOptions(restOptions) {
@@ -36,14 +36,15 @@ function assertNoUnknownOptions(restOptions) {
  * @returns {void}
  */
 export default function useDestroyedEvent(modelClassOrModels, callback, options = {}) {
-  const {active = true, debounce = false, onConnected, ...restOptions} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount, ...restOptions} = options
   assertNoUnknownOptions(restOptions)
 
   const classModel = typeof modelClassOrModels === "function" ? modelClassOrModels : null
   const instanceModels = typeof modelClassOrModels === "function" ? null : modelClassOrModels
+  const projectionOptions = {abilities, preload, queryData, select, withCount}
 
-  useModelClassEvent(classModel, "destroy", callback, {active: active && Boolean(classModel), debounce, onConnected})
-  useInstanceDestroyedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected})
+  useModelClassEvent(classModel, "destroy", callback, {active: active && Boolean(classModel), debounce, onConnected, ...projectionOptions})
+  useInstanceDestroyedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected, ...projectionOptions})
 }
 
 /**
@@ -53,9 +54,12 @@ export default function useDestroyedEvent(modelClassOrModels, callback, options 
  * @returns {void}
  */
 function useInstanceDestroyedEvent(modelOrModels, callback, options) {
-  const {active = true, debounce = false, onConnected} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount} = options
+  const projectionKey = JSON.stringify({abilities, preload, queryData, select, withCount})
+  const projectionOptionsRef = useRef({abilities, preload, queryData, select, withCount})
   const callbackRef = useRef(callback)
   const activeRef = useRef(active)
+  projectionOptionsRef.current = {abilities, preload, queryData, select, withCount}
   callbackRef.current = callback
   activeRef.current = active
 
@@ -86,7 +90,7 @@ function useInstanceDestroyedEvent(modelOrModels, callback, options) {
 
     void (async () => {
       for (const model of models) {
-        const unsubscribe = await model.onDestroy(subscriptionCallback)
+        const unsubscribe = await model.onDestroy(subscriptionCallback, projectionOptionsRef.current)
 
         if (closed) {
           unsubscribe()
@@ -107,5 +111,5 @@ function useInstanceDestroyedEvent(modelOrModels, callback, options) {
 
       clearPendingDebouncedCallback(eventCallback)
     }
-  }, [active, eventCallback, modelsKey, onConnected])
+  }, [active, eventCallback, modelsKey, onConnected, projectionKey])
 }

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -12,7 +12,7 @@ import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js
 /** @typedef {{id: string}} FrontendModelDestroyEventPayload */
 /** @typedef {FrontendModelCreateUpdateEventPayload | FrontendModelDestroyEventPayload} FrontendModelClassEventPayload */
 /** @typedef {(payload: FrontendModelClassEventPayload) => void} FrontendModelClassEventCallback */
-/** @typedef {{active?: boolean, debounce?: boolean | number, onConnected?: () => void}} UseModelClassEventOptions */
+/** @typedef {{active?: boolean, debounce?: boolean | number, onConnected?: () => void} & import("./query.js").FrontendModelProjectionOptions} UseModelClassEventOptions */
 
 /**
  * @param {FrontendModelClassEventName | FrontendModelClassEventName[]} eventOrEvents - Event name or names.
@@ -31,7 +31,7 @@ function eventNamesDependencyKey(eventNames) {
 }
 
 /**
- * @param {Record<string, unknown>} restOptions - Unknown options object.
+ * @param {Record<string, import("./query.js").FrontendModelTransportValue | (() => void) | undefined>} restOptions - Unknown options object.
  * @returns {void}
  */
 function assertNoUnknownOptions(restOptions) {
@@ -46,12 +46,13 @@ function assertNoUnknownOptions(restOptions) {
  * @param {FrontendModelClass} modelClass - Frontend model class.
  * @param {FrontendModelClassEventName} eventName - Event name.
  * @param {FrontendModelClassEventCallback} callback - Event callback.
+ * @param {import("./query.js").FrontendModelProjectionOptions} options - Event record projection options.
  * @returns {Promise<() => void>} - Unsubscribe callback.
  */
-async function subscribeToModelClassEvent(modelClass, eventName, callback) {
-  if (eventName === "create") return await modelClass.onCreate(callback)
-  if (eventName === "update") return await modelClass.onUpdate(callback)
-  if (eventName === "destroy") return await modelClass.onDestroy(callback)
+async function subscribeToModelClassEvent(modelClass, eventName, callback, options) {
+  if (eventName === "create") return await modelClass.onCreate(callback, options)
+  if (eventName === "update") return await modelClass.onUpdate(callback, options)
+  if (eventName === "destroy") return await modelClass.onDestroy(callback, options)
 
   throw new Error(`Unsupported frontend model class event: ${eventName}`)
 }
@@ -65,11 +66,14 @@ async function subscribeToModelClassEvent(modelClass, eventName, callback) {
  * @returns {void}
  */
 export default function useModelClassEvent(modelClass, eventOrEvents, callback, options = {}) {
-  const {active = true, debounce = false, onConnected, ...restOptions} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount, ...restOptions} = options
   assertNoUnknownOptions(restOptions)
 
+  const projectionKey = JSON.stringify({abilities, preload, queryData, select, withCount})
+  const projectionOptionsRef = useRef({abilities, preload, queryData, select, withCount})
   const callbackRef = useRef(callback)
   const activeRef = useRef(active)
+  projectionOptionsRef.current = {abilities, preload, queryData, select, withCount}
   callbackRef.current = callback
   activeRef.current = active
 
@@ -98,7 +102,7 @@ export default function useModelClassEvent(modelClass, eventOrEvents, callback, 
 
     void (async () => {
       for (const eventName of eventNames) {
-        const unsubscribe = await subscribeToModelClassEvent(modelClass, eventName, subscriptionCallback)
+        const unsubscribe = await subscribeToModelClassEvent(modelClass, eventName, subscriptionCallback, projectionOptionsRef.current)
 
         if (closed) {
           unsubscribe()
@@ -119,5 +123,5 @@ export default function useModelClassEvent(modelClass, eventOrEvents, callback, 
 
       clearPendingDebouncedCallback(eventCallback)
     }
-  }, [active, eventsKey, eventCallback, modelClass, onConnected])
+  }, [active, eventsKey, eventCallback, modelClass, onConnected, projectionKey])
 }

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -16,7 +16,7 @@ import useModelClassEvent from "./use-model-class-event.js"
 /** @typedef {(payload: FrontendModelUpdateEventPayload) => void} FrontendModelUpdateEventCallback */
 
 /**
- * @param {Record<string, unknown>} restOptions - Unknown options object.
+ * @param {Record<string, import("./query.js").FrontendModelTransportValue | (() => void) | undefined>} restOptions - Unknown options object.
  * @returns {void}
  */
 function assertNoUnknownOptions(restOptions) {
@@ -36,16 +36,17 @@ function assertNoUnknownOptions(restOptions) {
  * @returns {void}
  */
 export default function useUpdatedEvent(modelClassOrModels, callback, options = {}) {
-  const {active = true, debounce = false, onConnected, ...restOptions} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount, ...restOptions} = options
   assertNoUnknownOptions(restOptions)
 
   const classModel = typeof modelClassOrModels === "function" ? modelClassOrModels : null
   const instanceModels = typeof modelClassOrModels === "function" ? null : modelClassOrModels
+  const projectionOptions = {abilities, preload, queryData, select, withCount}
 
   useModelClassEvent(classModel, "update", (payload) => {
     callback(/** @type {FrontendModelClassUpdateEventPayload} */ (payload))
-  }, {active: active && Boolean(classModel), debounce, onConnected})
-  useInstanceUpdatedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected})
+  }, {active: active && Boolean(classModel), debounce, onConnected, ...projectionOptions})
+  useInstanceUpdatedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected, ...projectionOptions})
 }
 
 /**
@@ -55,9 +56,12 @@ export default function useUpdatedEvent(modelClassOrModels, callback, options = 
  * @returns {void}
  */
 function useInstanceUpdatedEvent(modelOrModels, callback, options) {
-  const {active = true, debounce = false, onConnected} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount} = options
+  const projectionKey = JSON.stringify({abilities, preload, queryData, select, withCount})
+  const projectionOptionsRef = useRef({abilities, preload, queryData, select, withCount})
   const callbackRef = useRef(callback)
   const activeRef = useRef(active)
+  projectionOptionsRef.current = {abilities, preload, queryData, select, withCount}
   callbackRef.current = callback
   activeRef.current = active
 
@@ -88,7 +92,7 @@ function useInstanceUpdatedEvent(modelOrModels, callback, options) {
 
     void (async () => {
       for (const model of models) {
-        const unsubscribe = await model.onUpdate(subscriptionCallback)
+        const unsubscribe = await model.onUpdate(subscriptionCallback, projectionOptionsRef.current)
 
         if (closed) {
           unsubscribe()
@@ -109,5 +113,5 @@ function useInstanceUpdatedEvent(modelOrModels, callback, options) {
 
       clearPendingDebouncedCallback(eventCallback)
     }
-  }, [active, eventCallback, modelsKey, onConnected])
+  }, [active, eventCallback, modelsKey, onConnected, projectionKey])
 }

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -93,7 +93,6 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
     const projectedRecord = await this._projectedRecordForEventId(body.id)
 
     if (!projectedRecord) {
-      this.sendMessage(body, meta)
       return
     }
 

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -2,6 +2,17 @@
 
 import VelociousWebsocketChannel from "../http-server/websocket-channel.js"
 import Response from "../http-server/client/response.js"
+import {serializeFrontendModelTransportValue} from "./transport-serialization.js"
+
+/**
+ * @typedef {{action?: string, id?: string | number, record?: import("./query.js").FrontendModelTransportValue, [key: string]: import("./query.js").FrontendModelTransportValue | undefined}} FrontendModelLifecycleBroadcastBody
+ */
+/**
+ * @typedef {{headers?: () => Record<string, string | string[] | undefined>, remoteAddress?: () => string | undefined}} FrontendModelWebsocketUpgradeRequest
+ */
+/**
+ * @typedef {{headers: () => Record<string, string | string[] | undefined>, header: (name: string) => string | string[] | undefined, metadata: (key?: string) => Record<string, import("./query.js").FrontendModelTransportValue> | import("./query.js").FrontendModelTransportValue | undefined, path: () => string, httpMethod: () => string, remoteAddress: () => string | undefined, origin: () => string | string[] | undefined}} FrontendModelWebsocketSyntheticRequest
+ */
 
 /**
  * Per-session channel subscription for frontend-model lifecycle events.
@@ -20,6 +31,9 @@ import Response from "../http-server/client/response.js"
  * `matches()` routes by model name.
  */
 export default class FrontendModelWebsocketChannel extends VelociousWebsocketChannel {
+  /** @type {import("../authorization/ability.js").default | null} */
+  _ability = null
+
   /** @returns {Promise<boolean>} Whether the frontend-model subscription is authorized. */
   async canSubscribe() {
     const modelName = this._modelName()
@@ -34,11 +48,12 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
 
     const ability = await configuration.resolveAbility?.({
       params: {model: modelName},
-      request: /** @type {any} */ (this._syntheticRequest()),
+      request: /** @type {import("../http-server/client/request.js").default} */ (this._syntheticRequest()),
       response: new Response({configuration})
     })
 
     if (!ability) return false
+    this._ability = ability
 
     // Load resource-declared rules for this model class before checking,
     // otherwise `rulesFor` returns empty for abilities whose resources
@@ -55,7 +70,41 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
   }
 
   /**
-   * @param {Record<string, any>} broadcastParams - Params from `broadcastToChannel`.
+   * @param {FrontendModelLifecycleBroadcastBody} body - Broadcast body.
+   * @param {{eventId?: string}} [meta] - Optional event metadata.
+   * @returns {Promise<void>} Resolves after delivery.
+   */
+  async deliverBroadcast(body, meta) {
+    if (!this._hasProjectionParams()) {
+      this.sendMessage(body, meta)
+      return
+    }
+
+    if (!body || typeof body !== "object" || body.action === "destroy") {
+      this.sendMessage(body, meta)
+      return
+    }
+
+    if (body.id === undefined || body.id === null) {
+      this.sendMessage(body, meta)
+      return
+    }
+
+    const projectedRecord = await this._projectedRecordForEventId(body.id)
+
+    if (!projectedRecord) {
+      this.sendMessage(body, meta)
+      return
+    }
+
+    this.sendMessage({
+      ...body,
+      record: serializeFrontendModelTransportValue(projectedRecord)
+    }, meta)
+  }
+
+  /**
+   * @param {Record<string, import("./query.js").FrontendModelTransportValue>} broadcastParams - Params from `broadcastToChannel`.
    * @returns {boolean} Whether the broadcast matches this subscriber's model.
    */
   matches(broadcastParams) {
@@ -69,6 +118,91 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
       : null
   }
 
+  /** @returns {boolean} - Whether this subscription requested per-event record projection. */
+  _hasProjectionParams() {
+    return this.params.select !== undefined
+      || this.params.preload !== undefined
+      || this.params.withCount !== undefined
+      || this.params.abilities !== undefined
+      || this.params.queryData !== undefined
+  }
+
+  /**
+   * @param {typeof import("../frontend-model-controller.js").default} FrontendModelController - Server-side frontend-model controller class.
+   * @returns {import("../frontend-model-controller.js").default} - Synthetic controller used for resource serialization.
+   */
+  _frontendModelController(FrontendModelController) {
+    const configuration = this.session.configuration
+    const controller = new FrontendModelController({
+      action: "websocketEvent",
+      configuration,
+      controller: "frontend-models",
+      params: {
+        abilities: this.params.abilities,
+        model: this._modelName(),
+        preload: this.params.preload,
+        queryData: this.params.queryData,
+        select: this.params.select,
+        withCount: this.params.withCount
+      },
+      request: /** @type {import("../http-server/client/request.js").default} */ (this._syntheticRequest()),
+      response: new Response({configuration}),
+      viewPath: "/"
+    })
+
+    controller._frontendModelAbilityOverride = this._ability || undefined
+
+    return controller
+  }
+
+  /**
+   * @param {string | number} id - Event record id.
+   * @returns {Promise<Record<string, import("./query.js").FrontendModelTransportValue> | null>} - Serialized projected record.
+   */
+  async _projectedRecordForEventId(id) {
+    const frontendModelControllerPath = "../frontend-model-controller.js"
+    const {default: FrontendModelController} = await import(frontendModelControllerPath)
+    const controller = this._frontendModelController(FrontendModelController)
+
+    await controller.ensureFrontendModelClassInitialized()
+
+    const ModelClass = controller.frontendModelClass()
+    const primaryKey = ModelClass.primaryKey()
+    let query = ModelClass.where({[primaryKey]: id})
+    const preload = controller.frontendModelPreload()
+
+    if (preload) query = query.preload(preload)
+
+    for (const entry of controller.frontendModelWithCount()) {
+      /** @type {Record<string, boolean | {relationship?: string, where?: Record<string, import("./query.js").FrontendModelTransportValue>}>} */
+      const spec = {}
+
+      spec[entry.attributeName] = {
+        relationship: entry.relationshipName,
+        where: entry.where ? /** @type {Record<string, import("./query.js").FrontendModelTransportValue>} */ (entry.where) : undefined
+      }
+      query.withCount(spec)
+    }
+
+    const queryData = controller.frontendModelQueryData()
+
+    if (queryData !== null) query.queryData(queryData)
+
+    query = controller.applyFrontendModelTranslatedAttributePreloads({query})
+
+    const model = await query.first()
+
+    if (!model) return null
+
+    if (this.params.abilities !== undefined) {
+      await controller.frontendModelComputeAbilities([model])
+    }
+
+    controller._frontendModelAbilityOverride = undefined
+
+    return await controller.frontendModelResourceInstance().serialize(model, "find")
+  }
+
   /**
    * Minimal Request-like stub used only for ability resolution. Avoids
    * importing `WebsocketRequest` here because its `node:querystring`
@@ -79,14 +213,14 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
    * map uses `"Cookie"` or `"cookie"`. Session metadata stays separate
    * from headers and is exposed through `metadata(...)` for ability
    * resolvers that need websocket-delivered session data.
-   * @returns {{headers: () => Record<string, any>, header: (name: string) => any, metadata: (key?: string) => any, path: () => string, httpMethod: () => string, remoteAddress: () => string | undefined, origin: () => any}} Request-like object for ability resolution.
+   * @returns {FrontendModelWebsocketSyntheticRequest} Request-like object for ability resolution.
    */
   _syntheticRequest() {
-    const upgradeRequest = /** @type {any} */ (this.session.upgradeRequest)
+    const upgradeRequest = /** @type {FrontendModelWebsocketUpgradeRequest} */ (this.session.upgradeRequest)
     const rawHeaders = typeof upgradeRequest?.headers === "function" ? upgradeRequest.headers() : {}
     const metadata = typeof this.session.getMetadata === "function" ? this.session.getMetadata() : {}
     const remoteAddress = typeof upgradeRequest?.remoteAddress === "function" ? upgradeRequest.remoteAddress() : undefined
-    /** @type {Record<string, any>} */
+    /** @type {Record<string, string | string[] | undefined>} */
     const headerMap = {}
 
     for (const key of Object.keys(rawHeaders || {})) {

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -1282,7 +1282,7 @@ export default class VelociousHttpServerClientWebsocketSession {
     for (const event of events) {
       if (subscription.isClosed()) break
 
-      subscription.sendMessage(event.payload)
+      subscription.sendMessage(/** @type {import("../websocket-channel.js").WebsocketJsonValue} */ (event.payload))
     }
   }
 

--- a/src/http-server/websocket-channel.js
+++ b/src/http-server/websocket-channel.js
@@ -1,6 +1,13 @@
 // @ts-check
 
 /**
+ * @typedef {null | boolean | number | string | object} WebsocketJsonValue
+ */
+/**
+ * @typedef {Record<string, WebsocketJsonValue>} WebsocketParams
+ */
+
+/**
  * Base class for app-defined 1:N pub/sub channels.
  *
  * Subclasses override:
@@ -12,7 +19,7 @@ export default class VelociousWebsocketChannel {
   /**
    * @param {object} args
    * @param {string} args.subscriptionId - Client-assigned id, unique within the session.
-   * @param {Record<string, any>} args.params - Subscribe params.
+   * @param {WebsocketParams} args.params - Subscribe params.
    * @param {import("./client/websocket-session.js").default} args.session - Owning session.
    */
   constructor({subscriptionId, params, session}) {
@@ -71,7 +78,7 @@ export default class VelociousWebsocketChannel {
    * sign-in / locale change). Override to react to session-level
    * metadata updates.
    *
-   * @param {Record<string, any>} _metadata - Updated metadata.
+   * @param {WebsocketParams} _metadata - Updated metadata.
    * @returns {void | Promise<void>}
    */
   onMetadataChanged(_metadata) {}
@@ -82,17 +89,30 @@ export default class VelociousWebsocketChannel {
    * `sendMessage`. Default matches all broadcasts regardless of
    * params; override for per-subscriber filtering.
    *
-   * @param {...any} _broadcastArgs - Params forwarded from `broadcastToChannel` (ignored by default).
+   * @param {...WebsocketJsonValue} _broadcastArgs - Params forwarded from `broadcastToChannel` (ignored by default).
    * @returns {boolean} - True to deliver the broadcast to this subscriber.
    */
   matches(..._broadcastArgs) { return true }
+
+  /**
+   * Delivers a matched broadcast to this subscriber. Subclasses can
+   * override when the outbound body must be tailored to subscription
+   * params before sending.
+   *
+   * @param {WebsocketJsonValue} body
+   * @param {{eventId?: string}} [meta] - Optional event metadata.
+   * @returns {void | Promise<void>}
+   */
+  deliverBroadcast(body, meta) {
+    this.sendMessage(body, meta)
+  }
 
   /**
    * Sends a `channel-message` frame to THIS subscriber only.
    * When `meta.eventId` is provided, the client receives it so it
    * can track its checkpoint for `lastEventId` replay on reconnect.
    *
-   * @param {any} body
+   * @param {WebsocketJsonValue} body
    * @param {{eventId?: string}} [meta] - Optional event metadata.
    * @returns {void}
    */

--- a/src/testing/browser-frontend-model-event-hook-scenarios.js
+++ b/src/testing/browser-frontend-model-event-hook-scenarios.js
@@ -5,14 +5,19 @@ import {createRoot} from "react-dom/client"
 
 import useDestroyedEvent from "../frontend-models/use-destroyed-event.js"
 import useCreatedEvent from "../frontend-models/use-created-event.js"
+import FrontendModelBase from "../frontend-models/base.js"
 import useModelClassEvent from "../frontend-models/use-model-class-event.js"
 import useUpdatedEvent from "../frontend-models/use-updated-event.js"
 
+/** @typedef {import("../frontend-models/query.js").FrontendModelProjectionOptions} FrontendModelProjectionOptions */
+/** @typedef {{id: string, model: FrontendModelBase}} FrontendModelHookTestCreateUpdatePayload */
+/** @typedef {{id: string}} FrontendModelHookTestDestroyPayload */
 /**
  * @typedef {object} FakeSubscriptions
- * @property {Set<(payload: unknown) => void>} create - Create callbacks.
- * @property {Set<(payload: unknown) => void>} destroy - Destroy callbacks.
- * @property {Set<(payload: unknown) => void>} update - Update callbacks.
+ * @property {Set<(payload: FrontendModelHookTestCreateUpdatePayload) => void>} create - Create callbacks.
+ * @property {Set<(payload: FrontendModelHookTestDestroyPayload) => void>} destroy - Destroy callbacks.
+ * @property {{create: FrontendModelProjectionOptions[], destroy: FrontendModelProjectionOptions[], update: FrontendModelProjectionOptions[]}} options - Subscription options.
+ * @property {Set<(payload: FrontendModelHookTestCreateUpdatePayload) => void>} update - Update callbacks.
  */
 
 /** @returns {Promise<void>} - Resolves after React effects have run. */
@@ -43,6 +48,16 @@ async function waitFor(callback) {
   }
 }
 
+/** @returns {FakeSubscriptions} - Empty fake subscription store. */
+function buildFakeSubscriptions() {
+  return {
+    create: new Set(),
+    destroy: new Set(),
+    options: {create: [], destroy: [], update: []},
+    update: new Set()
+  }
+}
+
 /**
  * @param {React.ReactElement} element - Element to render.
  * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
@@ -68,41 +83,70 @@ async function renderElement(element) {
   }
 }
 
-/** @returns {{ModelClass: typeof import("../frontend-models/base.js").default, subscriptions: FakeSubscriptions}} - Fake model class setup. */
+/** @returns {{ModelClass: typeof FrontendModelBase, subscriptions: FakeSubscriptions}} - Fake model class setup. */
 function buildFakeModelClass() {
-  const subscriptions = {
-    create: new Set(),
-    destroy: new Set(),
-    update: new Set()
-  }
-  const ModelClass = /** @type {typeof import("../frontend-models/base.js").default} */ (/** @type {unknown} */ ({
-    onCreate: async (/** @type {(payload: unknown) => void} */ callback) => {
+  const subscriptions = buildFakeSubscriptions()
+
+  class FakeModelClass extends FrontendModelBase {
+    /**
+     * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
+     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @returns {Promise<() => void>} - Unsubscribe callback.
+     */
+    static async onCreate(callback, options = {}) {
       subscriptions.create.add(callback)
+      subscriptions.options.create.push(options)
 
       return () => subscriptions.create.delete(callback)
-    },
-    onDestroy: async (/** @type {(payload: unknown) => void} */ callback) => {
+    }
+
+    /**
+     * @param {(payload: FrontendModelHookTestDestroyPayload) => void} callback - Event callback.
+     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @returns {Promise<() => void>} - Unsubscribe callback.
+     */
+    static async onDestroy(callback, options = {}) {
       subscriptions.destroy.add(callback)
+      subscriptions.options.destroy.push(options)
 
       return () => subscriptions.destroy.delete(callback)
-    },
-    onUpdate: async (/** @type {(payload: unknown) => void} */ callback) => {
+    }
+
+    /**
+     * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
+     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @returns {Promise<() => void>} - Unsubscribe callback.
+     */
+    static async onUpdate(callback, options = {}) {
       subscriptions.update.add(callback)
+      subscriptions.options.update.push(options)
 
       return () => subscriptions.update.delete(callback)
     }
-  }))
+  }
 
-  return {ModelClass, subscriptions}
+  return {ModelClass: FakeModelClass, subscriptions}
 }
 
 /**
  * @param {FakeSubscriptions} subscriptions - Callback sets.
  * @param {"create" | "destroy" | "update"} eventName - Event name.
- * @param {unknown} payload - Event payload.
+ * @param {FrontendModelHookTestCreateUpdatePayload | FrontendModelHookTestDestroyPayload} payload - Event payload.
  * @returns {void}
  */
 function emitEvent(subscriptions, eventName, payload) {
+  if (eventName === "destroy") {
+    for (const callback of subscriptions.destroy) {
+      callback({id: payload.id})
+    }
+
+    return
+  }
+
+  if (!("model" in payload)) {
+    throw new Error(`Expected model payload for ${eventName}`)
+  }
+
   for (const callback of subscriptions[eventName]) {
     callback(payload)
   }
@@ -111,28 +155,49 @@ function emitEvent(subscriptions, eventName, payload) {
 /**
  * @param {string} id - Model id.
  * @param {FakeSubscriptions} subscriptions - Callback sets.
- * @returns {import("../frontend-models/base.js").default} - Fake model instance.
+ * @returns {FrontendModelBase} - Fake model instance.
  */
 function buildFakeModel(id, subscriptions) {
-  return /** @type {import("../frontend-models/base.js").default} */ (/** @type {unknown} */ ({
-    onDestroy: async (/** @type {(payload: unknown) => void} */ callback) => {
+  class FakeModel extends FrontendModelBase {
+    /**
+     * @param {(payload: FrontendModelHookTestDestroyPayload) => void} callback - Event callback.
+     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @returns {Promise<() => void>} - Unsubscribe callback.
+     */
+    async onDestroy(callback, options = {}) {
       subscriptions.destroy.add(callback)
+      subscriptions.options.destroy.push(options)
 
       return () => subscriptions.destroy.delete(callback)
-    },
-    onUpdate: async (/** @type {(payload: unknown) => void} */ callback) => {
+    }
+
+    /**
+     * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
+     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @returns {Promise<() => void>} - Unsubscribe callback.
+     */
+    async onUpdate(callback, options = {}) {
       subscriptions.update.add(callback)
+      subscriptions.options.update.push(options)
 
       return () => subscriptions.update.delete(callback)
-    },
-    primaryKeyValue: () => id
-  }))
+    }
+
+    /** @returns {string} - Primary key value. */
+    primaryKeyValue() {
+      return id
+    }
+  }
+
+  return new FakeModel({id})
 }
 
 /** @returns {Promise<Record<string, number>>} - Scenario result. */
 async function classLifecycleScenario() {
   const {ModelClass, subscriptions} = buildFakeModelClass()
-  const receivedEvents = /** @type {unknown[]} */ ([])
+  const eventModel = buildFakeModel("1", buildFakeSubscriptions())
+  /** @type {Array<FrontendModelHookTestCreateUpdatePayload | FrontendModelHookTestDestroyPayload>} */
+  const receivedEvents = []
   let connectedCount = 0
 
   /** @returns {React.ReactElement} - Test element. */
@@ -153,8 +218,8 @@ async function classLifecycleScenario() {
   const mountedDestroySubscriptions = subscriptions.destroy.size
   const mountedConnectedCount = connectedCount
 
-  emitEvent(subscriptions, "create", {id: "1", model: {id: "1"}})
-  emitEvent(subscriptions, "update", {id: "1", model: {id: "1"}})
+  emitEvent(subscriptions, "create", {id: "1", model: eventModel})
+  emitEvent(subscriptions, "update", {id: "1", model: eventModel})
   emitEvent(subscriptions, "destroy", {id: "1"})
 
   const receivedEventsAfterEmit = receivedEvents.length
@@ -174,9 +239,10 @@ async function classLifecycleScenario() {
 
 /** @returns {Promise<Record<string, number>>} - Scenario result. */
 async function instanceLifecycleScenario() {
-  const subscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const subscriptions = buildFakeSubscriptions()
   const model = buildFakeModel("task-1", subscriptions)
-  const receivedEvents = /** @type {unknown[]} */ ([])
+  /** @type {Array<FrontendModelHookTestCreateUpdatePayload | FrontendModelHookTestDestroyPayload>} */
+  const receivedEvents = []
   let connectedCount = 0
 
   /** @returns {React.ReactElement} - Test element. */
@@ -216,11 +282,55 @@ async function instanceLifecycleScenario() {
 }
 
 /** @returns {Promise<Record<string, number>>} - Scenario result. */
+async function projectionOptionsScenario() {
+  const {ModelClass, subscriptions: classSubscriptions} = buildFakeModelClass()
+  const instanceSubscriptions = buildFakeSubscriptions()
+  const model = buildFakeModel("task-1", instanceSubscriptions)
+
+  /** @returns {React.ReactElement} - Test element. */
+  function TestComponent() {
+    useCreatedEvent(ModelClass, () => {}, {
+      preload: "project",
+      select: {Task: ["id", "nameUppercase"]}
+    })
+    useUpdatedEvent(model, () => {}, {
+      select: ["id"],
+      withCount: "comments"
+    })
+    useDestroyedEvent(model, () => {}, {
+      preload: "project",
+      select: ["id"]
+    })
+
+    return React.createElement("div")
+  }
+
+  const controls = await renderElement(React.createElement(TestComponent))
+  await waitFor(() => classSubscriptions.create.size === 1 && instanceSubscriptions.update.size === 1 && instanceSubscriptions.destroy.size === 1)
+
+  const createOptions = classSubscriptions.options.create[0] || {}
+  const updateOptions = instanceSubscriptions.options.update[0] || {}
+  const destroyOptions = instanceSubscriptions.options.destroy[0] || {}
+
+  await controls.unmount()
+
+  return {
+    classCreatePreloadProject: createOptions.preload === "project" ? 1 : 0,
+    classCreateSelectCount: createOptions.select && typeof createOptions.select === "object" && !Array.isArray(createOptions.select) && Array.isArray(createOptions.select.Task) ? createOptions.select.Task.length : 0,
+    instanceDestroyPreloadProject: destroyOptions.preload === "project" ? 1 : 0,
+    instanceDestroySelectCount: Array.isArray(destroyOptions.select) ? destroyOptions.select.length : 0,
+    instanceUpdateSelectCount: Array.isArray(updateOptions.select) ? updateOptions.select.length : 0,
+    instanceUpdateWithCountComments: updateOptions.withCount === "comments" ? 1 : 0
+  }
+}
+
+/** @returns {Promise<Record<string, number>>} - Scenario result. */
 async function debounceUnmountScenario() {
   const {ModelClass, subscriptions: classSubscriptions} = buildFakeModelClass()
-  const instanceSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const instanceSubscriptions = buildFakeSubscriptions()
   const model = buildFakeModel("task-1", instanceSubscriptions)
-  const receivedEvents = /** @type {unknown[]} */ ([])
+  /** @type {Array<FrontendModelHookTestCreateUpdatePayload | FrontendModelHookTestDestroyPayload>} */
+  const receivedEvents = []
 
   /** @returns {React.ReactElement} - Test element. */
   function TestComponent() {
@@ -246,11 +356,12 @@ async function debounceUnmountScenario() {
 
 /** @returns {Promise<Record<string, number>>} - Scenario result. */
 async function resubscribeInstanceScenario() {
-  const firstSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
-  const secondSubscriptions = {create: new Set(), destroy: new Set(), update: new Set()}
+  const firstSubscriptions = buildFakeSubscriptions()
+  const secondSubscriptions = buildFakeSubscriptions()
   const firstModel = buildFakeModel("task-1", firstSubscriptions)
   const secondModel = buildFakeModel("task-1", secondSubscriptions)
-  const receivedEvents = /** @type {unknown[]} */ ([])
+  /** @type {Array<FrontendModelHookTestCreateUpdatePayload | FrontendModelHookTestDestroyPayload>} */
+  const receivedEvents = []
 
   /**
    * @param {{model: import("../frontend-models/base.js").default}} props - Component props.
@@ -300,6 +411,7 @@ const scenarios = {
   classLifecycle: classLifecycleScenario,
   debounceUnmount: debounceUnmountScenario,
   instanceLifecycle: instanceLifecycleScenario,
+  projectionOptions: projectionOptionsScenario,
   resubscribeInstance: resubscribeInstanceScenario
 }
 

--- a/src/testing/browser-frontend-model-event-hook-scenarios.js
+++ b/src/testing/browser-frontend-model-event-hook-scenarios.js
@@ -10,6 +10,7 @@ import useModelClassEvent from "../frontend-models/use-model-class-event.js"
 import useUpdatedEvent from "../frontend-models/use-updated-event.js"
 
 /** @typedef {import("../frontend-models/query.js").FrontendModelProjectionOptions} FrontendModelProjectionOptions */
+/** @typedef {import("../frontend-models/base.js").FrontendModelResourceConfig} FrontendModelResourceConfig */
 /** @typedef {{id: string, model: FrontendModelBase}} FrontendModelHookTestCreateUpdatePayload */
 /** @typedef {{id: string}} FrontendModelHookTestDestroyPayload */
 /**
@@ -59,6 +60,18 @@ function buildFakeSubscriptions() {
 }
 
 /**
+ * @param {string} modelName - Fake frontend model name.
+ * @returns {FrontendModelResourceConfig} - Minimal resource config for fake subclasses.
+ */
+function fakeResourceConfig(modelName) {
+  return {
+    attributes: ["id"],
+    modelName,
+    primaryKey: "id"
+  }
+}
+
+/**
  * @param {React.ReactElement} element - Element to render.
  * @returns {Promise<{rerender: (nextElement: React.ReactElement) => Promise<void>, unmount: () => Promise<void>}>} - Render controls.
  */
@@ -88,6 +101,11 @@ function buildFakeModelClass() {
   const subscriptions = buildFakeSubscriptions()
 
   class FakeModelClass extends FrontendModelBase {
+    /** @returns {FrontendModelResourceConfig} - Fake resource config. */
+    static resourceConfig() {
+      return fakeResourceConfig("HookFakeClassModel")
+    }
+
     /**
      * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
      * @param {FrontendModelProjectionOptions} [options] - Projection options.
@@ -159,6 +177,11 @@ function emitEvent(subscriptions, eventName, payload) {
  */
 function buildFakeModel(id, subscriptions) {
   class FakeModel extends FrontendModelBase {
+    /** @returns {FrontendModelResourceConfig} - Fake resource config. */
+    static resourceConfig() {
+      return fakeResourceConfig("HookFakeInstanceModel")
+    }
+
     /**
      * @param {(payload: FrontendModelHookTestDestroyPayload) => void} callback - Event callback.
      * @param {FrontendModelProjectionOptions} [options] - Projection options.


### PR DESCRIPTION
Adds projection-aware frontend-model lifecycle websocket subscriptions so onCreate/onUpdate and React hook helpers can request select/preload/withCount/abilities/queryData payloads matching normal frontend-model reads. Also adds focused integration coverage and lint enforcement for loose JSDoc types in the cleaned realtime event path.

Validation:
- npm test -- spec/frontend-models/base.http-integration-spec.js
- npm test -- spec/frontend-models/model-event-hooks.browser-spec.js
- npm run typecheck
- npm run lint
- git diff --check