### PR TITLE
Fix database connection cleanup

### DIFF
--- a/changelog.d/20260605205451-db-connection-cleanup.md
+++ b/changelog.d/20260605205451-db-connection-cleanup.md
@@ -1,0 +1,1 @@
+Fix several CLI and background-job shutdown paths so database connections are closed after command execution, shutdown, and MSSQL reconnects.

--- a/spec/background-jobs/worker-shutdown-spec.js
+++ b/spec/background-jobs/worker-shutdown-spec.js
@@ -87,9 +87,15 @@ describe("Background jobs main - shutdown", () => {
         })
       })
     })
+    main.server = /** @type {import("net").Server} */ ({
+      close: (callback) => {
+        events.push("close-server")
+        callback()
+      }
+    })
 
     await main.stop()
 
-    expect(events).toEqual(["disconnect-beacon", "close-db"])
+    expect(events).toEqual(["disconnect-beacon", "close-server", "close-db"])
   })
 })

--- a/spec/background-jobs/worker-shutdown-spec.js
+++ b/spec/background-jobs/worker-shutdown-spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
 
 /**
  * Builds a worker with a tracked fake forked-runner child whose `kill()` signals
@@ -50,5 +51,45 @@ describe("Background jobs worker - shutdown", () => {
     await worker.stop({timeoutMs: 1000})
 
     expect(signals).toEqual([])
+  })
+
+  it("closes database connections after disconnecting beacon", async () => {
+    /** @type {string[]} */
+    const events = []
+    const worker = new BackgroundJobsWorker({
+      configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeDatabaseConnections: async () => { events.push("close-db") },
+        disconnectBeacon: async () => { events.push("disconnect-beacon") }
+      })
+    })
+    worker.configuration = await worker.configurationPromise
+
+    await worker.stop()
+
+    expect(events).toEqual(["disconnect-beacon", "close-db"])
+  })
+})
+
+describe("Background jobs main - shutdown", () => {
+  it("closes database connections after disconnecting beacon", async () => {
+    /** @type {string[]} */
+    const events = []
+    const main = new BackgroundJobsMain({
+      configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeDatabaseConnections: async () => { events.push("close-db") },
+        disconnectBeacon: async () => { events.push("disconnect-beacon") },
+        getBackgroundJobsConfig: () => ({
+          databaseIdentifier: "default",
+          dispatchStrategy: "beacon",
+          host: "127.0.0.1",
+          pollIntervalMs: 1000,
+          port: 0
+        })
+      })
+    })
+
+    await main.stop()
+
+    expect(events).toEqual(["disconnect-beacon", "close-db"])
   })
 })

--- a/spec/cli/commands/db/create-spec.js
+++ b/spec/cli/commands/db/create-spec.js
@@ -1,7 +1,40 @@
 import Cli from "../../../../src/cli/index.js"
+import DbCreate from "../../../../src/cli/commands/db/create.js"
 import dummyConfiguration from "../../../dummy/src/config/configuration.js"
 import dummyDirectory from "../../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+
+class FakeCreateDriver {
+  static instances = []
+
+  constructor() {
+    this.closed = false
+    this.connected = false
+    FakeCreateDriver.instances.push(this)
+  }
+
+  async connect() { this.connected = true }
+  async close() { this.closed = true }
+  createDatabaseSql() { return ["CREATE DATABASE fake"] }
+  async createTableSql() { return ["CREATE TABLE fake"] }
+}
+
+function fakeMssqlCreateConfiguration() {
+  return {
+    getDatabaseConfiguration: () => ({default: {database: "velocious_test"}}),
+    getDatabaseIdentifiers: () => ["default"],
+    getDatabasePool: () => ({
+      getConfiguration: () => ({
+        driver: FakeCreateDriver,
+        sqlConfig: {database: "velocious_test"},
+        type: "mssql",
+        useDatabase: "master"
+      })
+    }),
+    getDatabaseType: () => "mssql",
+    getEnvironmentHandler: () => ({})
+  }
+}
 
 describe("Cli - Commands - db:create", () => {
   it("generates SQL to create a new database", async () => {
@@ -54,5 +87,22 @@ describe("Cli - Commands - db:create", () => {
         ]
       )
     }
+  })
+
+  it("closes direct MSSQL connections after generating SQL", async () => {
+    FakeCreateDriver.instances = []
+    const command = new DbCreate({
+      args: {
+        configuration: /** @type {import("../../../../src/configuration.js").default} */ (fakeMssqlCreateConfiguration()),
+        testing: true
+      },
+      cli: /** @type {import("../../../../src/cli/index.js").default} */ ({})
+    })
+
+    await command.execute()
+
+    expect(FakeCreateDriver.instances.length).toEqual(1)
+    expect(FakeCreateDriver.instances[0].connected).toBe(true)
+    expect(FakeCreateDriver.instances[0].closed).toBe(true)
   })
 })

