### PR TITLE
Improve async database pool reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,7 +1368,7 @@ To prime *all* configured pools at once, call `configuration.ensureGlobalConnect
 
 When an async context exists, that connection is still preferred over the global one.
 
-Checked-in `AsyncTrackedMultiConnection` connections are closed after 5 seconds of idle time by default. This keeps tenant-scoped and short-lived background-job connections from accumulating in long-running processes while still allowing immediate reuse by nearby async work. Configure `database.<environment>.<identifier>.pool.idleTimeoutMillis` to change the timeout, or set it to `null` to disable idle reaping for that pool:
+Checked-in `AsyncTrackedMultiConnection` connections are closed after 5 seconds of idle time by default. This keeps tenant-scoped and short-lived background-job connections from accumulating in long-running processes while still allowing immediate reuse by nearby async work. Configure `database.<environment>.<identifier>.pool.idleTimeoutMillis` to change the timeout, set it to `0` to close idle connections immediately unless a matching checkout is already waiting, or set it to `null` to disable idle reaping for that pool. A matching idle connection is reused before expired idle connections are reaped.
 
 ```js
 database: {
@@ -1378,12 +1378,15 @@ database: {
       poolType: AsyncTrackedMultiConnection,
       type: "mysql",
       pool: {
-        idleTimeoutMillis: 10000
+        idleTimeoutMillis: 10000,
+        max: 25
       }
     }
   }
 }
 ```
+
+`pool.max` caps live async-tracked connections for that pool. When the cap is reached, new checkouts wait until a matching checked-in connection can be handed over or capacity is freed.
 
 # Websockets
 

--- a/changelog.d/20260601065135-async-pool-reuse.md
+++ b/changelog.d/20260601065135-async-pool-reuse.md
@@ -1,0 +1,1 @@
+Async tracked database pools now reuse matching idle connections before reaping expired ones, support immediate idle close with `idleTimeoutMillis: 0`, and honor `pool.max` by waiting for checked-in capacity instead of spawning beyond the cap.

--- a/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
@@ -6,6 +6,36 @@ import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.j
 import {describe, expect, it} from "../../../src/testing/test.js"
 
 describe("database - pool - async tracked multi connection idle reaper", () => {
+  it("reuses matching idle connections before reaping expired connections", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-reuse-before-reap")
+
+    try {
+      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 1}
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      let firstConnection
+
+      await pool.withConnection(async (connection) => {
+        firstConnection = connection
+      })
+
+      pool.clearIdleConnectionReaperTimer()
+      await wait(0.02)
+
+      let secondConnection
+
+      await pool.withConnection(async (connection) => {
+        secondConnection = connection
+      })
+
+      expect(secondConnection).toBe(firstConnection)
+    } finally {
+      await cleanup()
+    }
+  })
+
   it("closes checked-in idle connections after the configured idle timeout", async () => {
     const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-reaper")
 
@@ -32,6 +62,27 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
       await pool.reapIdleConnections()
 
       expect(checkedInConnection.connection).toEqual(undefined)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("closes checked-in idle connections immediately when idle timeout is zero", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-reaper-zero")
+
+    try {
+      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 0}
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      let checkedInConnection
+
+      await pool.withConnection(async (connection) => {
+        checkedInConnection = connection
+      })
+
+      expect(pool.connections.includes(checkedInConnection)).toBe(false)
     } finally {
       await cleanup()
     }
@@ -65,6 +116,37 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
         expect(connection).toBe(transactionConnection)
         await connection.rollbackTransaction()
       })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("keeps checked-in transaction connections when idle timeout is zero", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-transaction-zero")
+
+    try {
+      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 0}
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      let transactionConnection
+
+      await pool.withConnection(async (connection) => {
+        transactionConnection = connection
+        await connection.startTransaction()
+      })
+
+      if (!transactionConnection) throw new Error("Expected transaction connection")
+
+      expect(pool.connections.includes(transactionConnection)).toBe(true)
+
+      await pool.withConnection(async (connection) => {
+        expect(connection).toBe(transactionConnection)
+        await connection.rollbackTransaction()
+      })
+
+      expect(pool.connections.includes(transactionConnection)).toBe(false)
     } finally {
       await cleanup()
     }

--- a/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
@@ -2,6 +2,7 @@
 
 import AsyncTrackedMultiConnection from "../../../src/database/pool/async-tracked-multi-connection.js"
 import Dummy from "../../dummy/index.js"
+import wait from "awaitery/build/wait.js"
 import dummyConfiguration from "../../dummy/src/config/configuration.js"
 import {describe, expect, it} from "../../../src/testing/test.js"
 
@@ -45,6 +46,98 @@ describe("database - pool - async tracked multi connection reuse", () => {
       })
 
       expect(secondConnection).toBe(firstConnection)
+    }, {fresh: true})
+  })
+
+  it("waits when max connections are checked out and hands checked-in connections to waiters", async () => {
+    await Dummy.run(async () => {
+      const pool = getPool()
+
+      if (!pool) return
+
+      pool.getConfiguration().pool = {idleTimeoutMillis: 0, max: 1}
+
+      const firstConnection = await pool.checkout()
+      let secondResolved = false
+      const secondConnectionPromise = pool.checkout().then((connection) => {
+        secondResolved = true
+
+        return connection
+      })
+
+      await wait(0.02)
+
+      expect(secondResolved).toBe(false)
+
+      await pool.checkin(firstConnection)
+
+      const secondConnection = await secondConnectionPromise
+
+      expect(secondConnection).toBe(firstConnection)
+
+      await pool.checkin(secondConnection)
+      expect(pool.connections.includes(secondConnection)).toBe(false)
+    }, {fresh: true})
+  })
+
+  it("rejects pending checkouts when the pool is closed", async () => {
+    await Dummy.run(async () => {
+      const pool = getPool()
+
+      if (!pool) return
+
+      pool.getConfiguration().pool = {max: 1}
+
+      const firstConnection = await pool.checkout()
+      const secondConnectionPromise = pool.checkout()
+
+      await wait(0.02)
+      await pool.closeAll()
+
+      await expect(async () => secondConnectionPromise).toThrow("Database pool was closed before checkout completed.")
+
+      if (firstConnection.getIdSeq() !== undefined) {
+        firstConnection.setIdSeq(undefined)
+      }
+    }, {fresh: true})
+  })
+
+  it("does not hand open transaction connections to pending checkouts", async () => {
+    await Dummy.run(async () => {
+      const pool = getPool()
+
+      if (!pool) return
+
+      pool.getConfiguration().pool = {idleTimeoutMillis: 0, max: 1}
+
+      const transactionConnection = await pool.checkout()
+      await transactionConnection.startTransaction()
+
+      let pendingResolved = false
+      const pendingCheckoutPromise = pool.checkout().then((connection) => {
+        pendingResolved = true
+
+        return connection
+      })
+
+      await wait(0.02)
+      await pool.checkin(transactionConnection)
+      await wait(0.02)
+
+      expect(pendingResolved).toBe(false)
+
+      const rollbackConnection = await pool.checkout()
+
+      expect(rollbackConnection).toBe(transactionConnection)
+
+      await rollbackConnection.rollbackTransaction()
+      await pool.checkin(rollbackConnection)
+
+      const pendingConnection = await pendingCheckoutPromise
+
+      expect(pendingConnection).toBe(transactionConnection)
+
+      await pool.checkin(pendingConnection)
     }, {fresh: true})
   })
 })

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -54,6 +54,7 @@
 /**
  * @typedef {object} DatabasePoolConfiguration
  * @property {number | null} [idleTimeoutMillis] - Idle timeout before closing a checked-in async-tracked connection. Set null to disable idle reaping. Default: 5000.
+ * @property {number} [max] - Maximum live async-tracked connections for this pool. Extra checkouts wait until a matching connection is checked in or capacity is freed.
  */
 
 /**

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -1,11 +1,18 @@
 // @ts-check
 
 import {AsyncLocalStorage} from "async_hooks"
-import BasePool from "./base.js"
+import BasePool, {POOL_CONFIGURATION_KEY} from "./base.js"
 
 export const CLOSED_CONNECTION = Symbol("velociousClosedConnection")
 const IDLE_CONNECTION_CHECKED_IN_AT = Symbol("velociousIdleConnectionCheckedInAt")
 const DEFAULT_IDLE_TIMEOUT_MILLIS = 5000
+
+/**
+ * @typedef {object} PendingCheckout
+ * @property {string} reuseKey - Database configuration reuse key needed by the checkout.
+ * @property {(connection: import("../drivers/base.js").default) => void} resolve - Resolves with an activated connection.
+ * @property {(error: Error) => void} reject - Rejects when checkout cannot complete.
+ */
 
 export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends BasePool {
   /**
@@ -30,6 +37,15 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   /** @type {Record<number, import("../drivers/base.js").default>} */
   connectionsInUse = {}
 
+  /** @type {PendingCheckout[]} */
+  pendingCheckouts = []
+
+  /** @type {number} */
+  connectionsBeingSpawned = 0
+
+  /** @type {Promise<void> | undefined} */
+  pendingCheckoutDrainPromise = undefined
+
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   idleConnectionReaperTimer = undefined
 
@@ -44,8 +60,11 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     super({configuration, identifier})
   }
 
-  /** @param {import("../drivers/base.js").default} connection - Database connection instance. */
-  checkin(connection) {
+  /**
+   * @param {import("../drivers/base.js").default} connection - Database connection instance.
+   * @returns {Promise<void>} - Resolves when the connection is checked in or closed.
+   */
+  async checkin(connection) {
     const id = connection.getIdSeq()
 
     if (typeof id !== "number") {
@@ -64,21 +83,70 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT] = Date.now()
     this.connections.push(connection)
-    this.scheduleIdleConnectionReaper()
+    await this.drainPendingCheckouts()
+
+    if (this.idleTimeoutMillis() === 0) {
+      await this.reapIdleConnections()
+    } else {
+      this.scheduleIdleConnectionReaper()
+    }
 
   }
 
   /** @returns {Promise<import("../drivers/base.js").default>} - Resolves with the checkout.  */
   async checkout() {
+    const reuseKey = this.getConfigurationReuseKey()
+    let connection = this.takeIdleConnectionForReuseKey(reuseKey)
+
+    if (connection) return this.activateConnection(connection)
+
     await this.reapIdleConnections()
+    connection = this.takeIdleConnectionForReuseKey(reuseKey)
 
-    const connectionIndex = this.connections.findIndex((queuedConnection) => this.connectionMatchesCurrentConfiguration(queuedConnection))
-    let connection = connectionIndex === -1 ? undefined : this.connections.splice(connectionIndex, 1)[0]
+    if (connection) return this.activateConnection(connection)
 
-    if (!connection) {
-      connection = await this.spawnConnection()
+    if (this.canSpawnConnection()) {
+      connection = await this.spawnConnectionForCheckout()
+
+      return this.activateConnection(connection)
     }
 
+    return await this.waitForCheckout(reuseKey)
+  }
+
+  /**
+   * @param {string} reuseKey - Database configuration reuse key.
+   * @param {object} [args] - Options.
+   * @param {boolean} [args.includeOpenTransactions] - Whether connections with open transactions may be returned.
+   * @returns {import("../drivers/base.js").default | undefined} - Matching idle connection.
+   */
+  takeIdleConnectionForReuseKey(reuseKey, {includeOpenTransactions = true} = {}) {
+    const connectionIndex = this.connections.findIndex((queuedConnection) => {
+      if (!includeOpenTransactions && this.connectionHasOpenTransaction(queuedConnection)) return false
+
+      return this.connectionMatchesReuseKey(queuedConnection, reuseKey)
+    })
+    const connection = connectionIndex === -1 ? undefined : this.connections.splice(connectionIndex, 1)[0]
+
+    return connection
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection.
+   * @param {string} reuseKey - Database configuration reuse key.
+   * @returns {boolean} - Whether the connection matches the reuse key.
+   */
+  connectionMatchesReuseKey(connection, reuseKey) {
+    const connectionWithPoolKey = /** @type {import("../drivers/base.js").default & {[POOL_CONFIGURATION_KEY]?: string}} */ (connection)
+
+    return connectionWithPoolKey[POOL_CONFIGURATION_KEY] === reuseKey
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection.
+   * @returns {import("../drivers/base.js").default} - Activated connection.
+   */
+  activateConnection(connection) {
     if (connection.getIdSeq() !== undefined) throw new Error(`Connection already has an ID-seq - is it in use? ${connection.getIdSeq()}`)
 
     const id = this.idSeq++
@@ -90,6 +158,119 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     this.connectionsInUse[id] = connection
 
     return connection
+  }
+
+  /** @returns {number | undefined} - Configured max live connections. */
+  maxConnections() {
+    const value = this.getConfiguration().pool?.max
+
+    if (typeof value === "number" && Number.isFinite(value) && value >= 1) return value
+
+    return
+  }
+
+  /** @returns {number} - Number of live and in-progress connections. */
+  liveConnectionCount() {
+    return this.connections.length + Object.keys(this.connectionsInUse).length + this.connectionsBeingSpawned
+  }
+
+  /** @returns {boolean} - Whether a new connection can be spawned. */
+  canSpawnConnection() {
+    const maxConnections = this.maxConnections()
+
+    return maxConnections === undefined || this.liveConnectionCount() < maxConnections
+  }
+
+  /** @returns {Promise<import("../drivers/base.js").default>} - Spawned connection. */
+  async spawnConnectionForCheckout() {
+    this.connectionsBeingSpawned++
+
+    try {
+      return await this.spawnConnection()
+    } finally {
+      this.connectionsBeingSpawned--
+    }
+  }
+
+  /**
+   * @param {string} reuseKey - Database configuration reuse key.
+   * @returns {Promise<import("../drivers/base.js").default>} - Resolves with an activated connection.
+   */
+  async waitForCheckout(reuseKey) {
+    return await new Promise((resolve, reject) => {
+      this.pendingCheckouts.push({reject, resolve, reuseKey})
+      void this.drainPendingCheckouts().catch((error) => {
+        const checkoutError = error instanceof Error ? error : new Error("Failed to drain pending database connection checkouts.", {cause: error})
+
+        this.rejectPendingCheckouts(checkoutError)
+      })
+    })
+  }
+
+  /** @returns {Promise<void>} - Resolves when pending checkouts have been drained as far as possible. */
+  async drainPendingCheckouts() {
+    if (this.pendingCheckoutDrainPromise) {
+      await this.pendingCheckoutDrainPromise
+      return
+    }
+
+    this.pendingCheckoutDrainPromise = this.drainPendingCheckoutsActual()
+
+    try {
+      await this.pendingCheckoutDrainPromise
+    } finally {
+      this.pendingCheckoutDrainPromise = undefined
+    }
+  }
+
+  /** @returns {Promise<void>} - Resolves when pending checkouts have been drained as far as possible. */
+  async drainPendingCheckoutsActual() {
+    while (this.pendingCheckouts.length > 0) {
+      const checkout = this.pendingCheckouts[0]
+      let connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+
+      if (!connection) {
+        await this.reapIdleConnections()
+        connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+      }
+
+      if (!connection && !this.canSpawnConnection()) {
+        const closedConnection = await this.closeOneIdleConnectionForCapacity()
+
+        if (closedConnection) continue
+      }
+
+      if (!connection && this.canSpawnConnection()) {
+        this.pendingCheckouts.shift()
+
+        try {
+          connection = await this.spawnConnectionForCheckout()
+        } catch (error) {
+          checkout.reject(error instanceof Error ? error : new Error("Failed to spawn database connection.", {cause: error}))
+          continue
+        }
+
+        checkout.resolve(this.activateConnection(connection))
+        continue
+      }
+
+      if (!connection) return
+
+      this.pendingCheckouts.shift()
+      checkout.resolve(this.activateConnection(connection))
+    }
+  }
+
+  /** @returns {Promise<boolean>} - Whether an idle connection was closed to free capacity. */
+  async closeOneIdleConnectionForCapacity() {
+    const connection = this.connections.find((candidate) => !this.connectionHasOpenTransaction(candidate))
+
+    if (!connection) return false
+
+    this.connections = this.connections.filter((candidate) => candidate !== connection)
+    await this.closeConnection(connection)
+
+    return true
   }
 
   /**
@@ -105,7 +286,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       try {
         return await callback(connection)
       } finally {
-        this.checkin(connection)
+        await this.checkin(connection)
       }
     })
   }
@@ -372,6 +553,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    */
   async closeAll() {
     this.clearIdleConnectionReaperTimer()
+    this.rejectPendingCheckouts(new Error("Database pool was closed before checkout completed."))
 
     const connections = new Set([
       ...this.connections,
@@ -388,6 +570,20 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       await this.closeConnection(connection)
     }
 
+  }
+
+  /**
+   * @param {Error} error - Error to reject pending checkouts with.
+   * @returns {void}
+   */
+  rejectPendingCheckouts(error) {
+    const pendingCheckouts = this.pendingCheckouts
+
+    this.pendingCheckouts = []
+
+    for (const checkout of pendingCheckouts) {
+      checkout.reject(error)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- reuse matching async-tracked DB connections before idle reaping
- add waiter handoff and pool.max enforcement for async-tracked pools
- document idleTimeoutMillis=0 and pool.max behavior

## Tests
- npm run test -- spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js spec/database/pool/async-tracked-multi-connection-reuse-spec.js spec/database/pool/async-tracked-multi-connection-checkin-validation-spec.js spec/database/pool/async-tracked-multi-connection-context-spec.js
- npm run lint
- npm run typecheck