### PR TITLE
Add query-filtered frontend model event subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * Declarative state machines for models (see [docs/state-machine.md](docs/state-machine.md))
 * Migrations for schema changes
 * Controllers and views for HTTP endpoints
-* Frontend-model transport for creating, updating, and querying records over HTTP, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
+* Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))
 * Gap-less positional lists with automatic reordering via `actsAsList` (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))

--- a/changelog.d/20260604083824-frontend-model-event-query-filters.md
+++ b/changelog.d/20260604083824-frontend-model-event-query-filters.md
@@ -1,0 +1,1 @@
+Added query-filtered frontend-model create/update event subscriptions so lifecycle callbacks and React event hooks can narrow delivered events while reusing the same query for payload projection.

--- a/changelog.d/20260604105534-falsy-column-default.md
+++ b/changelog.d/20260604105534-falsy-column-default.md
@@ -1,0 +1,1 @@
+Fixed column DEFAULT generation dropping falsy defaults (`default: 0`, `default: false`, `default: ""`). The column SQL builder used a truthiness check, so a falsy default was omitted and the column was created NOT NULL with no default — making inserts that rely on the default fail in strict mode. Falsy defaults are now emitted for both `createTable` and `addColumn`.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -103,13 +103,22 @@
 - Pass an array of event names to subscribe one callback to several class-level events, for example `useModelClassEvent(Subscription, ["create", "update"], reloadStatus)`.
 - Convenience wrappers are available as `useCreatedEvent(ModelClass, callback)`, `useUpdatedEvent(ModelClassOrModel, callback)`, and `useDestroyedEvent(ModelClassOrModel, callback)`.
 - `useUpdatedEvent` and `useDestroyedEvent` accept a model instance or array of model instances for instance-level subscriptions.
-- Hook options support `{active, debounce, onConnected}` plus event record projection options: `select`, `preload`, `withCount`, `abilities`, and `queryData`. The hooks own subscribe/unsubscribe cleanup, so components do not need lifecycle methods just to remove event listeners.
+- Hook options support `{active, debounce, onConnected}` plus event record projection options: `select`, `selectsExtra`, `preload`, `withCount`, `abilities`, and `queryData`. The hooks own subscribe/unsubscribe cleanup, so components do not need lifecycle methods just to remove event listeners.
+- `onCreate` and `onUpdate` can receive a frontend-model query instead of a plain options object. React hooks can receive the same query through the `query` option. The query's `where`, `joins`, and `search` predicates narrow which create/update events reach that callback. The same query's `select`, `selectsExtra`, `preload`, `withCount`, `abilities`, and `queryData` control the event payload.
+- Event queries intentionally reject list-only options such as `limit`, `offset`, `page`, `perPage`, `sort`, `group`, and `distinct` because lifecycle events match one saved record at a time.
+- Destroy events carry only ids after the row is gone, so query-filtered destroy subscriptions are not supported. Use an unfiltered destroy listener and check local ids when a screen needs deletion cleanup.
 
 ```js
-useUpdatedEvent(BuildGroup, onBuildGroupUpdated, {
-  select: {BuildGroup: ["id", "status", "rebuildableBuildsCount"]},
-  withCount: "builds"
-})
+useUpdatedEvent(
+  BuildGroup,
+  onBuildGroupUpdated,
+  {
+    query: BuildGroup
+      .where({projectId})
+      .select({BuildGroup: ["id", "status", "rebuildableBuildsCount"]})
+      .withCount("builds")
+  }
+)
 ```
 
 ## Attachment support

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -1075,13 +1075,13 @@
         "count": 10
       },
       "crap_critical": {
-        "count": 16
+        "count": 17
       },
       "crap_high": {
         "count": 14
       },
       "crap_moderate": {
-        "count": 13
+        "count": 12
       }
     },
     "src/frontend-models/preloader.js": {
@@ -1103,7 +1103,7 @@
         "count": 8
       },
       "crap_high": {
-        "count": 11
+        "count": 12
       },
       "crap_moderate": {
         "count": 9
@@ -1155,8 +1155,14 @@
       }
     },
     "src/frontend-models/websocket-channel.js": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
       "crap_high": {
-        "count": 4
+        "count": 3
       },
       "crap_moderate": {
         "count": 1
@@ -1596,8 +1602,8 @@
     "src/frontend-models/outgoing-event-buffer.js:dead code",
     "src/database/query/where-model-class-hash.js:complexity",
     "src/environment-handlers/node/cli/commands/test.js:complexity",
-    "src/database/query/preloader/belongs-to.js:complexity",
     "src/utils/format-value.js:untested risk",
+    "src/database/query/preloader/belongs-to.js:complexity",
     "src/mailer/base.js:circular dependency",
     "spec/dummy/src/config/testing.js:untested risk",
     "src/database/query/preloader/has-many.js:complexity",

--- a/spec/database/drivers/mysql/sql/alter-table-spec.js
+++ b/spec/database/drivers/mysql/sql/alter-table-spec.js
@@ -23,6 +23,18 @@ describe("database/drivers/mysql/sql/alter-table", {databaseCleaning: {transacti
     ])
   })
 