--- a/spec/cli/commands/db/drop-spec.js
+++ b/spec/cli/commands/db/drop-spec.js
@@ -1,7 +1,40 @@
 import Cli from "../../../../src/cli/index.js"
+import DbDrop from "../../../../src/cli/commands/db/drop.js"
 import dummyConfiguration from "../../../dummy/src/config/configuration.js"
 import dummyDirectory from "../../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+
+class FakeDropDriver {
+  static instances = []
+
+  constructor() {
+    this.closed = false
+    this.connected = false
+    FakeDropDriver.instances.push(this)
+  }
+
+  async connect() { this.connected = true }
+  async close() { this.closed = true }
+  dropDatabaseSql() { return ["DROP DATABASE fake"] }
+}
+
+function fakeMssqlDropConfiguration() {
+  return {
+    getDatabaseConfiguration: () => ({default: {database: "velocious_test"}}),
+    getDatabaseIdentifiers: () => ["default"],
+    getDatabasePool: () => ({
+      getConfiguration: () => ({
+        driver: FakeDropDriver,
+        sqlConfig: {database: "velocious_test"},
+        type: "mssql",
+        useDatabase: "master"
+      })
+    }),
+    getDatabaseType: () => "mssql",
+    getEnvironment: () => "test",
+    getEnvironmentHandler: () => ({})
+  }
+}
 
 describe("Cli - Commands - db:drop", () => {
   it("generates SQL to drop an existing database", async () => {
@@ -51,5 +84,22 @@ describe("Cli - Commands - db:drop", () => {
         ]
       )
     }
+  })
+
+  it("closes direct MSSQL connections after generating SQL", async () => {
+    FakeDropDriver.instances = []
+    const command = new DbDrop({
+      args: {
+        configuration: /** @type {import("../../../../src/configuration.js").default} */ (fakeMssqlDropConfiguration()),
+        testing: true
+      },
+      cli: /** @type {import("../../../../src/cli/index.js").default} */ ({})
+    })
+
+    await command.execute()
+
+    expect(FakeDropDriver.instances.length).toEqual(1)
+    expect(FakeDropDriver.instances[0].connected).toBe(true)
+    expect(FakeDropDriver.instances[0].closed).toBe(true)
   })
 })

--- a/spec/cli/multiple-commands-spec.js
+++ b/spec/cli/multiple-commands-spec.js
@@ -73,14 +73,17 @@ class FakeEnvironmentHandler {
 }
 
 /**
- * @returns {{closeDatabaseConnections: () => Promise<void>, getEnvironmentHandler: () => FakeEnvironmentHandler, state: {closeCalls: number, executions: string[][]}}} - Fake configuration.
+ * @param {object} [args] - Options object.
+ * @param {Record<string, unknown>} [args.currentConnections] - Current database connections.
+ * @returns {{closeDatabaseConnections: () => Promise<void>, getCurrentConnections: () => Record<string, unknown>, getEnvironmentHandler: () => FakeEnvironmentHandler, state: {closeCalls: number, executions: string[][]}}} - Fake configuration.
  */
