### PR TITLE
Add configurable HTTP server workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 * Translated model attributes with current-locale relationship sorting (see [docs/translations.md](docs/translations.md))
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon`, including background job runner processes (see [docs/beacon.md](docs/beacon.md))
+* Configurable HTTP server worker handlers for higher request and websocket throughput (see [docs/http-server.md](docs/http-server.md))
 * Background jobs with failure events for production reporting (see [docs/background-jobs.md](docs/background-jobs.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 * EJS-backed mailers with delivery, queueing, and payload rendering support (see [docs/mailers.md](docs/mailers.md))

--- a/changelog.d/20260608162212-http-server-workers.md
+++ b/changelog.d/20260608162212-http-server-workers.md
@@ -1,2 +1,3 @@
 HTTP server processes can now start a configured number of worker handlers via
-`httpServer.workers` or `npx velocious server --workers <count>`.
+`configuration.httpServer.workers`, direct `Application` HTTP server options, or
+`npx velocious server --workers <count>`.

--- a/changelog.d/20260608162212-http-server-workers.md
+++ b/changelog.d/20260608162212-http-server-workers.md
@@ -1,0 +1,2 @@
+HTTP server processes can now start a configured number of worker handlers via
+`httpServer.workers` or `npx velocious server --workers <count>`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder contains implementation learnings and practical guidance discovered 
 ## Index
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
 - `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
+- `docs/http-server.md`: HTTP server worker configuration and socket distribution behavior.
 - `docs/expo-metro-compatibility.md`: Expo/Metro integration rules and the repository Expo export check.
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.
 - `docs/query-bulk-operations.md`: `updateAll` for efficient batch updates and `destroyAll` behavior.

--- a/docs/http-server.md
+++ b/docs/http-server.md
@@ -1,0 +1,39 @@
+# HTTP Server
+
+Velocious serves HTTP requests through worker handlers. The default is one
+worker, which keeps development and small deployments predictable. Applications
+that need more request or websocket throughput can opt into multiple workers.
+
+## CLI Workers
+
+Start a server with a fixed worker count:
+
+```bash
+npx velocious server --host 127.0.0.1 --port 3006 --workers 4
+```
+
+`--workers` must be a positive integer. Each incoming socket is assigned to the
+next worker in round-robin order. Websocket broadcasts still use the configured
+cross-worker broadcast bus, so channels can publish from one worker and deliver
+to subscribers hosted by another worker.
+
+## Application Workers
+
+Code that starts `Application` directly can pass the same option through the
+HTTP server config:
+
+```js
+const application = new Application({
+  configuration,
+  httpServer: {
+    host: "127.0.0.1",
+    port: 3006,
+    workers: 4
+  },
+  type: "server"
+})
+```
+
+`maxWorkers` remains accepted as a compatibility alias when `workers` is not
+provided, but new code should use `workers` because it describes the actual
+number of handlers started.

--- a/docs/http-server.md
+++ b/docs/http-server.md
@@ -17,10 +17,30 @@ next worker in round-robin order. Websocket broadcasts still use the configured
 cross-worker broadcast bus, so channels can publish from one worker and deliver
 to subscribers hosted by another worker.
 
+CLI arguments override `configuration.httpServer` values. When neither the CLI
+nor the configuration supplies a value, the CLI defaults to `127.0.0.1:3006`.
+
+## Configuration Workers
+
+Applications can keep server defaults in their Velocious configuration:
+
+```js
+const configuration = new Configuration({
+  httpServer: {
+    host: "127.0.0.1",
+    port: 3006,
+    workers: 4
+  }
+})
+```
+
+This is the preferred place for application-owned defaults such as production
+worker counts.
+
 ## Application Workers
 
 Code that starts `Application` directly can pass the same option through the
