### PR TITLE
Add model-level preload onto already-loaded records

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ This creates `src/frontend-models/user.js` (and one file per configured resource
 - State helpers like `user.isNewRecord()`, `user.isPersisted()`, `user.isChanged()`, and `user.changes()`
 - Attribute methods like `user.name()` and `user.setName(...)`
 - Relationship helpers (when `relationships` are configured), for example `task.project()`, `await task.projectOrLoad()`, `await project.tasks().toArray()`, `await project.tasks().load()`, and `project.tasks().build({...})`
+- Preload relationships onto records you already have with `await record.preload(Model.preload({...}).select({...}))` (or `Preloader.preload(records, ...)` for arrays) — see [docs/relationships.md](docs/relationships.md#preloading-onto-already-loaded-records)
 - Attachment helpers (when `attachments` are configured), for example `await task.descriptionFile().attach(file)`, `await task.descriptionFile().download()`, and `await task.update({descriptionFile: file})`
 
 React components can subscribe to lifecycle broadcasts without manual cleanup code:

--- a/changelog.d/20260603120000-model-instance-preload.md
+++ b/changelog.d/20260603120000-model-instance-preload.md
@@ -1,0 +1,1 @@
+Add `record.preload(...)` and `Preloader.preload(records, ...)` to preload relationships onto already-loaded records, with per-target-model `select`/`selectsExtra` column control, idempotent skipping when already loaded, and a `force` option to reload.

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -151,3 +151,57 @@ The batch preloader for through relationships uses a two-query strategy:
 3. Map target records back to their parent models via the intermediate mapping.
 
 This avoids JOIN-based column projection issues and works consistently across all supported database drivers (MySQL/MariaDB, PostgreSQL, SQLite, MSSQL).
+
+## Preloading onto already-loaded records
+
+`Query#preload` loads relationships while a query runs. The same machinery can be pointed at records you already have in memory, so the loaded data lands on the relationship cache and later accessors reuse it instead of issuing their own identical queries.
+
+Call `preload` on a single record with a query built from the model class (or a raw preload spec):
+
+```js
+const serviceToken = await ServiceToken.find(id)
+
+await serviceToken.preload(ServiceToken.preload({account: "projects"}))
+
+const projects = serviceToken.account()?.projects()
+
+// Raw spec forms are accepted too.
+await serviceToken.preload("account")
+await serviceToken.preload({account: "projects"})
+```
+
+Preload across many records at once with the `Preloader.preload` static:
+
+```js
+import Preloader from "velocious/build/src/database/query/preloader.js"
+
+await Preloader.preload(serviceTokens, ServiceToken.preload({account: "projects"}))
+```
+
+### Limiting loaded columns
+
+Pass an object keyed by **target model name** to `select(...)` to narrow the columns loaded for a preloaded relationship. The primary/foreign keys needed to map results back to their parents are always included:
+
+```js
+await serviceToken.preload(
+  ServiceToken.preload({account: "projects"}).select({Account: ["id"], Project: ["id", "name"]})
+)
+```
+
+Reading a non-selected attribute on a partially-loaded target raises the usual "attribute hasn't been loaded" error.
+
+Use `selectsExtra(...)` (same object-by-model-name shape) to keep the default `SELECT *` columns and load extra computed selects in addition:
+
+```js
+await serviceToken.preload(
+  ServiceToken.preload({account: true}).selectsExtra({Account: ["(SELECT count(*) FROM projects WHERE projects.account_id = accounts.id) AS projects_count"]})
+)
+```
+
+### Idempotency and forcing a reload
+
+A relationship that is already preloaded with all the required columns present is left untouched — no query runs. Requesting a wider column set than was previously loaded re-queries to fetch the missing columns. Pass `{force: true}` to reload regardless, for example when the underlying rows are known to have changed:
+
+```js
+await serviceToken.preload(ServiceToken.preload({account: true}), {force: true})
+```

--- a/spec/database/record/preloader/model-preload.browser-spec.js
+++ b/spec/database/record/preloader/model-preload.browser-spec.js
@@ -1,0 +1,120 @@
+import Preloader from "../../../../src/database/query/preloader.js"
+import Project from "../../../dummy/src/models/project.js"
+import Task from "../../../dummy/src/models/task.js"
+
+describe("Record - preloader - model preload", {tags: ["dummy"]}, () => {
+  it("preloads a relationship onto an already-loaded record", async () => {
+    const project = await Project.create({})
+    const task = await Task.create({projectId: project.id(), name: "Model preload task"})
+    const found = /** @type {Task} */ (await Task.find(task.id()))
+
+    await found.preload(Task.preload("project"))
+
+    expect(found.project().id()).toEqual(project.id())
+  })
+
+  it("preloads nested relationships onto an already-loaded record", async () => {
+    const project = await Project.create({})
+
+    await Task.create({projectId: project.id(), name: "Nested preload task"})
+
+    const found = /** @type {Task} */ (await Task.find((await Task.last()).id()))
+
+    await found.preload(Task.preload({project: "tasks"}))
+
+    const loadedProject = found.project()
+    const tasks = /** @type {Task[]} */ (loadedProject.tasks().loaded())
+
+    expect(tasks.length).toBeGreaterThan(0)
+  })
+
+  it("preloads across an array of records via Preloader.preload", async () => {
+    const project = await Project.create({})
+    const task1 = await Task.create({projectId: project.id(), name: "Array preload 1"})
+    const task2 = await Task.create({projectId: project.id(), name: "Array preload 2"})
+    const found1 = /** @type {Task} */ (await Task.find(task1.id()))
+    const found2 = /** @type {Task} */ (await Task.find(task2.id()))
+
+    await Preloader.preload([found1, found2], Task.preload("project"))
+
+    expect(found1.project().id()).toEqual(project.id())
+    expect(found2.project().id()).toEqual(project.id())
+  })
+
+  it("accepts a raw preload spec instead of a query", async () => {
+    const project = await Project.create({})
+    const task = await Task.create({projectId: project.id(), name: "Raw spec preload"})
+    const found = /** @type {Task} */ (await Task.find(task.id()))
+
+    await found.preload("project")
+
+    expect(found.project().id()).toEqual(project.id())
+  })
+
+  it("limits the loaded columns with select keyed by model name", async () => {
+    const project = await Project.create({creatingUserReference: "ref-select"})
+    const task = await Task.create({projectId: project.id(), name: "Select preload"})
+    const found = /** @type {Task} */ (await Task.find(task.id()))
+
+    await found.preload(Task.preload("project").select({Project: ["id"]}))
+
+    const loadedProject = found.project()
+
+    expect(loadedProject.id()).toEqual(project.id())
+    expect(() => loadedProject.readColumn("creating_user_reference")).toThrow()
+  })
+
+  it("loads the default columns plus extras with selectsExtra", async () => {
+    const project = await Project.create({creatingUserReference: "ref-extra"})
+    const task = await Task.create({projectId: project.id(), name: "Extra preload"})
+    const found = /** @type {Task} */ (await Task.find(task.id()))
+
+    await found.preload(Task.preload("project").selectsExtra({Project: ["1 AS extra_flag"]}))
+
+    const loadedProject = found.project()
+
+    expect(loadedProject.readColumn("creating_user_reference")).toEqual("ref-extra")
+    expect(loadedProject.readColumn("extra_flag")).toEqual(1)
+  })
+
+  it("skips re-loading an already-preloaded relationship unless forced", async () => {
+    const project = await Project.create({creatingUserReference: "ref-before"})
+    const task = await Task.create({projectId: project.id(), name: "Idempotent preload"})
+    const found = /** @type {Task} */ (await Task.find(task.id()))
+
+    await found.preload(Task.preload("project"))
+
+    expect(found.project().readColumn("creating_user_reference")).toEqual("ref-before")
+
+    // Mutate the project in the database through a separate instance.
+    const projectAgain = /** @type {Project} */ (await Project.find(project.id()))
+
+    projectAgain.assign({creatingUserReference: "ref-after"})
+    await projectAgain.save()
+
+    // Without force the cached value is reused (no re-query).
+    await found.preload(Task.preload("project"))
+
+    expect(found.project().readColumn("creating_user_reference")).toEqual("ref-before")
+
+    // With force the relationship is re-loaded and picks up the change.
+    await found.preload(Task.preload("project"), {force: true})
+
+    expect(found.project().readColumn("creating_user_reference")).toEqual("ref-after")
+  })
+
+  it("re-loads when a wider column set is requested than was previously preloaded", async () => {
+    const project = await Project.create({creatingUserReference: "ref-widen"})
+    const task = await Task.create({projectId: project.id(), name: "Widen preload"})
+    const found = /** @type {Task} */ (await Task.find(task.id()))
+
+    await found.preload(Task.preload("project").select({Project: ["id"]}))
+
+    expect(() => found.project().readColumn("creating_user_reference")).toThrow()
+
+    // Re-preloading without a narrowing select requires all columns, so it loads again.
+    await found.preload(Task.preload("project"))
+
+    expect(found.project().readColumn("creating_user_reference")).toEqual("ref-widen")
+  })
+})

--- a/spec/database/record/preloader/model-preload.browser-spec.js
+++ b/spec/database/record/preloader/model-preload.browser-spec.js
@@ -103,6 +103,14 @@ describe("Record - preloader - model preload", {tags: ["dummy"]}, () => {
     expect(found.project().readColumn("creating_user_reference")).toEqual("ref-after")
   })
 
+  it("keeps preload selects independent across cloned queries", async () => {
+    const base = Task.preload("project").select({Project: ["id"]})
+    const branch = base.clone().select({Project: ["name"]})
+
+    expect(base._preloadSelects.Project).toEqual(["id"])
+    expect(branch._preloadSelects.Project).toEqual(["id", "name"])
+  })
+
   it("re-loads when a wider column set is requested than was previously preloaded", async () => {
     const project = await Project.create({creatingUserReference: "ref-widen"})
     const task = await Task.create({projectId: project.id(), name: "Widen preload"})

--- a/src/database/query/index.js
+++ b/src/database/query/index.js
@@ -17,7 +17,7 @@ import WherePlain from "./where-plain.js"
 /**
  * @typedef {{[key: string]: boolean | string | string[] | NestedPreloadRecord }} NestedPreloadRecord
  * @typedef {string | number | import("./order-base.js").default | import("./order-column.js").OrderColumnInput} OrderArgumentType
- * @typedef {string | string[] | import("./select-base.js").default | import("./select-base.js").default[]} SelectArgumentType
+ * @typedef {string | string[] | import("./select-base.js").default | import("./select-base.js").default[] | Record<string, string | string[]>} SelectArgumentType
  * @typedef {object | string} WhereArgumentType
  */
 
@@ -114,6 +114,8 @@ function mergeJoinValue(existing, incoming) {
  * @property {number | null} [page] - Page number for pagination.
  * @property {number} [perPage] - Records per page for pagination.
  * @property {NestedPreloadRecord} [preload] - Preload graph for related records.
+ * @property {Record<string, string[]>} [preloadSelects] - Attribute names to load for preloaded relationships, keyed by target model name.
+ * @property {Record<string, string[]>} [preloadSelectsExtra] - Extra selects to load in addition to the defaults for preloaded relationships, keyed by target model name.
  * @property {Array<import("./select-base.js").default>} [selects] - SELECT clauses for the query.
  * @property {boolean} [distinct] - Whether the query should use DISTINCT.
  * @property {Array<import("./where-base.js").default>} [wheres] - WHERE conditions for the query.
@@ -135,6 +137,8 @@ export default class VelociousDatabaseQuery {
     page = null,
     perPage,
     preload = {},
+    preloadSelects = {},
+    preloadSelectsExtra = {},
     distinct = false,
     selects = [],
     wheres = []
@@ -155,6 +159,12 @@ export default class VelociousDatabaseQuery {
     this._page = page
     this._perPage = perPage
     this._preload = preload
+
+    /** @type {Record<string, string[]>} */
+    this._preloadSelects = preloadSelects
+
+    /** @type {Record<string, string[]>} */
+    this._preloadSelectsExtra = preloadSelectsExtra
     this._distinct = distinct
     this._selects = selects
 

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -185,6 +185,8 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       page: this._page,
       perPage: this._perPage,
       preload: {...this._preload},
+      preloadSelects: {...this._preloadSelects},
+      preloadSelectsExtra: {...this._preloadSelectsExtra},
       distinct: this._distinct,
       selects: [...this._selects],
       wheres: [...this._wheres],
@@ -344,7 +346,50 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       }
     }
 
+    // Object form keyed by target model name, e.g. `.select({Account: ["id"]})`.
+    // These limit the attributes loaded for preloaded relationship targets
+    // rather than the root query's SELECT clause.
+    if (isPlainObject(select)) {
+      this._mergePreloadSelect(this._preloadSelects, select)
+
+      return this
+    }
+
     return super.select(select)
+  }
+
+  /**
+   * Loads the default columns plus the given extra selects for preloaded
+   * relationship targets, keyed by target model name, e.g.
+   * `.selectsExtra({Account: ["(SELECT count(*) FROM projects) AS projects_count"]})`.
+   * Unlike `select({...})`, which narrows to only the listed columns, this keeps
+   * the default `SELECT *` columns and adds the extras on top.
+   * @param {Record<string, string | string[]>} select - Extra selects keyed by target model name.
+   * @returns {this} - This query, for chaining.
+   */
+  selectsExtra(select) {
+    this._mergePreloadSelect(this._preloadSelectsExtra, select)
+
+    return this
+  }
+
+  /**
+   * Merges an object-form preload select (keyed by target model name) into the
+   * given target map, de-duplicating attribute/expression entries.
+   * @param {Record<string, string[]>} target - Map to merge into.
+   * @param {Record<string, string | string[]>} select - Object-form select.
+   * @returns {void} - No return value.
+   */
+  _mergePreloadSelect(target, select) {
+    for (const [modelName, attributes] of Object.entries(select)) {
+      const normalizedAttributes = Array.isArray(attributes) ? attributes : [attributes]
+
+      if (!target[modelName]) target[modelName] = []
+
+      for (const attribute of normalizedAttributes) {
+        if (!target[modelName].includes(attribute)) target[modelName].push(attribute)
+      }
+    }
   }
 
   /**
@@ -782,7 +827,9 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       const preloader = new Preloader({
         modelClass: this.modelClass,
         models,
-        preload: this._preload
+        preload: this._preload,
+        preloadSelects: this._preloadSelects,
+        preloadSelectsExtra: this._preloadSelectsExtra
       })
 
       await preloader.run()

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -78,6 +78,23 @@ function normalizeScopePath(path) {
 }
 
 /**
+ * Deep-copies a preload select map (keyed by model name with attribute arrays)
+ * so a cloned query's selections can be mutated without affecting the original.
+ * @param {Record<string, string[]>} map - Preload select map to copy.
+ * @returns {Record<string, string[]>} - A copy with independent arrays.
+ */
+function clonePreloadSelectMap(map) {
+  /** @type {Record<string, string[]>} */
+  const result = {}
+
+  for (const [modelName, attributes] of Object.entries(map)) {
+    result[modelName] = [...attributes]
+  }
+
+  return result
+}
+
+/**
  * @param {import("./index.js").NestedPreloadRecord | string | Array<string | import("./index.js").NestedPreloadRecord>} preload - Preload data in shorthand or nested form.
  * @returns {import("./index.js").NestedPreloadRecord} - Normalized preload record.
  */
@@ -185,8 +202,8 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       page: this._page,
       perPage: this._perPage,
       preload: {...this._preload},
-      preloadSelects: {...this._preloadSelects},
-      preloadSelectsExtra: {...this._preloadSelectsExtra},
+      preloadSelects: clonePreloadSelectMap(this._preloadSelects),
+      preloadSelectsExtra: clonePreloadSelectMap(this._preloadSelectsExtra),
       distinct: this._distinct,
       selects: [...this._selects],
       wheres: [...this._wheres],

--- a/src/database/query/preloader.js
+++ b/src/database/query/preloader.js
@@ -3,6 +3,7 @@
 import BelongsToPreloader from "./preloader/belongs-to.js"
 import HasManyPreloader from "./preloader/has-many.js"
 import HasOnePreloader from "./preloader/has-one.js"
+import PreloaderSelection from "./preloader/selection.js"
 import restArgsError from "../../utils/rest-args-error.js"
 
 /**
@@ -70,17 +71,56 @@ function normalizeNestedPreload(preload) {
 
 export default class VelociousDatabaseQueryPreloader {
   /**
+   * Preloads relationship(s) onto one or more already-loaded model instances.
+   * Accepts either a query built via `Model.preload(...).select(...)` (its
+   * preload graph and selects are used) or a raw preload spec
+   * (string / array / nested object).
+   * @param {Array<import("../record/index.js").default>} models - Model instances to preload onto.
+   * @param {import("./model-class-query.js").default | import("./index.js").NestedPreloadRecord | string | Array<string | import("./index.js").NestedPreloadRecord>} queryOrSpec - Preload source.
+   * @param {{force?: boolean}} [options] - Options.
+   * @returns {Promise<void>} - Resolves when preloading completes.
+   */
+  static async preload(models, queryOrSpec, {force = false} = {}) {
+    if (models.length == 0) return
+
+    const modelClass = /** @type {typeof import("../record/index.js").default} */ (models[0].constructor)
+    const isQuery = Boolean(queryOrSpec) && typeof queryOrSpec == "object" && "_preload" in queryOrSpec
+    // Reuse the query builder's preload/select normalization for raw specs
+    // instead of duplicating it here.
+    const query = isQuery
+      ? /** @type {import("./model-class-query.js").default} */ (queryOrSpec)
+      : modelClass.preload(/** @type {any} */ (queryOrSpec))
+
+    const preloader = new VelociousDatabaseQueryPreloader({
+      modelClass,
+      models,
+      preload: query._preload,
+      selection: new PreloaderSelection({
+        preloadSelects: query._preloadSelects,
+        preloadSelectsExtra: query._preloadSelectsExtra,
+        force
+      })
+    })
+
+    await preloader.run()
+  }
+
+  /**
    * @param {object} args - Options object.
    * @param {typeof import("../record/index.js").default} args.modelClass - Model class.
    * @param {import("../record/index.js").default[]} args.models - Model instances.
    * @param {import("../query/index.js").NestedPreloadRecord} args.preload - Preload.
+   * @param {Record<string, string[]>} [args.preloadSelects] - Narrowing selects keyed by target model name.
+   * @param {Record<string, string[]>} [args.preloadSelectsExtra] - Extra selects keyed by target model name.
+   * @param {PreloaderSelection} [args.selection] - Pre-built selection (takes precedence over the select maps when given).
    */
-  constructor({modelClass, models, preload, ...restArgs}) {
+  constructor({modelClass, models, preload, preloadSelects = {}, preloadSelectsExtra = {}, selection, ...restArgs}) {
     restArgsError(restArgs)
 
     this.modelClass = modelClass
     this.models = models
     this.preload = preload
+    this.selection = selection || new PreloaderSelection({preloadSelects, preloadSelectsExtra})
   }
 
   async run() {
@@ -90,17 +130,17 @@ export default class VelociousDatabaseQueryPreloader {
 
       if (relationship.getType() == "belongsTo") {
         const belongsToRelationship = /** @type {import("../record/relationships/belongs-to.js").default} */ (relationship)
-        const hasManyPreloader = new BelongsToPreloader({models: this.models, relationship: belongsToRelationship})
+        const hasManyPreloader = new BelongsToPreloader({models: this.models, relationship: belongsToRelationship, selection: this.selection})
 
         preloadResult = await hasManyPreloader.run()
       } else if (relationship.getType() == "hasMany") {
         const hasManyRelationship = /** @type {import("../record/relationships/has-many.js").default} */ (relationship)
-        const hasManyPreloader = new HasManyPreloader({models: this.models, relationship: hasManyRelationship})
+        const hasManyPreloader = new HasManyPreloader({models: this.models, relationship: hasManyRelationship, selection: this.selection})
 
         preloadResult = await hasManyPreloader.run()
       } else if (relationship.getType() == "hasOne") {
         const hasOneRelationship = /** @type {import("../record/relationships/has-one.js").default} */ (relationship)
-        const hasOnePreloader = new HasOnePreloader({models: this.models, relationship: hasOneRelationship})
+        const hasOnePreloader = new HasOnePreloader({models: this.models, relationship: hasOneRelationship, selection: this.selection})
 
         preloadResult = await hasOnePreloader.run()
       } else {
@@ -124,7 +164,7 @@ export default class VelociousDatabaseQueryPreloader {
             if (models.length == 0) continue
 
             const targetModelClass = configuration.getModelClass(className)
-            const preloader = new VelociousDatabaseQueryPreloader({modelClass: targetModelClass, models, preload: normalizedPreload})
+            const preloader = new VelociousDatabaseQueryPreloader({modelClass: targetModelClass, models, preload: normalizedPreload, selection: this.selection})
 
             await preloader.run()
           }
@@ -133,7 +173,7 @@ export default class VelociousDatabaseQueryPreloader {
 
           if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
 
-          const preloader = new VelociousDatabaseQueryPreloader({modelClass: targetModelClass, models: targetModels, preload: normalizedPreload})
+          const preloader = new VelociousDatabaseQueryPreloader({modelClass: targetModelClass, models: targetModels, preload: normalizedPreload, selection: this.selection})
 
           await preloader.run()
         }

--- a/src/database/query/preloader/belongs-to.js
+++ b/src/database/query/preloader/belongs-to.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
+import PreloaderSelection from "./selection.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
 export default class VelociousDatabaseQueryPreloaderBelongsTo {
@@ -8,97 +9,52 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
    * @param {object} args - Options object.
    * @param {import("../../record/index.js").default[]} args.models - Model instances.
    * @param {import("../../record/relationships/belongs-to.js").default} args.relationship - Relationship.
+   * @param {PreloaderSelection} [args.selection] - Column selection and idempotency rules.
    */
-  constructor({models, relationship, ...restArgs}) {
+  constructor({models, relationship, selection, ...restArgs}) {
     restArgsError(restArgs)
 
     this.models = models
     this.relationship = relationship
+    this.selection = selection || new PreloaderSelection()
   }
 
   async run() {
     const foreignKey = this.relationship.getForeignKey()
     const primaryKey = this.relationship.getPrimaryKey()
+    const relationshipName = this.relationship.getRelationshipName()
 
     if (this.relationship.getPolymorphic()) {
-      const typeColumn = this.relationship.getPolymorphicTypeColumn()
-      const configuration = this.relationship.getConfiguration()
-
-      /** @type {{foreignKeyValue: number | string | undefined, model: import("../../record/index.js").default, targetType: string | undefined}[]} */
-      const modelMeta = []
-
-      for (const model of this.models) {
-        modelMeta.push({
-          foreignKeyValue: /** @type {string | number | undefined} */ (model.readColumn(foreignKey)),
-          model,
-          targetType: /** @type {string | undefined} */ (model.readColumn(typeColumn))
-        })
-      }
-
-      /** @type {Record<string, Array<number | string>>} */
-      const foreignKeyValuesByType = {}
-
-      for (const meta of modelMeta) {
-        if (meta.targetType === undefined || meta.targetType === null) continue
-        if (meta.foreignKeyValue === undefined || meta.foreignKeyValue === null) continue
-
-        if (!foreignKeyValuesByType[meta.targetType]) foreignKeyValuesByType[meta.targetType] = []
-        if (!foreignKeyValuesByType[meta.targetType].includes(meta.foreignKeyValue)) foreignKeyValuesByType[meta.targetType].push(meta.foreignKeyValue)
-      }
-
-      /** @type {Record<string, Record<number | string, import("../../record/index.js").default>>} */
-      const targetModelsByTypeAndId = {}
-
-      /** @type {Record<string, import("../../record/index.js").default[]>} */
-      const targetModelsByClassName = {}
-
-      /** @type {import("../../record/index.js").default[]} */
-      const targetModels = []
-
-      for (const targetType in foreignKeyValuesByType) {
-        const targetModelClass = configuration.getModelClass(targetType)
-
-        await ensureModelClassInitialized(targetModelClass, configuration)
-
-        /** @type {Record<string, string | number | Array<string | number>>} */
-        const whereArgs = {}
-
-        whereArgs[primaryKey] = foreignKeyValuesByType[targetType]
-
-        let query = targetModelClass.where(whereArgs)
-
-        query = this.relationship.applyScope(query)
-
-        const foundTargetModels = await query.toArray()
-
-        targetModels.push(...foundTargetModels)
-        targetModelsByClassName[targetModelClass.getModelName()] = foundTargetModels
-        targetModelsByTypeAndId[targetType] = {}
-
-        for (const targetModel of foundTargetModels) {
-          const primaryKeyValue = /** @type {string | number} */ (targetModel.readColumn(primaryKey))
-
-          targetModelsByTypeAndId[targetType][primaryKeyValue] = targetModel
-        }
-      }
-
-      for (const meta of modelMeta) {
-        const modelRelationship = meta.model.getRelationshipByName(this.relationship.getRelationshipName())
-        const targetModel = (meta.targetType && meta.foreignKeyValue !== undefined && meta.foreignKeyValue !== null)
-          ? targetModelsByTypeAndId[meta.targetType]?.[meta.foreignKeyValue]
-          : undefined
-
-        modelRelationship.setPreloaded(true)
-        modelRelationship.setLoaded(targetModel)
-      }
-
-      return {targetModels, targetModelsByClassName}
+      return await this._runPolymorphic({foreignKey, primaryKey, relationshipName})
     }
+
+    const targetModelClass = this.relationship.getTargetModelClass()
+
+    if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
+
+    /** @type {import("../../record/index.js").default[]} */
+    const satisfiedTargets = []
+    /** @type {import("../../record/index.js").default[]} */
+    const modelsToLoad = []
+
+    for (const model of this.models) {
+      const instanceRelationship = model.getRelationshipByName(relationshipName)
+
+      if (this.selection.isSatisfied({instanceRelationship, targetModelClass, mappingColumns: [primaryKey]})) {
+        const loaded = /** @type {import("../../record/index.js").default | undefined} */ (instanceRelationship.getLoadedOrUndefined())
+
+        if (loaded) satisfiedTargets.push(loaded)
+      } else {
+        modelsToLoad.push(model)
+      }
+    }
+
+    if (modelsToLoad.length == 0) return satisfiedTargets
 
     /** @type {Array<number | string>} */
     const foreignKeyValues = []
 
-    for (const model of this.models) {
+    for (const model of modelsToLoad) {
       const foreignKeyValue = /** @type {string | number | null | undefined} */ (model.readColumn(foreignKey))
 
       // Skip null/undefined foreign keys: a belongsTo with no foreign key has no
@@ -108,10 +64,6 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
 
       if (!foreignKeyValues.includes(foreignKeyValue)) foreignKeyValues.push(foreignKeyValue)
     }
-
-    const targetModelClass = this.relationship.getTargetModelClass()
-
-    if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
 
     /** @type {Record<string, import("../../record/index.js").default>} */
     const targetModelsById = {}
@@ -132,26 +84,139 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
       let query = targetModelClass.where(whereArgs)
 
       query = this.relationship.applyScope(query)
+      query = this.selection.applyToQuery({query, targetModelClass, mappingColumns: [primaryKey]})
 
       targetModels = await query.toArray()
 
       for (const targetModel of targetModels) {
-        const primaryKeyValue = /** @type {string | number} */ (targetModel.readColumn(this.relationship.getPrimaryKey()))
+        const primaryKeyValue = /** @type {string | number} */ (targetModel.readColumn(primaryKey))
 
         targetModelsById[primaryKeyValue] = targetModel
       }
     }
 
     // Set the target preloaded models on the given models
-    for (const model of this.models) {
+    for (const model of modelsToLoad) {
       const foreignKeyValue = /** @type {string | number} */ (model.readColumn(foreignKey))
       const targetModel = targetModelsById[foreignKeyValue]
-      const modelRelationship = model.getRelationshipByName(this.relationship.getRelationshipName())
+      const modelRelationship = model.getRelationshipByName(relationshipName)
 
       modelRelationship.setPreloaded(true)
       modelRelationship.setLoaded(targetModel)
     }
 
-    return targetModels
+    return [...satisfiedTargets, ...targetModels]
+  }
+
+  /**
+   * Preload a polymorphic belongsTo, grouping models by their target type so
+   * each concrete target model class is queried separately.
+   * @param {object} args - Options object.
+   * @param {string} args.foreignKey - Foreign key column.
+   * @param {string} args.primaryKey - Primary key column on the target.
+   * @param {string} args.relationshipName - Relationship name.
+   * @returns {Promise<{targetModels: import("../../record/index.js").default[], targetModelsByClassName: Record<string, import("../../record/index.js").default[]>}>} - Loaded targets and a per-class-name grouping.
+   */
+  async _runPolymorphic({foreignKey, primaryKey, relationshipName}) {
+    const typeColumn = this.relationship.getPolymorphicTypeColumn()
+    const configuration = this.relationship.getConfiguration()
+
+    /** @type {{foreignKeyValue: number | string | undefined, model: import("../../record/index.js").default, targetType: string | undefined}[]} */
+    const modelMeta = []
+
+    /** @type {import("../../record/index.js").default[]} */
+    const satisfiedTargets = []
+
+    /** @type {Record<string, import("../../record/index.js").default[]>} */
+    const targetModelsByClassName = {}
+
+    for (const model of this.models) {
+      const targetType = /** @type {string | undefined} */ (model.readColumn(typeColumn))
+      const instanceRelationship = model.getRelationshipByName(relationshipName)
+      const targetModelClass = targetType ? configuration.getModelClass(targetType) : undefined
+
+      if (targetModelClass && this.selection.isSatisfied({instanceRelationship, targetModelClass, mappingColumns: [primaryKey]})) {
+        const loaded = /** @type {import("../../record/index.js").default | undefined} */ (instanceRelationship.getLoadedOrUndefined())
+
+        if (loaded) {
+          satisfiedTargets.push(loaded)
+
+          const className = /** @type {typeof import("../../record/index.js").default} */ (loaded.constructor).getModelName()
+
+          if (!targetModelsByClassName[className]) targetModelsByClassName[className] = []
+          targetModelsByClassName[className].push(loaded)
+        }
+
+        continue
+      }
+
+      modelMeta.push({
+        foreignKeyValue: /** @type {string | number | undefined} */ (model.readColumn(foreignKey)),
+        model,
+        targetType
+      })
+    }
+
+    /** @type {Record<string, Array<number | string>>} */
+    const foreignKeyValuesByType = {}
+
+    for (const meta of modelMeta) {
+      if (meta.targetType === undefined || meta.targetType === null) continue
+      if (meta.foreignKeyValue === undefined || meta.foreignKeyValue === null) continue
+
+      if (!foreignKeyValuesByType[meta.targetType]) foreignKeyValuesByType[meta.targetType] = []
+      if (!foreignKeyValuesByType[meta.targetType].includes(meta.foreignKeyValue)) foreignKeyValuesByType[meta.targetType].push(meta.foreignKeyValue)
+    }
+
+    /** @type {Record<string, Record<number | string, import("../../record/index.js").default>>} */
+    const targetModelsByTypeAndId = {}
+
+    /** @type {import("../../record/index.js").default[]} */
+    const targetModels = []
+
+    for (const targetType in foreignKeyValuesByType) {
+      const targetModelClass = configuration.getModelClass(targetType)
+
+      await ensureModelClassInitialized(targetModelClass, configuration)
+
+      /** @type {Record<string, string | number | Array<string | number>>} */
+      const whereArgs = {}
+
+      whereArgs[primaryKey] = foreignKeyValuesByType[targetType]
+
+      let query = targetModelClass.where(whereArgs)
+
+      query = this.relationship.applyScope(query)
+      query = this.selection.applyToQuery({query, targetModelClass, mappingColumns: [primaryKey]})
+
+      const foundTargetModels = await query.toArray()
+
+      targetModels.push(...foundTargetModels)
+
+      const className = targetModelClass.getModelName()
+
+      if (!targetModelsByClassName[className]) targetModelsByClassName[className] = []
+      targetModelsByClassName[className].push(...foundTargetModels)
+
+      targetModelsByTypeAndId[targetType] = {}
+
+      for (const targetModel of foundTargetModels) {
+        const primaryKeyValue = /** @type {string | number} */ (targetModel.readColumn(primaryKey))
+
+        targetModelsByTypeAndId[targetType][primaryKeyValue] = targetModel
+      }
+    }
+
+    for (const meta of modelMeta) {
+      const modelRelationship = meta.model.getRelationshipByName(relationshipName)
+      const targetModel = (meta.targetType && meta.foreignKeyValue !== undefined && meta.foreignKeyValue !== null)
+        ? targetModelsByTypeAndId[meta.targetType]?.[meta.foreignKeyValue]
+        : undefined
+
+      modelRelationship.setPreloaded(true)
+      modelRelationship.setLoaded(targetModel)
+    }
+
+    return {targetModels: [...satisfiedTargets, ...targetModels], targetModelsByClassName}
   }
 }

--- a/src/database/query/preloader/has-many.js
+++ b/src/database/query/preloader/has-many.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
+import PreloaderSelection from "./selection.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
 export default class VelociousDatabaseQueryPreloaderHasMany {
@@ -8,12 +9,14 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
    * @param {object} args - Options object.
    * @param {import("../../record/index.js").default[]} args.models - Model instances.
    * @param {import("../../record/relationships/has-many.js").default} args.relationship - Relationship.
+   * @param {PreloaderSelection} [args.selection] - Column selection and idempotency rules.
    */
-  constructor({models, relationship, ...restArgs}) {
+  constructor({models, relationship, selection, ...restArgs}) {
     restArgsError(restArgs)
 
     this.models = models
     this.relationship = relationship
+    this.selection = selection || new PreloaderSelection()
   }
 
   /** @returns {Promise<import("../../record/index.js").default[]>} - Loaded target models. */
@@ -23,6 +26,36 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
     }
 
     return await this._runDirect()
+  }
+
+  /**
+   * Partitions `this.models` into those already satisfied by the current
+   * selection (skip) and those that still need loading. Satisfied models'
+   * already-loaded targets are collected so nested preloads keep working.
+   * @param {typeof import("../../record/index.js").default} targetModelClass - Target model class.
+   * @param {string[]} mappingColumns - Columns required for mapping (foreign key).
+   * @returns {{modelsToLoad: import("../../record/index.js").default[], satisfiedTargets: import("../../record/index.js").default[]}} - The partition.
+   */
+  _partition(targetModelClass, mappingColumns) {
+    const relationshipName = this.relationship.getRelationshipName()
+    /** @type {import("../../record/index.js").default[]} */
+    const modelsToLoad = []
+    /** @type {import("../../record/index.js").default[]} */
+    const satisfiedTargets = []
+
+    for (const model of this.models) {
+      const instanceRelationship = model.getRelationshipByName(relationshipName)
+
+      if (this.selection.isSatisfied({instanceRelationship, targetModelClass, mappingColumns})) {
+        const loaded = instanceRelationship.getLoadedOrUndefined()
+
+        if (Array.isArray(loaded)) satisfiedTargets.push(...loaded)
+      } else {
+        modelsToLoad.push(model)
+      }
+    }
+
+    return {modelsToLoad, satisfiedTargets}
   }
 
   /**
@@ -48,6 +81,11 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
     if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
 
+    const targetForeignKey = this.relationship.getForeignKey()
+    const {modelsToLoad, satisfiedTargets} = this._partition(targetModelClass, [targetForeignKey])
+
+    if (modelsToLoad.length == 0) return satisfiedTargets
+
     const configuration = this.relationship.getConfiguration()
 
     await ensureModelClassInitialized(throughModelClass, configuration)
@@ -64,7 +102,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
     /** @type {Record<number | string, Array<import("../../record/index.js").default>>} */
     const preloadCollections = {}
 
-    for (const model of this.models) {
+    for (const model of modelsToLoad) {
       const primaryKeyValue = /** @type {string | number} */ (model.readColumn(primaryKey))
 
       preloadCollections[primaryKeyValue] = []
@@ -86,8 +124,6 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
     /** @type {Set<string | number>} */
     const allTargetIds = new Set()
 
-    const targetForeignKey = this.relationship.getForeignKey()
-
     for (const throughModel of throughModels) {
       const parentId = /** @type {string | number} */ (throughModel.readColumn(throughForeignKey))
       const throughId = /** @type {string | number} */ (throughModel.readColumn(throughModelClass.primaryKey()))
@@ -106,6 +142,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
       let query = targetModelClass.where({[targetForeignKey]: [...allTargetIds]})
 
       query = this.relationship.applyScope(query)
+      query = this.selection.applyToQuery({query, targetModelClass, mappingColumns: [targetForeignKey]})
       targetModels = await query.toArray()
     }
 
@@ -142,17 +179,14 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
       for (const model of modelsByPrimaryKeyValue[modelValue]) {
         const modelRelationship = model.getRelationshipByName(this.relationship.getRelationshipName())
 
-        if (preloadedCollection.length == 0) {
-          modelRelationship.setLoaded([])
-        } else {
-          modelRelationship.addToLoaded(preloadedCollection)
-        }
-
+        // Replace rather than append: `modelsToLoad` are exactly the records we
+        // intend to (re)load, so a forced re-preload must not duplicate entries.
+        modelRelationship.setLoaded(preloadedCollection)
         modelRelationship.setPreloaded(true)
       }
     }
 
-    return targetModels
+    return [...satisfiedTargets, ...targetModels]
   }
 
   /**
@@ -161,23 +195,31 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
    * @returns {Promise<import("../../record/index.js").default[]>} - Loaded target models.
    */
   async _runDirect() {
+    const foreignKey = this.relationship.getForeignKey()
+    const primaryKey = this.relationship.getPrimaryKey()
+
+    if (!primaryKey) {
+      throw new Error(`${this.relationship.getModelClass().name}#${this.relationship.getRelationshipName()} doesn't have a primary key`)
+    }
+
+    const targetModelClass = this.relationship.getTargetModelClass()
+
+    if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
+
+    const {modelsToLoad, satisfiedTargets} = this._partition(targetModelClass, [foreignKey])
+
+    if (modelsToLoad.length == 0) return satisfiedTargets
+
     /** @type {Array<number | string>} */
     const modelsPrimaryKeyValues = []
 
     /** @type {Record<number | string, Array<import("../../record/index.js").default>>} */
     const modelsByPrimaryKeyValue = {}
 
-    const foreignKey = this.relationship.getForeignKey()
-    const primaryKey = this.relationship.getPrimaryKey()
-
     /** @type {Record<number | string, Array<import("../../record/index.js").default>>} */
     const preloadCollections = {}
 
-    if (!primaryKey) {
-      throw new Error(`${this.relationship.getModelClass().name}#${this.relationship.getRelationshipName()} doesn't have a primary key`)
-    }
-
-    for (const model of this.models) {
+    for (const model of modelsToLoad) {
       const primaryKeyValue = /** @type {string | number} */ (model.readColumn(primaryKey))
 
       preloadCollections[primaryKeyValue] = []
@@ -199,15 +241,12 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
       whereArgs[typeColumn] = this.relationship.getModelClass().getModelName()
     }
 
-    const targetModelClass = this.relationship.getTargetModelClass()
-
-    if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
-
     await ensureModelClassInitialized(targetModelClass, this.relationship.getConfiguration())
 
     let query = targetModelClass.where(whereArgs)
 
     query = this.relationship.applyScope(query)
+    query = this.selection.applyToQuery({query, targetModelClass, mappingColumns: [foreignKey]})
 
     const targetModels = await query.toArray()
 
@@ -223,16 +262,13 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
       for (const model of modelsByPrimaryKeyValue[modelValue]) {
         const modelRelationship = model.getRelationshipByName(this.relationship.getRelationshipName())
 
-        if (preloadedCollection.length == 0) {
-          modelRelationship.setLoaded([])
-        } else {
-          modelRelationship.addToLoaded(preloadedCollection)
-        }
-
+        // Replace rather than append: `modelsToLoad` are exactly the records we
+        // intend to (re)load, so a forced re-preload must not duplicate entries.
+        modelRelationship.setLoaded(preloadedCollection)
         modelRelationship.setPreloaded(true)
       }
     }
 
-    return targetModels
+    return [...satisfiedTargets, ...targetModels]
   }
 }

--- a/src/database/query/preloader/has-one.js
+++ b/src/database/query/preloader/has-one.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
+import PreloaderSelection from "./selection.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
 export default class VelociousDatabaseQueryPreloaderHasOne {
@@ -8,12 +9,14 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
    * @param {object} args - Options object.
    * @param {Array<import("../../record/index.js").default>} args.models - Model instances.
    * @param {import("../../record/relationships/has-one.js").default} args.relationship - Relationship.
+   * @param {PreloaderSelection} [args.selection] - Column selection and idempotency rules.
    */
-  constructor({models, relationship, ...restArgs}) {
+  constructor({models, relationship, selection, ...restArgs}) {
     restArgsError(restArgs)
 
     this.models = models
     this.relationship = relationship
+    this.selection = selection || new PreloaderSelection()
   }
 
   async run() {
@@ -25,11 +28,28 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
 
     const foreignKey = this.relationship.getForeignKey()
     const primaryKey = this.relationship.getPrimaryKey()
+    const relationshipName = this.relationship.getRelationshipName()
+
+    const targetModelClass = this.relationship.getTargetModelClass()
+
+    if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
 
     /** @type {Record<number | string, import("../../record/index.js").default | undefined>} */
     const preloadCollections = {}
 
+    /** @type {import("../../record/index.js").default[]} */
+    const satisfiedTargets = []
+
     for (const model of this.models) {
+      const instanceRelationship = model.getRelationshipByName(relationshipName)
+
+      if (this.selection.isSatisfied({instanceRelationship, targetModelClass, mappingColumns: [foreignKey]})) {
+        const loaded = /** @type {import("../../record/index.js").default | undefined} */ (instanceRelationship.getLoadedOrUndefined())
+
+        if (loaded) satisfiedTargets.push(loaded)
+        continue
+      }
+
       const primaryKeyValue = /** @type {string | number} */ (model.readColumn(primaryKey))
 
       preloadCollections[primaryKeyValue] = undefined
@@ -39,6 +59,8 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
 
       modelsByPrimaryKeyValue[primaryKeyValue].push(model)
     }
+
+    if (modelsPrimaryKeyValues.length == 0) return satisfiedTargets
 
     /** @type {Record<string, string | number | Array<string | number>>} */
     const whereArgs = {}
@@ -51,16 +73,13 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
       whereArgs[typeColumn] = this.relationship.getModelClass().getModelName()
     }
 
-    const targetModelClass = this.relationship.getTargetModelClass()
-
-    if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
-
     await ensureModelClassInitialized(targetModelClass, this.relationship.getConfiguration())
 
     // Load target models to be preloaded on the given models
     let query = targetModelClass.where(whereArgs)
 
     query = this.relationship.applyScope(query)
+    query = this.selection.applyToQuery({query, targetModelClass, mappingColumns: [foreignKey]})
 
     const targetModels = await query.toArray()
 
@@ -75,13 +94,13 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
       const preloadedModel = preloadCollections[modelValue]
 
       for (const model of modelsByPrimaryKeyValue[modelValue]) {
-        const modelRelationship = model.getRelationshipByName(this.relationship.getRelationshipName())
+        const modelRelationship = model.getRelationshipByName(relationshipName)
 
         modelRelationship.setPreloaded(true)
         modelRelationship.setLoaded(preloadedModel)
       }
     }
 
-    return targetModels
+    return [...satisfiedTargets, ...targetModels]
   }
 }

--- a/src/database/query/preloader/selection.js
+++ b/src/database/query/preloader/selection.js
@@ -1,0 +1,144 @@
+// @ts-check
+
+const IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+
+/**
+ * Encapsulates the column selection and idempotency rules for preloading.
+ *
+ * Two per-target-model-name maps drive the behaviour, both keyed by the target
+ * model name (e.g. `"Account"`):
+ *
+ * - `preloadSelects` (from `.select({Account: ["id"]})`) narrows the columns
+ *   loaded for that target to the listed attributes (plus the primary/foreign
+ *   keys needed to map results back to their parents).
+ * - `preloadSelectsExtra` (from `.selectsExtra({Account: ["..."]})`) keeps the
+ *   default `SELECT *` columns and loads the listed extra selects in addition.
+ *
+ * `force` re-loads relationships even when they are already preloaded.
+ */
+export default class VelociousDatabaseQueryPreloaderSelection {
+  /**
+   * @param {object} [args] - Options object.
+   * @param {Record<string, string[]>} [args.preloadSelects] - Narrowing selects keyed by target model name.
+   * @param {Record<string, string[]>} [args.preloadSelectsExtra] - Extra selects keyed by target model name.
+   * @param {boolean} [args.force] - Whether to re-load already-preloaded relationships.
+   */
+  constructor({preloadSelects = {}, preloadSelectsExtra = {}, force = false} = {}) {
+    this.preloadSelects = preloadSelects
+    this.preloadSelectsExtra = preloadSelectsExtra
+    this.force = force
+  }
+
+  /** @returns {boolean} - Whether already-preloaded relationships should still be re-loaded. */
+  getForce() { return this.force }
+
+  /**
+   * @param {typeof import("../../record/index.js").default} targetModelClass - Target model class.
+   * @returns {string[] | undefined} - Narrowing select attributes for the class, if any.
+   */
+  _narrowingFor(targetModelClass) {
+    return this.preloadSelects[targetModelClass.getModelName()]
+  }
+
+  /**
+   * @param {typeof import("../../record/index.js").default} targetModelClass - Target model class.
+   * @returns {string[] | undefined} - Extra select attributes/expressions for the class, if any.
+   */
+  _extraFor(targetModelClass) {
+    return this.preloadSelectsExtra[targetModelClass.getModelName()]
+  }
+
+  /**
+   * Apply the configured select clauses to a target query.
+   * @template {import("../model-class-query.js").default} T
+   * @param {object} args - Options object.
+   * @param {T} args.query - Target query to apply selects to.
+   * @param {typeof import("../../record/index.js").default} args.targetModelClass - Target model class.
+   * @param {string[]} args.mappingColumns - Columns that must always be loaded so results can be mapped back to parents (primary/foreign keys).
+   * @returns {T} - The query, with selects applied when a selection is configured.
+   */
+  applyToQuery({query, targetModelClass, mappingColumns}) {
+    const narrowing = this._narrowingFor(targetModelClass)
+    const extra = this._extraFor(targetModelClass)
+
+    if (narrowing) {
+      const selects = [...new Set([...narrowing, ...mappingColumns, ...(extra || [])])]
+
+      return /** @type {T} */ (query.select(selects))
+    }
+
+    if (extra) {
+      const allColumns = `${query.driver.quoteTable(targetModelClass.tableName())}.*`
+
+      return /** @type {T} */ (query.select([allColumns, ...extra]))
+    }
+
+    return query
+  }
+
+  /**
+   * Whether an already-preloaded relationship's loaded target(s) satisfy the
+   * configured selection, so the relationship can be skipped. Returns false
+   * when `force` is set, when the relationship hasn't been preloaded, or when a
+   * required column is missing from a loaded target.
+   * @param {object} args - Options object.
+   * @param {import("../../record/instance-relationships/base.js").default} args.instanceRelationship - The source model's instance relationship.
+   * @param {typeof import("../../record/index.js").default} args.targetModelClass - Target model class.
+   * @param {string[]} args.mappingColumns - Primary/foreign key columns required for mapping.
+   * @returns {boolean} - Whether the relationship is already satisfied.
+   */
+  isSatisfied({instanceRelationship, targetModelClass, mappingColumns}) {
+    if (this.force) return false
+    if (!instanceRelationship.getPreloaded()) return false
+
+    const required = this._requiredColumnsFor({targetModelClass, mappingColumns})
+
+    if (!required) return false
+
+    const loaded = instanceRelationship.getLoadedOrUndefined()
+    const targets = loaded === undefined ? [] : (Array.isArray(loaded) ? loaded : [loaded])
+
+    for (const target of targets) {
+      for (const column of required) {
+        if (!target.hasLoadedColumn(column)) return false
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * The set of columns that must be present on a loaded target for it to count
+   * as satisfied. Returns null when satisfaction can't be verified (an extra
+   * select is a raw SQL expression whose resulting column can't be derived), in
+   * which case the relationship is always re-loaded.
+   * @param {object} args - Options object.
+   * @param {typeof import("../../record/index.js").default} args.targetModelClass - Target model class.
+   * @param {string[]} args.mappingColumns - Primary/foreign key columns required for mapping.
+   * @returns {string[] | null} - Required column names, or null when unverifiable.
+   */
+  _requiredColumnsFor({targetModelClass, mappingColumns}) {
+    const attributeMap = targetModelClass.getAttributeNameToColumnNameMap()
+    const narrowing = this._narrowingFor(targetModelClass)
+    const extra = this._extraFor(targetModelClass)
+    /** @type {string[]} */
+    const columns = []
+
+    if (narrowing) {
+      for (const attribute of narrowing) columns.push(attributeMap[attribute] || attribute)
+      for (const column of mappingColumns) columns.push(column)
+    } else {
+      for (const column of targetModelClass.getColumnNames()) columns.push(column)
+    }
+
+    if (extra) {
+      for (const entry of extra) {
+        if (!IDENTIFIER_REGEX.test(entry)) return null
+
+        columns.push(attributeMap[entry] || entry)
+      }
+    }
+
+    return columns
+  }
+}

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -22,6 +22,7 @@ import HasOneRelationship from "./relationships/has-one.js"
 import RecordAttachmentHandle from "./attachments/handle.js"
 import * as inflection from "inflection"
 import ModelClassQuery from "../query/model-class-query.js"
+import Preloader from "../query/preloader.js"
 import restArgsError from "../../utils/rest-args-error.js"
 import singularizeModelName from "../../utils/singularize-model-name.js"
 import {defineModelScope} from "../../utils/model-scope.js"
@@ -770,6 +771,21 @@ class VelociousDatabaseRecord {
     }
 
     return this._instanceRelationships[relationshipName]
+  }
+
+  /**
+   * Preloads relationship(s) onto this already-loaded record. Accepts either a
+   * query built via `Model.preload(...).select(...)` or a raw preload spec
+   * (string / array / nested object). A relationship that is already preloaded
+   * with all the required columns present is left untouched unless `force` is
+   * set. Preloading onto the relationship cache lets later accessors reuse the
+   * loaded data instead of issuing identical queries.
+   * @param {import("../query/model-class-query.js").default | import("../query/index.js").NestedPreloadRecord | string | Array<string | import("../query/index.js").NestedPreloadRecord>} queryOrSpec - Preload source.
+   * @param {{force?: boolean}} [options] - Options.
+   * @returns {Promise<void>} - Resolves when preloading completes.
+   */
+  async preload(queryOrSpec, options = {}) {
+    await Preloader.preload([this], queryOrSpec, options)
   }
 
   /**
@@ -3161,6 +3177,17 @@ class VelociousDatabaseRecord {
     result = this._normalizeBooleanValueForRead({columnType, value: result})
 
     return result
+  }
+
+  /**
+   * Whether a column value is currently loaded on this record (either as a
+   * persisted attribute or a pending change). Used to decide whether a preload
+   * can be skipped because the required columns are already present.
+   * @param {string} columnName - The column name to check.
+   * @returns {boolean} - Whether the column is loaded.
+   */
+  hasLoadedColumn(columnName) {
+    return columnName in this._changes || columnName in this._attributes
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a way to preload relationships onto records you already have in memory, instead of only while a query runs. Preloaded data lands on the relationship cache, so later accessors reuse it rather than issuing identical queries.

```js
await serviceToken.preload(ServiceToken.preload({account: "projects"}).select({Account: ["id"]}))
const projects = serviceToken.account()?.projects()

// And across an array of records:
await Preloader.preload(serviceTokens, ServiceToken.preload({account: "projects"}))
```

## What's included

- **`record.preload(queryOrSpec, {force})`** — instance method delegating to the new static below. Accepts a query built via `Model.preload(...)` or a raw preload spec (string / array / nested object).
- **`Preloader.preload(records, queryOrSpec, {force})`** — static that preloads onto an array of records, reusing `VelociousDatabaseQueryPreloader`.
- **`select({ModelName: [...]})`** — object form keyed by target model name narrows the columns loaded for preloaded targets. Primary/foreign keys needed for mapping are always kept. Reading a non-selected attribute raises the usual "attribute hasn't been loaded" error.
- **`selectsExtra({ModelName: [...]})`** — keeps the default `SELECT *` columns and loads extra computed selects on top.
- **Idempotency** — a relationship already preloaded with all required columns present is left untouched (no query). Requesting a wider column set re-queries; `{force: true}` reloads regardless. This logic lives in a shared `PreloaderSelection` helper threaded through the belongs-to / has-many / has-one preloaders.
- **Bug fix** — the has-many preloader now replaces rather than appends loaded records, so a forced re-preload no longer duplicates entries.

The object-form `select`/`selectsExtra` only affect preloaded relationship targets on the backend query; they are independent of the frontend-model serialization-layer `select`.

## Testing

- New `spec/database/record/preloader/model-preload.browser-spec.js` (8 cases): instance preload, nested preload, array preload, raw-spec preload, column-limiting `select`, `selectsExtra`, idempotent skip + `force`, and widening re-query.
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors.
- Re-ran existing preloader / autoload / query specs (49) and frontend-model specs (193) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)