-function createConfiguration() {
+function createConfiguration(args = {}) {
   const environmentHandler = new FakeEnvironmentHandler()
   const configuration = {
     closeDatabaseConnections: async () => {
       configuration.state.closeCalls += 1
     },
+    getCurrentConnections: () => args.currentConnections || {},
     getEnvironmentHandler: () => environmentHandler,
     state: {
       closeCalls: 0,
@@ -120,6 +123,21 @@ describe("Cli - Multiple commands", () => {
     expect(result).toEqual("first")
     expect(configuration.state.executions).toEqual([["first"]])
     expect(configuration.state.closeCalls).toEqual(1)
+  })
+
+  it("does not close an existing connection context after a nested command", async () => {
+    const configuration = createConfiguration({currentConnections: {default: {}}})
+    const cli = new Cli({
+      configuration: /** @type {import("../../src/configuration.js").default} */ (configuration),
+      processArgs: ["first"],
+      testing: true
+    })
+
+    const result = await cli.execute()
+
+    expect(result).toEqual("first")
+    expect(configuration.state.executions).toEqual([["first"]])
+    expect(configuration.state.closeCalls).toEqual(0)
   })
 
   it("closes connections when a command fails", async () => {

--- a/spec/cli/multiple-commands-spec.js
+++ b/spec/cli/multiple-commands-spec.js
@@ -27,6 +27,13 @@ class SecondCommand extends BaseCommand {
   }
 }
 
+class FailingCommand extends BaseCommand {
+  /** @returns {Promise<void>} */
+  async execute() {
+    throw new Error("command failed")
+  }
+}
+
 class FakeEnvironmentHandler {
   /**
    * @param {object} args - Args.
@@ -46,7 +53,7 @@ class FakeEnvironmentHandler {
 
   /** @returns {Promise<Array<{name: string}>>} - Available commands. */
   async findCommands() {
-    return [{name: "first"}, {name: "second"}]
+    return [{name: "failing"}, {name: "first"}, {name: "second"}]
   }
 
   /**
@@ -59,6 +66,7 @@ class FakeEnvironmentHandler {
 
     if (commandName == "first") return FirstCommand
     if (commandName == "second") return SecondCommand
+    if (commandName == "failing") return FailingCommand
 
     throw new Error(`Unknown command: ${commandName}`)
   }
@@ -84,7 +92,7 @@ function createConfiguration() {
 }
 
 describe("Cli - Multiple commands", () => {
-  it("runs multiple commands sequentially and closes connections between them", async () => {
+  it("runs multiple commands sequentially and closes connections after each command", async () => {
     const configuration = createConfiguration()
     const cli = new Cli({
       configuration: /** @type {import("../../src/configuration.js").default} */ (configuration),
@@ -96,6 +104,39 @@ describe("Cli - Multiple commands", () => {
 
     expect(result).toEqual("second")
     expect(configuration.state.executions).toEqual([["first"], ["second"]])
+    expect(configuration.state.closeCalls).toEqual(2)
+  })
+
+  it("closes connections after a single command", async () => {
+    const configuration = createConfiguration()
+    const cli = new Cli({
+      configuration: /** @type {import("../../src/configuration.js").default} */ (configuration),
+      processArgs: ["first"],
+      testing: true
+    })
+
+    const result = await cli.execute()
+
+    expect(result).toEqual("first")
+    expect(configuration.state.executions).toEqual([["first"]])
+    expect(configuration.state.closeCalls).toEqual(1)
+  })
+
+  it("closes connections when a command fails", async () => {
+    const configuration = createConfiguration()
+    const cli = new Cli({
+      configuration: /** @type {import("../../src/configuration.js").default} */ (configuration),
+      processArgs: ["failing"],
+      testing: true
+    })
+
+    try {
+      await cli.execute()
+      throw new Error("Expected command to fail")
+    } catch (error) {
+      expect(error.message).toEqual("command failed")
+    }
+
     expect(configuration.state.closeCalls).toEqual(1)
   })
 

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -155,13 +155,16 @@ export default class BackgroundJobsMain {
     try {
       await this.configuration.disconnectBeacon()
     } finally {
-      await this.configuration.closeDatabaseConnections()
+      try {
+        if (this.server) {
+          const {server} = this
+          this.server = undefined
+          await new Promise((resolve) => server.close(() => resolve(undefined)))
+        }
+      } finally {
+        await this.configuration.closeDatabaseConnections()
+      }
     }
-
-    if (!this.server) return
-
-    const {server} = this
-    await new Promise((resolve) => server.close(() => resolve(undefined)))
   }
 
   /**

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -152,7 +152,11 @@ export default class BackgroundJobsMain {
 
     this.scheduler?.stop()
 
-    await this.configuration.disconnectBeacon()
+    try {
+      await this.configuration.disconnectBeacon()
+    } finally {
+      await this.configuration.closeDatabaseConnections()
+    }
 
     if (!this.server) return
 

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -151,7 +151,13 @@ export default class BackgroundJobsWorker {
     await this._terminateForkedChildren()
 
     if (this.jsonSocket) this.jsonSocket.close()
-    if (this.configuration) await this.configuration.disconnectBeacon()
+    if (this.configuration) {
+      try {
+        await this.configuration.disconnectBeacon()
+      } finally {
+        await this.configuration.closeDatabaseConnections()
+      }
+    }
   }
 
   /**

--- a/src/cli/commands/db/create.js
+++ b/src/cli/commands/db/create.js
@@ -38,9 +38,7 @@ export default class DbCreate extends BaseCommand{
 
         await this.createSchemaMigrationsTable()
       } finally {
-        if (databaseType != "mssql") {
-          await this.databaseConnection.close()
-        }
+        await this.databaseConnection.close()
       }
 
       if (this.args.testing) return this.result

--- a/src/cli/commands/db/drop.js
+++ b/src/cli/commands/db/drop.js
@@ -50,9 +50,7 @@ export default class DbDrop extends BaseCommand {
         try {
           await this.dropDatabase(databaseIdentifier)
         } finally {
-          if (databaseType != "mssql") {
-            await this.databaseConnection.close()
-          }
+          await this.databaseConnection.close()
         }
       }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -29,10 +29,14 @@ export default class VelociousCli {
     let result
 
     for (const commandProcessArgs of commandGroups) {
+      const shouldCloseDatabaseConnections = !this.hasCurrentDatabaseConnections()
+
       try {
         result = await this.executeCommand(commandProcessArgs)
       } finally {
-        await this.getConfiguration().closeDatabaseConnections()
+        if (shouldCloseDatabaseConnections) {
+          await this.getConfiguration().closeDatabaseConnections()
+        }
       }
     }
 
@@ -112,6 +116,17 @@ export default class VelociousCli {
 
   /** @returns {import("../configuration.js").default} configuration */
   getConfiguration() { return this.configuration }
+
+  /** @returns {boolean} - Whether the current async context already has database connections. */
+  hasCurrentDatabaseConnections() {
+    try {
+      return Object.keys(this.getConfiguration().getCurrentConnections()).length > 0
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith("No database configuration for environment:")) return false
+
+      throw error
+    }
+  }
 
   /** @returns {boolean} - Whether testing.  */
   getTesting() {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -28,12 +28,12 @@ export default class VelociousCli {
     const commandGroups = await this.commandGroups()
     let result
 
-    for (const [index, commandProcessArgs] of commandGroups.entries()) {
-      if (index > 0) {
+    for (const commandProcessArgs of commandGroups) {
+      try {
+        result = await this.executeCommand(commandProcessArgs)
+      } finally {
         await this.getConfiguration().closeDatabaseConnections()
       }
-
-      result = await this.executeCommand(commandProcessArgs)
     }
 
     return result

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -28,6 +28,8 @@ export default class VelociousDatabaseDriversMssql extends Base{
     const sqlConfig = digg(args, "sqlConfig")
 
     try {
+      if (this.connection) await this.close()
+
       if (sqlConfig?.server && !sqlConfig.options?.serverName && net.isIP(sqlConfig.server)) {
         sqlConfig.options = Object.assign({}, sqlConfig.options, {serverName: ""})
       }
@@ -213,7 +215,7 @@ export default class VelociousDatabaseDriversMssql extends Base{
       } catch (error) {
         if (error instanceof Error && error.message == "No connection is specified for that request." && tries <= 3) {
           this.logger.warn("Reconnecting to database")
-          await this.connect()
+          await this.reconnect()
           // Retry
         } else if (error instanceof Error) {
           // Re-throw error because the stack-trace is broken and can't be used for app-development.

--- a/src/environment-handlers/node/cli/commands/server.js
+++ b/src/environment-handlers/node/cli/commands/server.js
@@ -78,13 +78,6 @@ export function waitForApplicationWithSignalShutdown({application, processObject
 export default class VelociousCliCommandsServer extends BaseCommand{
   /** @returns {Promise<void>} - Starts the HTTP server and waits until it stops. */
   async execute() {
-    this.databasePool = this.getConfiguration().getDatabasePool()
-    /** @type {import("../../../../configuration-types.js").DatabaseConfigurationType} */
-    this.newConfiguration = Object.assign({}, this.databasePool.getConfiguration())
-    this.databaseConnection = await this.databasePool.spawnConnectionWithConfiguration(this.newConfiguration)
-
-    await this.databaseConnection.connect()
-
     const parsedProcessArgs = this.args?.parsedProcessArgs || {}
     const host = String(parsedProcessArgs.h || parsedProcessArgs.host || "127.0.0.1")
     const port = Number(parsedProcessArgs.p || parsedProcessArgs.port || 3006)


### PR DESCRIPTION
## Summary
- close CLI database connections after every command, including failures and single commands
- close direct db:create/db:drop connections for MSSQL and reconnect MSSQL through the cleanup path
- close background-job database pools during main/worker shutdown

## Validation
- npm run test -- spec/cli/multiple-commands-spec.js spec/cli/commands/db/create-spec.js spec/cli/commands/db/drop-spec.js spec/background-jobs/worker-shutdown-spec.js
- npm run lint
- npm run typecheck
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow