### PR TITLE
Expose pool checkout timing in debug snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1442,7 +1442,7 @@ database: {
 }
 ```
 
-`pool.max` caps live async-tracked connections for that pool. When the cap is reached, new checkouts wait until a matching checked-in connection can be handed over or capacity is freed.
+`pool.max` caps live async-tracked connections for that pool. When the cap is reached, new checkouts wait until a matching checked-in connection can be handed over or capacity is freed. The built-in debug endpoint reports each in-use connection's `checkedOutForMs`, each idle connection's `idleForMs`, and queued `pendingCheckouts[].waitingForMs` so production diagnostics can distinguish long-held checkouts from pool-capacity waits.
 
 # Websockets
 

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -44,4 +44,4 @@ For MySQL and MariaDB, Velocious also writes the active checkout name to the ses
 
 For PostgreSQL, Velocious sets `application_name` to the active checkout name and resets it when the connection is checked in. This exposes the checkout owner in `pg_stat_activity.application_name`, including idle checked-out sessions.
 
-When the built-in [Debug Endpoint](debug-endpoint.md) is enabled, its database pool snapshots include live checkout names, active query annotations, transaction depth, and schema-cache sizes for Velocious-owned connections.
+When the built-in [Debug Endpoint](debug-endpoint.md) is enabled, its database pool snapshots include live checkout names, active query annotations, transaction depth, schema-cache sizes, in-use checkout timing (`checkedOutAt`/`checkedOutForMs`), checked-in idle timing (`checkedInAt`/`idleForMs`), and pending checkout timing (`pendingCheckouts[].enqueuedAt`/`waitingForMs`) for Velocious-owned connections.

--- a/docs/debug-endpoint.md
+++ b/docs/debug-endpoint.md
@@ -22,11 +22,11 @@ The payload includes:
 
 * server runtime details such as environment, PID, uptime, Node version, platform, and memory usage
 * configuration flags relevant to debugging, including `debug`, `debugEndpoint`, `autoload`, and tenant database scope enforcement
-* database pool state for every active database identifier, including pool class, resolved non-secret database configuration, idle/in-use/pending connection counts, and spawned connection count
-* live database connection snapshots, including driver class, checkout name, open transaction count, schema cache size, current pool state, reuse key, and active query details when a query is running
+* database pool state for every active database identifier, including pool class, resolved non-secret database configuration, idle/in-use/pending connection counts, spawned connection count, and pending checkout snapshots with `checkoutName`, `enqueuedAt`, and `waitingForMs`
+* live database connection snapshots, including driver class, checkout name, open transaction count, schema cache size, current pool state, reuse key, checkout/check-in timestamps (`checkedOutAt`/`checkedInAt`), elapsed checkout/idle durations (`checkedOutForMs`/`idleForMs`), and active query details when a query is running
 * WebSocket registration and subscription counts
 * background job configuration presence
 
-Database connection snapshots include the same checkout names configured through `configuration.withConnections({name}, ...)` and `configuration.ensureConnections({name}, ...)`. While a query is running, the active query snapshot also includes the active database annotations from `withDatabaseAnnotation(...)`. See [Database Connections](database-connections.md) for checkout names and query annotations.
+Database connection snapshots include the same checkout names configured through `configuration.withConnections({name}, ...)` and `configuration.ensureConnections({name}, ...)`. Use `checkedOutForMs` to find long-held in-use connections, `idleForMs` to confirm checked-in connections are waiting for reuse or reaping, and `pendingCheckouts[].waitingForMs` to spot callers waiting for pool capacity. While a query is running, the active query snapshot also includes the active database annotations from `withDatabaseAnnotation(...)`. See [Database Connections](database-connections.md) for checkout names and query annotations.
 
 Do not enable this endpoint on publicly reachable production servers unless it is protected by application-level network or authentication controls. The response intentionally omits database passwords and cookie secrets, but it still exposes operational details that are useful to attackers.

--- a/spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js
@@ -48,15 +48,27 @@ async function testConfiguration() {
   })
 }
 
+/**
+ * @param {(pool: AsyncTrackedMultiConnection) => Promise<void>} callback - Spec body.
+ * @returns {Promise<void>} - Resolves after closing database connections.
+ */
+async function withCheckoutNamePool(callback) {
+  const configuration = await testConfiguration()
+
+  try {
+    const pool = configuration.getDatabasePool("default")
+
+    if (!(pool instanceof AsyncTrackedMultiConnection)) throw new Error("Expected async tracked pool")
+
+    await callback(pool)
+  } finally {
+    await configuration.closeDatabaseConnections()
+  }
+}
+
 describe("database - pool - async tracked multi connection checkout names", () => {
   it("rejects a queued checkout when activation fails", async () => {
-    const configuration = await testConfiguration()
-
-    try {
-      const pool = configuration.getDatabasePool("default")
-
-      if (!(pool instanceof AsyncTrackedMultiConnection)) throw new Error("Expected async tracked pool")
-
+    await withCheckoutNamePool(async (pool) => {
       const firstConnection = await pool.checkout({name: "first checkout"})
       const queuedCheckout = pool.checkout({name: "fail activation"})
 
@@ -73,19 +85,11 @@ describe("database - pool - async tracked multi connection checkout names", () =
       })
 
       expect(pool.pendingCheckouts.length).toBe(0)
-    } finally {
-      await configuration.closeDatabaseConnections()
-    }
+    })
   })
 
   it("reports in-use and pending checkout timing in debug snapshots", async () => {
-    const configuration = await testConfiguration()
-
-    try {
-      const pool = configuration.getDatabasePool("default")
-
-      if (!(pool instanceof AsyncTrackedMultiConnection)) throw new Error("Expected async tracked pool")
-
+    await withCheckoutNamePool(async (pool) => {
       const firstConnection = await pool.checkout({name: "long checkout"})
       const queuedCheckout = pool.checkout({name: "waiting checkout"})
 
@@ -109,8 +113,6 @@ describe("database - pool - async tracked multi connection checkout names", () =
       const secondConnection = await queuedCheckout
 
       await pool.checkin(secondConnection)
-    } finally {
-      await configuration.closeDatabaseConnections()
-    }
+    })
   })
 })

--- a/spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js
@@ -66,6 +66,29 @@ async function withCheckoutNamePool(callback) {
   }
 }
 
+/**
+ * @param {import("../../../src/database/pool/base.js").DatabasePoolDebugSnapshot} snapshot - Pool debug snapshot.
+ * @returns {void}
+ */
+function expectWaitingCheckoutSnapshot(snapshot) {
+  expect(snapshot.inUseCount).toBe(1)
+  expect(snapshot.pendingCheckoutCount).toBe(1)
+  expect(snapshot.pendingCheckouts?.[0]?.checkoutName).toBe("waiting checkout")
+  expect(snapshot.pendingCheckouts?.[0]?.waitingForMs).toBeGreaterThanOrEqual(0)
+}
+
+/**
+ * @param {import("../../../src/database/pool/base.js").DatabasePoolDebugSnapshot} snapshot - Pool debug snapshot.
+ * @returns {void}
+ */
+function expectLongCheckoutSnapshot(snapshot) {
+  const inUseConnection = snapshot.connections.find((connection) => connection.state === "in-use")
+
+  expect(inUseConnection?.checkoutName).toBe("long checkout")
+  expect(inUseConnection?.checkedOutAt).toBeGreaterThan(0)
+  expect(inUseConnection?.checkedOutForMs).toBeGreaterThanOrEqual(0)
+}
+
 describe("database - pool - async tracked multi connection checkout names", () => {
   it("rejects a queued checkout when activation fails", async () => {
     await withCheckoutNamePool(async (pool) => {
@@ -97,16 +120,8 @@ describe("database - pool - async tracked multi connection checkout names", () =
 
       const snapshot = pool.getDebugSnapshot()
 
-      expect(snapshot.inUseCount).toBe(1)
-      expect(snapshot.pendingCheckoutCount).toBe(1)
-      expect(snapshot.pendingCheckouts?.[0]?.checkoutName).toBe("waiting checkout")
-      expect(snapshot.pendingCheckouts?.[0]?.waitingForMs).toBeGreaterThanOrEqual(0)
-
-      const inUseConnection = snapshot.connections.find((connection) => connection.state === "in-use")
-
-      expect(inUseConnection?.checkoutName).toBe("long checkout")
-      expect(inUseConnection?.checkedOutAt).toBeGreaterThan(0)
-      expect(inUseConnection?.checkedOutForMs).toBeGreaterThanOrEqual(0)
+      expectWaitingCheckoutSnapshot(snapshot)
+      expectLongCheckoutSnapshot(snapshot)
 
       await pool.checkin(firstConnection)
 

--- a/spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js
@@ -8,6 +8,7 @@ import os from "os"
 import path from "path"
 import SqliteDriver from "../../../src/database/drivers/sqlite/index.js"
 import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
 import {describe, expect, it} from "../../../src/testing/test.js"
 
 class CheckoutNameFailingSqliteDriver extends SqliteDriver {
@@ -72,6 +73,42 @@ describe("database - pool - async tracked multi connection checkout names", () =
       })
 
       expect(pool.pendingCheckouts.length).toBe(0)
+    } finally {
+      await configuration.closeDatabaseConnections()
+    }
+  })
+
+  it("reports in-use and pending checkout timing in debug snapshots", async () => {
+    const configuration = await testConfiguration()
+
+    try {
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) throw new Error("Expected async tracked pool")
+
+      const firstConnection = await pool.checkout({name: "long checkout"})
+      const queuedCheckout = pool.checkout({name: "waiting checkout"})
+
+      await wait(0.02)
+
+      const snapshot = pool.getDebugSnapshot()
+
+      expect(snapshot.inUseCount).toBe(1)
+      expect(snapshot.pendingCheckoutCount).toBe(1)
+      expect(snapshot.pendingCheckouts?.[0]?.checkoutName).toBe("waiting checkout")
+      expect(snapshot.pendingCheckouts?.[0]?.waitingForMs).toBeGreaterThanOrEqual(0)
+
+      const inUseConnection = snapshot.connections.find((connection) => connection.state === "in-use")
+
+      expect(inUseConnection?.checkoutName).toBe("long checkout")
+      expect(inUseConnection?.checkedOutAt).toBeGreaterThan(0)
+      expect(inUseConnection?.checkedOutForMs).toBeGreaterThanOrEqual(0)
+
+      await pool.checkin(firstConnection)
+
+      const secondConnection = await queuedCheckout
+
+      await pool.checkin(secondConnection)
     } finally {
       await configuration.closeDatabaseConnections()
     }

--- a/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
@@ -5,6 +5,45 @@ import wait from "awaitery/build/wait.js"
 import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.js"
 import {describe, expect, it} from "../../../src/testing/test.js"
 
+/**
+ * @param {string} databaseName - Test database name.
+ * @param {number} idleTimeoutMillis - Pool idle timeout.
+ * @param {(pool: AsyncTrackedMultiConnection) => Promise<void>} callback - Spec body.
+ * @returns {Promise<void>} - Resolves after cleanup.
+ */
+async function withIdleReaperPool(databaseName, idleTimeoutMillis, callback) {
+  const {cleanup, configuration} = await createTenantTestConfiguration(databaseName)
+
+  try {
+    configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis}
+    const pool = configuration.getDatabasePool("default")
+
+    if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+    await callback(pool)
+  } finally {
+    await cleanup()
+  }
+}
+
+/**
+ * @param {AsyncTrackedMultiConnection} pool - Pool to checkout from.
+ * @returns {Promise<import("../../../src/database/drivers/base.js").default>} - Connection that was checked in with a rolled-back transaction.
+ */
+async function checkedInTransactionConnection(pool) {
+  /** @type {import("../../../src/database/drivers/base.js").default | undefined} */
+  let transactionConnection
+
+  await pool.withConnection(async (connection) => {
+    transactionConnection = connection
+    await connection.startTransaction()
+  })
+
+  if (!transactionConnection) throw new Error("Expected transaction connection")
+
+  return transactionConnection
+}
+
 describe("database - pool - async tracked multi connection idle reaper", () => {
   it("reuses matching idle connections before reaping expired connections", async () => {
     const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-reuse-before-reap")
@@ -68,14 +107,7 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
   })
 
   it("reports checked-in idle timing in debug snapshots", async () => {
-    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-debug-timing")
-
-    try {
-      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 60000}
-      const pool = configuration.getDatabasePool("default")
-
-      if (!(pool instanceof AsyncTrackedMultiConnection)) return
-
+    await withIdleReaperPool("velocious-pool-idle-debug-timing", 60000, async (pool) => {
       /** @type {import("../../../src/database/drivers/base.js").default | undefined} */
       let checkedInConnection
 
@@ -94,9 +126,7 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
       expect(idleConnection.idleForMs).toBeGreaterThanOrEqual(0)
       expect(idleConnection.checkoutName).toBeUndefined()
       expect(pool.connections.includes(checkedInConnection)).toBe(true)
-    } finally {
-      await cleanup()
-    }
+    })
   })
 
   it("closes a connection only once when reaped concurrently", async () => {
@@ -165,25 +195,10 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
   })
 
   it("rolls back a left-open transaction on check-in and then reaps the now-clean connection", async () => {
-    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-transaction")
-
-    try {
-      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 1}
-      const pool = configuration.getDatabasePool("default")
-
-      if (!(pool instanceof AsyncTrackedMultiConnection)) return
-
-      /** @type {import("../../../src/database/drivers/base.js").default | undefined} */
-      let transactionConnection
-
+    await withIdleReaperPool("velocious-pool-idle-transaction", 1, async (pool) => {
       // The holder leaves a transaction open; check-in must roll it back so the
       // connection never re-enters the pool dirty.
-      await pool.withConnection(async (connection) => {
-        transactionConnection = connection
-        await connection.startTransaction()
-      })
-
-      if (!transactionConnection) throw new Error("Expected transaction connection")
+      const transactionConnection = await checkedInTransactionConnection(pool)
 
       expect(pool.connectionHasOpenTransaction(transactionConnection)).toBe(false)
 
@@ -192,35 +207,17 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
       await pool.reapIdleConnections()
 
       expect(pool.connections.includes(transactionConnection)).toBe(false)
-    } finally {
-      await cleanup()
-    }
+    })
   })
 
   it("rolls back a left-open transaction and reaps the connection immediately when idle timeout is zero", async () => {
-    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-transaction-zero")
-
-    try {
-      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 0}
-      const pool = configuration.getDatabasePool("default")
-
-      if (!(pool instanceof AsyncTrackedMultiConnection)) return
-
-      let transactionConnection
-
-      await pool.withConnection(async (connection) => {
-        transactionConnection = connection
-        await connection.startTransaction()
-      })
-
-      if (!transactionConnection) throw new Error("Expected transaction connection")
+    await withIdleReaperPool("velocious-pool-idle-transaction-zero", 0, async (pool) => {
+      const transactionConnection = await checkedInTransactionConnection(pool)
 
       // checkin rolled the transaction back and the zero idle timeout reaped the
       // now-clean connection immediately.
       expect(transactionConnection._transactionsCount).toBe(0)
       expect(pool.connections.includes(transactionConnection)).toBe(false)
-    } finally {
-      await cleanup()
-    }
+    })
   })
 })

--- a/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
@@ -67,6 +67,38 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
     }
   })
 
+  it("reports checked-in idle timing in debug snapshots", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-debug-timing")
+
+    try {
+      configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: 60000}
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      /** @type {import("../../../src/database/drivers/base.js").default | undefined} */
+      let checkedInConnection
+
+      await pool.withConnection({name: "debug idle checkout"}, async (connection) => {
+        checkedInConnection = connection
+      })
+
+      await wait(0.02)
+
+      const snapshot = pool.getDebugSnapshot()
+      const idleConnection = snapshot.connections.find((connection) => connection.state === "idle")
+
+      if (!idleConnection) throw new Error("Expected an idle connection debug snapshot")
+
+      expect(idleConnection.checkedInAt).toBeGreaterThan(0)
+      expect(idleConnection.idleForMs).toBeGreaterThanOrEqual(0)
+      expect(idleConnection.checkoutName).toBeUndefined()
+      expect(pool.connections.includes(checkedInConnection)).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
   it("closes a connection only once when reaped concurrently", async () => {
     const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-idle-double-close")
 

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -5,11 +5,13 @@ import BasePool, {POOL_CONFIGURATION_KEY} from "./base.js"
 
 export const CLOSED_CONNECTION = Symbol("velociousClosedConnection")
 const IDLE_CONNECTION_CHECKED_IN_AT = Symbol("velociousIdleConnectionCheckedInAt")
+const CONNECTION_CHECKED_OUT_AT = Symbol("velociousConnectionCheckedOutAt")
 const DEFAULT_IDLE_TIMEOUT_MILLIS = 5000
 
 /**
  * @typedef {object} PendingCheckout
  * @property {import("../../configuration-types.js").DatabaseConfigurationType} databaseConfig - Resolved database configuration needed by the checkout.
+ * @property {number} enqueuedAt - Timestamp when the checkout started waiting.
  * @property {import("./base.js").ConnectionCheckoutOptions} options - Checkout options.
  * @property {string} reuseKey - Database configuration reuse key needed by the checkout.
  * @property {(connection: import("../drivers/base.js").default) => void} resolve - Resolves with an activated connection.
@@ -97,7 +99,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     connection.setIdSeq(undefined)
 
-    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [CONNECTION_CHECKED_OUT_AT]?: number, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
 
     if (trackedConnection[CLOSED_CONNECTION]) return
 
@@ -112,6 +114,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     }
 
     trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT] = Date.now()
+    delete trackedConnection[CONNECTION_CHECKED_OUT_AT]
     this.connections.push(connection)
     await this.drainPendingCheckouts()
 
@@ -191,8 +194,9 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     const id = this.idSeq++
 
-    const trackedConnection = /** @type {import("../drivers/base.js").default & {[IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CONNECTION_CHECKED_OUT_AT]?: number, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
     delete trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
+    trackedConnection[CONNECTION_CHECKED_OUT_AT] = Date.now()
 
     connection.setIdSeq(id)
     this.connectionsInUse[id] = connection
@@ -269,7 +273,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    */
   async waitForCheckout(databaseConfig, reuseKey, options = {}) {
     return await new Promise((resolve, reject) => {
-      this.pendingCheckouts.push({databaseConfig, options, reject, resolve, reuseKey})
+      this.pendingCheckouts.push({databaseConfig, enqueuedAt: Date.now(), options, reject, resolve, reuseKey})
       void this.drainPendingCheckouts().catch((error) => {
         const checkoutError = error instanceof Error ? error : new Error("Failed to drain pending database connection checkouts.", {cause: error})
 
@@ -489,8 +493,12 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     const now = Date.now()
 
     for (const [id, connection] of Object.entries(this.connectionsInUse)) {
+      const trackedConnection = /** @type {import("../drivers/base.js").default & {[CONNECTION_CHECKED_OUT_AT]?: number}} */ (connection)
+      const checkedOutAt = trackedConnection[CONNECTION_CHECKED_OUT_AT]
+      const checkedOutForMs = typeof checkedOutAt === "number" ? Math.max(0, now - checkedOutAt) : undefined
+
       seenConnections.add(connection)
-      connections.push(this.debugConnectionSnapshot(connection, {checkoutId: id, state: "in-use"}))
+      connections.push(this.debugConnectionSnapshot(connection, {checkedOutAt, checkedOutForMs, checkoutId: id, state: "in-use"}))
     }
 
     for (const connection of this.connections) {
@@ -502,8 +510,16 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
       const idleForMs = typeof checkedInAt === "number" ? Math.max(0, now - checkedInAt) : undefined
 
-      connections.push(this.debugConnectionSnapshot(connection, {idleForMs, state: "idle"}))
+      connections.push(this.debugConnectionSnapshot(connection, {checkedInAt, idleForMs, state: "idle"}))
     }
+
+    const pendingCheckouts = this.pendingCheckouts.map((checkout, index) => ({
+      checkoutName: checkout.options.name,
+      enqueuedAt: checkout.enqueuedAt,
+      index,
+      reuseKey: checkout.reuseKey,
+      waitingForMs: Math.max(0, now - checkout.enqueuedAt)
+    }))
 
     const globalConnection = this.getGlobalConnectionForIdentifier()
 
@@ -522,6 +538,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       connectionsBeingSpawned: this.connectionsBeingSpawned,
       idleCount: this.connections.length,
       inUseCount: Object.keys(this.connectionsInUse).length,
+      pendingCheckouts,
       pendingCheckoutCount: this.pendingCheckouts.length
     }
   }
@@ -728,9 +745,10 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       return await existingClose
     }
 
-    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [CONNECTION_CHECKED_OUT_AT]?: number, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
 
     trackedConnection[CLOSED_CONNECTION] = true
+    delete trackedConnection[CONNECTION_CHECKED_OUT_AT]
     delete trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
 
     const closePromise = (async () => {

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -89,15 +89,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   async checkin(connection) {
     const id = connection.getIdSeq()
 
-    if (typeof id !== "number") {
-      throw new Error(`idSeq on connection wasn't set? '${typeof id}' = ${id}`)
-    }
-
-    if (id in this.connectionsInUse) {
-      delete this.connectionsInUse[id]
-    }
-
-    connection.setIdSeq(undefined)
+    this.untrackConnectionInUse(connection, id)
 
     const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [CONNECTION_CHECKED_OUT_AT]?: number, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
 
