### PR TITLE
Expose websocket subscription debug details

### DIFF
--- a/spec/frontend-models/websocket-channel-spec.js
+++ b/spec/frontend-models/websocket-channel-spec.js
@@ -67,6 +67,34 @@ describe("FrontendModelWebsocketChannel", {databaseCleaning: {transaction: true}
     expect(request.metadata("X-Session-Token")).toEqual("metadata-token")
   })
 
+  it("exposes debug-safe subscription details", () => {
+    const channel = new FrontendModelWebsocketChannel({
+      params: {
+        eventFilters: [
+          {key: "paid", where: {state: "paid"}}
+        ],
+        model: "Invoice",
+        preload: {organization: true},
+        select: {Invoice: ["id", "state"]},
+        unfilteredEventDelivery: true
+      },
+      session: /** @type {any} */ ({}),
+      subscriptionId: "debug-subscription"
+    })
+
+    expect(channel.debugSnapshot()).toEqual({
+      abilities: false,
+      eventFilterCount: 1,
+      model: "Invoice",
+      preload: true,
+      queryData: false,
+      select: true,
+      selectsExtra: false,
+      unfilteredEventDelivery: true,
+      withCount: false
+    })
+  })
+
   it("skips projected lifecycle events when the record cannot be reloaded", async () => {
     /** @type {Array<{body?: object, type?: string}>} */
     const sentFrames = []

--- a/spec/http-server/debug-snapshot-spec.js
+++ b/spec/http-server/debug-snapshot-spec.js
@@ -1,0 +1,90 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import HttpServer from "../../src/http-server/index.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class DebugWorkerHandler {
+  /**
+   * @param {object} args - Options object.
+   * @param {number} args.workerCount - Worker number.
+   */
+  constructor({workerCount}) {
+    this.workerCount = workerCount
+  }
+
+  /** @returns {Promise<void>} Resolves when started. */
+  async start() {}
+
+  /** @returns {Promise<void>} Resolves when stopped. */
+  async stop() {}
+
+  /** @returns {Promise<Record<string, unknown>>} Worker debug snapshot. */
+  async getDebugSnapshot() {
+    return {
+      active: true,
+      snapshot: {
+        database: {
+          activeIdentifiers: ["default"],
+          pools: {}
+        }
+      },
+      workerCount: this.workerCount
+    }
+  }
+}
+
+describe("HttpServer debug snapshots", {databaseCleaning: {transaction: true}}, () => {
+  it("includes per-worker debug snapshots", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      logging: {console: false, file: false}
+    })
+    const httpServer = new HttpServer({
+      configuration,
+      workerHandlerFactory: ({workerCount}) => new DebugWorkerHandler({workerCount}),
+      workers: 2
+    })
+
+    await httpServer._ensureWorkers()
+
+    try {
+      const snapshot = await httpServer.getDebugSnapshot()
+
+      expect(snapshot.configuredWorkerCount).toEqual(2)
+      expect(snapshot.workerCount).toEqual(2)
+      expect(snapshot.workers).toEqual([
+        {
+          active: true,
+          snapshot: {
+            database: {
+              activeIdentifiers: ["default"],
+              pools: {}
+            }
+          },
+          workerCount: 0
+        },
+        {
+          active: true,
+          snapshot: {
+            database: {
+              activeIdentifiers: ["default"],
+              pools: {}
+            }
+          },
+          workerCount: 1
+        }
+      ])
+    } finally {
+      await httpServer.stop()
+    }
+  })
+})

--- a/spec/http-server/debug-snapshot-spec.js
+++ b/spec/http-server/debug-snapshot-spec.js
@@ -5,52 +5,27 @@ import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
 import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 
