### PR TITLE
Reuse pending checkout connections before reaping

### DIFF
--- a/spec/database/pool/async-tracked-multi-connection-fallback-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-fallback-spec.js
@@ -67,6 +67,23 @@ describe("database - pool - async tracked multi connection", () => {
     }, {fresh: true})
   })
 
+  it("marks global fallback connections as non-reapable in debug snapshots", async () => {
+    await Dummy.run(async () => {
+      const pool = getPool()
+
+      if (!pool) return
+
+      await pool.ensureGlobalConnection()
+
+      const snapshot = pool.getDebugSnapshot()
+      const globalConnection = snapshot.connections.find((connection) => connection.state === "global")
+
+      if (!globalConnection) throw new Error("Expected global connection snapshot")
+
+      expect(globalConnection.reapable).toBe(false)
+    }, {fresh: true})
+  })
+
   it("does not replace an existing global connection when ensuring", async () => {
     await Dummy.run(async () => {
       const pool = getPool()

--- a/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
@@ -297,6 +297,107 @@ describe("database - pool - async tracked multi connection reuse", () => {
     })
   })
 
+  it("hands a matching idle connection to pending checkouts before waiting for spawn capacity", async () => {
+    await withIsolatedPool(async (pool) => {
+      pool.getConfiguration().pool = {idleTimeoutMillis: 0, max: 1}
+
+      const firstConnection = await pool.checkout()
+      const reuseKey = pool.getConfigurationReuseKey()
+
+      let pendingResolved = false
+      const pendingConnectionPromise = new Promise((resolve, reject) => {
+        pool.pendingCheckouts.push({
+          databaseConfig: pool.getConfiguration(),
+          enqueuedAt: Date.now(),
+          options: {},
+          reject,
+          resolve,
+          reuseKey
+        })
+      }).then((connection) => {
+        pendingResolved = true
+
+        return connection
+      })
+
+      await pool.checkin(firstConnection)
+
+      expect(pendingResolved).toBe(true)
+
+      const pendingConnection = await pendingConnectionPromise
+
+      expect(pendingConnection).toBe(firstConnection)
+      expect(pool.connections.includes(firstConnection)).toBe(false)
+
+      await pool.checkin(firstConnection)
+    })
+  })
+
+  it("does not let a blocked pending checkout prevent later matching idle reuse", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-pool-pending-head-of-line")
+
+    try {
+      configuration.getDatabaseConfiguration().projectTenant.pool = {max: 2}
+      const pool = configuration.getDatabasePool("projectTenant")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) return
+
+      const betaConnection = await configuration.runWithTenant({slug: "beta"}, async () => {
+        return await pool.checkout()
+      })
+      const gammaConnection = await configuration.runWithTenant({slug: "gamma"}, async () => {
+        return await pool.checkout()
+      })
+
+      await configuration.runWithTenant({slug: "gamma"}, async () => {
+        await pool.checkin(gammaConnection)
+      })
+
+      let alphaResolved = false
+      let gammaResolved = false
+      const alphaConnectionPromise = configuration.runWithTenant({slug: "alpha"}, async () => {
+        const connection = await pool.checkout()
+
+        alphaResolved = true
+
+        return connection
+      })
+      const pendingGammaConnectionPromise = configuration.runWithTenant({slug: "gamma"}, async () => {
+        const connection = await pool.checkout()
+
+        gammaResolved = true
+
+        return connection
+      })
+
+      await wait(0.02)
+
+      expect(alphaResolved).toBe(false)
+      expect(gammaResolved).toBe(true)
+
+      const pendingGammaConnection = await pendingGammaConnectionPromise
+
+      expect(pendingGammaConnection).toBe(gammaConnection)
+
+      await configuration.runWithTenant({slug: "beta"}, async () => {
+        await pool.checkin(betaConnection)
+      })
+
+      const alphaConnection = await alphaConnectionPromise
+
+      expect(alphaConnection.getArgs().name).toEqual("velocious-pool-pending-head-of-line-projectTenant-alpha")
+
+      await configuration.runWithTenant({slug: "gamma"}, async () => {
+        await pool.checkin(pendingGammaConnection)
+      })
+      await configuration.runWithTenant({slug: "alpha"}, async () => {
+        await pool.checkin(alphaConnection)
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
   it("counts in-progress direct checkout spawns against the max connection cap", async () => {
     const {cleanup, configuration} = await createSpawnBlockingConfiguration("velocious-pool-spawn-cap")
 

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -318,14 +318,9 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   /** @returns {Promise<void>} - Resolves when pending checkouts have been drained as far as possible. */
   async drainPendingCheckoutsActual() {
     while (this.pendingCheckouts.length > 0) {
-      const checkout = this.pendingCheckouts[0]
-      const connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+      if (await this.resolvePendingCheckoutWithMatchingIdleConnection()) continue
 
-      if (connection) {
-        this.pendingCheckouts.shift()
-        await this.resolvePendingCheckout(checkout, connection)
-        continue
-      }
+      const checkout = this.pendingCheckouts[0]
 
       if (await this.closeIdleConnectionForPendingCheckoutCapacity(checkout)) continue
       if (this.canSpawnConnection()) {
@@ -341,6 +336,23 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       this.pendingCheckouts.shift()
       await this.resolvePendingCheckout(checkout, reapedConnection)
     }
+  }
+
+  /** @returns {Promise<boolean>} - Whether a pending checkout was resolved with an idle connection. */
+  async resolvePendingCheckoutWithMatchingIdleConnection() {
+    for (let index = 0; index < this.pendingCheckouts.length; index++) {
+      const checkout = this.pendingCheckouts[index]
+      const connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+
+      if (!connection) continue
+
+      this.pendingCheckouts.splice(index, 1)
+      await this.resolvePendingCheckout(checkout, connection)
+
+      return true
+    }
+
+    return false
   }
 
   /**

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -109,7 +109,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     delete trackedConnection[CONNECTION_CHECKED_OUT_AT]
     this.connections.push(connection)
     await this.drainPendingCheckouts()
-    await this.handleCheckedInIdleConnection()
+    if (this.connections.includes(connection)) await this.handleCheckedInIdleConnection()
   }
 
   /**
@@ -319,6 +319,13 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   async drainPendingCheckoutsActual() {
     while (this.pendingCheckouts.length > 0) {
       const checkout = this.pendingCheckouts[0]
+      const connection = this.takeIdleConnectionForReuseKey(checkout.reuseKey, {includeOpenTransactions: false})
+
+      if (connection) {
+        this.pendingCheckouts.shift()
+        await this.resolvePendingCheckout(checkout, connection)
+        continue
+      }
 
       if (await this.closeIdleConnectionForPendingCheckoutCapacity(checkout)) continue
       if (this.canSpawnConnection()) {
@@ -327,12 +334,12 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
         continue
       }
 
-      const connection = await this.idleConnectionForPendingCheckout(checkout)
+      const reapedConnection = await this.idleConnectionForPendingCheckout(checkout)
 
-      if (!connection) return
+      if (!reapedConnection) return
 
       this.pendingCheckouts.shift()
-      await this.resolvePendingCheckout(checkout, connection)
+      await this.resolvePendingCheckout(checkout, reapedConnection)
     }
   }
 
@@ -611,19 +618,19 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {void}
    */
   addFallbackDebugConnectionSnapshots({connections, seenConnections}) {
-    this.addDebugConnectionSnapshotIfUnseen({connection: this.getGlobalConnectionForIdentifier(), connections, seenConnections, state: "global"})
-    this.addDebugConnectionSnapshotIfUnseen({connection: this._testSharedConnection, connections, seenConnections, state: "test-shared"})
+    this.addDebugConnectionSnapshotIfUnseen({connection: this.getGlobalConnectionForIdentifier(), connections, reapable: false, seenConnections, state: "global"})
+    this.addDebugConnectionSnapshotIfUnseen({connection: this._testSharedConnection, connections, reapable: false, seenConnections, state: "test-shared"})
   }
 
   /**
-   * @param {{connection: import("../drivers/base.js").default | undefined, connections: Array<Record<string, unknown>>, seenConnections: Set<import("../drivers/base.js").default>, state: string}} args - Snapshot collection state.
+   * @param {{connection: import("../drivers/base.js").default | undefined, connections: Array<Record<string, unknown>>, reapable?: boolean, seenConnections: Set<import("../drivers/base.js").default>, state: string}} args - Snapshot collection state.
    * @returns {void}
    */
-  addDebugConnectionSnapshotIfUnseen({connection, connections, seenConnections, state}) {
+  addDebugConnectionSnapshotIfUnseen({connection, connections, reapable, seenConnections, state}) {
     if (!connection || seenConnections.has(connection)) return
 
     seenConnections.add(connection)
-    connections.push(this.debugConnectionSnapshot(connection, {state}))
+    connections.push(this.debugConnectionSnapshot(connection, {reapable, state}))
   }
 
   /**


### PR DESCRIPTION
## Summary
- reuse matching idle connections for pending checkouts before reaping/spawn decisions
- avoid running idle reaper handling after check-in when a pending checkout immediately takes the connection
- mark global/test-shared debug snapshot connections as non-reapable

## Validation
- npm run test -- spec/database/pool/async-tracked-multi-connection-reuse-spec.js
- npm run test -- spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
- npm run test -- spec/database/pool/async-tracked-multi-connection-fallback-spec.js
- npm run lint -- src/database/pool/async-tracked-multi-connection.js spec/database/pool/async-tracked-multi-connection-reuse-spec.js spec/database/pool/async-tracked-multi-connection-fallback-spec.js
- npm run typecheck
- npm run fallow