-HTTP server config:
+HTTP server config. These values override `configuration.httpServer`:
 
 ```js
 const application = new Application({

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -134,20 +134,7 @@
       }
     },
     "spec/frontend-models/autoload-spec.js": {
-      "crap_critical": {
-        "count": 1
-      },
       "crap_moderate": {
-        "count": 4
-      }
-    },
-    "spec/frontend-models/base-spec.js": {
-      "crap_high": {
-        "count": 1
-      }
-    },
-    "spec/frontend-models/model-preload-spec.js": {
-      "crap_high": {
         "count": 1
       }
     },
@@ -343,10 +330,10 @@
         "count": 1
       },
       "crap_critical": {
-        "count": 5
+        "count": 6
       },
       "crap_high": {
-        "count": 9
+        "count": 8
       },
       "crap_moderate": {
         "count": 12
@@ -570,14 +557,8 @@
       }
     },
     "src/database/pool/async-tracked-multi-connection.js": {
-      "crap_critical": {
-        "count": 1
-      },
-      "crap_high": {
-        "count": 2
-      },
       "crap_moderate": {
-        "count": 6
+        "count": 1
       }
     },
     "src/database/query-parser/from-parser.js": {
@@ -1001,7 +982,7 @@
       }
     },
     "src/environment-handlers/node/cli/commands/server.js": {
-      "crap_high": {
+      "crap_moderate": {
         "count": 1
       }
     },

--- a/spec/application/http-server-configuration-spec.js
+++ b/spec/application/http-server-configuration-spec.js
@@ -1,0 +1,114 @@
+// @ts-check
+
+import Application from "../../src/application.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class HttpServerConfigurationTestConfiguration {
+  debug = false
+  websocketEvents = null
+
+  /** @param {{httpServer?: import("../../src/configuration-types.js").HttpServerConfiguration}} args */
+  constructor({httpServer = {}} = {}) {
+    this.httpServer = httpServer
+  }
+
+  /** @returns {string} */
+  getEnvironment() {
+    return "test"
+  }
+
+  /** @returns {unknown} */
+  getWebsocketEvents() {
+    return this.websocketEvents
+  }
+
+  /** @param {unknown} websocketEvents */
+  setWebsocketEvents(websocketEvents) {
+    this.websocketEvents = websocketEvents
+  }
+
+  /** @returns {Promise<void>} */
+  async connectBeacon() {}
+
+  /** @returns {Promise<void>} */
+  async disconnectBeacon() {}
+
+  /** @returns {Promise<void>} */
+  async closeDatabaseConnections() {}
+}
+
+/**
+ * @param {Application} application - Application to start.
+ * @param {object} expected - Expected HTTP server values.
+ * @param {string} expected.host - Expected host.
+ * @param {boolean} expected.inProcess - Whether in-process workers are expected.
+ * @param {number} expected.port - Expected port.
+ * @param {number} expected.workers - Expected worker count.
+ * @returns {Promise<void>}
+ */
+async function expectStartedHttpServer(application, expected) {
+  try {
+    await application.startHttpServer()
+
+    const {httpServer} = application
+    if (!httpServer) throw new Error("Expected application to start an HTTP server")
+
+    expect(httpServer.host).toEqual(expected.host)
+    expect(httpServer.inProcess).toEqual(expected.inProcess)
+    expect(httpServer.port).toEqual(expected.port)
+    expect(httpServer.workers).toEqual(expected.workers)
+    expect(httpServer.workerHandlers).toHaveLength(expected.workers)
+  } finally {
+    await application.stop()
+  }
+}
+
+describe("Application HTTP server configuration", {databaseCleaning: {transaction: true}}, () => {
+  it("uses configuration httpServer defaults", async () => {
+    const configuration = new HttpServerConfigurationTestConfiguration({
+      httpServer: {
+        host: "127.0.0.1",
+        inProcess: true,
+        port: 0,
+        workers: 2
+      }
+    })
+    const application = new Application({
+      configuration: /** @type {import("../../src/configuration.js").default} */ (/** @type {unknown} */ (configuration)),
+      type: "test"
+    })
+
+    await expectStartedHttpServer(application, {
+      host: "127.0.0.1",
+      inProcess: true,
+      port: 0,
+      workers: 2
+    })
+  })
+
+  it("lets direct application httpServer args override configuration defaults", async () => {
+    const configuration = new HttpServerConfigurationTestConfiguration({
+      httpServer: {
+        host: "127.0.0.1",
+        inProcess: true,
+        port: 31006,
+        workers: 2
+      }
+    })
+    const application = new Application({
+      configuration: /** @type {import("../../src/configuration.js").default} */ (/** @type {unknown} */ (configuration)),
+      httpServer: {
+        port: 0,
+        workers: 1
+      },
+      type: "test"
+    })
+
+    await expectStartedHttpServer(application, {
+      host: "127.0.0.1",
+      inProcess: true,
+      port: 0,
+      workers: 1
+    })
+  })
+})

--- a/spec/cli/commands/server-signal-shutdown-spec.js
+++ b/spec/cli/commands/server-signal-shutdown-spec.js
@@ -60,6 +60,19 @@ describe("VelociousCliCommandsServer signal shutdown", () => {
     })
   })
 
+  it("uses configuration HTTP server defaults and lets CLI args override them", () => {
+    expect(httpServerConfigFromParsedArgs({}, {host: "0.0.0.0", port: 4100, workers: 2})).toEqual({
+      host: "0.0.0.0",
+      port: 4100,
+      workers: 2
+    })
+    expect(httpServerConfigFromParsedArgs({port: "4200", workers: "4"}, {host: "0.0.0.0", port: 4100, workers: 2})).toEqual({
+      host: "0.0.0.0",
+      port: 4200,
+      workers: 4
+    })
+  })
+
   it("rejects invalid server worker counts", () => {
     expect(() => httpServerConfigFromParsedArgs({workers: true})).toThrowError("--workers must be a positive integer")
     expect(() => httpServerConfigFromParsedArgs({workers: "0"})).toThrowError("--workers must be a positive integer")

--- a/spec/cli/commands/server-signal-shutdown-spec.js
+++ b/spec/cli/commands/server-signal-shutdown-spec.js
@@ -2,7 +2,7 @@
 
 import {EventEmitter} from "node:events"
 import {describe, expect, it} from "../../../src/testing/test.js"
-import {waitForApplicationWithSignalShutdown} from "../../../src/environment-handlers/node/cli/commands/server.js"
+import {httpServerConfigFromParsedArgs, waitForApplicationWithSignalShutdown} from "../../../src/environment-handlers/node/cli/commands/server.js"
 
 /** Fake application for signal-shutdown command tests. */
 class FakeApplication {
@@ -48,6 +48,24 @@ function waitForTick() {
 }
 
 describe("VelociousCliCommandsServer signal shutdown", () => {
+  it("builds server HTTP config with optional workers", () => {
+    expect(httpServerConfigFromParsedArgs({host: "0.0.0.0", port: "4000", workers: "4"})).toEqual({
+      host: "0.0.0.0",
+      port: 4000,
+      workers: 4
+    })
+    expect(httpServerConfigFromParsedArgs({})).toEqual({
+      host: "127.0.0.1",
+      port: 3006
+    })
+  })
+
+  it("rejects invalid server worker counts", () => {
+    expect(() => httpServerConfigFromParsedArgs({workers: true})).toThrowError("--workers must be a positive integer")
+    expect(() => httpServerConfigFromParsedArgs({workers: "0"})).toThrowError("--workers must be a positive integer")
+    expect(() => httpServerConfigFromParsedArgs({workers: "two"})).toThrowError("--workers must be a positive integer")
+  })
+
   it("stops the application when SIGTERM is received", async () => {
     const application = new FakeApplication()
     const processObject = new EventEmitter()

--- a/spec/http-server/listen-error-spec.js
+++ b/spec/http-server/listen-error-spec.js
@@ -73,7 +73,8 @@ describe("HttpServer - listen errors", {databaseCleaning: {transaction: true}}, 
       configuration: buildConfiguration(),
       host: "127.0.0.1",
       port,
-      workerHandlerFactory: ({workerCount}) => new TestWorkerHandler({stoppedWorkers, workerCount})
+      workerHandlerFactory: ({workerCount}) => new TestWorkerHandler({stoppedWorkers, workerCount}),
+      workers: 3
     })
 
     let startupError
@@ -94,7 +95,7 @@ describe("HttpServer - listen errors", {databaseCleaning: {transaction: true}}, 
     })
 
     expect(startupError.code).toEqual("EADDRINUSE")
-    expect(stoppedWorkers).toEqual(["worker-0"])
+    expect(stoppedWorkers).toEqual(["worker-0", "worker-1", "worker-2"])
     expect(server.isActive()).toBeFalse()
   })
 

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -29,6 +29,16 @@ class FakeWorkerHandler {
   }
 }
 
+/** @returns {HttpServer} - Test HTTP server with the minimal worker-handler configuration. */
+function buildWorkerHandlerTestServer() {
+  return new HttpServer({
+    configuration: {
+      debug: false,
+      getEnvironment: () => "test"
+    }
+  })
+}
+
 describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}}, () => {
   it("starts the configured worker handlers", async () => {
     const startedHandlers = []
@@ -55,12 +65,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
   })
 
   it("assigns connections across workers in round-robin order", () => {
-    const server = new HttpServer({
-      configuration: {
-        debug: false,
-        getEnvironment: () => "test"
-      }
-    })
+    const server = buildWorkerHandlerTestServer()
 
     server.workerHandlers = [
       {workerCount: 0},
@@ -72,6 +77,38 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     expect(server.workerHandlerToUse().workerCount).toEqual(1)
     expect(server.workerHandlerToUse().workerCount).toEqual(2)
     expect(server.workerHandlerToUse().workerCount).toEqual(0)
+  })
+
+  it("keeps sticky connections on the same worker", () => {
+    const server = buildWorkerHandlerTestServer()
+
+    server.workerHandlers = [
+      {workerCount: 0},
+      {workerCount: 1},
+      {workerCount: 2}
+    ]
+
+    expect(server.workerHandlerToUse({stickyKey: "client-a"}).workerCount).toEqual(0)
+    expect(server.workerHandlerToUse({stickyKey: "client-b"}).workerCount).toEqual(1)
+    expect(server.workerHandlerToUse({stickyKey: "client-a"}).workerCount).toEqual(0)
+    expect(server.workerHandlerToUse().workerCount).toEqual(2)
+  })
+
+  it("drops stale sticky workers after replacement", () => {
+    const server = buildWorkerHandlerTestServer()
+
+    server.workerHandlers = [
+      {workerCount: 0}
+    ]
+
+    expect(server.workerHandlerToUse({stickyKey: "client-a"}).workerCount).toEqual(0)
+
+    server.workerHandlers = [
+      {workerCount: 1}
+    ]
+    server.nextWorkerHandlerIndex = 0
+
+    expect(server.workerHandlerToUse({stickyKey: "client-a"}).workerCount).toEqual(1)
   })
 
   it("closes client connections when the worker exits unexpectedly", () => {

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -5,7 +5,75 @@ import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 import websocketEventsHost from "../../src/http-server/websocket-events-host.js"
 
+class FakeWorkerHandler {
+  /**
+   * @param {object} args - Options object.
+   * @param {Array<number>} [args.startedHandlers] - Worker ids recorded on start.
+   * @param {Array<number>} [args.stoppedHandlers] - Worker ids recorded on stop.
+   * @param {number} args.workerCount - Worker id.
+   */
+  constructor({startedHandlers = [], stoppedHandlers = [], workerCount}) {
+    this.startedHandlers = startedHandlers
+    this.stoppedHandlers = stoppedHandlers
+    this.workerCount = workerCount
+  }
+
+  /** @returns {Promise<void>} - Resolves when started. */
+  async start() {
+    this.startedHandlers.push(this.workerCount)
+  }
+
+  /** @returns {Promise<void>} - Resolves when stopped. */
+  async stop() {
+    this.stoppedHandlers.push(this.workerCount)
+  }
+}
+
 describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}}, () => {
+  it("starts the configured worker handlers", async () => {
+    const startedHandlers = []
+    const stoppedHandlers = []
+
+    const server = new HttpServer({
+      configuration: {
+        debug: false,
+        getEnvironment: () => "test"
+      },
+      port: 0,
+      workerHandlerFactory: ({workerCount}) => new FakeWorkerHandler({startedHandlers, stoppedHandlers, workerCount}),
+      workers: 3
+    })
+
+    await server.start()
+
+    expect(startedHandlers).toEqual([0, 1, 2])
+    expect(server.workerHandlers.map((handler) => handler.workerCount)).toEqual([0, 1, 2])
+
+    await server.stop()
+
+    expect(stoppedHandlers).toEqual([0, 1, 2])
+  })
+
+  it("assigns connections across workers in round-robin order", () => {
+    const server = new HttpServer({
+      configuration: {
+        debug: false,
+        getEnvironment: () => "test"
+      }
+    })
+
+    server.workerHandlers = [
+      {workerCount: 0},
+      {workerCount: 1},
+      {workerCount: 2}
+    ]
+
+    expect(server.workerHandlerToUse().workerCount).toEqual(0)
+    expect(server.workerHandlerToUse().workerCount).toEqual(1)
+    expect(server.workerHandlerToUse().workerCount).toEqual(2)
+    expect(server.workerHandlerToUse().workerCount).toEqual(0)
+  })
+
   it("closes client connections when the worker exits unexpectedly", () => {
     const configuration = {debug: false}
     const handler = new WorkerHandler({configuration, workerCount: 1})
@@ -98,20 +166,6 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     const startedHandlers = []
     const stoppedHandlers = []
 
-    class FakeWorkerHandler {
-      constructor({workerCount}) {
-        this.workerCount = workerCount
-      }
-
-      async start() {
-        startedHandlers.push(this.workerCount)
-      }
-
-      async stop() {
-        stoppedHandlers.push(this.workerCount)
-      }
-    }
-
     const server = new HttpServer({
       configuration: {
         debug: false,
@@ -121,13 +175,10 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
     server.inProcess = false
     server.workerCount = 0
-    server.workerHandlers = [new FakeWorkerHandler({workerCount: 0})]
-    server.workerHandlers[0].stop = async () => {
-      stoppedHandlers.push(0)
-    }
+    server.workerHandlers = [new FakeWorkerHandler({stoppedHandlers, workerCount: 0})]
 
     server._buildWorkerHandler = async function () {
-      const workerHandler = new FakeWorkerHandler({workerCount: this.workerCount})
+      const workerHandler = new FakeWorkerHandler({startedHandlers, stoppedHandlers, workerCount: this.workerCount})
 
       this.workerCount++
       await workerHandler.start()
@@ -140,5 +191,32 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     expect(startedHandlers).toEqual([0])
     expect(stoppedHandlers).toEqual([0])
     expect(server.workerHandlers.map((handler) => handler.workerCount)).toEqual([0])
+  })
+
+  it("recycles every configured worker on development reload", async () => {
+    const startedHandlers = []
+    const stoppedHandlers = []
+
+    const server = new HttpServer({
+      configuration: {
+        debug: false,
+        getEnvironment: () => "development"
+      },
+      workerHandlerFactory: ({workerCount}) => new FakeWorkerHandler({startedHandlers, stoppedHandlers, workerCount}),
+      workers: 2
+    })
+
+    server.inProcess = false
+    server.workerCount = 2
+    server.workerHandlers = [
+      new FakeWorkerHandler({stoppedHandlers, workerCount: 0}),
+      new FakeWorkerHandler({stoppedHandlers, workerCount: 1})
+    ]
+
+    await server.reloadWorkersForDevelopment()
+
+    expect(startedHandlers).toEqual([2, 3])
+    expect(stoppedHandlers).toEqual([0, 1])
+    expect(server.workerHandlers.map((handler) => handler.workerCount)).toEqual([2, 3])
   })
 })

--- a/src/application.js
+++ b/src/application.js
@@ -6,14 +6,7 @@ import HttpServer from "./http-server/index.js"
 import websocketEventsHost from "./http-server/websocket-events-host.js"
 import restArgsError from "./utils/rest-args-error.js"
 
-/**
- * @typedef {object} HttpServerConfiguration
- * @property {boolean} [inProcess] - Run HTTP handlers in the main thread instead of worker threads.
- * @property {number} [maxWorkers] - Max worker threads for the HTTP server.
- * @property {number} [workers] - Worker threads to start for the HTTP server.
- * @property {string} [host] - Hostname to bind the HTTP server to.
- * @property {number} [port] - Port to bind the HTTP server to.
- */
+/** @typedef {import("./configuration-types.js").HttpServerConfiguration} HttpServerConfiguration */
 
 export default class VelociousApplication {
   /**
@@ -30,7 +23,7 @@ export default class VelociousApplication {
     this.configuration = configuration
 
     /** @type {HttpServerConfiguration} */
-    this.httpServerConfiguration = httpServer ?? {port: undefined}
+    this.httpServerConfiguration = httpServer ?? {}
 
     this.logger = new Logger(this)
     this._type = type
@@ -78,8 +71,12 @@ export default class VelociousApplication {
 
   /** @returns {Promise<void>} - Resolves when complete.  */
   async startHttpServer() {
-    const {configuration, httpServerConfiguration} = this
-    const port = httpServerConfiguration.port || 3006
+    const {configuration} = this
+    const httpServerConfiguration = {
+      ...configuration.httpServer,
+      ...this.httpServerConfiguration
+    }
+    const port = httpServerConfiguration.port ?? 3006
 
     await this.logger.debug(`Starting server on port ${port}`)
 

--- a/src/application.js
+++ b/src/application.js
@@ -10,6 +10,7 @@ import restArgsError from "./utils/rest-args-error.js"
  * @typedef {object} HttpServerConfiguration
  * @property {boolean} [inProcess] - Run HTTP handlers in the main thread instead of worker threads.
  * @property {number} [maxWorkers] - Max worker threads for the HTTP server.
+ * @property {number} [workers] - Worker threads to start for the HTTP server.
  * @property {string} [host] - Hostname to bind the HTTP server to.
  * @property {number} [port] - Port to bind the HTTP server to.
  */
@@ -88,7 +89,14 @@ export default class VelociousApplication {
 
     await configuration.connectBeacon({peerType: "server"})
 
-    this.httpServer = new HttpServer({configuration, inProcess: httpServerConfiguration.inProcess, port})
+    this.httpServer = new HttpServer({
+      configuration,
+      host: httpServerConfiguration.host,
+      inProcess: httpServerConfiguration.inProcess,
+      maxWorkers: httpServerConfiguration.maxWorkers,
+      port,
+      workers: httpServerConfiguration.workers
+    })
     this.httpServer.events.on("close", this.onHttpServerClose)
 
     await this.httpServer.start()

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -176,6 +176,15 @@
  */
 
 /**
+ * @typedef {object} HttpServerConfiguration
+ * @property {string} [host] - Hostname to bind the HTTP server to.
+ * @property {boolean} [inProcess] - Run HTTP handlers in the main thread instead of worker threads.
+ * @property {number} [maxWorkers] - Backward-compatible alias for workers.
+ * @property {number} [port] - Port to bind the HTTP server to.
+ * @property {number} [workers] - Worker handlers to start for the HTTP server.
+ */
+
+/**
  * @typedef {object} ScheduledBackgroundJobEveryOptions
  * @property {number | string} [firstIn] - Delay before the first enqueue.
  * @property {number | string} [first_in] - Sidekiq-style alias for `firstIn`.
@@ -384,6 +393,7 @@
  * @property {string} [environment] - Current environment name.
  * @property {import("./environment-handlers/base.js").default} environmentHandler - Environment handler instance.
  * @property {boolean} [exposeInternalErrorsToClients] - Return unexpected internal error details in client API payloads outside production. Defaults to false.
+ * @property {HttpServerConfiguration} [httpServer] - Default HTTP server configuration for applications started from this configuration.
  * @property {LoggingConfiguration} [logging] - Logging configuration.
  * @property {BackgroundJobsConfiguration} [backgroundJobs] - Background jobs configuration.
  * @property {BeaconConfiguration} [beacon] - Beacon broadcast bus configuration.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -65,7 +65,7 @@ export default class VelociousConfiguration {
   }
 
   /** @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments. */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -92,6 +92,7 @@ export default class VelociousConfiguration {
     this._directory = directory
     this._initializeModels = initializeModels
     this._isInitialized = false
+    this.httpServer = httpServer || {}
     this.locale = locale
     this.localeFallbacks = localeFallbacks
     this.locales = locales

--- a/src/environment-handlers/node/cli/commands/server.js
+++ b/src/environment-handlers/node/cli/commands/server.js
@@ -76,21 +76,40 @@ export function waitForApplicationWithSignalShutdown({application, processObject
 }
 
 /**
- * @param {Record<string, string | number | boolean | undefined>} parsedProcessArgs - Parsed CLI args.
- * @returns {{host: string, port: number, workers?: number}} - HTTP server config.
+ * @template T
+ * @param {...(T | undefined)} values - Candidate values in priority order.
+ * @returns {T | undefined} - First configured value.
  */
-export function httpServerConfigFromParsedArgs(parsedProcessArgs = {}) {
-  const host = String(parsedProcessArgs.h || parsedProcessArgs.host || "127.0.0.1")
-  const port = Number(parsedProcessArgs.p || parsedProcessArgs.port || 3006)
-  const workersArg = parsedProcessArgs.workers
+function firstConfiguredValue(...values) {
+  return values.find((value) => value !== undefined)
+}
 
-  if (workersArg === undefined) return {host, port}
+/**
+ * @param {string | number | boolean | undefined} workersArg - Worker count argument.
+ * @returns {number | undefined} - Normalized worker count.
+ */
+function httpServerWorkersFromArg(workersArg) {
+  if (workersArg === undefined) return undefined
   if (typeof workersArg === "boolean") throw new Error("--workers must be a positive integer")
 
   const workers = Number(workersArg)
 
   if (!Number.isInteger(workers) || workers < 1) throw new Error("--workers must be a positive integer")
 
+  return workers
+}
+
+/**
+ * @param {Record<string, string | number | boolean | undefined>} parsedProcessArgs - Parsed CLI args.
+ * @param {import("../../../../configuration-types.js").HttpServerConfiguration} [defaults] - Default HTTP server config.
+ * @returns {{host: string, port: number, workers?: number}} - HTTP server config.
+ */
+export function httpServerConfigFromParsedArgs(parsedProcessArgs = {}, defaults = {}) {
+  const host = String(firstConfiguredValue(parsedProcessArgs.h, parsedProcessArgs.host, defaults.host, "127.0.0.1"))
+  const port = Number(firstConfiguredValue(parsedProcessArgs.p, parsedProcessArgs.port, defaults.port, 3006))
+  const workers = httpServerWorkersFromArg(firstConfiguredValue(parsedProcessArgs.workers, defaults.workers))
+
+  if (workers === undefined) return {host, port}
   return {host, port, workers}
 }
 
@@ -98,13 +117,14 @@ export default class VelociousCliCommandsServer extends BaseCommand{
   /** @returns {Promise<void>} - Starts the HTTP server and waits until it stops. */
   async execute() {
     const parsedProcessArgs = this.args?.parsedProcessArgs || {}
-    const httpServer = httpServerConfigFromParsedArgs(parsedProcessArgs)
+    const configuration = this.getConfiguration()
+    const httpServer = httpServerConfigFromParsedArgs(parsedProcessArgs, configuration.httpServer)
     const application = new Application({
-      configuration: this.getConfiguration(),
+      configuration,
       httpServer,
       type: "server"
     })
-    const environment = this.getConfiguration().getEnvironment()
+    const environment = configuration.getEnvironment()
 
     await application.initialize()
     await application.startHttpServer()

--- a/src/environment-handlers/node/cli/commands/server.js
+++ b/src/environment-handlers/node/cli/commands/server.js
@@ -75,25 +75,40 @@ export function waitForApplicationWithSignalShutdown({application, processObject
   })
 }
 
+/**
+ * @param {Record<string, string | number | boolean | undefined>} parsedProcessArgs - Parsed CLI args.
+ * @returns {{host: string, port: number, workers?: number}} - HTTP server config.
+ */
+export function httpServerConfigFromParsedArgs(parsedProcessArgs = {}) {
+  const host = String(parsedProcessArgs.h || parsedProcessArgs.host || "127.0.0.1")
+  const port = Number(parsedProcessArgs.p || parsedProcessArgs.port || 3006)
+  const workersArg = parsedProcessArgs.workers
+
+  if (workersArg === undefined) return {host, port}
+  if (typeof workersArg === "boolean") throw new Error("--workers must be a positive integer")
+
+  const workers = Number(workersArg)
+
+  if (!Number.isInteger(workers) || workers < 1) throw new Error("--workers must be a positive integer")
+
+  return {host, port, workers}
+}
+
 export default class VelociousCliCommandsServer extends BaseCommand{
   /** @returns {Promise<void>} - Starts the HTTP server and waits until it stops. */
   async execute() {
     const parsedProcessArgs = this.args?.parsedProcessArgs || {}
-    const host = String(parsedProcessArgs.h || parsedProcessArgs.host || "127.0.0.1")
-    const port = Number(parsedProcessArgs.p || parsedProcessArgs.port || 3006)
+    const httpServer = httpServerConfigFromParsedArgs(parsedProcessArgs)
     const application = new Application({
       configuration: this.getConfiguration(),
-      httpServer: {
-        host,
-        port
-      },
+      httpServer,
       type: "server"
     })
     const environment = this.getConfiguration().getEnvironment()
 
     await application.initialize()
     await application.startHttpServer()
-    console.log(`Started Velocious HTTP server on ${host}:${port} in ${environment} environment`)
+    console.log(`Started Velocious HTTP server on ${httpServer.host}:${httpServer.port} in ${environment} environment`)
     await waitForApplicationWithSignalShutdown({application})
   }
 }

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -12,6 +12,22 @@ import WorkerHandler from "./worker-handler/index.js"
 /** @typedef {{start: () => Promise<void>, stop: () => Promise<void>}} DevelopmentReloaderLike */
 /** @typedef {function({configuration: import("../configuration.js").default, workerCount: number}) : (WorkerHandler | InProcessHandler)} WorkerHandlerFactory */
 
+/**
+ * @param {object} args - Options object.
+ * @param {number} [args.maxWorkers] - Backward-compatible worker count alias.
+ * @param {number} [args.workers] - Configured worker count.
+ * @returns {number} - Normalized worker count.
+ */
+function normalizeWorkerCount({maxWorkers, workers}) {
+  const workerCount = workers ?? maxWorkers ?? 1
+
+  if (!Number.isInteger(workerCount) || workerCount < 1) {
+    throw new Error("HTTP server workers must be a positive integer")
+  }
+
+  return workerCount
+}
+
 export default class VelociousHttpServer {
   clientCount = 0
   _starting = false
@@ -36,6 +52,7 @@ export default class VelociousHttpServer {
 
   /** @type {Array<WorkerHandler | InProcessHandler>} */
   workerHandlers = []
+  nextWorkerHandlerIndex = 0
 
   /**
    * @param {object} args - Options object.
@@ -44,10 +61,11 @@ export default class VelociousHttpServer {
    * @param {boolean} [args.inProcess] - Run HTTP handlers in the main thread instead of worker threads.
    * @param {number} [args.port] - Port.
    * @param {number} [args.maxWorkers] - Max workers.
+   * @param {number} [args.workers] - Worker handlers to start.
    * @param {function({configuration: import("../configuration.js").default, onReload: function({changedPath: string}) : Promise<void>}) : {start: () => Promise<void>, stop: () => Promise<void>}} [args.developmentReloaderFactory] - Development reloader factory.
    * @param {WorkerHandlerFactory} [args.workerHandlerFactory] - Worker handler factory.
    */
-  constructor({configuration, developmentReloaderFactory, host, inProcess, maxWorkers, port, workerHandlerFactory}) {
+  constructor({configuration, developmentReloaderFactory, host, inProcess, maxWorkers, port, workerHandlerFactory, workers}) {
     this.configuration = configuration
     this.developmentReloaderFactory = developmentReloaderFactory
     this.workerHandlerFactory = workerHandlerFactory
@@ -55,7 +73,7 @@ export default class VelociousHttpServer {
     this.logger = new Logger(this)
     this.host = host ?? "0.0.0.0"
     this.port = port ?? 3006
-    this.maxWorkers = maxWorkers ?? 16
+    this.workers = normalizeWorkerCount({maxWorkers, workers})
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
@@ -67,7 +85,7 @@ export default class VelociousHttpServer {
     const startupState = this._captureStartupState()
 
     try {
-      await this._ensureAtLeastOneWorker()
+      await this._ensureWorkers()
       await this._startDevelopmentReloader()
       /** @type {import("net").Server} */
       const netServer = new Net.Server()
@@ -143,8 +161,8 @@ export default class VelociousHttpServer {
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
-  async _ensureAtLeastOneWorker() {
-    if (this.workerHandlers.length == 0) {
+  async _ensureWorkers() {
+    while (this.workerHandlers.length < this.workers) {
       await this.spawnWorker()
     }
   }
@@ -290,6 +308,18 @@ export default class VelociousHttpServer {
     this.workerHandlers.push(workerHandler)
   }
 
+  /** @returns {Promise<Array<WorkerHandler | InProcessHandler>>} - Started worker handlers. */
+  async _buildWorkerHandlers() {
+    /** @type {Array<WorkerHandler | InProcessHandler>} */
+    const workerHandlers = []
+
+    for (let index = 0; index < this.workers; index += 1) {
+      workerHandlers.push(await this._buildWorkerHandler())
+    }
+
+    return workerHandlers
+  }
+
   /** @returns {Promise<WorkerHandler | InProcessHandler>} - Started worker handler. */
   async _buildWorkerHandler() {
     const workerCount = this.workerCount
@@ -313,12 +343,14 @@ export default class VelociousHttpServer {
   workerHandlerToUse() {
     this.logger.debug(`Worker handlers length: ${this.workerHandlers.length}`)
 
-    const randomWorkerNumber = Math.floor(Math.random() * this.workerHandlers.length)
-    const workerHandler = this.workerHandlers[randomWorkerNumber]
+    const workerHandlerIndex = this.nextWorkerHandlerIndex % this.workerHandlers.length
+    const workerHandler = this.workerHandlers[workerHandlerIndex]
 
     if (!workerHandler) {
-      throw new Error(`No workerHandler by that number: ${randomWorkerNumber}`)
+      throw new Error(`No workerHandler by that number: ${workerHandlerIndex}`)
     }
+
+    this.nextWorkerHandlerIndex += 1
 
     return workerHandler
   }
@@ -363,9 +395,10 @@ export default class VelociousHttpServer {
         this._reloadWorkersForDevelopmentQueued = false
 
         const oldWorkerHandlers = [...this.workerHandlers]
-        const newWorkerHandler = await this._buildWorkerHandler()
+        const newWorkerHandlers = await this._buildWorkerHandlers()
 
-        this.workerHandlers = [newWorkerHandler]
+        this.workerHandlers = newWorkerHandlers
+        this.nextWorkerHandlerIndex = 0
 
         await Promise.all(oldWorkerHandlers.map((workerHandler) => workerHandler.stop()))
       } while (this._reloadWorkersForDevelopmentQueued && !this._stopping)

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -53,6 +53,8 @@ export default class VelociousHttpServer {
   /** @type {Array<WorkerHandler | InProcessHandler>} */
   workerHandlers = []
   nextWorkerHandlerIndex = 0
+  /** @type {Map<string, WorkerHandler | InProcessHandler>} */
+  stickyWorkerHandlers = new Map()
 
   /**
    * @param {object} args - Options object.
@@ -134,6 +136,7 @@ export default class VelociousHttpServer {
     this.developmentReloader = startupState.developmentReloader
     this.netServer = startupState.netServer
     this.workerHandlers = startupState.workerHandlers
+    this.stickyWorkerHandlers.clear()
   }
 
   /** @returns {Promise<void>} - Resolves when complete.  */
@@ -232,6 +235,7 @@ export default class VelociousHttpServer {
     const stopTasks = this.workerHandlers.map((handler) => handler.stop())
     await Promise.all(stopTasks)
     this.workerHandlers = []
+    this.stickyWorkerHandlers.clear()
   }
 
   /** @returns {void} - No return value.  */
@@ -266,7 +270,9 @@ export default class VelociousHttpServer {
     this.clientCount++
 
     try {
-      const workerHandler = this.workerHandlerToUse()
+      // Paused WebSocket sessions are worker-local, so reconnects from
+      // the same client address must return to the same worker.
+      const workerHandler = this.workerHandlerToUse({stickyKey: socket.remoteAddress})
       const client = new ServerClient({
         clientCount,
         configuration: this.configuration,
@@ -339,8 +345,31 @@ export default class VelociousHttpServer {
     return workerHandler
   }
 
-  /** @returns {WorkerHandler | InProcessHandler} - The worker handler to use. */
-  workerHandlerToUse() {
+  /**
+   * @param {object} [args] - Options object.
+   * @param {string} [args.stickyKey] - Stable key that must keep routing to the same worker.
+   * @returns {WorkerHandler | InProcessHandler} - The worker handler to use.
+   */
+  workerHandlerToUse({stickyKey} = {}) {
+    if (stickyKey) {
+      const stickyWorkerHandler = this.stickyWorkerHandlers.get(stickyKey)
+
+      if (stickyWorkerHandler && this.workerHandlers.includes(stickyWorkerHandler)) {
+        return stickyWorkerHandler
+      }
+
+      const workerHandler = this._nextRoundRobinWorkerHandler()
+
+      this.stickyWorkerHandlers.set(stickyKey, workerHandler)
+
+      return workerHandler
+    }
+
+    return this._nextRoundRobinWorkerHandler()
+  }
+
+  /** @returns {WorkerHandler | InProcessHandler} - The next round-robin worker handler. */
+  _nextRoundRobinWorkerHandler() {
     this.logger.debug(`Worker handlers length: ${this.workerHandlers.length}`)
 
     const workerHandlerIndex = this.nextWorkerHandlerIndex % this.workerHandlers.length
@@ -399,6 +428,7 @@ export default class VelociousHttpServer {
 
         this.workerHandlers = newWorkerHandlers
         this.nextWorkerHandlerIndex = 0
+        this.stickyWorkerHandlers.clear()
 
         await Promise.all(oldWorkerHandlers.map((workerHandler) => workerHandler.stop()))
       } while (this._reloadWorkersForDevelopmentQueued && !this._stopping)


### PR DESCRIPTION
Summary:
- add HTTP server workers config and --workers CLI option
- distribute sockets round-robin across configured worker handlers
- document HTTP server worker configuration and add changelog entry

Tests:
- npm run test -- spec/http-server/worker-handler-spec.js spec/http-server/listen-error-spec.js spec/cli/commands/server-signal-shutdown-spec.js
- npm run build
- npm run lint
- npm run typecheck
- npm run fallow