### PR TITLE
Avoid server route resolver in browser configuration bundles

### DIFF
--- a/spec/configuration-browser-bundle-spec.js
+++ b/spec/configuration-browser-bundle-spec.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {build} from "esbuild"
+
+import {describe, expect, it} from "../src/testing/test.js"
+
+describe("Configuration browser bundle", () => {
+  it("bundles without pulling in the server route resolver", async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+    const result = await build({
+      bundle: true,
+      format: "esm",
+      logLevel: "silent",
+      metafile: true,
+      platform: "browser",
+      stdin: {
+        contents: `
+          import Configuration from "./src/configuration.js"
+          import BrowserEnvironmentHandler from "./src/environment-handlers/browser.js"
+          globalThis.VelociousConfiguration = Configuration
+          globalThis.VelociousBrowserEnvironmentHandler = BrowserEnvironmentHandler
+        `,
+        loader: "js",
+        resolveDir: repoRoot,
+        sourcefile: "configuration-browser-bundle-entry.js"
+      },
+      write: false
+    })
+
+    const inputs = Object.keys(result.metafile.inputs)
+
+    expect(inputs.some((filePath) => filePath.includes("routes/resolver") || filePath.includes("frontend-model-controller"))).toBeFalse()
+  })
+})

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -12,7 +12,6 @@ import Ability from "./authorization/ability.js"
 import EventEmitter from "./utils/event-emitter.js"
 import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channel-subscribers.js"
 import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
-import {ensureFrontendModelWebsocketPublishersRegistered} from "./frontend-models/websocket-publishers.js"
 import {frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
 import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
@@ -1011,7 +1010,7 @@ export default class VelociousConfiguration {
         await this._initializeModels({configuration: this, type: args.type})
       }
 
-      await ensureFrontendModelWebsocketPublishersRegistered(this)
+      await this.getEnvironmentHandler().initializeFrontendModelWebsocketPublishers(this)
     }
   }
 

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -474,4 +474,18 @@ export default class VelociousEnvironmentHandlerBase {
   async writeLogToFile(_args) { // eslint-disable-line no-unused-vars
     return
   }
+
+  /**
+   * Registers frontend-model websocket channel publishers so lifecycle
+   * event hooks (create/update/destroy) broadcast over the shared
+   * "frontend-models" channel. The base handler is a no-op — only the
+   * Node handler performs the registration because the required
+   * `frontend-model-controller` and `routes/resolver` imports pull in
+   * server-only modules that break browser bundlers.
+   * @param {import("../configuration.js").default} _configuration - Configuration instance.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async initializeFrontendModelWebsocketPublishers(_configuration) { // eslint-disable-line no-unused-vars
+    // No-op in base handler; Node handler does the real registration.
+  }
 }

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -787,4 +787,19 @@ export default class VelociousEnvironmentHandlerNode extends Base{
 
     return sqlByIdentifier
   }
+
+  /**
+   * Registers frontend-model websocket channel publishers so lifecycle
+   * event hooks broadcast over the shared "frontend-models" channel.
+   * This is only implemented by the Node handler because the required
+   * modules (`frontend-model-controller`, `routes/resolver`) pull in
+   * server-only Node APIs that break browser bundlers.
+   * @param {import("../configuration.js").default} configuration - Configuration instance.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async initializeFrontendModelWebsocketPublishers(configuration) {
+    const {ensureFrontendModelWebsocketPublishersRegistered} = await import("../frontend-models/websocket-publishers.js")
+
+    await ensureFrontendModelWebsocketPublishersRegistered(configuration)
+  }
 }


### PR DESCRIPTION
## Summary

The static import of `ensureFrontendModelWebsocketPublishersRegistered` in `configuration.js` pulled `frontend-model-controller.js`, `routes/resolver.js`, and their transitive server-only Node dependencies into every browser bundle that imports the `Configuration` class. Expo/Metro fails on the `import(controllerImportSpecifier)` dynamic import in `routes/resolver.js`.

## Changes

- **`src/environment-handlers/base.js`**: Added no-op `initializeFrontendModelWebsocketPublishers(configuration)` method.
- **`src/environment-handlers/node.js`**: Added implementation that dynamically imports `websocket-publishers.js` and calls `ensureFrontendModelWebsocketPublishersRegistered`. The Node handler already has the required dependency graph via `frontendModelCommandRouteHook`, so this import adds no new transitive deps for the server.
- **`src/configuration.js`**: Removed the static import of `ensureFrontendModelWebsocketPublishersRegistered` and replaced the direct call with `this.getEnvironmentHandler().initializeFrontendModelWebsocketPublishers(this)`.
- **`spec/configuration-browser-bundle-spec.js`**: Regression test that bundling `Configuration` + `BrowserEnvironmentHandler` for the browser platform does not include `routes/resolver.js` or `frontend-model-controller.js` in the output.

## Verification

- `npm run typecheck` -- pass
- `npm run test -- spec/configuration-browser-bundle-spec.js spec/logger-browser-bundle-spec.js` -- pass
- `npm run test -- spec/frontend-models/websocket-channel-spec.js spec/beacon/configuration-integration-spec.js` -- pass (10 tests)