@@ -117,13 +109,30 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     delete trackedConnection[CONNECTION_CHECKED_OUT_AT]
     this.connections.push(connection)
     await this.drainPendingCheckouts()
+    await this.handleCheckedInIdleConnection()
+  }
 
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection being checked in.
+   * @param {number | undefined} id - Connection checkout id.
+   * @returns {void}
+   */
+  untrackConnectionInUse(connection, id) {
+    if (typeof id !== "number") {
+      throw new Error(`idSeq on connection wasn't set? '${typeof id}' = ${id}`)
+    }
+
+    delete this.connectionsInUse[id]
+    connection.setIdSeq(undefined)
+  }
+
+  /** @returns {Promise<void>} - Resolves once idle reaping has been scheduled or run. */
+  async handleCheckedInIdleConnection() {
     if (this.idleTimeoutMillis() === 0) {
       await this.reapIdleConnections()
     } else {
       this.scheduleIdleConnectionReaper()
     }
-
   }
 
   /**
@@ -218,9 +227,17 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   maxConnections() {
     const value = this.getConfiguration().pool?.max
 
-    if (typeof value === "number" && Number.isFinite(value) && value >= 1) return value
+    if (this.validMaxConnections(value)) return value
 
     return
+  }
+
+  /**
+   * @param {unknown} value - Candidate max connection count.
+   * @returns {value is number} - Whether the value is a valid max connection count.
+   */
+  validMaxConnections(value) {
+    return typeof value === "number" && Number.isFinite(value) && value >= 1
   }
 
   /** @returns {number} - Number of live and in-progress connections. */