+  it("emits a falsy default of 0 when adding a column", async () => {
+    const tableData = new TableData("github_webhooks")
+
+    tableData.integer("attempt_count", {default: 0, null: false})
+
+    const sqls = await buildDriver().alterTableSQLs(tableData)
+
+    expect(sqls).toEqual([
+      "ALTER TABLE `github_webhooks` ADD COLUMN `attempt_count` INTEGER DEFAULT 0 NOT NULL"
+    ])
+  })
+
   it("does not force an algorithm for foreign-key alters", async () => {
     const tableData = new TableData("build_artifacts")
 

--- a/spec/database/drivers/mysql/sql/create-table-spec.js
+++ b/spec/database/drivers/mysql/sql/create-table-spec.js
@@ -37,4 +37,40 @@ describe("database/drivers/mysql/sql/create-table", {databaseCleaning: {transact
       "CREATE TABLE `auth_tokens` (`force_valid_domain` TINYINT(1) NOT NULL COMMENT 'velocious:type=boolean') DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
     ])
   })
+
+  it("emits a falsy integer default of 0 (truthiness check used to drop it)", async () => {
+    const tableData = new TableData("counters")
+
+    tableData.integer("count", {default: 0, null: false})
+
+    const sqls = await buildDriver().createTableSql(tableData)
+
+    expect(sqls).toEqual([
+      "CREATE TABLE `counters` (`count` INTEGER DEFAULT 0 NOT NULL) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    ])
+  })
+
+  it("emits a falsy boolean default of false as 0", async () => {
+    const tableData = new TableData("flags")
+
+    tableData.boolean("enabled", {default: false, null: false})
+
+    const sqls = await buildDriver().createTableSql(tableData)
+
+    expect(sqls).toEqual([
+      "CREATE TABLE `flags` (`enabled` TINYINT(1) DEFAULT 0 NOT NULL COMMENT 'velocious:type=boolean') DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    ])
+  })
+
+  it("emits a falsy empty-string default", async () => {
+    const tableData = new TableData("notes")
+
+    tableData.string("body", {default: "", null: false})
+
+    const sqls = await buildDriver().createTableSql(tableData)
+
+    expect(sqls).toEqual([
+      "CREATE TABLE `notes` (`body` VARCHAR(255) DEFAULT '' NOT NULL) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    ])
+  })
 })

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -303,6 +303,14 @@ describe("Frontend models - base", {databaseCleaning: {transaction: true}}, () =
     expect(query.wherePayload()).toEqual({where: {isDone: false, name: "Keep me"}})
   })
 
+  it("rejects query filters for destroy event subscriptions", async () => {
+    const Task = buildTestModelClass()
+
+    await expect(async () => {
+      await Task.onDestroy(() => {}, Task.where({id: 1}))
+    }).toThrow(/destroy event subscriptions do not support query filters/)
+  })
+
   it("uses the shared frontend-model API and batches requests by default", async () => {
     const originalFetch = globalThis.fetch
     /** @type {FetchCall[]} */

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import {waitFor} from "awaitery"
+import {wait, waitFor} from "awaitery"
 import {describe, expect, it} from "../../src/testing/test.js"
 import FrontendModelBase, {AttributeNotSelectedError} from "../../src/frontend-models/base.js"
 import FrontendModelPreloader from "../../src/frontend-models/preloader.js"
@@ -507,6 +507,51 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
         expect(projectedTask.readCount("commentsCount")).toEqual(1)
         expect(projectedProject.id()).toEqual(project.id())
         expect(() => projectedTask.name()).toThrow(/Task#name was not selected/)
+      } finally {
+        offUpdate()
+        resetFrontendModelTransport()
+        await websocketClient.close()
+      }
+    })
+  })
+
+  it("filters model lifecycle update events with a frontend query", async () => {
+    await Dummy.run(async () => {
+      const websocketClient = new WebsocketClient()
+      const matchingProject = await ProjectRecord.create({name: "Filtered event project"})
+      const otherProject = await ProjectRecord.create({name: "Filtered event other project"})
+      const matchingTask = await TaskRecord.create({name: "Filtered matching original", project: matchingProject})
+      const otherTask = await TaskRecord.create({name: "Filtered other original", project: otherProject})
+
+      configureWebsocketSharedTransport(websocketClient)
+
+      /** @type {Array<{id: string, model: Task}>} */
+      const updates = []
+      const offUpdate = await Task.onUpdate((event) => {
+        updates.push({id: event.id, model: /** @type {Task} */ (event.model)})
+      }, Task
+        .where({project: {id: matchingProject.id()}})
+        .select(["id"])
+      )
+
+      try {
+        otherTask.setName("Filtered other renamed")
+        await otherTask.save()
+        await wait(100)
+
+        expect(updates).toEqual([])
+
+        matchingTask.setName("Filtered matching renamed")
+        await matchingTask.save()
+
+        await waitFor(() => {
+          if (updates.length < 1) throw new Error(`Expected filtered onUpdate but got ${updates.length}`)
+        })
+        await wait(100)
+
+        expect(updates.map((update) => update.id)).toEqual([String(matchingTask.id())])
+        expect(updates[0].model.id()).toEqual(matchingTask.id())
+        expect(() => updates[0].model.name()).toThrow(/Task#name was not selected/)
       } finally {
         offUpdate()
         resetFrontendModelTransport()

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -560,6 +560,27 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
     })
   })
 
+  it("rejects tampered frontend-model event filter params", async () => {
+    await Dummy.run(async () => {
+      const websocketClient = new WebsocketClient()
+      await websocketClient.connect()
+      const subscription = websocketClient.subscribeChannel("frontend-models", {
+        params: {
+          eventFilters: [{key: "tampered", model: "Project", where: {id: 1}}],
+          model: "Task"
+        }
+      })
+
+      try {
+        await expect(async () => {
+          await subscription.waitForReady()
+        }).toThrow(/eventFilters entries cannot include model/)
+      } finally {
+        await websocketClient.close()
+      }
+    })
+  })
+
   it("auto-merges attributes on instance-level onUpdate and fires onDestroy once", async () => {
     await Dummy.run(async () => {
       const websocketClient = new WebsocketClient()

--- a/spec/frontend-models/model-event-hooks.browser-spec.js
+++ b/spec/frontend-models/model-event-hooks.browser-spec.js
@@ -67,6 +67,7 @@ describe("Frontend model event hooks", () => {
     if (!result) return
 
     expect(result.classCreatePreloadProject).toEqual(1)
+    expect(result.classCreateQueryPassed).toEqual(1)
     expect(result.classCreateSelectCount).toEqual(2)
     expect(result.instanceUpdateSelectCount).toEqual(1)
     expect(result.instanceUpdateWithCountComments).toEqual(1)

--- a/src/database/table-data/table-column.js
+++ b/src/database/table-data/table-column.js
@@ -344,7 +344,10 @@ export default class TableColumn {
       }
 
       sql += ")"
-    } else if (defaultValue) {
+    } else if (defaultValue !== undefined && defaultValue !== null) {
+      // Emit falsy defaults too (`0`, `false`, `""`). A truthiness check here
+      // silently dropped `default: 0`, leaving the column NOT NULL with no
+      // default so inserts that omit it fail in strict mode.
       sql += ` DEFAULT ${options.quote(defaultValue)}`
     }
 

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -3,7 +3,7 @@
 import * as inflection from "inflection"
 import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
-import FrontendModelQuery, {frontendModelProjectionPayload} from "./query.js"
+import FrontendModelQuery, {frontendModelEventOptionsPayload} from "./query.js"
 import FrontendModelPreloader from "./preloader.js"
 import {registerFrontendModel, resolveFrontendModelClass} from "./model-registry.js"
 import {validateFrontendModelResourceCommandName, validateFrontendModelResourcePath} from "./resource-config-validation.js"
@@ -728,7 +728,7 @@ function cloneFrontendModelAttributes(value) {
 const FRONTEND_MODELS_CHANNEL_NAME = "frontend-models"
 
 /**
- * @typedef {{callback: (payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void, projectionPayload: import("./query.js").FrontendModelProjectionPayload}} FrontendModelModelEventCallbackEntry
+ * @typedef {{callback: (payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void, eventFilterKey: string | null, eventFilterPayload: import("./query.js").FrontendModelEventFilterPayload | null, projectionPayload: import("./query.js").FrontendModelProjectionPayload}} FrontendModelModelEventCallbackEntry
  */
 /**
  * @typedef {{callback: (payload: {id: string}) => void}} FrontendModelDestroyEventCallbackEntry
@@ -811,6 +811,11 @@ function mergeFrontendModelEventProjectionPayload(target, source) {
     mergeFrontendModelEventSelect(target.select, source.select)
   }
 
+  if (source.selectsExtra) {
+    if (!target.selectsExtra) target.selectsExtra = {}
+    mergeFrontendModelEventSelect(target.selectsExtra, source.selectsExtra)
+  }
+
   if (source.withCount) {
     if (!target.withCount) target.withCount = []
     mergeUniqueFrontendModelEventEntries(target.withCount, source.withCount)
@@ -831,6 +836,44 @@ function mergeFrontendModelEventProjectionPayload(target, source) {
       targetQueryData.push(entry)
     }
   }
+}
+
+/**
+ * @param {unknown} body - Raw websocket event body.
+ * @returns {Set<string>} - Matched event filter keys delivered by the backend.
+ */
+function frontendModelMatchedEventFilterKeys(body) {
+  if (!body || typeof body !== "object") return new Set()
+
+  const keys = /** @type {{matchedEventFilterKeys?: unknown}} */ (body).matchedEventFilterKeys
+
+  if (!Array.isArray(keys)) return new Set()
+
+  return new Set(keys.map((key) => String(key)))
+}
+
+/**
+ * @param {FrontendModelModelEventCallbackEntry} entry - Callback entry.
+ * @param {Set<string>} matchedEventFilterKeys - Backend matched filter keys.
+ * @returns {boolean} Whether the callback should receive the event.
+ */
+function frontendModelEventEntryMatches(entry, matchedEventFilterKeys) {
+  if (!entry.eventFilterKey) return true
+
+  return matchedEventFilterKeys.has(entry.eventFilterKey)
+}
+
+/**
+ * @param {typeof FrontendModelBase} ModelClass - Event model class.
+ * @param {import("./query.js").FrontendModelEventOptions} options - Event options.
+ * @returns {void}
+ */
+function assertNoDestroyEventFilter(ModelClass, options) {
+  const eventOptionsPayload = frontendModelEventOptionsPayload(ModelClass, options)
+
+  if (!eventOptionsPayload.eventFilterKey) return
+
+  throw new Error("Frontend model destroy event subscriptions do not support query filters")
 }
 
 /**
@@ -865,26 +908,48 @@ class FrontendModelEventSubscription {
   }
 
   /**
-   * @returns {{model: string} & import("./query.js").FrontendModelProjectionPayload} - Current websocket subscription params.
+   * @returns {{model: string, eventFilters?: import("./query.js").FrontendModelEventFilterPayloadEntry[], unfilteredEventDelivery?: boolean} & import("./query.js").FrontendModelProjectionPayload} - Current websocket subscription params.
    */
   subscriptionParams() {
     /** @type {import("./query.js").FrontendModelProjectionPayload} */
     const projectionPayload = {}
+    /** @type {Record<string, import("./query.js").FrontendModelEventFilterPayloadEntry>} */
+    const eventFiltersByKey = {}
     const projectionEntries = []
+    let hasUnfilteredEventDelivery = this.classDestroyCallbacks.size > 0
 
     for (const entry of this.classCreateCallbacks) projectionEntries.push(entry)
     for (const entry of this.classUpdateCallbacks) projectionEntries.push(entry)
 
     for (const listener of this.instanceListeners.values()) {
       for (const entry of listener.updateCallbacks) projectionEntries.push(entry)
+      if (listener.destroyCallbacks.size > 0) hasUnfilteredEventDelivery = true
     }
 
     for (const entry of projectionEntries) {
       mergeFrontendModelEventProjectionPayload(projectionPayload, entry.projectionPayload)
+
+      if (entry.eventFilterKey && entry.eventFilterPayload) {
+        eventFiltersByKey[entry.eventFilterKey] = {
+          ...entry.eventFilterPayload,
+          key: entry.eventFilterKey
+        }
+      } else {
+        hasUnfilteredEventDelivery = true
+      }
     }
+
+    const eventFilters = Object.values(eventFiltersByKey)
+    const eventFilterParams = eventFilters.length > 0
+      ? {
+          eventFilters,
+          ...(hasUnfilteredEventDelivery ? {unfilteredEventDelivery: true} : {})
+        }
+      : {}
 
     return {
       model: this.ModelClass.getModelName(),
+      ...eventFilterParams,
       ...projectionPayload
     }
   }
@@ -964,6 +1029,7 @@ class FrontendModelEventSubscription {
     if (rawId === undefined || rawId === null) return
 
     const id = String(rawId)
+    const matchedEventFilterKeys = frontendModelMatchedEventFilterKeys(body)
 
     if (action === "destroy") {
       const listener = this.instanceListeners.get(id)
@@ -987,21 +1053,29 @@ class FrontendModelEventSubscription {
     const listener = this.instanceListeners.get(id)
 
     if (action === "update" && listener) {
-      // Auto-merge into the registered instance so callers reading
-      // through the same handle see fresh attributes.
-      const instanceAny = /** @type {any} */ (listener.instance)
+      const matchingUpdateCallbacks = Array.from(listener.updateCallbacks).filter((entry) =>
+        frontendModelEventEntryMatches(entry, matchedEventFilterKeys)
+      )
 
-      instanceAny.assignAttributes(freshModel.attributes())
-      instanceAny._persistedAttributes = cloneFrontendModelAttributes(listener.instance.attributes())
+      if (matchingUpdateCallbacks.length > 0) {
+        // Auto-merge into the registered instance so callers reading
+        // through the same handle see fresh attributes.
+        const instanceAny = /** @type {any} */ (listener.instance)
 
-      for (const entry of listener.updateCallbacks) {
-        try { entry.callback({id, model: listener.instance}) } catch (error) { console.error(error) }
+        instanceAny.assignAttributes(freshModel.attributes())
+        instanceAny._persistedAttributes = cloneFrontendModelAttributes(listener.instance.attributes())
+
+        for (const entry of matchingUpdateCallbacks) {
+          try { entry.callback({id, model: listener.instance}) } catch (error) { console.error(error) }
+        }
       }
     }
 
     const classCallbacks = action === "create" ? this.classCreateCallbacks : this.classUpdateCallbacks
 
     for (const entry of classCallbacks) {
+      if (!frontendModelEventEntryMatches(entry, matchedEventFilterKeys)) continue
+
       try { entry.callback({id, model: freshModel}) } catch (error) { console.error(error) }
     }
   }
@@ -2673,16 +2747,17 @@ export default class FrontendModelBase {
   /**
    * Class-level hook fired when any record of this model is created.
    * Subscribe-time authorization only — once a subscription is
-   * accepted, every future `create` event for this model is delivered
-   * without re-checking per-record visibility.
+   * accepted, future `create` events for this model are delivered
+   * without re-checking per-record visibility. Query options can still
+   * narrow which events reach this callback.
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
-   * @param {import("./query.js").FrontendModelProjectionOptions} [options] - Event record projection options.
+   * @param {import("./query.js").FrontendModelEventOptions} [options] - Event query or record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
   static async onCreate(callback, options = {}) {
     const sub = ensureFrontendModelEventSubscription(this)
-    const entry = {callback, projectionPayload: frontendModelProjectionPayload(this, options)}
+    const entry = {callback, ...frontendModelEventOptionsPayload(this, options)}
 
     sub.classCreateCallbacks.add(entry)
     await sub.ensureSubscribed()
@@ -2697,12 +2772,12 @@ export default class FrontendModelBase {
    * Class-level hook fired when any record of this model is updated.
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
-   * @param {import("./query.js").FrontendModelProjectionOptions} [options] - Event record projection options.
+   * @param {import("./query.js").FrontendModelEventOptions} [options] - Event query or record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
   static async onUpdate(callback, options = {}) {
     const sub = ensureFrontendModelEventSubscription(this)
-    const entry = {callback, projectionPayload: frontendModelProjectionPayload(this, options)}
+    const entry = {callback, ...frontendModelEventOptionsPayload(this, options)}
 
     sub.classUpdateCallbacks.add(entry)
     await sub.ensureSubscribed()
@@ -2717,10 +2792,12 @@ export default class FrontendModelBase {
    * Class-level hook fired when any record of this model is destroyed.
    * @this {typeof FrontendModelBase}
    * @param {(payload: {id: string}) => void} callback - Event callback.
-   * @param {import("./query.js").FrontendModelProjectionOptions} [_options] - Accepted for API symmetry; destroy events carry ids only.
+   * @param {import("./query.js").FrontendModelEventOptions} [options] - Accepted for API symmetry; destroy events carry ids only.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  static async onDestroy(callback, _options = {}) {
+  static async onDestroy(callback, options = {}) {
+    assertNoDestroyEventFilter(this, options)
+
     const sub = ensureFrontendModelEventSubscription(this)
     const entry = {callback}
 
@@ -2739,7 +2816,7 @@ export default class FrontendModelBase {
    * before the callback runs, so callers can read fresh values via
    * `this.someAttr()` without re-fetching.
    * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
-   * @param {import("./query.js").FrontendModelProjectionOptions} [options] - Event record projection options.
+   * @param {import("./query.js").FrontendModelEventOptions} [options] - Event query or record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
   async onUpdate(callback, options = {}) {
@@ -2747,7 +2824,7 @@ export default class FrontendModelBase {
     const ModelClass = /** @type {typeof FrontendModelBase} */ (this.constructor)
     const sub = ensureFrontendModelEventSubscription(ModelClass)
     const id = String(self.id())
-    const entry = {callback, projectionPayload: frontendModelProjectionPayload(ModelClass, options)}
+    const entry = {callback, ...frontendModelEventOptionsPayload(ModelClass, options)}
     let listener = sub.instanceListeners.get(id)
 
     if (!listener) {
@@ -2776,12 +2853,15 @@ export default class FrontendModelBase {
   /**
    * Instance-level hook fired when THIS record is destroyed.
    * @param {(payload: {id: string}) => void} callback - Event callback.
-   * @param {import("./query.js").FrontendModelProjectionOptions} [_options] - Accepted for API symmetry; destroy events carry ids only.
+   * @param {import("./query.js").FrontendModelEventOptions} [options] - Accepted for API symmetry; destroy events carry ids only.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
-  async onDestroy(callback, _options = {}) {
+  async onDestroy(callback, options = {}) {
     const self = /** @type {any} */ (this)
     const ModelClass = /** @type {typeof FrontendModelBase} */ (this.constructor)
+
+    assertNoDestroyEventFilter(ModelClass, options)
+
     const sub = ensureFrontendModelEventSubscription(ModelClass)
     const id = String(self.id())
     const entry = {callback}

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -30,6 +30,12 @@ import {isModelScopeDescriptor} from "../utils/model-scope.js"
  * @property {string | Array<string | Record<string, FrontendModelTransportValue>> | Record<string, FrontendModelTransportValue>} [queryData] - Backend query data names/spec.
  */
 /**
+ * @typedef {FrontendModelProjectionOptions & {query?: FrontendModelQuery<typeof import("./base.js").default>}} FrontendModelEventOptionsObject
+ */
+/**
+ * @typedef {FrontendModelEventOptionsObject | FrontendModelQuery<typeof import("./base.js").default>} FrontendModelEventOptions
+ */
+/**
  * @typedef {object} FrontendModelProjectionPayload
  * @property {Record<string, string[]>} [select] - Normalized select map.
  * @property {Record<string, string[]>} [selectsExtra] - Normalized extra select map.
@@ -37,6 +43,21 @@ import {isModelScopeDescriptor} from "../utils/model-scope.js"
  * @property {FrontendModelWithCountPayloadEntry[]} [withCount] - Normalized count specs.
  * @property {FrontendModelAbilitiesPayloadEntry[]} [abilities] - Normalized ability specs.
  * @property {FrontendModelTransportValue} [queryData] - Normalized queryData spec.
+ */
+/**
+ * @typedef {object} FrontendModelEventFilterPayload
+ * @property {Record<string, FrontendModelTransportValue>} [joins] - Relationship joins needed for matching.
+ * @property {FrontendModelSearch[]} [searches] - Search predicates needed for matching.
+ * @property {Record<string, FrontendModelTransportValue>} [where] - Structured where predicates needed for matching.
+ */
+/**
+ * @typedef {FrontendModelEventFilterPayload & {key: string}} FrontendModelEventFilterPayloadEntry
+ */
+/**
+ * @typedef {object} FrontendModelEventOptionsPayload
+ * @property {string | null} eventFilterKey - Stable event filter key, or null when no filter is present.
+ * @property {FrontendModelEventFilterPayload | null} eventFilterPayload - Normalized event filter payload, or null when unfiltered.
+ * @property {FrontendModelProjectionPayload} projectionPayload - Normalized event serialization projection payload.
  */
 
 /**
@@ -1648,6 +1669,68 @@ export default class FrontendModelQuery {
   }
 
   /**
+   * @returns {void}
+   * @throws {Error} When the query contains list-only options that cannot filter a single lifecycle event.
+   */
+  assertEventQuerySupported() {
+    /** @type {string[]} */
+    const unsupportedOptions = []
+
+    if (this._sort.length > 0) unsupportedOptions.push("sort")
+    if (this._group.length > 0) unsupportedOptions.push("group")
+    if (this._distinct) unsupportedOptions.push("distinct")
+    if (this._limit !== null || this._offset !== null || this._page !== null || this._perPage !== null) unsupportedOptions.push("pagination")
+
+    if (unsupportedOptions.length === 0) return
+
+    throw new Error(`Frontend model event queries do not support ${unsupportedOptions.join(", ")}`)
+  }
+
+  /**
+   * @returns {FrontendModelProjectionPayload} - Projection payload used when serializing lifecycle events.
+   */
+  eventProjectionPayload() {
+    this.assertEventQuerySupported()
+
+    return {
+      ...this.preloadPayload(),
+      ...this.selectPayload(),
+      ...this.selectsExtraPayload(),
+      ...this.withCountPayload(),
+      ...this.abilitiesPayload(),
+      ...this.queryDataPayload()
+    }
+  }
+
+  /**
+   * @returns {FrontendModelEventFilterPayload | null} - Query pieces used to match lifecycle events.
+   */
+  eventFilterPayload() {
+    this.assertEventQuerySupported()
+
+    const payload = {
+      ...this.joinsPayload(),
+      ...this.searchPayload(),
+      ...this.wherePayload()
+    }
+
+    return Object.keys(payload).length === 0 ? null : payload
+  }
+
+  /**
+   * @returns {FrontendModelEventOptionsPayload} - Combined event filter and projection payload.
+   */
+  eventOptionsPayload() {
+    const eventFilterPayload = this.eventFilterPayload()
+
+    return {
+      eventFilterKey: eventFilterPayload ? frontendModelEventFilterKey(eventFilterPayload) : null,
+      eventFilterPayload,
+      projectionPayload: this.eventProjectionPayload()
+    }
+  }
+
+  /**
    * @returns {Promise<InstanceType<T>[]>} - Loaded model instances.
    */
   async load() {
@@ -1919,6 +2002,63 @@ export default class FrontendModelQuery {
 }
 
 /**
+ * @param {FrontendModelEventFilterPayload} payload - Event filter payload.
+ * @returns {string} - Stable key for event filter matching.
+ */
+function frontendModelEventFilterKey(payload) {
+  return JSON.stringify(payload)
+}
+
+/**
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Query receiving projection options.
+ * @param {FrontendModelProjectionOptions} options - Projection options.
+ * @returns {void}
+ */
+function applyFrontendModelProjectionOptions(query, options) {
+  if (options.select !== undefined) query.select(options.select)
+  if (options.selectsExtra !== undefined) query.selectsExtra(options.selectsExtra)
+  if (options.preload !== undefined) query.preload(options.preload)
+  if (options.withCount !== undefined) query.withCount(options.withCount)
+  if (options.abilities !== undefined) query.abilities(options.abilities)
+  if (options.queryData !== undefined) query.queryData(options.queryData)
+}
+
+/**
+ * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {FrontendModelEventOptions} [options] - Event query or projection options.
+ * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Normalized query used by event subscriptions.
+ */
+function frontendModelEventQuery(modelClass, options = {}) {
+  if (options instanceof FrontendModelQuery) {
+    if (options.modelClass !== modelClass) {
+      throw new Error(`Cannot subscribe ${modelClass.name} events with a ${options.modelClass.name} query`)
+    }
+
+    return options.clone()
+  }
+
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new Error(`Frontend model event options must be a query or an options object, got: ${options}`)
+  }
+
+  if (options.query !== undefined && !(options.query instanceof FrontendModelQuery)) {
+    throw new Error("Frontend model event option query must be a FrontendModelQuery")
+  }
+
+  const query = options.query
+    ? options.query.clone()
+    : new FrontendModelQuery({modelClass})
+
+  if (query.modelClass !== modelClass) {
+    throw new Error(`Cannot subscribe ${modelClass.name} events with a ${query.modelClass.name} query`)
+  }
+
+  applyFrontendModelProjectionOptions(query, options)
+
+  return query
+}
+
+/**
  * @param {typeof import("./base.js").default} modelClass - Frontend model class.
  * @param {FrontendModelProjectionOptions} [options] - Projection options.
  * @returns {FrontendModelProjectionPayload} - Normalized frontend-model projection payload.
@@ -1926,21 +2066,18 @@ export default class FrontendModelQuery {
 export function frontendModelProjectionPayload(modelClass, options = {}) {
   const query = new FrontendModelQuery({modelClass})
 
-  if (options.select !== undefined) query.select(options.select)
-  if (options.selectsExtra !== undefined) query.selectsExtra(options.selectsExtra)
-  if (options.preload !== undefined) query.preload(options.preload)
-  if (options.withCount !== undefined) query.withCount(options.withCount)
-  if (options.abilities !== undefined) query.abilities(options.abilities)
-  if (options.queryData !== undefined) query.queryData(options.queryData)
+  applyFrontendModelProjectionOptions(query, options)
 
-  return {
-    ...query.preloadPayload(),
-    ...query.selectPayload(),
-    ...query.selectsExtraPayload(),
-    ...query.withCountPayload(),
-    ...query.abilitiesPayload(),
-    ...query.queryDataPayload()
-  }
+  return query.eventProjectionPayload()
+}
+
+/**
+ * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {FrontendModelEventOptions} [options] - Event query or projection options.
+ * @returns {FrontendModelEventOptionsPayload} - Normalized event subscription payload.
+ */
+export function frontendModelEventOptionsPayload(modelClass, options = {}) {
+  return frontendModelEventQuery(modelClass, options).eventOptionsPayload()
 }
 
 /**

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -1671,6 +1671,69 @@ export default class FrontendModelQuery {
   }
 
   /**
+   * @returns {void}
+   * @throws {Error} When the query contains list-only options that cannot filter a single lifecycle event.
+   */
+  assertEventQuerySupported() {
+    /** @type {string[]} */
+    const unsupportedOptions = []
+
+    if (this._sort.length > 0) unsupportedOptions.push("sort")
+    if (this._group.length > 0) unsupportedOptions.push("group")
+    if (this._distinct) unsupportedOptions.push("distinct")
+    if (this._limit !== null || this._offset !== null || this._page !== null || this._perPage !== null) unsupportedOptions.push("pagination")
+
+    if (unsupportedOptions.length === 0) return
+
+    throw new Error(`Frontend model event queries do not support ${unsupportedOptions.join(", ")}`)
+  }
+
+  /**
+   * @returns {FrontendModelProjectionPayload} - Projection payload used when serializing lifecycle events.
+   */
+  eventProjectionPayload() {
+    this.assertEventQuerySupported()
+
+    return {
+      ...this.preloadPayload(),
+      ...this.selectPayload(),
+      ...this.selectsExtraPayload(),
+      ...this.withCountPayload(),
+      ...this.abilitiesPayload(),
+      ...this.queryDataPayload()
+    }
+  }
+
+  /**
+   * @returns {FrontendModelEventFilterPayload | null} - Query pieces used to match lifecycle events.
+   */
+  eventFilterPayload() {
+    this.assertEventQuerySupported()
+
+    const payload = {
+      ...this.joinsPayload(),
+      ...this.searchPayload(),
+      ...this.wherePayload()
+    }
+
+    return Object.keys(payload).length === 0 ? null : payload
+  }
+
+  /**
+   * @returns {FrontendModelEventOptionsPayload} - Combined event filter and projection payload.
+   */
+  // fallow-ignore-next-line unused-class-member
+  eventOptionsPayload() {
+    const eventFilterPayload = this.eventFilterPayload()
+
+    return {
+      eventFilterKey: eventFilterPayload ? frontendModelEventFilterKey(eventFilterPayload) : null,
+      eventFilterPayload,
+      projectionPayload: this.eventProjectionPayload()
+    }
+  }
+
+  /**
    * @returns {Promise<InstanceType<T>[]>} - Loaded model instances.
    */
   async load() {
@@ -1950,72 +2013,6 @@ function frontendModelEventFilterKey(payload) {
 }
 
 /**
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
- * @returns {void}
- * @throws {Error} When the query contains list-only options that cannot filter a single lifecycle event.
- */
-function assertFrontendModelEventQuerySupported(query) {
-  /** @type {string[]} */
-  const unsupportedOptions = []
-
-  if (query._sort.length > 0) unsupportedOptions.push("sort")
-  if (query._group.length > 0) unsupportedOptions.push("group")
-  if (query._distinct) unsupportedOptions.push("distinct")
-  if (query._limit !== null || query._offset !== null || query._page !== null || query._perPage !== null) unsupportedOptions.push("pagination")
-
-  if (unsupportedOptions.length === 0) return
-
-  throw new Error(`Frontend model event queries do not support ${unsupportedOptions.join(", ")}`)
-}
-
-/**
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
- * @returns {FrontendModelProjectionPayload} - Projection payload used when serializing lifecycle events.
- */
-function frontendModelEventProjectionPayload(query) {
-  assertFrontendModelEventQuerySupported(query)
-
-  return {
-    ...query.preloadPayload(),
-    ...query.selectPayload(),
-    ...query.selectsExtraPayload(),
-    ...query.withCountPayload(),
-    ...query.abilitiesPayload(),
-    ...query.queryDataPayload()
-  }
-}
-
-/**
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
- * @returns {FrontendModelEventFilterPayload | null} - Query pieces used to match lifecycle events.
- */
-function frontendModelEventFilterPayload(query) {
-  assertFrontendModelEventQuerySupported(query)
-
-  const payload = {
-    ...query.joinsPayload(),
-    ...query.searchPayload(),
-    ...query.wherePayload()
-  }
-
-  return Object.keys(payload).length === 0 ? null : payload
-}
-
-/**
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
- * @returns {FrontendModelEventOptionsPayload} - Combined event filter and projection payload.
- */
-function frontendModelEventOptionsPayloadFromQuery(query) {
-  const eventFilterPayload = frontendModelEventFilterPayload(query)
-
-  return {
-    eventFilterKey: eventFilterPayload ? frontendModelEventFilterKey(eventFilterPayload) : null,
-    eventFilterPayload,
-    projectionPayload: frontendModelEventProjectionPayload(query)
-  }
-}
-
-/**
  * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Query receiving projection options.
  * @param {FrontendModelProjectionOptions} options - Projection options.
  * @returns {void}
@@ -2030,23 +2027,43 @@ function applyFrontendModelProjectionOptions(query, options) {
 }
 
 /**
- * @param {typeof import("./base.js").default} modelClass - Frontend model class.
- * @param {FrontendModelEventOptions} [options] - Event query or projection options.
- * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Normalized query used by event subscriptions.
+ * @param {typeof import("./base.js").default} modelClass - Expected frontend model class.
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @returns {void}
  */
-function frontendModelEventQuery(modelClass, options = {}) {
-  if (options instanceof FrontendModelQuery) {
-    if (options.modelClass !== modelClass) {
-      throw new Error(`Cannot subscribe ${modelClass.name} events with a ${options.modelClass.name} query`)
-    }
+function assertFrontendModelEventQueryClass(modelClass, query) {
+  if (query.modelClass === modelClass) return
 
-    return options.clone()
-  }
+  throw new Error(`Cannot subscribe ${modelClass.name} events with a ${query.modelClass.name} query`)
+}
 
-  if (!options || typeof options !== "object" || Array.isArray(options)) {
-    throw new Error(`Frontend model event options must be a query or an options object, got: ${options}`)
-  }
+/**
+ * @param {FrontendModelEventOptions} options - Candidate event options.
+ * @returns {void}
+ */
+function assertFrontendModelEventOptionsObject(options) {
+  if (options && typeof options === "object" && !Array.isArray(options)) return
 
+  throw new Error(`Frontend model event options must be a query or an options object, got: ${options}`)
+}
+
+/**
+ * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Cloned query used by event subscriptions.
+ */
+function clonedFrontendModelEventQuery(modelClass, query) {
+  assertFrontendModelEventQueryClass(modelClass, query)
+
+  return query.clone()
+}
+
+/**
+ * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {FrontendModelEventOptionsObject} options - Event options object.
+ * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Query used by event subscriptions.
+ */
+function frontendModelEventQueryFromOptionsObject(modelClass, options) {
   if (options.query !== undefined && !(options.query instanceof FrontendModelQuery)) {
     throw new Error("Frontend model event option query must be a FrontendModelQuery")
   }
@@ -2055,11 +2072,25 @@ function frontendModelEventQuery(modelClass, options = {}) {
     ? options.query.clone()
     : new FrontendModelQuery({modelClass})
 
-  if (query.modelClass !== modelClass) {
-    throw new Error(`Cannot subscribe ${modelClass.name} events with a ${query.modelClass.name} query`)
-  }
+  assertFrontendModelEventQueryClass(modelClass, query)
 
-  applyFrontendModelProjectionOptions(query, options)
+  return query
+}
+
+/**
+ * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {FrontendModelEventOptions} [options] - Event query or projection options.
+ * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Normalized query used by event subscriptions.
+ */
+function frontendModelEventQuery(modelClass, options = {}) {
+  if (options instanceof FrontendModelQuery) return clonedFrontendModelEventQuery(modelClass, options)
+
+  assertFrontendModelEventOptionsObject(options)
+
+  const optionsObject = /** @type {FrontendModelEventOptionsObject} */ (options)
+  const query = frontendModelEventQueryFromOptionsObject(modelClass, optionsObject)
+
+  applyFrontendModelProjectionOptions(query, optionsObject)
 
   return query
 }
@@ -2070,7 +2101,7 @@ function frontendModelEventQuery(modelClass, options = {}) {
  * @returns {FrontendModelEventOptionsPayload} - Normalized event subscription payload.
  */
 export function frontendModelEventOptionsPayload(modelClass, options = {}) {
-  return frontendModelEventOptionsPayloadFromQuery(frontendModelEventQuery(modelClass, options))
+  return frontendModelEventQuery(modelClass, options).eventOptionsPayload()
 }
 
 /**

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -1324,6 +1324,7 @@ export default class FrontendModelQuery {
    * @param {any} value - Search value.
    * @returns {this} - Query with appended search.
    */
+  // fallow-ignore-next-line unused-class-member
   search(path, column, operator, value) {
     if (!Array.isArray(path)) {
       throw new Error(`search path must be an array, got: ${typeof path}`)
@@ -1401,6 +1402,7 @@ export default class FrontendModelQuery {
    * @param {number} value - Maximum number of records.
    * @returns {this} - Query with limit.
    */
+  // fallow-ignore-next-line unused-class-member
   limit(value) {
     this._limit = normalizeIntegerArgument(value, "limit", {min: 0})
     this._page = null
@@ -1666,68 +1668,6 @@ export default class FrontendModelQuery {
     if (this._perPage !== null) payload.perPage = this._perPage
 
     return payload
-  }
-
-  /**
-   * @returns {void}
-   * @throws {Error} When the query contains list-only options that cannot filter a single lifecycle event.
-   */
-  assertEventQuerySupported() {
-    /** @type {string[]} */
-    const unsupportedOptions = []
-
-    if (this._sort.length > 0) unsupportedOptions.push("sort")
-    if (this._group.length > 0) unsupportedOptions.push("group")
-    if (this._distinct) unsupportedOptions.push("distinct")
-    if (this._limit !== null || this._offset !== null || this._page !== null || this._perPage !== null) unsupportedOptions.push("pagination")
-
-    if (unsupportedOptions.length === 0) return
-
-    throw new Error(`Frontend model event queries do not support ${unsupportedOptions.join(", ")}`)
-  }
-
-  /**
-   * @returns {FrontendModelProjectionPayload} - Projection payload used when serializing lifecycle events.
-   */
-  eventProjectionPayload() {
-    this.assertEventQuerySupported()
-
-    return {
-      ...this.preloadPayload(),
-      ...this.selectPayload(),
-      ...this.selectsExtraPayload(),
-      ...this.withCountPayload(),
-      ...this.abilitiesPayload(),
-      ...this.queryDataPayload()
-    }
-  }
-
-  /**
-   * @returns {FrontendModelEventFilterPayload | null} - Query pieces used to match lifecycle events.
-   */
-  eventFilterPayload() {
-    this.assertEventQuerySupported()
-
-    const payload = {
-      ...this.joinsPayload(),
-      ...this.searchPayload(),
-      ...this.wherePayload()
-    }
-
-    return Object.keys(payload).length === 0 ? null : payload
-  }
-
-  /**
-   * @returns {FrontendModelEventOptionsPayload} - Combined event filter and projection payload.
-   */
-  eventOptionsPayload() {
-    const eventFilterPayload = this.eventFilterPayload()
-
-    return {
-      eventFilterKey: eventFilterPayload ? frontendModelEventFilterKey(eventFilterPayload) : null,
-      eventFilterPayload,
-      projectionPayload: this.eventProjectionPayload()
-    }
   }
 
   /**
@@ -2010,6 +1950,72 @@ function frontendModelEventFilterKey(payload) {
 }
 
 /**
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @returns {void}
+ * @throws {Error} When the query contains list-only options that cannot filter a single lifecycle event.
+ */
+function assertFrontendModelEventQuerySupported(query) {
+  /** @type {string[]} */
+  const unsupportedOptions = []
+
+  if (query._sort.length > 0) unsupportedOptions.push("sort")
+  if (query._group.length > 0) unsupportedOptions.push("group")
+  if (query._distinct) unsupportedOptions.push("distinct")
+  if (query._limit !== null || query._offset !== null || query._page !== null || query._perPage !== null) unsupportedOptions.push("pagination")
+
+  if (unsupportedOptions.length === 0) return
+
+  throw new Error(`Frontend model event queries do not support ${unsupportedOptions.join(", ")}`)
+}
+
+/**
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @returns {FrontendModelProjectionPayload} - Projection payload used when serializing lifecycle events.
+ */
+function frontendModelEventProjectionPayload(query) {
+  assertFrontendModelEventQuerySupported(query)
+
+  return {
+    ...query.preloadPayload(),
+    ...query.selectPayload(),
+    ...query.selectsExtraPayload(),
+    ...query.withCountPayload(),
+    ...query.abilitiesPayload(),
+    ...query.queryDataPayload()
+  }
+}
+
+/**
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @returns {FrontendModelEventFilterPayload | null} - Query pieces used to match lifecycle events.
+ */
+function frontendModelEventFilterPayload(query) {
+  assertFrontendModelEventQuerySupported(query)
+
+  const payload = {
+    ...query.joinsPayload(),
+    ...query.searchPayload(),
+    ...query.wherePayload()
+  }
+
+  return Object.keys(payload).length === 0 ? null : payload
+}
+
+/**
+ * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @returns {FrontendModelEventOptionsPayload} - Combined event filter and projection payload.
+ */
+function frontendModelEventOptionsPayloadFromQuery(query) {
+  const eventFilterPayload = frontendModelEventFilterPayload(query)
+
+  return {
+    eventFilterKey: eventFilterPayload ? frontendModelEventFilterKey(eventFilterPayload) : null,
+    eventFilterPayload,
+    projectionPayload: frontendModelEventProjectionPayload(query)
+  }
+}
+
+/**
  * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Query receiving projection options.
  * @param {FrontendModelProjectionOptions} options - Projection options.
  * @returns {void}
@@ -2060,24 +2066,11 @@ function frontendModelEventQuery(modelClass, options = {}) {
 
 /**
  * @param {typeof import("./base.js").default} modelClass - Frontend model class.
- * @param {FrontendModelProjectionOptions} [options] - Projection options.
- * @returns {FrontendModelProjectionPayload} - Normalized frontend-model projection payload.
- */
-export function frontendModelProjectionPayload(modelClass, options = {}) {
-  const query = new FrontendModelQuery({modelClass})
-
-  applyFrontendModelProjectionOptions(query, options)
-
-  return query.eventProjectionPayload()
-}
-
-/**
- * @param {typeof import("./base.js").default} modelClass - Frontend model class.
  * @param {FrontendModelEventOptions} [options] - Event query or projection options.
  * @returns {FrontendModelEventOptionsPayload} - Normalized event subscription payload.
  */
 export function frontendModelEventOptionsPayload(modelClass, options = {}) {
-  return frontendModelEventQuery(modelClass, options).eventOptionsPayload()
+  return frontendModelEventOptionsPayloadFromQuery(frontendModelEventQuery(modelClass, options))
 }
 
 /**

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -5,6 +5,7 @@ import {useEffect, useMemo, useRef} from "react"
 
 import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
 import {modelsDependencyKey, modelsFromInput} from "./event-hook-models.js"
+import {frontendModelEventOptionsPayload} from "./query.js"
 import useModelClassEvent from "./use-model-class-event.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
@@ -34,7 +35,7 @@ function assertNoUnknownOptions(restOptions) {
 function eventQueryDependencyPayload(query) {
   if (!query) return null
 
-  return query.eventOptionsPayload()
+  return frontendModelEventOptionsPayload(query.modelClass, query)
 }
 
 /**

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -28,6 +28,16 @@ function assertNoUnknownOptions(restOptions) {
 }
 
 /**
+ * @param {import("./query.js").default<FrontendModelClass> | undefined} query - Event query option.
+ * @returns {import("./query.js").FrontendModelEventOptionsPayload | null} Stable dependency payload.
+ */
+function eventQueryDependencyPayload(query) {
+  if (!query) return null
+
+  return query.eventOptionsPayload()
+}
+
+/**
  * React hook for frontend-model destroy events. Pass a model class for class-level
  * destroy events, or a model / model array for instance-level destroy events.
  * @param {FrontendModelClass | FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelClassOrModels - Model class, model, or models.
@@ -36,12 +46,12 @@ function assertNoUnknownOptions(restOptions) {
  * @returns {void}
  */
 export default function useDestroyedEvent(modelClassOrModels, callback, options = {}) {
-  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount, ...restOptions} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, query, queryData, select, selectsExtra, withCount, ...restOptions} = options
   assertNoUnknownOptions(restOptions)
 
   const classModel = typeof modelClassOrModels === "function" ? modelClassOrModels : null
   const instanceModels = typeof modelClassOrModels === "function" ? null : modelClassOrModels
-  const projectionOptions = {abilities, preload, queryData, select, withCount}
+  const projectionOptions = {abilities, preload, query, queryData, select, selectsExtra, withCount}
 
   useModelClassEvent(classModel, "destroy", callback, {active: active && Boolean(classModel), debounce, onConnected, ...projectionOptions})
   useInstanceDestroyedEvent(instanceModels, callback, {active: active && !classModel, debounce, onConnected, ...projectionOptions})
@@ -54,12 +64,12 @@ export default function useDestroyedEvent(modelClassOrModels, callback, options 
  * @returns {void}
  */
 function useInstanceDestroyedEvent(modelOrModels, callback, options) {
-  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount} = options
-  const projectionKey = JSON.stringify({abilities, preload, queryData, select, withCount})
-  const projectionOptionsRef = useRef({abilities, preload, queryData, select, withCount})
+  const {active = true, abilities, debounce = false, onConnected, preload, query, queryData, select, selectsExtra, withCount} = options
+  const projectionKey = JSON.stringify({abilities, preload, query: eventQueryDependencyPayload(query), queryData, select, selectsExtra, withCount})
+  const projectionOptionsRef = useRef({abilities, preload, query, queryData, select, selectsExtra, withCount})
   const callbackRef = useRef(callback)
   const activeRef = useRef(active)
-  projectionOptionsRef.current = {abilities, preload, queryData, select, withCount}
+  projectionOptionsRef.current = {abilities, preload, query, queryData, select, selectsExtra, withCount}
   callbackRef.current = callback
   activeRef.current = active
 

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -5,7 +5,6 @@ import {useEffect, useMemo, useRef} from "react"
 
 import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
 import {modelsDependencyKey, modelsFromInput} from "./event-hook-models.js"
-import {frontendModelEventOptionsPayload} from "./query.js"
 import useModelClassEvent from "./use-model-class-event.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
@@ -23,9 +22,9 @@ import useModelClassEvent from "./use-model-class-event.js"
 function assertNoUnknownOptions(restOptions) {
   const unknownOptionNames = Object.keys(restOptions)
 
-  if (unknownOptionNames.length > 0) {
-    throw new Error(`Unknown options given to useDestroyedEvent: ${unknownOptionNames.join(", ")}`)
-  }
+  if (unknownOptionNames.length === 0) return
+
+  throw new Error(`Unknown options given to useDestroyedEvent: ${unknownOptionNames.join(", ")}`)
 }
 
 /**
@@ -35,7 +34,7 @@ function assertNoUnknownOptions(restOptions) {
 function eventQueryDependencyPayload(query) {
   if (!query) return null
 
-  return frontendModelEventOptionsPayload(query.modelClass, query)
+  return query.eventOptionsPayload()
 }
 
 /**

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -12,7 +12,7 @@ import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js
 /** @typedef {{id: string}} FrontendModelDestroyEventPayload */
 /** @typedef {FrontendModelCreateUpdateEventPayload | FrontendModelDestroyEventPayload} FrontendModelClassEventPayload */
 /** @typedef {(payload: FrontendModelClassEventPayload) => void} FrontendModelClassEventCallback */
-/** @typedef {{active?: boolean, debounce?: boolean | number, onConnected?: () => void} & import("./query.js").FrontendModelProjectionOptions} UseModelClassEventOptions */
+/** @typedef {{active?: boolean, debounce?: boolean | number, onConnected?: () => void} & import("./query.js").FrontendModelEventOptionsObject} UseModelClassEventOptions */
 
 /**
  * @param {FrontendModelClassEventName | FrontendModelClassEventName[]} eventOrEvents - Event name or names.
@@ -43,10 +43,20 @@ function assertNoUnknownOptions(restOptions) {
 }
 
 /**
+ * @param {import("./query.js").default<FrontendModelClass> | undefined} query - Event query option.
+ * @returns {import("./query.js").FrontendModelEventOptionsPayload | null} Stable dependency payload.
+ */
+function eventQueryDependencyPayload(query) {
+  if (!query) return null
+
+  return query.eventOptionsPayload()
+}
+
+/**
  * @param {FrontendModelClass} modelClass - Frontend model class.
  * @param {FrontendModelClassEventName} eventName - Event name.
  * @param {FrontendModelClassEventCallback} callback - Event callback.
- * @param {import("./query.js").FrontendModelProjectionOptions} options - Event record projection options.
+ * @param {import("./query.js").FrontendModelEventOptionsObject} options - Event query or record projection options.
  * @returns {Promise<() => void>} - Unsubscribe callback.
  */
 async function subscribeToModelClassEvent(modelClass, eventName, callback, options) {
@@ -66,14 +76,14 @@ async function subscribeToModelClassEvent(modelClass, eventName, callback, optio
  * @returns {void}
  */
 export default function useModelClassEvent(modelClass, eventOrEvents, callback, options = {}) {
-  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount, ...restOptions} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, query, queryData, select, selectsExtra, withCount, ...restOptions} = options
   assertNoUnknownOptions(restOptions)
 
-  const projectionKey = JSON.stringify({abilities, preload, queryData, select, withCount})
-  const projectionOptionsRef = useRef({abilities, preload, queryData, select, withCount})
+  const projectionKey = JSON.stringify({abilities, preload, query: eventQueryDependencyPayload(query), queryData, select, selectsExtra, withCount})
+  const projectionOptionsRef = useRef({abilities, preload, query, queryData, select, selectsExtra, withCount})
   const callbackRef = useRef(callback)
   const activeRef = useRef(active)
-  projectionOptionsRef.current = {abilities, preload, queryData, select, withCount}
+  projectionOptionsRef.current = {abilities, preload, query, queryData, select, selectsExtra, withCount}
   callbackRef.current = callback
   activeRef.current = active
 

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -4,6 +4,7 @@ import debounceFunction from "debounce"
 import {useEffect, useMemo, useRef} from "react"
 
 import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
+import {frontendModelEventOptionsPayload} from "./query.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
 /** @typedef {InstanceType<FrontendModelClass>} FrontendModelInstance */
@@ -49,7 +50,7 @@ function assertNoUnknownOptions(restOptions) {
 function eventQueryDependencyPayload(query) {
   if (!query) return null
 
-  return query.eventOptionsPayload()
+  return frontendModelEventOptionsPayload(query.modelClass, query)
 }
 
 /**

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -4,7 +4,6 @@ import debounceFunction from "debounce"
 import {useEffect, useMemo, useRef} from "react"
 
 import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
-import {frontendModelEventOptionsPayload} from "./query.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
 /** @typedef {InstanceType<FrontendModelClass>} FrontendModelInstance */
@@ -14,22 +13,6 @@ import {frontendModelEventOptionsPayload} from "./query.js"
 /** @typedef {FrontendModelCreateUpdateEventPayload | FrontendModelDestroyEventPayload} FrontendModelClassEventPayload */
 /** @typedef {(payload: FrontendModelClassEventPayload) => void} FrontendModelClassEventCallback */
 /** @typedef {{active?: boolean, debounce?: boolean | number, onConnected?: () => void} & import("./query.js").FrontendModelEventOptionsObject} UseModelClassEventOptions */
-
-/**
- * @param {FrontendModelClassEventName | FrontendModelClassEventName[]} eventOrEvents - Event name or names.
- * @returns {FrontendModelClassEventName[]} - Normalized event names.
- */
-function normalizeEventNames(eventOrEvents) {
-  return Array.isArray(eventOrEvents) ? eventOrEvents : [eventOrEvents]
-}
-
-/**
- * @param {FrontendModelClassEventName[]} eventNames - Event names.
- * @returns {string} - Stable dependency key.
- */
-function eventNamesDependencyKey(eventNames) {
-  return eventNames.join("|")
-}
 
 /**
  * @param {Record<string, import("./query.js").FrontendModelTransportValue | (() => void) | undefined>} restOptions - Unknown options object.
@@ -50,7 +33,23 @@ function assertNoUnknownOptions(restOptions) {
 function eventQueryDependencyPayload(query) {
   if (!query) return null
 
-  return frontendModelEventOptionsPayload(query.modelClass, query)
+  return query.eventOptionsPayload()
+}
+
+/**
+ * @param {FrontendModelClassEventName | FrontendModelClassEventName[]} eventOrEvents - Event name or names.
+ * @returns {FrontendModelClassEventName[]} - Normalized event names.
+ */
+function normalizeEventNames(eventOrEvents) {
+  return Array.isArray(eventOrEvents) ? eventOrEvents : [eventOrEvents]
+}
+
+/**
+ * @param {FrontendModelClassEventName[]} eventNames - Event names.
+ * @returns {string} - Stable dependency key.
+ */
+function eventNamesDependencyKey(eventNames) {
+  return eventNames.join("|")
 }
 
 /**

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -5,7 +5,6 @@ import {useEffect, useMemo, useRef} from "react"
 
 import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
 import {modelsDependencyKey, modelsFromInput} from "./event-hook-models.js"
-import {frontendModelEventOptionsPayload} from "./query.js"
 import useModelClassEvent from "./use-model-class-event.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
@@ -35,7 +34,7 @@ function assertNoUnknownOptions(restOptions) {
 function eventQueryDependencyPayload(query) {
   if (!query) return null
 
-  return frontendModelEventOptionsPayload(query.modelClass, query)
+  return query.eventOptionsPayload()
 }
 
 /**

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -28,6 +28,16 @@ function assertNoUnknownOptions(restOptions) {
 }
 
 /**
+ * @param {import("./query.js").default<FrontendModelClass> | undefined} query - Event query option.
+ * @returns {import("./query.js").FrontendModelEventOptionsPayload | null} Stable dependency payload.
+ */
+function eventQueryDependencyPayload(query) {
+  if (!query) return null
+
+  return query.eventOptionsPayload()
+}
+
+/**
  * React hook for frontend-model update events. Pass a model class for class-level
  * update events, or a model / model array for instance-level update events.
  * @param {FrontendModelClass | FrontendModelInstance | FrontendModelInstance[] | null | undefined} modelClassOrModels - Model class, model, or models.
@@ -36,12 +46,12 @@ function assertNoUnknownOptions(restOptions) {
  * @returns {void}
  */
 export default function useUpdatedEvent(modelClassOrModels, callback, options = {}) {
-  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount, ...restOptions} = options
+  const {active = true, abilities, debounce = false, onConnected, preload, query, queryData, select, selectsExtra, withCount, ...restOptions} = options
   assertNoUnknownOptions(restOptions)
 
   const classModel = typeof modelClassOrModels === "function" ? modelClassOrModels : null
   const instanceModels = typeof modelClassOrModels === "function" ? null : modelClassOrModels
-  const projectionOptions = {abilities, preload, queryData, select, withCount}
+  const projectionOptions = {abilities, preload, query, queryData, select, selectsExtra, withCount}
 
   useModelClassEvent(classModel, "update", (payload) => {
     callback(/** @type {FrontendModelClassUpdateEventPayload} */ (payload))
@@ -56,12 +66,12 @@ export default function useUpdatedEvent(modelClassOrModels, callback, options = 
  * @returns {void}
  */
 function useInstanceUpdatedEvent(modelOrModels, callback, options) {
-  const {active = true, abilities, debounce = false, onConnected, preload, queryData, select, withCount} = options
-  const projectionKey = JSON.stringify({abilities, preload, queryData, select, withCount})
-  const projectionOptionsRef = useRef({abilities, preload, queryData, select, withCount})
+  const {active = true, abilities, debounce = false, onConnected, preload, query, queryData, select, selectsExtra, withCount} = options
+  const projectionKey = JSON.stringify({abilities, preload, query: eventQueryDependencyPayload(query), queryData, select, selectsExtra, withCount})
+  const projectionOptionsRef = useRef({abilities, preload, query, queryData, select, selectsExtra, withCount})
   const callbackRef = useRef(callback)
   const activeRef = useRef(active)
-  projectionOptionsRef.current = {abilities, preload, queryData, select, withCount}
+  projectionOptionsRef.current = {abilities, preload, query, queryData, select, selectsExtra, withCount}
   callbackRef.current = callback
   activeRef.current = active
 

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -5,6 +5,7 @@ import {useEffect, useMemo, useRef} from "react"
 
 import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js"
 import {modelsDependencyKey, modelsFromInput} from "./event-hook-models.js"
+import {frontendModelEventOptionsPayload} from "./query.js"
 import useModelClassEvent from "./use-model-class-event.js"
 
 /** @typedef {typeof import("./base.js").default} FrontendModelClass */
@@ -34,7 +35,7 @@ function assertNoUnknownOptions(restOptions) {
 function eventQueryDependencyPayload(query) {
   if (!query) return null
 
-  return query.eventOptionsPayload()
+  return frontendModelEventOptionsPayload(query.modelClass, query)
 }
 
 /**

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -4,6 +4,8 @@ import VelociousWebsocketChannel from "../http-server/websocket-channel.js"
 import Response from "../http-server/client/response.js"
 import {serializeFrontendModelTransportValue} from "./transport-serialization.js"
 
+const EVENT_FILTER_KEYS = new Set(["joins", "key", "searches", "where"])
+
 /**
  * @typedef {{action?: string, id?: string | number, matchedEventFilterKeys?: string[], record?: import("./query.js").FrontendModelTransportValue, [key: string]: import("./query.js").FrontendModelTransportValue | string[] | undefined}} FrontendModelLifecycleBroadcastBody
  */
@@ -200,12 +202,32 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
       }
 
       const eventFilter = /** @type {Record<string, unknown>} */ (entry)
+      const unknownKeys = Object.keys(eventFilter).filter((key) => !EVENT_FILTER_KEYS.has(key))
+
+      if (unknownKeys.length > 0) {
+        throw new Error(`Frontend model eventFilters entries cannot include ${unknownKeys.join(", ")}`)
+      }
 
       if (typeof eventFilter.key !== "string" || eventFilter.key.length === 0) {
         throw new Error("Frontend model eventFilters entries require a key")
       }
 
-      return /** @type {import("./query.js").FrontendModelEventFilterPayloadEntry} */ (eventFilter)
+      /** @type {import("./query.js").FrontendModelEventFilterPayloadEntry} */
+      const sanitizedEventFilter = {key: eventFilter.key}
+
+      if (eventFilter.joins !== undefined) {
+        sanitizedEventFilter.joins = /** @type {Record<string, import("./query.js").FrontendModelTransportValue>} */ (eventFilter.joins)
+      }
+
+      if (eventFilter.searches !== undefined) {
+        sanitizedEventFilter.searches = /** @type {import("./query.js").FrontendModelSearch[]} */ (eventFilter.searches)
+      }
+
+      if (eventFilter.where !== undefined) {
+        sanitizedEventFilter.where = /** @type {Record<string, import("./query.js").FrontendModelTransportValue>} */ (eventFilter.where)
+      }
+
+      return sanitizedEventFilter
     })
   }
 
@@ -281,7 +303,11 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
    * @returns {Promise<boolean>} Whether the record matches the filter.
    */
   async _eventMatchesFilter({FrontendModelController, eventFilter, id}) {
-    const controller = this._frontendModelController(FrontendModelController, eventFilter)
+    const controller = this._frontendModelController(FrontendModelController, {
+      joins: eventFilter.joins,
+      searches: eventFilter.searches,
+      where: eventFilter.where
+    })
 
     await controller.ensureFrontendModelClassInitialized()
 

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -5,7 +5,7 @@ import Response from "../http-server/client/response.js"
 import {serializeFrontendModelTransportValue} from "./transport-serialization.js"
 
 /**
- * @typedef {{action?: string, id?: string | number, record?: import("./query.js").FrontendModelTransportValue, [key: string]: import("./query.js").FrontendModelTransportValue | undefined}} FrontendModelLifecycleBroadcastBody
+ * @typedef {{action?: string, id?: string | number, matchedEventFilterKeys?: string[], record?: import("./query.js").FrontendModelTransportValue, [key: string]: import("./query.js").FrontendModelTransportValue | string[] | undefined}} FrontendModelLifecycleBroadcastBody
  */
 /**
  * @typedef {{headers?: () => Record<string, string | string[] | undefined>, remoteAddress?: () => string | undefined}} FrontendModelWebsocketUpgradeRequest
@@ -20,10 +20,13 @@ import {serializeFrontendModelTransportValue} from "./transport-serialization.js
  *
  * Auth model: subscribe-time only. `canSubscribe` resolves the caller's
  * ability once, checks that at least one `allow` rule exists for
- * `read` on the requested model class, and then delivers every future
- * lifecycle broadcast for that model without re-authorizing per event.
+ * `read` on the requested model class, and then delivers future
+ * lifecycle broadcasts for that model without re-authorizing per event.
  * This matches the explicit design decision in Phase 3 to trade
  * per-record visibility guarantees for massively cheaper broadcast fan-out.
+ * Subscriber-provided event filters can still narrow which create/update
+ * events are delivered, but they are matching predicates rather than
+ * per-record authorization checks.
  *
  * Wire: subscribe with `subscribeChannel("frontend-models", {params: {model: ModelName}})`.
  * Backend publishes `{action, id, record}` via
@@ -39,6 +42,7 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
     const modelName = this._modelName()
 
     if (!modelName) return false
+    this._eventFilters()
 
     const configuration = this.session.configuration
     const modelClasses = configuration.getModelClasses?.() || {}
@@ -75,31 +79,77 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
    * @returns {Promise<void>} Resolves after delivery.
    */
   async deliverBroadcast(body, meta) {
-    if (!this._hasProjectionParams()) {
+    const configuration = this.session.configuration
+
+    if (configuration && typeof configuration.ensureConnections === "function") {
+      await configuration.ensureConnections(async () => {
+        await this._deliverBroadcast(body, meta)
+      })
+      return
+    }
+
+    await this._deliverBroadcast(body, meta)
+  }
+
+  /**
+   * @param {FrontendModelLifecycleBroadcastBody} body - Broadcast body.
+   * @param {{eventId?: string}} [meta] - Optional event metadata.
+   * @returns {Promise<void>} Resolves after delivery.
+   */
+  async _deliverBroadcast(body, meta) {
+    const hasEventFilters = this._hasEventFilterParams()
+
+    if (!this._hasProjectionParams() && !hasEventFilters) {
       this.sendMessage(body, meta)
       return
     }
 
-    if (!body || typeof body !== "object" || body.action === "destroy") {
-      this.sendMessage(body, meta)
+    if (!body || typeof body !== "object") {
+      if (!hasEventFilters || this._hasUnfilteredEventDelivery()) this.sendMessage(body, meta)
+      return
+    }
+
+    if (body.action === "destroy") {
+      if (!hasEventFilters || this._hasUnfilteredEventDelivery()) this.sendMessage(body, meta)
       return
     }
 
     if (body.id === undefined || body.id === null) {
-      this.sendMessage(body, meta)
+      if (!hasEventFilters || this._hasUnfilteredEventDelivery()) this.sendMessage(body, meta)
       return
     }
 
-    const projectedRecord = await this._projectedRecordForEventId(body.id)
+    const FrontendModelController = await this._frontendModelControllerClass()
+    const matchedEventFilterKeys = await this._matchedEventFilterKeysForEventId(body.id, FrontendModelController)
 
-    if (!projectedRecord) {
+    if (hasEventFilters && matchedEventFilterKeys.length === 0 && !this._hasUnfilteredEventDelivery()) {
       return
     }
 
-    this.sendMessage({
-      ...body,
-      record: serializeFrontendModelTransportValue(projectedRecord)
-    }, meta)
+    /** @type {FrontendModelLifecycleBroadcastBody} */
+    let deliverBody = body
+
+    if (this._hasProjectionParams()) {
+      const projectedRecord = await this._projectedRecordForEventId(body.id, FrontendModelController)
+
+      if (!projectedRecord) {
+        return
+      }
+
+      deliverBody = {
+        ...deliverBody,
+        record: /** @type {import("./query.js").FrontendModelTransportValue} */ (serializeFrontendModelTransportValue(projectedRecord))
+      }
+    }
+
+    if (hasEventFilters) {
+      deliverBody = {
+        ...deliverBody,
+        matchedEventFilterKeys
+      }
+    }
+
+    this.sendMessage(deliverBody, meta)
   }
 
   /**
@@ -120,17 +170,59 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
   /** @returns {boolean} - Whether this subscription requested per-event record projection. */
   _hasProjectionParams() {
     return this.params.select !== undefined
+      || this.params.selectsExtra !== undefined
       || this.params.preload !== undefined
       || this.params.withCount !== undefined
       || this.params.abilities !== undefined
       || this.params.queryData !== undefined
   }
 
+  /** @returns {boolean} - Whether this subscription requested event query filters. */
+  _hasEventFilterParams() {
+    return this._eventFilters().length > 0
+  }
+
+  /** @returns {boolean} - Whether unfiltered callbacks should receive every event. */
+  _hasUnfilteredEventDelivery() {
+    return this.params.unfilteredEventDelivery === true
+  }
+
+  /** @returns {import("./query.js").FrontendModelEventFilterPayloadEntry[]} - Valid event filters. */
+  _eventFilters() {
+    if (this.params.eventFilters === undefined) return []
+    if (!Array.isArray(this.params.eventFilters)) {
+      throw new Error("Frontend model eventFilters must be an array")
+    }
+
+    return this.params.eventFilters.map((entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error("Frontend model eventFilters entries must be objects")
+      }
+
+      const eventFilter = /** @type {Record<string, unknown>} */ (entry)
+
+      if (typeof eventFilter.key !== "string" || eventFilter.key.length === 0) {
+        throw new Error("Frontend model eventFilters entries require a key")
+      }
+
+      return /** @type {import("./query.js").FrontendModelEventFilterPayloadEntry} */ (eventFilter)
+    })
+  }
+
+  /** @returns {Promise<typeof import("../frontend-model-controller.js").default>} - Frontend model controller class. */
+  async _frontendModelControllerClass() {
+    const frontendModelControllerPath = "../frontend-model-controller.js"
+    const {default: FrontendModelController} = await import(frontendModelControllerPath)
+
+    return FrontendModelController
+  }
+
   /**
    * @param {typeof import("../frontend-model-controller.js").default} FrontendModelController - Server-side frontend-model controller class.
+   * @param {Record<string, unknown>} [params] - Optional params override.
    * @returns {import("../frontend-model-controller.js").default} - Synthetic controller used for resource serialization.
    */
-  _frontendModelController(FrontendModelController) {
+  _frontendModelController(FrontendModelController, params = {}) {
     const configuration = this.session.configuration
     const controller = new FrontendModelController({
       action: "websocketEvent",
@@ -138,10 +230,15 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
       controller: "frontend-models",
       params: {
         abilities: this.params.abilities,
+        joins: this.params.joins,
         model: this._modelName(),
         preload: this.params.preload,
         queryData: this.params.queryData,
+        searches: this.params.searches,
         select: this.params.select,
+        selectsExtra: this.params.selectsExtra,
+        where: this.params.where,
+        ...params,
         withCount: this.params.withCount
       },
       request: /** @type {import("../http-server/client/request.js").default} */ (this._syntheticRequest()),
@@ -156,18 +253,67 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
 
   /**
    * @param {string | number} id - Event record id.
+   * @param {typeof import("../frontend-model-controller.js").default} FrontendModelController - Server-side frontend-model controller class.
+   * @returns {Promise<string[]>} - Event filter keys matched by the record.
+   */
+  async _matchedEventFilterKeysForEventId(id, FrontendModelController) {
+    /** @type {string[]} */
+    const matchedEventFilterKeys = []
+
+    for (const eventFilter of this._eventFilters()) {
+      const matches = await this._eventMatchesFilter({
+        FrontendModelController,
+        eventFilter,
+        id
+      })
+
+      if (matches) matchedEventFilterKeys.push(eventFilter.key)
+    }
+
+    return matchedEventFilterKeys
+  }
+
+  /**
+   * @param {object} args - Filter args.
+   * @param {typeof import("../frontend-model-controller.js").default} args.FrontendModelController - Server-side frontend-model controller class.
+   * @param {import("./query.js").FrontendModelEventFilterPayloadEntry} args.eventFilter - Event filter payload.
+   * @param {string | number} args.id - Event record id.
+   * @returns {Promise<boolean>} Whether the record matches the filter.
+   */
+  async _eventMatchesFilter({FrontendModelController, eventFilter, id}) {
+    const controller = this._frontendModelController(FrontendModelController, eventFilter)
+
+    await controller.ensureFrontendModelClassInitialized()
+
+    const ModelClass = controller.frontendModelClass()
+    const primaryKey = ModelClass.primaryKey()
+    const where = controller.frontendModelWhere()
+    const joins = controller.frontendModelJoins()
+    let query = ModelClass.where({[ModelClass.tableName()]: {[primaryKey]: id}})
+
+    if (where) controller.applyFrontendModelWhere({query, where})
+    if (joins) controller.applyFrontendModelJoins({joins, query})
+
+    for (const search of controller.frontendModelSearches()) {
+      controller.applyFrontendModelSearch({query, search})
+    }
+
+    return Boolean(await query.first())
+  }
+
+  /**
+   * @param {string | number} id - Event record id.
+   * @param {typeof import("../frontend-model-controller.js").default} FrontendModelController - Server-side frontend-model controller class.
    * @returns {Promise<Record<string, import("./query.js").FrontendModelTransportValue> | null>} - Serialized projected record.
    */
-  async _projectedRecordForEventId(id) {
-    const frontendModelControllerPath = "../frontend-model-controller.js"
-    const {default: FrontendModelController} = await import(frontendModelControllerPath)
+  async _projectedRecordForEventId(id, FrontendModelController) {
     const controller = this._frontendModelController(FrontendModelController)
 
     await controller.ensureFrontendModelClassInitialized()
 
     const ModelClass = controller.frontendModelClass()
     const primaryKey = ModelClass.primaryKey()
-    let query = ModelClass.where({[primaryKey]: id})
+    let query = ModelClass.where({[ModelClass.tableName()]: {[primaryKey]: id}})
     const preload = controller.frontendModelPreload()
 
     if (preload) query = query.preload(preload)

--- a/src/testing/browser-frontend-model-event-hook-scenarios.js
+++ b/src/testing/browser-frontend-model-event-hook-scenarios.js
@@ -10,7 +10,6 @@ import useModelClassEvent from "../frontend-models/use-model-class-event.js"
 import useUpdatedEvent from "../frontend-models/use-updated-event.js"
 import wait from "awaitery/build/wait.js"
 
-/** @typedef {import("../frontend-models/query.js").FrontendModelProjectionOptions} FrontendModelProjectionOptions */
 /** @typedef {import("../frontend-models/base.js").FrontendModelResourceConfig} FrontendModelResourceConfig */
 /** @typedef {{id: string, model: FrontendModelBase}} FrontendModelHookTestCreateUpdatePayload */
 /** @typedef {{id: string}} FrontendModelHookTestDestroyPayload */
@@ -18,7 +17,7 @@ import wait from "awaitery/build/wait.js"
  * @typedef {object} FakeSubscriptions
  * @property {Set<(payload: FrontendModelHookTestCreateUpdatePayload) => void>} create - Create callbacks.
  * @property {Set<(payload: FrontendModelHookTestDestroyPayload) => void>} destroy - Destroy callbacks.
- * @property {{create: FrontendModelProjectionOptions[], destroy: FrontendModelProjectionOptions[], update: FrontendModelProjectionOptions[]}} options - Subscription options.
+ * @property {{create: import("../frontend-models/query.js").FrontendModelEventOptionsObject[], destroy: import("../frontend-models/query.js").FrontendModelEventOptionsObject[], update: import("../frontend-models/query.js").FrontendModelEventOptionsObject[]}} options - Subscription options.
  * @property {Set<(payload: FrontendModelHookTestCreateUpdatePayload) => void>} update - Update callbacks.
  */
 
@@ -101,7 +100,7 @@ function buildFakeModelClass() {
 
     /**
      * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
-     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @param {import("../frontend-models/query.js").FrontendModelEventOptionsObject} [options] - Event query or projection options.
      * @returns {Promise<() => void>} - Unsubscribe callback.
      */
     static async onCreate(callback, options = {}) {
@@ -113,7 +112,7 @@ function buildFakeModelClass() {
 
     /**
      * @param {(payload: FrontendModelHookTestDestroyPayload) => void} callback - Event callback.
-     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @param {import("../frontend-models/query.js").FrontendModelEventOptionsObject} [options] - Event query or projection options.
      * @returns {Promise<() => void>} - Unsubscribe callback.
      */
     static async onDestroy(callback, options = {}) {
@@ -125,7 +124,7 @@ function buildFakeModelClass() {
 
     /**
      * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
-     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @param {import("../frontend-models/query.js").FrontendModelEventOptionsObject} [options] - Event query or projection options.
      * @returns {Promise<() => void>} - Unsubscribe callback.
      */
     static async onUpdate(callback, options = {}) {
@@ -177,7 +176,7 @@ function buildFakeModel(id, subscriptions) {
 
     /**
      * @param {(payload: FrontendModelHookTestDestroyPayload) => void} callback - Event callback.
-     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @param {import("../frontend-models/query.js").FrontendModelEventOptionsObject} [options] - Event query or projection options.
      * @returns {Promise<() => void>} - Unsubscribe callback.
      */
     async onDestroy(callback, options = {}) {
@@ -189,7 +188,7 @@ function buildFakeModel(id, subscriptions) {
 
     /**
      * @param {(payload: FrontendModelHookTestCreateUpdatePayload) => void} callback - Event callback.
-     * @param {FrontendModelProjectionOptions} [options] - Projection options.
+     * @param {import("../frontend-models/query.js").FrontendModelEventOptionsObject} [options] - Event query or projection options.
      * @returns {Promise<() => void>} - Unsubscribe callback.
      */
     async onUpdate(callback, options = {}) {
@@ -302,11 +301,15 @@ async function projectionOptionsScenario() {
   const {ModelClass, subscriptions: classSubscriptions} = buildFakeModelClass()
   const instanceSubscriptions = buildFakeSubscriptions()
   const model = buildFakeModel("task-1", instanceSubscriptions)
+  const classQuery = ModelClass
+    .where({id: "task-1"})
+    .select(["id"])
 
   /** @returns {React.ReactElement} - Test element. */
   function TestComponent() {
     useCreatedEvent(ModelClass, () => {}, {
       preload: "project",
+      query: classQuery,
       select: {Task: ["id", "nameUppercase"]}
     })
     useUpdatedEvent(model, () => {}, {
@@ -332,6 +335,7 @@ async function projectionOptionsScenario() {
 
   return {
     classCreatePreloadProject: createOptions.preload === "project" ? 1 : 0,
+    classCreateQueryPassed: createOptions.query === classQuery ? 1 : 0,
     classCreateSelectCount: createOptions.select && typeof createOptions.select === "object" && !Array.isArray(createOptions.select) && Array.isArray(createOptions.select.Task) ? createOptions.select.Task.length : 0,
     instanceDestroyPreloadProject: destroyOptions.preload === "project" ? 1 : 0,
     instanceDestroySelectCount: Array.isArray(destroyOptions.select) ? destroyOptions.select.length : 0,


### PR DESCRIPTION
## Summary
- Add query-backed filtering for frontend-model create/update subscriptions while preserving projection options.
- Route matched event-filter keys from the backend websocket channel so multiplexed callbacks only receive matching events.
- Document the event-query API and add focused HTTP/browser coverage.

## Verification
- npm test -- spec/frontend-models/base-spec.js spec/frontend-models/base.http-integration-spec.js
- npm run lint (passes with existing warnings)
- npm run typecheck
- PATH="/tmp/opencode/chromedriver-cache/chromedriver/linux-146.0.7680.165/chromedriver-linux64:$PATH" VELOCIOUS_ENV=test npm run test:browser -- spec/frontend-models/model-event-hooks.browser-spec.js