-class DebugWorkerHandler {
-  /**
-   * @param {object} args - Options object.
-   * @param {number} args.workerCount - Worker number.
-   */
-  constructor({workerCount}) {
-    this.workerCount = workerCount
-  }
-
-  /** @returns {Promise<void>} Resolves when started. */
-  async start() {}
-
-  /** @returns {Promise<void>} Resolves when stopped. */
-  async stop() {}
-
-  /** @returns {Promise<Record<string, unknown>>} Worker debug snapshot. */
-  async getDebugSnapshot() {
-    return {
-      active: true,
-      snapshot: {
-        database: {
-          activeIdentifiers: ["default"],
-          pools: {}
-        }
-      },
-      workerCount: this.workerCount
-    }
-  }
+/** @returns {Configuration} Test configuration for debug snapshot specs. */
+function debugSnapshotConfiguration() {
+  return new Configuration({
+    database: {test: {}},
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    logging: {console: false, file: false}
+  })
 }
 
 describe("HttpServer debug snapshots", {databaseCleaning: {transaction: true}}, () => {
   it("includes per-worker debug snapshots", async () => {
-    const configuration = new Configuration({
-      database: {test: {}},
-      directory: process.cwd(),
-      environment: "test",
-      environmentHandler: new EnvironmentHandlerNode(),
-      initializeModels: async () => {},
-      locale: "en",
-      localeFallbacks: {en: ["en"]},
-      locales: ["en"],
-      logging: {console: false, file: false}
-    })
+    const configuration = debugSnapshotConfiguration()
     const httpServer = new HttpServer({
       configuration,
-      workerHandlerFactory: ({workerCount}) => new DebugWorkerHandler({workerCount}),
+      inProcess: true,
       workers: 2
     })
 
@@ -61,28 +36,12 @@ describe("HttpServer debug snapshots", {databaseCleaning: {transaction: true}}, 
 
       expect(snapshot.configuredWorkerCount).toEqual(2)
       expect(snapshot.workerCount).toEqual(2)
-      expect(snapshot.workers).toEqual([
-        {
-          active: true,
-          snapshot: {
-            database: {
-              activeIdentifiers: ["default"],
-              pools: {}
-            }
-          },
-          workerCount: 0
-        },
-        {
-          active: true,
-          snapshot: {
-            database: {
-              activeIdentifiers: ["default"],
-              pools: {}
-            }
-          },
-          workerCount: 1
-        }
+      expect(snapshot.workers.map((worker) => ({active: worker.active, workerCount: worker.workerCount}))).toEqual([
+        {active: true, workerCount: 0},
+        {active: true, workerCount: 1}
       ])
+      expect(snapshot.workers[0].snapshot.database).toMatchObject({initializedPools: []})
+      expect(snapshot.workers[1].snapshot.database).toMatchObject({initializedPools: []})
     } finally {
       await httpServer.stop()
     }

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -5,6 +5,21 @@ import Dummy from "../dummy/index.js"
 import WebsocketClient from "../../src/http-client/websocket-client.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import wait from "awaitery/build/wait.js"
+import WebsocketChannel from "../../src/http-server/websocket-channel.js"
+
+class ReorderedDebugChannel extends WebsocketChannel {
+  /** @returns {boolean} Whether the subscription is allowed. */
+  canSubscribe() { return true }
+
+  /** @returns {Record<string, unknown>} Debug details with intentionally unstable key order. */
+  debugSnapshot() {
+    if (this.params.reversed === true) {
+      return {outer: {b: 2, a: 1}, value: "same"}
+    }
+
+    return {value: "same", outer: {a: 1, b: 2}}
+  }
+}
 
 /**
  * @param {() => boolean} predicate
@@ -184,6 +199,41 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
         expect(counterSubscription?.details).toContainEqual({
           count: counterSubscription?.count,
           details: {}
+        })
+      } finally {
+        await clientA.close()
+        await clientB.close()
+      }
+    })
+  })
+
+  it("canonicalizes channel subscription debug snapshot keys before grouping", async () => {
+    await Dummy.run(async () => {
+      dummyConfiguration.registerWebsocketChannel("ReorderedDebug", ReorderedDebugChannel)
+      const clientA = new WebsocketClient()
+      const clientB = new WebsocketClient()
+
+      try {
+        await clientA.connect()
+        await clientB.connect()
+
+        const subA = clientA.subscribeChannel("ReorderedDebug", {params: {reversed: false}})
+        const subB = clientB.subscribeChannel("ReorderedDebug", {params: {reversed: true}})
+
+        await Promise.all([subA.ready, subB.ready])
+
+        const snapshot = dummyConfiguration.getLocalDebugSnapshot()
+        const reorderedSubscription = snapshot.websockets.subscriptions.find((subscription) => subscription.channel === "ReorderedDebug")
+
+        expect(reorderedSubscription).toEqual({
+          channel: "ReorderedDebug",
+          count: 2,
+          details: [
+            {
+              count: 2,
+              details: {outer: {a: 1, b: 2}, value: "same"}
+            }
+          ]
         })
       } finally {
         await clientA.close()

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -177,7 +177,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
         await Promise.all([subA.ready, subB.ready])
 
-        const snapshot = dummyConfiguration.getDebugSnapshot()
+        const snapshot = dummyConfiguration.getLocalDebugSnapshot()
         const counterSubscription = snapshot.websockets.subscriptions.find((subscription) => subscription.channel === "Counter")
 
         expect(counterSubscription?.count).toBeGreaterThanOrEqual(2)

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -163,6 +163,35 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
     })
   })
 
+  it("groups channel subscription debug snapshots", async () => {
+    await Dummy.run(async () => {
+      const clientA = new WebsocketClient()
+      const clientB = new WebsocketClient()
+
+      try {
+        await clientA.connect()
+        await clientB.connect()
+
+        const subA = clientA.subscribeChannel("Counter", {params: {allow: true, topic: "alpha"}})
+        const subB = clientB.subscribeChannel("Counter", {params: {allow: true, topic: "beta"}})
+
+        await Promise.all([subA.ready, subB.ready])
+
+        const snapshot = dummyConfiguration.getDebugSnapshot()
+        const counterSubscription = snapshot.websockets.subscriptions.find((subscription) => subscription.channel === "Counter")
+
+        expect(counterSubscription?.count).toBeGreaterThanOrEqual(2)
+        expect(counterSubscription?.details).toContainEqual({
+          count: counterSubscription?.count,
+          details: {}
+        })
+      } finally {
+        await clientA.close()
+        await clientB.close()
+      }
+    })
+  })
+
   it("waitForReady resolves the initial subscribe and reports ready state", async () => {
     await Dummy.run(async () => {
       const client = new WebsocketClient()

--- a/src/application.js
+++ b/src/application.js
@@ -95,6 +95,7 @@ export default class VelociousApplication {
       workers: httpServerConfiguration.workers
     })
     this.httpServer.events.on("close", this.onHttpServerClose)
+    configuration.setHttpServerInstance(this.httpServer)
 
     await this.httpServer.start()
   }
@@ -103,6 +104,7 @@ export default class VelociousApplication {
   async stop() {
     await this.logger.debug("Stopping server")
     await this.httpServer?.stop()
+    this.configuration.setHttpServerInstance(undefined)
     await this.configuration.disconnectBeacon()
     await this.configuration.closeDatabaseConnections()
   }

--- a/src/application.js
+++ b/src/application.js
@@ -95,7 +95,7 @@ export default class VelociousApplication {
       workers: httpServerConfiguration.workers
     })
     this.httpServer.events.on("close", this.onHttpServerClose)
-    configuration.setHttpServerInstance(this.httpServer)
+    configuration._httpServerInstance = this.httpServer
 
     await this.httpServer.start()
   }
@@ -104,7 +104,7 @@ export default class VelociousApplication {
   async stop() {
     await this.logger.debug("Stopping server")
     await this.httpServer?.stop()
-    this.configuration.setHttpServerInstance(undefined)
+    this.configuration._httpServerInstance = undefined
     await this.configuration.disconnectBeacon()
     await this.configuration.closeDatabaseConnections()
   }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -93,6 +93,7 @@ export default class VelociousConfiguration {
     this._initializeModels = initializeModels
     this._isInitialized = false
     this.httpServer = httpServer || {}
+    this._httpServerInstance = undefined
     this.locale = locale
     this.localeFallbacks = localeFallbacks
     this.locales = locales
@@ -162,6 +163,9 @@ export default class VelociousConfiguration {
 
   /** @returns {boolean} Whether unexpected internal error details may be returned to API clients. */
   getExposeInternalErrorsToClients() { return this._exposeInternalErrorsToClients === true }
+
+  /** @param {{getDebugSnapshot?: () => Promise<Record<string, unknown>>} | undefined} httpServer - Active HTTP server. */
+  setHttpServerInstance(httpServer) { this._httpServerInstance = httpServer }
 
   /** @returns {{enabled: boolean, path: string, token: string | null}} - Debug endpoint configuration. */
   getDebugEndpoint() { return this._debugEndpoint }
@@ -332,8 +336,18 @@ export default class VelociousConfiguration {
     return identifiers.filter((identifier) => !disabledIdentifiers.has(identifier) && this.isDatabaseIdentifierActive(identifier))
   }
 
-  /** @returns {Record<string, unknown>} - Human-readable server diagnostics. */
-  getDebugSnapshot() {
+  /** @returns {Promise<Record<string, unknown>>} - Human-readable server diagnostics. */
+  async getDebugSnapshot() {
+    const localSnapshot = this.getLocalDebugSnapshot()
+
+    return {
+      ...localSnapshot,
+      httpServer: await this._debugHttpServerSnapshot()
+    }
+  }
+
+  /** @returns {Record<string, unknown>} - Human-readable diagnostics for this process only. */
+  getLocalDebugSnapshot() {
     return {
       backgroundJobs: this._debugBackgroundJobsSnapshot(),
       configuration: this._debugConfigurationSnapshot(),
@@ -342,6 +356,17 @@ export default class VelociousConfiguration {
       server: this._debugServerSnapshot(),
       websockets: this._debugWebsocketSnapshot()
     }
+  }
+
+  /** @returns {Promise<Record<string, unknown>>} - HTTP server worker diagnostics. */
+  async _debugHttpServerSnapshot() {
+    const httpServer = /** @type {{getDebugSnapshot?: () => Promise<Record<string, unknown>>} | undefined} */ (this._httpServerInstance)
+
+    if (!httpServer?.getDebugSnapshot) {
+      return {configured: Boolean(this.httpServer), active: false}
+    }
+
+    return await httpServer.getDebugSnapshot()
   }
 
   /** @returns {Record<string, unknown>} - Server runtime diagnostics. */

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -107,6 +107,7 @@ export default class VelociousConfiguration {
     this._initializeModels = initializeModels
     this._isInitialized = false
     this.httpServer = httpServer || {}
+    /** @type {{getDebugSnapshot: () => Promise<Record<string, unknown>>} | undefined} */
     this._httpServerInstance = undefined
     this.locale = locale
     this.localeFallbacks = localeFallbacks
@@ -177,9 +178,6 @@ export default class VelociousConfiguration {
 
   /** @returns {boolean} Whether unexpected internal error details may be returned to API clients. */
   getExposeInternalErrorsToClients() { return this._exposeInternalErrorsToClients === true }
-
-  /** @param {{getDebugSnapshot?: () => Promise<Record<string, unknown>>} | undefined} httpServer - Active HTTP server. */
-  setHttpServerInstance(httpServer) { this._httpServerInstance = httpServer }
 
   /** @returns {{enabled: boolean, path: string, token: string | null}} - Debug endpoint configuration. */
   getDebugEndpoint() { return this._debugEndpoint }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -402,12 +402,35 @@ export default class VelociousConfiguration {
 
   /** @returns {Record<string, unknown>} - WebSocket diagnostics. */
   _debugWebsocketSnapshot() {
+    const subscriptions = Array.from(this._websocketChannelSubscriptions.entries()).map(([channel, channelSubscriptions]) => {
+      /** @type {Map<string, {count: number, details: Record<string, unknown>}>} */
+      const detailsBuckets = new Map()
+
+      for (const subscription of channelSubscriptions) {
+        const details = subscription.debugSnapshot()
+        const key = JSON.stringify(details)
+        const existingBucket = detailsBuckets.get(key)
+
+        if (existingBucket) {
+          existingBucket.count += 1
+        } else {
+          detailsBuckets.set(key, {count: 1, details})
+        }
+      }
+
+      return {
+        channel,
+        count: channelSubscriptions.size,
+        details: Array.from(detailsBuckets.values()).sort((a, b) => b.count - a.count)
+      }
+    })
+
     return {
       pausedSessions: this._pausedWebsocketSessions.size,
       registeredChannels: Array.from(this._websocketChannelClasses.keys()),
       registeredConnections: Array.from(this._websocketConnectionClasses.keys()),
       subscriptionGroups: this._websocketChannelSubscriptions.size,
-      subscriptions: Array.from(this._websocketChannelSubscriptions.entries()).map(([channel, subscriptions]) => ({channel, count: subscriptions.size}))
+      subscriptions
     }
   }
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -35,6 +35,20 @@ function currentWorkingDirectory() {
 }
 
 /**
+ * @param {unknown} value - Snapshot value to canonicalize.
+ * @returns {unknown} Snapshot value with object keys sorted recursively.
+ */
+function canonicalDebugSnapshotValue(value) {
+  if (!value || typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map((entry) => canonicalDebugSnapshotValue(entry))
+
+  return Object.keys(value).sort().reduce((result, key) => {
+    result[key] = canonicalDebugSnapshotValue(/** @type {Record<string, unknown>} */ (value)[key])
+    return result
+  }, /** @type {Record<string, unknown>} */ ({}))
+}
+
+/**
  * @param {import("./configuration-types.js").DatabaseConfigurationType} databaseConfiguration - Base database configuration.
  * @param {import("./configuration-types.js").DatabaseConfigurationType | Partial<import("./configuration-types.js").DatabaseConfigurationType> | void} overrideConfiguration - Tenant override configuration.
  * @returns {import("./configuration-types.js").DatabaseConfigurationType} - Merged database configuration.
@@ -432,7 +446,7 @@ export default class VelociousConfiguration {
       const detailsBuckets = new Map()
 
       for (const subscription of channelSubscriptions) {
-        const details = subscription.debugSnapshot()
+        const details = /** @type {Record<string, unknown>} */ (canonicalDebugSnapshotValue(subscription.debugSnapshot()))
         const key = JSON.stringify(details)
         const existingBucket = detailsBuckets.get(key)
 

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -162,6 +162,23 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
     return broadcastParams?.model === this._modelName()
   }
 
+  /** @returns {Record<string, unknown>} Debug-safe subscription details. */
+  debugSnapshot() {
+    const eventFilters = this._eventFilters()
+
+    return {
+      abilities: this.params.abilities !== undefined,
+      eventFilterCount: eventFilters.length,
+      model: this._modelName(),
+      preload: this.params.preload !== undefined,
+      queryData: this.params.queryData !== undefined,
+      select: this.params.select !== undefined,
+      selectsExtra: this.params.selectsExtra !== undefined,
+      unfilteredEventDelivery: this.params.unfilteredEventDelivery === true,
+      withCount: this.params.withCount !== undefined
+    }
+  }
+
   /** @returns {string | null} - Requested frontend-model name or null. */
   _modelName() {
     return typeof this.params?.model === "string" && this.params.model.length > 0

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -188,7 +188,31 @@ export default class VelociousHttpServer {
       configuredWorkerCount: this.workers,
       inProcess: this.inProcess,
       workerCount: this.workerHandlers.length,
-      workers: await Promise.all(this.workerHandlers.map((handler) => handler.getDebugSnapshot()))
+      workers: await Promise.all(this.workerHandlers.map((handler) => this.workerDebugSnapshot(handler)))
+    }
+  }
+
+  /**
+   * @param {WorkerHandler | InProcessHandler} workerHandler - Worker handler to inspect.
+   * @returns {Promise<Record<string, unknown>>} Worker debug snapshot.
+   */
+  async workerDebugSnapshot(workerHandler) {
+    if (workerHandler instanceof WorkerHandler) return await workerHandler.getDebugSnapshot()
+    if (workerHandler instanceof InProcessHandler) return this.inProcessWorkerDebugSnapshot(workerHandler)
+
+    return {active: false, error: "Unknown worker handler type"}
+  }
+
+  /**
+   * @param {InProcessHandler} workerHandler - In-process worker handler to inspect.
+   * @returns {Record<string, unknown>} Worker debug snapshot.
+   */
+  inProcessWorkerDebugSnapshot(workerHandler) {
+    return {
+      active: true,
+      clientCount: Object.keys(workerHandler.clients).length,
+      snapshot: workerHandler.configuration.getLocalDebugSnapshot(),
+      workerCount: workerHandler.workerCount
     }
   }
 

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -179,6 +179,19 @@ export default class VelociousHttpServer {
     return false
   }
 
+  /** @returns {Promise<Record<string, unknown>>} - HTTP server worker diagnostics. */
+  async getDebugSnapshot() {
+    return {
+      active: this.isActive(),
+      activeSocketCount: this._activeSockets.size,
+      clientCount: Object.keys(this.clients).length,
+      configuredWorkerCount: this.workers,
+      inProcess: this.inProcess,
+      workerCount: this.workerHandlers.length,
+      workers: await Promise.all(this.workerHandlers.map((handler) => handler.getDebugSnapshot()))
+    }
+  }
+
   /** @returns {Promise<void>} - Resolves when complete.  */
   async stopClients() {
     const promises = []

--- a/src/http-server/websocket-channel.js
+++ b/src/http-server/websocket-channel.js
@@ -95,6 +95,13 @@ export default class VelociousWebsocketChannel {
   matches(..._broadcastArgs) { return true }
 
   /**
+   * Returns sanitized diagnostics for debug snapshots.
+   * Subclasses can override to expose non-sensitive routing details.
+   * @returns {Record<string, unknown>} Debug-safe subscription details.
+   */
+  debugSnapshot() { return {} }
+
+  /**
    * Delivers a matched broadcast to this subscriber. Subclasses can
    * override when the outbound body must be tailored to subscription
    * params before sending.

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -93,6 +93,16 @@ export default class VelociousHttpServerInProcessHandler {
     this.unregisterFromEventsHost?.()
   }
 
+  /** @returns {Promise<Record<string, unknown>>} - In-process worker diagnostics. */
+  async getDebugSnapshot() {
+    return {
+      active: true,
+      clientCount: Object.keys(this.clients).length,
+      snapshot: this.configuration.getLocalDebugSnapshot(),
+      workerCount: this.workerCount
+    }
+  }
+
   /**
    * @param {object} args - Options object.
    * @param {string} args.channel - Channel name.

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -93,16 +93,6 @@ export default class VelociousHttpServerInProcessHandler {
     this.unregisterFromEventsHost?.()
   }
 
-  /** @returns {Promise<Record<string, unknown>>} - In-process worker diagnostics. */
-  async getDebugSnapshot() {
-    return {
-      active: true,
-      clientCount: Object.keys(this.clients).length,
-      snapshot: this.configuration.getLocalDebugSnapshot(),
-      workerCount: this.workerCount
-    }
-  }
-
   /**
    * @param {object} args - Options object.
    * @param {string} args.channel - Channel name.

--- a/src/http-server/worker-handler/index.js
+++ b/src/http-server/worker-handler/index.js
@@ -49,6 +49,9 @@ export default class VelociousHttpServerWorker {
     this.workerCount = workerCount
     this.workerStarted = false
     this._stopping = false
+    this._debugRequestId = 0
+    /** @type {Map<number, {resolve: (snapshot: Record<string, unknown>) => void}>} */
+    this._debugSnapshotRequests = new Map()
   }
 
   start() {
@@ -146,6 +149,8 @@ export default class VelociousHttpServerWorker {
    * @param {number} [data.clientCount] - Client count.
    * @param {string | Uint8Array} [data.output] - Output.
    * @param {string} [data.channel] - Channel name.
+   * @param {number} [data.requestId] - Debug request id.
+   * @param {Record<string, unknown>} [data.snapshot] - Worker debug snapshot.
    * @param {any} [data.payload] - Payload data.
    * @param {Record<string, any>} [data.broadcastParams] - V2 broadcast filter params.
    * @param {any} [data.body] - V2 broadcast body.
@@ -207,6 +212,15 @@ export default class VelociousHttpServerWorker {
       if (typeof clientCount === "number") {
         delete this.clients[clientCount]
       }
+    } else if (command == "debugSnapshot") {
+      const {requestId, snapshot} = data
+      if (typeof requestId !== "number") throw new Error("debugSnapshot requestId must be a number")
+      const request = this._debugSnapshotRequests.get(requestId)
+
+      if (request) {
+        this._debugSnapshotRequests.delete(requestId)
+        request.resolve(snapshot || {})
+      }
     } else if (command == "shutdownComplete") {
       this._stopResolve?.()
       this._stopResolve = null
@@ -229,6 +243,40 @@ export default class VelociousHttpServerWorker {
     } else {
       throw new Error(`Unknown command: ${command}`)
     }
+  }
+
+  /** @returns {Promise<Record<string, unknown>>} - Worker-local debug snapshot. */
+  getDebugSnapshot() {
+    if (!this.workerStarted || !this.worker) {
+      return Promise.resolve({active: false, workerCount: this.workerCount})
+    }
+
+    const requestId = ++this._debugRequestId
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        this._debugSnapshotRequests.delete(requestId)
+        resolve({active: true, error: "Timed out waiting for worker debug snapshot", workerCount: this.workerCount})
+      }, 2000)
+
+      if (typeof timeout.unref === "function") timeout.unref()
+
+      const worker = this.worker
+
+      if (!worker) {
+        clearTimeout(timeout)
+        resolve({active: false, workerCount: this.workerCount})
+        return
+      }
+
+      this._debugSnapshotRequests.set(requestId, {
+        resolve: (snapshot) => {
+          clearTimeout(timeout)
+          resolve({active: true, snapshot, workerCount: this.workerCount})
+        }
+      })
+      worker.postMessage({command: "debugSnapshot", requestId})
+    })
   }
 
   /**

--- a/src/http-server/worker-handler/worker-thread.js
+++ b/src/http-server/worker-handler/worker-thread.js
@@ -88,6 +88,7 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
    * @param {string} [data.channel] - Channel name.
    * @param {string} [data.createdAt] - Event creation time.
    * @param {string} [data.eventId] - Event identifier.
+   * @param {number} [data.requestId] - Debug request id.
    * @param {any} [data.payload] - Payload data.
    * @param {Record<string, any>} [data.broadcastParams] - V2 broadcast filter params.
    * @param {any} [data.body] - V2 broadcast body.
@@ -147,6 +148,17 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
       if (!this.configuration) throw new Error("Configuration not initialized")
 
       this.configuration._broadcastToChannelLocal(channel, broadcastParams || {}, body, {eventId})
+    } else if (command == "debugSnapshot") {
+      const {requestId} = data
+
+      if (typeof requestId !== "number") throw new Error("debugSnapshot requestId must be a number")
+      if (!this.configuration) throw new Error("Configuration not initialized")
+
+      this.parentPort.postMessage({
+        command: "debugSnapshot",
+        requestId,
+        snapshot: this.configuration.getLocalDebugSnapshot()
+      })
     } else if (command == "shutdown") {
       if (this.configuration?.closeDatabaseConnections) {
         await this.configuration.closeDatabaseConnections()

--- a/src/routes/built-in/debug/controller.js
+++ b/src/routes/built-in/debug/controller.js
@@ -4,6 +4,6 @@ export default class BuiltInDebugController extends Controller {
   /** @returns {Promise<void>} - Resolves when the debug snapshot has been rendered. */
   async show() {
     this._response.setHeader("Content-Type", "application/json; charset=UTF-8")
-    this._response.setBody(`${JSON.stringify(this.getConfiguration().getDebugSnapshot(), null, 2)}\n`)
+    this._response.setBody(`${JSON.stringify(await this.getConfiguration().getDebugSnapshot(), null, 2)}\n`)
   }
 }


### PR DESCRIPTION
## Summary
- bucket websocket debug subscriptions by sanitized channel detail snapshots
- expose frontend-model subscription model/projection/filter shape without query values
- cover the new debug snapshot output in focused websocket specs

## Validation
- node scripts/run-tests.js -- spec/frontend-models/websocket-channel-spec.js
- node scripts/run-tests.js -- spec/http-server/websocket-channel-spec.js
- npm run lint
- npm run typecheck