### PR TITLE
Avoid server route resolver in logger browser bundles

### DIFF
--- a/changelog.d/20260531073500-logger-browser-bundle.md
+++ b/changelog.d/20260531073500-logger-browser-bundle.md
@@ -1,0 +1,1 @@
+Avoid pulling server route resolution code into browser bundles that import the logger.

--- a/spec/logger-browser-bundle-spec.js
+++ b/spec/logger-browser-bundle-spec.js
@@ -1,0 +1,31 @@
+// @ts-check
+
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {build} from "esbuild"
+
+import {describe, it} from "../src/testing/test.js"
+
+describe("Logger browser bundle", () => {
+  it("bundles without pulling in the server configuration graph", async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+    await build({
+      bundle: true,
+      format: "esm",
+      logLevel: "silent",
+      platform: "browser",
+      stdin: {
+        contents: `
+          import Logger from "./src/logger.js"
+          globalThis.VelociousLogger = Logger
+        `,
+        loader: "js",
+        resolveDir: repoRoot,
+        sourcefile: "logger-browser-bundle-entry.js"
+      },
+      write: false
+    })
+  })
+})

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -11,18 +11,12 @@ import translate from "gettext-universal/build/src/translate.js"
 import Ability from "./authorization/ability.js"
 import EventEmitter from "./utils/event-emitter.js"
 import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channel-subscribers.js"
+import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
 import {ensureFrontendModelWebsocketPublishersRegistered} from "./frontend-models/websocket-publishers.js"
 import {frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
 import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
 import {withTrackedStack} from "./utils/with-tracked-stack.js"
-
-/** @type {{currentConfiguration: VelociousConfiguration | null}} */
-const shared = {
-  currentConfiguration: null
-}
-
-class CurrentConfigurationNotSetError extends Error {}
 
 export {CurrentConfigurationNotSetError}
 
@@ -64,9 +58,7 @@ export default class VelociousConfiguration {
   _closeDatabaseConnectionsPromise = null
   /** @returns {VelociousConfiguration} - The current.  */
   static current() {
-    if (!shared.currentConfiguration) throw new CurrentConfigurationNotSetError("A current configuration hasn't been set")
-
-    return shared.currentConfiguration
+    return currentConfiguration()
   }
 
   /** @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments. */
@@ -1114,7 +1106,7 @@ export default class VelociousConfiguration {
 
   /** @returns {void} - No return value.  */
   setCurrent() {
-    shared.currentConfiguration = this
+    setCurrentConfiguration(this)
   }
 
   /** @returns {import("./routes/index.js").default | undefined} - The routes.  */

--- a/src/current-configuration.js
+++ b/src/current-configuration.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {{currentConfiguration: import("./configuration.js").default | null}} */
+const shared = {
+  currentConfiguration: null
+}
+
+class CurrentConfigurationNotSetError extends Error {}
+
+/**
+ * @returns {import("./configuration.js").default} - Current configuration.
+ */
+export function currentConfiguration() {
+  if (!shared.currentConfiguration) throw new CurrentConfigurationNotSetError("A current configuration hasn't been set")
+
+  return shared.currentConfiguration
+}
+
+/**
+ * @param {import("./configuration.js").default} configuration - Current configuration.
+ * @returns {void} - No return value.
+ */
+export function setCurrentConfiguration(configuration) {
+  shared.currentConfiguration = configuration
+}
+
+export {CurrentConfigurationNotSetError}

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-import Configuration from "./configuration.js"
 import LoggerConsoleOutput from "./logger/outputs/console-output.js"
 import LoggerFileOutput from "./logger/outputs/file-output.js"
+import {currentConfiguration} from "./current-configuration.js"
 import {formatValue} from "./utils/format-value.js"
 import restArgsError from "./utils/rest-args-error.js"
 
@@ -359,7 +359,7 @@ export default class Logger {
   getConfiguration() {
     if (!this._configuration) {
       const objectWithConfig = /** @type {{configuration?: import("./configuration.js").default}} */ (this._object)
-      this._configuration = objectWithConfig?.configuration || Configuration.current()
+      this._configuration = objectWithConfig?.configuration || currentConfiguration()
     }
 
     return this._configuration


### PR DESCRIPTION
## Summary
- move the current-configuration singleton out of the main configuration module
- keep Logger from statically importing the full server configuration graph
- add a browser bundle regression spec for Logger imports

## Validation
- npm test -- spec/logger-browser-bundle-spec.js spec/routes/resolver-route-hooks-spec.js spec/routes/resolver-frontend-model-autoroute-spec.js spec/frontend-models/base.http-integration-spec.js
- npm run typecheck
- npm run lint (0 errors, existing warnings)
- git diff --check
- git diff --unified=0 | rg '^\+.*\b(any|unknown)\b' || true