### PR TITLE
Resolve websocket-channel subscription tenant inside a connection scope

### DIFF
--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -1206,7 +1206,16 @@ export default class VelociousHttpServerClientWebsocketSession {
     const subscription = new ChannelClass({subscriptionId, params, session: this})
 
     try {
-      const tenant = await this._resolveTenant({channel: channelType, params})
+      // Resolving the tenant can run database queries (e.g. looking up the
+      // record's project and the caller's access), so it must happen inside a
+      // connection scope. Without this the resolver borrows a connection that
+      // is checked back in before/while it queries, intermittently surfacing as
+      // "Connection … doesn't exist any more" or a falsely unauthorized
+      // subscription.
+      let tenant
+      await this._withConnections(async () => {
+        tenant = await this._resolveTenant({channel: channelType, params})
+      })
 
       await this.configuration.runWithTenant(tenant, async () => {
         let allowed = false
@@ -1419,7 +1428,12 @@ export default class VelociousHttpServerClientWebsocketSession {
     if (!resolver) return
 
     try {
-      const tenant = await this._resolveTenant({channel, params})
+      // Tenant resolution can run database queries, so it must happen inside a
+      // connection scope (see _handleChannelSubscribe).
+      let tenant
+      await this._withConnections(async () => {
+        tenant = await this._resolveTenant({channel, params})
+      })
       const resolved = await this.configuration.runWithTenant(tenant, async () => {
         return await resolver({
           client: this.client,


### PR DESCRIPTION
## Problem

Websocket channel subscriptions resolved the request tenant **outside** a connection scope. In `_handleChannelSubscribe` (and the legacy `_handleChannelSubscription` resolver path), `_resolveTenant()` was called before `_withConnections(...)`.

Apps whose `tenantResolver` runs database queries — e.g. looking up a record's project and the caller's access — therefore borrowed a connection that could be checked back in before/while those queries ran. This surfaced intermittently as either:

- `Connection N doesn't exist any more - has it been checked in again?`, or
- a falsely **unauthorized** subscription (the access query returns nothing).

Frontend-model subscriptions avoid this because their `canSubscribe()` runs inside `_withConnections`; only the custom-channel tenant-resolution path was affected, so it went unnoticed until an app shipped a custom `VelociousWebsocketChannel` whose tenant resolution hits the database.

## Fix

Wrap tenant resolution in `_withConnections` in both subscription paths so the resolver's queries run within a held connection.

## Notes / follow-up

This removes the connection-lifetime race for the **single-subscription** case. There is a separate, still-open concurrency symptom (under many simultaneous subscriptions a default-DB access query can resolve against the wrong context) that needs per-subscription connection/DB-context isolation — tracked separately, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