@@ -302,16 +319,15 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   async drainPendingCheckoutsActual() {
     while (this.pendingCheckouts.length > 0) {
       const checkout = this.pendingCheckouts[0]
-      const connection = await this.connectionForPendingCheckout(checkout)
 
-      if (connection === "retry") continue
-
-      if (!connection && this.canSpawnConnection()) {
+      if (await this.closeIdleConnectionForPendingCheckoutCapacity(checkout)) continue
+      if (this.canSpawnConnection()) {
         this.pendingCheckouts.shift()
         await this.spawnAndResolvePendingCheckout(checkout)
-
         continue
       }
+
+      const connection = await this.idleConnectionForPendingCheckout(checkout)
 
       if (!connection) return
 
@@ -322,15 +338,26 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
   /**
    * @param {PendingCheckout} checkout - Checkout waiting for a connection.
-   * @returns {Promise<import("../drivers/base.js").default | undefined | "retry">} - Connection, retry marker, or undefined when unavailable.
+   * @returns {Promise<boolean>} - Whether an idle connection was closed to free capacity.
    */
-  async connectionForPendingCheckout(checkout) {
-    const connection = await this.idleConnectionForPendingCheckout(checkout)
+  async closeIdleConnectionForPendingCheckoutCapacity(checkout) {
+    const connection = this.findIdleConnectionForReuseKey(checkout.reuseKey)
 
-    if (connection) return connection
-    if (this.canSpawnConnection()) return
+    if (connection) return false
 
-    return await this.closeOneIdleConnectionForCapacity() ? "retry" : undefined
+    await this.reapIdleConnections()
+
+    if (this.findIdleConnectionForReuseKey(checkout.reuseKey)) return false
+
+    return this.canSpawnConnection() ? false : await this.closeOneIdleConnectionForCapacity()
+  }
+
+  /**
+   * @param {string} reuseKey - Database configuration reuse key.
+   * @returns {import("../drivers/base.js").default | undefined} - Matching idle connection, if present.
+   */
+  findIdleConnectionForReuseKey(reuseKey) {
+    return this.connections.find((connection) => !this.connectionHasOpenTransaction(connection) && this.connectionMatchesReuseKey(connection, reuseKey))
   }
 
   /**
@@ -418,19 +445,9 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   getCurrentConnection() {
     const id = this.asyncLocalStorage.getStore()
 
-    if (id === undefined) {
-      const fallbackConnection = this.getGlobalConnection()
+    if (id === undefined) return this.currentFallbackConnectionOrFail()
 
-      if (fallbackConnection) {
-        return fallbackConnection
-      }
-
-      throw new Error("ID hasn't been set for this async context")
-    }
-
-    if (!(id in this.connectionsInUse)) {
-      throw new Error(`Connection ${id} doesn't exist any more - has it been checked in again?`)
-    }
+    this.ensureConnectionIsInUse(id)
 
     const currentConnection = this.connectionsInUse[id]
 
@@ -439,6 +456,25 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     }
 
     return currentConnection
+  }
+
+  /** @returns {import("../drivers/base.js").default} - Fallback connection, if present. */
+  currentFallbackConnectionOrFail() {
+    const fallbackConnection = this.getGlobalConnection()
+
+    if (fallbackConnection) return fallbackConnection
+
+    throw new Error("ID hasn't been set for this async context")
+  }
+
+  /**
+   * @param {number} id - Checked-out connection id.
+   * @returns {void}
+   */
+  ensureConnectionIsInUse(id) {
+    if (!(id in this.connectionsInUse)) {
+      throw new Error(`Connection ${id} doesn't exist any more - has it been checked in again?`)
+    }
   }
 
   /**
@@ -575,16 +611,19 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {void}
    */
   addFallbackDebugConnectionSnapshots({connections, seenConnections}) {
-    const globalConnection = this.getGlobalConnectionForIdentifier()
+    this.addDebugConnectionSnapshotIfUnseen({connection: this.getGlobalConnectionForIdentifier(), connections, seenConnections, state: "global"})
+    this.addDebugConnectionSnapshotIfUnseen({connection: this._testSharedConnection, connections, seenConnections, state: "test-shared"})
+  }
 
-    if (globalConnection && !seenConnections.has(globalConnection)) {
-      seenConnections.add(globalConnection)
-      connections.push(this.debugConnectionSnapshot(globalConnection, {state: "global"}))
-    }
+  /**
+   * @param {{connection: import("../drivers/base.js").default | undefined, connections: Array<Record<string, unknown>>, seenConnections: Set<import("../drivers/base.js").default>, state: string}} args - Snapshot collection state.
+   * @returns {void}
+   */
+  addDebugConnectionSnapshotIfUnseen({connection, connections, seenConnections, state}) {
+    if (!connection || seenConnections.has(connection)) return
 
-    if (this._testSharedConnection && !seenConnections.has(this._testSharedConnection)) {
-      connections.push(this.debugConnectionSnapshot(this._testSharedConnection, {state: "test-shared"}))
-    }
+    seenConnections.add(connection)
+    connections.push(this.debugConnectionSnapshot(connection, {state}))
   }
 
   /**
@@ -655,21 +694,25 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     const value = this.getConfiguration().pool?.idleTimeoutMillis
 
     if (value === null) return null
-    if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value
+    if (this.validIdleTimeoutMillis(value)) return value
 
     return DEFAULT_IDLE_TIMEOUT_MILLIS
+  }
+
+  /**
+   * @param {unknown} value - Candidate idle timeout value.
+   * @returns {value is number} - Whether the value is a valid idle timeout.
+   */
+  validIdleTimeoutMillis(value) {
+    return typeof value === "number" && Number.isFinite(value) && value >= 0
   }
 
   /** @returns {void} */
   scheduleIdleConnectionReaper() {
     if (this.idleConnectionReaperTimer) return
-    if (this.connections.length === 0) return
+    if (!this.hasIdleConnectionsToReap()) return
 
-    const idleTimeoutMillis = this.idleTimeoutMillis()
-
-    if (idleTimeoutMillis === null) return
-
-    const delay = this.nextIdleConnectionReapDelay(idleTimeoutMillis)
+    const delay = this.nextIdleConnectionReapDelay(/** @type {number} */ (this.idleTimeoutMillis()))
 
     this.idleConnectionReaperTimer = setTimeout(() => {
       this.idleConnectionReaperTimer = undefined
@@ -681,6 +724,11 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (typeof this.idleConnectionReaperTimer.unref === "function") {
       this.idleConnectionReaperTimer.unref()
     }
+  }
+
+  /** @returns {boolean} - Whether an idle reaper timer should be scheduled. */
+  hasIdleConnectionsToReap() {
+    return this.connections.length > 0 && this.idleTimeoutMillis() !== null
   }
 
   /**
@@ -716,26 +764,28 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     if (idleTimeoutMillis === null) return
 
-    const now = Date.now()
-    const {expiredConnections, keptConnections} = this.classifyIdleConnectionsForReaping({idleTimeoutMillis, now})
+    const {expiredConnections, keptConnections} = this.classifyIdleConnectionsForReaping({idleTimeoutMillis, now: Date.now()})
 
     this.connections = keptConnections
+    await this.closeExpiredIdleConnections(expiredConnections)
+    await this.awaitInflightConnectionCloses()
+    if (this.connections.length > 0) this.scheduleIdleConnectionReaper()
+  }
 
+  /**
+   * @param {import("../drivers/base.js").default[]} expiredConnections - Connections to close.
+   * @returns {Promise<void>} - Resolves when closed.
+   */
+  async closeExpiredIdleConnections(expiredConnections) {
     for (const connection of expiredConnections) {
       await this.closeConnection(connection)
     }
+  }
 
-    // A concurrent fire-and-forget scheduled reap may already be closing
-    // connections this call did not expire itself (it may have removed them from
-    // `this.connections` first). Await those in-flight closes too so a caller
-    // that awaits `reapIdleConnections()` is guaranteed the pool's idle
-    // connections are fully closed, not mid-`close()`.
+  /** @returns {Promise<void>} - Resolves once in-flight connection closes settle. */
+  async awaitInflightConnectionCloses() {
     if (this.inflightConnectionCloses.size > 0) {
       await Promise.allSettled([...this.inflightConnectionCloses])
-    }
-
-    if (this.connections.length > 0) {
-      this.scheduleIdleConnectionReaper()
     }
   }
 
@@ -761,22 +811,36 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {void}
    */
   classifyIdleConnectionForReaping({connection, expiredConnections, idleTimeoutMillis, keptConnections, now}) {
-    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
-
-    if (trackedConnection[CLOSED_CONNECTION]) return
+    if (this.connectionIsClosed(connection)) return
     if (this.connectionHasOpenTransaction(connection)) {
       keptConnections.push(connection)
       return
     }
 
-    const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
-    const expired = typeof checkedInAt === "number" && now - checkedInAt >= idleTimeoutMillis
+    const target = this.idleConnectionExpired({connection, idleTimeoutMillis, now}) ? expiredConnections : keptConnections
 
-    if (expired) {
-      expiredConnections.push(connection)
-    } else {
-      keptConnections.push(connection)
-    }
+    target.push(connection)
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection to inspect.
+   * @returns {boolean} - Whether the connection is marked closed.
+   */
+  connectionIsClosed(connection) {
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean}} */ (connection)
+
+    return Boolean(trackedConnection[CLOSED_CONNECTION])
+  }
+
+  /**
+   * @param {{connection: import("../drivers/base.js").default, idleTimeoutMillis: number, now: number}} args - Expiry inputs.
+   * @returns {boolean} - Whether the idle connection expired.
+   */
+  idleConnectionExpired({connection, idleTimeoutMillis, now}) {
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+    const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
+
+    return typeof checkedInAt === "number" && now - checkedInAt >= idleTimeoutMillis
   }
 
   /**
@@ -898,11 +962,6 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {void} - No return value.
    */
   static setGlobalConnections(connections, configuration) {
-    if (!connections && !configuration) {
-      this.globalConnections = new WeakMap()
-      return
-    }
-
     if (!configuration) {
       this.globalConnections = new WeakMap()
       return

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -302,18 +302,9 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   async drainPendingCheckoutsActual() {
     while (this.pendingCheckouts.length > 0) {
       const checkout = this.pendingCheckouts[0]
-      let connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+      const connection = await this.connectionForPendingCheckout(checkout)
 
-      if (!connection) {
-        await this.reapIdleConnections()
-        connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
-      }
-
-      if (!connection && !this.canSpawnConnection()) {
-        const closedConnection = await this.closeOneIdleConnectionForCapacity()
-
-        if (closedConnection) continue
-      }
+      if (connection === "retry") continue
 
       if (!connection && this.canSpawnConnection()) {
         this.pendingCheckouts.shift()
@@ -327,6 +318,34 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       this.pendingCheckouts.shift()
       await this.resolvePendingCheckout(checkout, connection)
     }
+  }
+
+  /**
+   * @param {PendingCheckout} checkout - Checkout waiting for a connection.
+   * @returns {Promise<import("../drivers/base.js").default | undefined | "retry">} - Connection, retry marker, or undefined when unavailable.
+   */
+  async connectionForPendingCheckout(checkout) {
+    const connection = await this.idleConnectionForPendingCheckout(checkout)
+
+    if (connection) return connection
+    if (this.canSpawnConnection()) return
+
+    return await this.closeOneIdleConnectionForCapacity() ? "retry" : undefined
+  }
+
+  /**
+   * @param {PendingCheckout} checkout - Checkout waiting for a connection.
+   * @returns {Promise<import("../drivers/base.js").default | undefined>} - Matching idle connection, if one can be reused.
+   */
+  async idleConnectionForPendingCheckout(checkout) {
+    let connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+
+    if (connection) return connection
+
+    await this.reapIdleConnections()
+    connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+
+    return connection
   }
 
   /**
@@ -488,10 +507,41 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   /** @returns {import("./base.js").DatabasePoolDebugSnapshot} - Diagnostic snapshot for this pool. */
   getDebugSnapshot() {
     const snapshot = super.getDebugSnapshot()
+    const now = Date.now()
+    const {connections} = this.debugConnectionSnapshots(now)
+
+    return {
+      ...snapshot,
+      connections,
+      connectionsBeingSpawned: this.connectionsBeingSpawned,
+      idleCount: this.connections.length,
+      inUseCount: Object.keys(this.connectionsInUse).length,
+      pendingCheckouts: this.pendingCheckoutDebugSnapshots(now),
+      pendingCheckoutCount: this.pendingCheckouts.length
+    }
+  }
+
+  /**
+   * @param {number} now - Current timestamp.
+   * @returns {{connections: Array<Record<string, unknown>>, seenConnections: Set<import("../drivers/base.js").default>}} - Connection snapshots and seen set.
+   */
+  debugConnectionSnapshots(now) {
+    /** @type {Array<Record<string, unknown>>} */
     const connections = []
     const seenConnections = new Set()
-    const now = Date.now()
 
+    this.addInUseDebugConnectionSnapshots({connections, now, seenConnections})
+    this.addIdleDebugConnectionSnapshots({connections, now, seenConnections})
+    this.addFallbackDebugConnectionSnapshots({connections, seenConnections})
+
+    return {connections, seenConnections}
+  }
+
+  /**
+   * @param {{connections: Array<Record<string, unknown>>, now: number, seenConnections: Set<import("../drivers/base.js").default>}} args - Snapshot collection state.
+   * @returns {void}
+   */
+  addInUseDebugConnectionSnapshots({connections, now, seenConnections}) {
     for (const [id, connection] of Object.entries(this.connectionsInUse)) {
       const trackedConnection = /** @type {import("../drivers/base.js").default & {[CONNECTION_CHECKED_OUT_AT]?: number}} */ (connection)
       const checkedOutAt = trackedConnection[CONNECTION_CHECKED_OUT_AT]
@@ -500,7 +550,13 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       seenConnections.add(connection)
       connections.push(this.debugConnectionSnapshot(connection, {checkedOutAt, checkedOutForMs, checkoutId: id, state: "in-use"}))
     }
+  }
 
+  /**
+   * @param {{connections: Array<Record<string, unknown>>, now: number, seenConnections: Set<import("../drivers/base.js").default>}} args - Snapshot collection state.
+   * @returns {void}
+   */
+  addIdleDebugConnectionSnapshots({connections, now, seenConnections}) {
     for (const connection of this.connections) {
       if (seenConnections.has(connection)) continue
 
@@ -512,15 +568,13 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
       connections.push(this.debugConnectionSnapshot(connection, {checkedInAt, idleForMs, state: "idle"}))
     }
+  }
 
-    const pendingCheckouts = this.pendingCheckouts.map((checkout, index) => ({
-      checkoutName: checkout.options.name,
-      enqueuedAt: checkout.enqueuedAt,
-      index,
-      reuseKey: checkout.reuseKey,
-      waitingForMs: Math.max(0, now - checkout.enqueuedAt)
-    }))
-
+  /**
+   * @param {{connections: Array<Record<string, unknown>>, seenConnections: Set<import("../drivers/base.js").default>}} args - Snapshot collection state.
+   * @returns {void}
+   */
+  addFallbackDebugConnectionSnapshots({connections, seenConnections}) {
     const globalConnection = this.getGlobalConnectionForIdentifier()
 
     if (globalConnection && !seenConnections.has(globalConnection)) {
@@ -531,16 +585,20 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (this._testSharedConnection && !seenConnections.has(this._testSharedConnection)) {
       connections.push(this.debugConnectionSnapshot(this._testSharedConnection, {state: "test-shared"}))
     }
+  }
 
-    return {
-      ...snapshot,
-      connections,
-      connectionsBeingSpawned: this.connectionsBeingSpawned,
-      idleCount: this.connections.length,
-      inUseCount: Object.keys(this.connectionsInUse).length,
-      pendingCheckouts,
-      pendingCheckoutCount: this.pendingCheckouts.length
-    }
+  /**
+   * @param {number} now - Current timestamp.
+   * @returns {Array<Record<string, unknown>>} - Pending checkout snapshots.
+   */
+  pendingCheckoutDebugSnapshots(now) {
+    return this.pendingCheckouts.map((checkout, index) => ({
+      checkoutName: checkout.options.name,
+      enqueuedAt: checkout.enqueuedAt,
+      index,
+      reuseKey: checkout.reuseKey,
+      waitingForMs: Math.max(0, now - checkout.enqueuedAt)
+    }))
   }
 
   /**
@@ -659,29 +717,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (idleTimeoutMillis === null) return
 
     const now = Date.now()
-    /** @type {import("../drivers/base.js").default[]} */
-    const keptConnections = []
-    /** @type {import("../drivers/base.js").default[]} */
-    const expiredConnections = []
-
-    for (const connection of this.connections) {
-      const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
-
-      if (trackedConnection[CLOSED_CONNECTION]) continue
-      if (this.connectionHasOpenTransaction(connection)) {
-        keptConnections.push(connection)
-        continue
-      }
-
-      const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
-      const expired = typeof checkedInAt === "number" && now - checkedInAt >= idleTimeoutMillis
-
-      if (expired) {
-        expiredConnections.push(connection)
-      } else {
-        keptConnections.push(connection)
-      }
-    }
+    const {expiredConnections, keptConnections} = this.classifyIdleConnectionsForReaping({idleTimeoutMillis, now})
 
     this.connections = keptConnections
 
@@ -700,6 +736,46 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     if (this.connections.length > 0) {
       this.scheduleIdleConnectionReaper()
+    }
+  }
+
+  /**
+   * @param {{idleTimeoutMillis: number, now: number}} args - Reaper classification inputs.
+   * @returns {{expiredConnections: import("../drivers/base.js").default[], keptConnections: import("../drivers/base.js").default[]}} - Classified idle connections.
+   */
+  classifyIdleConnectionsForReaping({idleTimeoutMillis, now}) {
+    /** @type {import("../drivers/base.js").default[]} */
+    const keptConnections = []
+    /** @type {import("../drivers/base.js").default[]} */
+    const expiredConnections = []
+
+    for (const connection of this.connections) {
+      this.classifyIdleConnectionForReaping({connection, expiredConnections, idleTimeoutMillis, keptConnections, now})
+    }
+
+    return {expiredConnections, keptConnections}
+  }
+
+  /**
+   * @param {{connection: import("../drivers/base.js").default, expiredConnections: import("../drivers/base.js").default[], idleTimeoutMillis: number, keptConnections: import("../drivers/base.js").default[], now: number}} args - Classification state.
+   * @returns {void}
+   */
+  classifyIdleConnectionForReaping({connection, expiredConnections, idleTimeoutMillis, keptConnections, now}) {
+    const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
+
+    if (trackedConnection[CLOSED_CONNECTION]) return
+    if (this.connectionHasOpenTransaction(connection)) {
+      keptConnections.push(connection)
+      return
+    }
+
+    const checkedInAt = trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT]
+    const expired = typeof checkedInAt === "number" && now - checkedInAt >= idleTimeoutMillis
+
+    if (expired) {
+      expiredConnections.push(connection)
+    } else {
+      keptConnections.push(connection)
     }
   }
 

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -85,7 +85,7 @@ class VelociousDatabasePoolBase {
    * @abstract
    * @param {import("../drivers/base.js").default} _connection - Connection.
    */
-  checkin(_connection) { // eslint-disable-line no-unused-vars
+  checkin(_connection) {
     throw new Error("'checkin' not implemented")
   }
 

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -19,6 +19,7 @@ export const POOL_CONFIGURATION_KEY = Symbol("velociousPoolConfigurationKey")
  * @property {number} idleCount - Number of idle connections.
  * @property {string} identifier - Database identifier.
  * @property {number} inUseCount - Number of checked-out connections.
+ * @property {Array<Record<string, unknown>>} [pendingCheckouts] - Waiting checkout snapshots.
  * @property {number} pendingCheckoutCount - Number of queued checkout requests.
  * @property {string} poolClass - Pool class name.
  */

--- a/src/database/pool/single-multi-use.js
+++ b/src/database/pool/single-multi-use.js
@@ -41,14 +41,15 @@ export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
    */
   async withConnection(optionsOrCallback, callback) {
     const options = typeof optionsOrCallback == "function" ? {} : optionsOrCallback
-    const actualCallback = typeof optionsOrCallback == "function" ? optionsOrCallback : callback
-
-    if (!actualCallback) throw new Error("withConnection requires a callback")
 
     const connection = await this.checkout(options)
 
     try {
-      return await actualCallback(connection)
+      if (typeof optionsOrCallback == "function") return await optionsOrCallback(connection)
+
+      if (!callback) throw new Error("withConnection requires a callback")
+
+      return await callback(connection)
     } finally {
       await this.checkin(connection)
     }


### PR DESCRIPTION
Adds checkout timing metadata to AsyncTrackedMultiConnection debug snapshots so production debug output can distinguish long-held in-use connections, idle checked-in connections, and pending checkout waits.\n\nValidation:\n- npm run test -- spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js\n- npm run typecheck\n- npm run lint -- src/database/pool/async-tracked-multi-connection.js src/database/pool/base.js spec/database/pool/async-tracked-multi-connection-checkout-name-spec.js spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js (warning only: existing unused eslint-disable in src/database/pool/base.js)