### PR TITLE
Only report beacon outages that persist past a grace window

### DIFF
--- a/docs/beacon.md
+++ b/docs/beacon.md
@@ -66,6 +66,10 @@ returns `undefined` and `broadcastToChannel` keeps using its existing
 local-only path. Set `beacon: {enabled: false}` to disable explicitly
 when env vars are present (useful in tests).
 
+`beacon: {unreachableReportMs}` tunes how long the broker must stay
+unreachable before a failure is reported (default `30000`); see
+*Error reporting* below.
+
 ## Connecting a peer
 
 Peers shipped by Velocious connect automatically:
@@ -175,24 +179,43 @@ connection drops mid-session, the failure is surfaced on
 ```js
 configuration.getErrorEvents().on("framework-error", ({context, error}) => {
   if (context.stage === "beacon-connect") {
-    // Broker unreachable on initial connect (or during reconnect attempts).
+    // Broker still unreachable after the grace window.
   } else if (context.stage === "beacon-disconnect") {
-    // An established connection dropped.
+    // Connection dropped and did not recover within the grace window.
   }
 
   Sentry.captureException(error, {tags: {component: "beacon", stage: context.stage}})
 })
 ```
 
-Stages emitted today:
+### Transient blips are not reported
 
-- `"beacon-connect"` — fired when the initial TCP connect fails or the
-  broker rejects the handshake. Reconnect attempts continue in the
-  background; further failures fire the same event again.
-- `"beacon-disconnect"` — fired once when an established connection
-  drops. The `error` is the underlying socket error if there was one,
-  or `Error("Beacon broker disconnected")` otherwise. Explicit
-  `disconnectBeacon()` calls do **not** fire this event.
+Connect/disconnect blips are expected during deploys (the broker
+restarts) and the BeaconClient auto-reconnects with backoff, so a
+single failure is **not** reported immediately. Instead, a failure
+starts a grace timer; the framework-error is emitted **only if the
+broker is still unreachable after `beacon.unreachableReportMs`**
+(default `30000`). A (re)connect within that window clears the pending
+report, so a transient outage that recovers is never surfaced. Each
+sustained outage is reported **once** (it does not re-fire on every
+reconnect attempt), and the state resets on recovery so a later outage
+reports again.
+
+Tune the grace window with `beacon: {unreachableReportMs}` — lower it
+for faster alerting, raise it to ride out longer deploy windows. Set it
+to `0` to report essentially immediately. Genuine sustained outages
+still alert.
+
+Stages emitted:
+
+- `"beacon-connect"` — the initial TCP connect failed (or the broker
+  rejected the handshake) and the broker was still unreachable after the
+  grace window. Reconnect attempts continue in the background.
+- `"beacon-disconnect"` — an established connection dropped and did not
+  recover within the grace window. The `error` is the underlying socket
+  error if there was one, or `Error("Beacon broker disconnected")`
+  otherwise. Explicit `disconnectBeacon()` calls do **not** fire this
+  event.
 - `"beacon-ready"` — fired by background job runner processes when the
   daemon does not acknowledge peer registration before the runner's
   readiness timeout. The job still runs, but broadcasts fall back to

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "build/**"
   ],
   "scripts": {
-    "all-checks": "npm run typecheck && npm run lint && npm run test",
+    "all-checks": "npm run lint && npm run test",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:ejs": "cpy \"src/routes/**/*.ejs\" build/src/routes",
     "copy:templates": "cpy \"src/templates/**/*.js\" build/src/templates",
     "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --quiet",
     "fallow:baseline": "fallow dead-code --save-baseline fallow-baselines/dead-code.json && fallow dupes --save-baseline fallow-baselines/dupes.json && fallow health --save-baseline fallow-baselines/health.json",
-    "lint": "eslint",
+    "eslint": "eslint",
+    "lint": "npm run eslint && npm run typecheck && npm run fallow",
     "prepare": "npm run build",
     "release:patch": "release-patch",
     "test": "node scripts/run-tests.js",

--- a/spec/beacon/error-reporting-spec.js
+++ b/spec/beacon/error-reporting-spec.js
@@ -16,7 +16,9 @@ import {describe, expect, it} from "../../src/testing/test.js"
  */
 function buildConfiguration(beacon) {
   return new Configuration({
-    beacon,
+    // Report beacon outages near-instantly by default so these specs don't wait out the real 30s grace
+    // window. Specs that exercise the grace/recovery behavior override `unreachableReportMs` explicitly.
+    beacon: {unreachableReportMs: 1, ...beacon},
     database: {test: {default: {driver: class {}, poolType: class {static clearGlobalConnections() {}}, type: "fake"}}},
     directory: process.cwd(),
     environment: "test",
@@ -265,5 +267,70 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
 
     await configuration.disconnectBeacon()
     await beacon.stop()
+  })
+
+  it("does not report a transient beacon blip that reconnects within the grace window", async () => {
+    const port = await reservedPort()
+    const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port})
+
+    await beacon.start()
+
+    // Long grace window: a reconnect should land well before it would report.
+    const configuration = buildConfiguration({host: "127.0.0.1", port, unreachableReportMs: 5000})
+
+    /** @type {Array<{stage: string}>} */
+    const frameworkErrors = []
+
+    configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push({stage: payload.context.stage}))
+
+    await configuration.connectBeacon({peerType: "test"})
+
+    await timeout({timeout: 1000}, async () => {
+      while (!configuration.getBeaconClient()?.isConnected()) await wait(0.01)
+    })
+
+    // Broker drops (e.g. a deploy restart) and comes back on the same port; the client auto-reconnects.
+    await beacon.stop()
+
+    const beaconAgain = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port})
+
+    await beaconAgain.start()
+
+    await timeout({timeout: 4000}, async () => {
+      while (!configuration.getBeaconClient()?.isConnected()) await wait(0.01)
+    })
+
+    // Settle past the reconnect; the transient blip must not have been reported.
+    await wait(0.3)
+
+    expect(frameworkErrors.length).toBe(0)
+
+    await configuration.disconnectBeacon()
+    await beaconAgain.stop()
+  })
+
+  it("reports a single framework-error when the beacon stays unreachable past the grace window", async () => {
+    const port = await reservedPort()
+    const configuration = buildConfiguration({host: "127.0.0.1", port, unreachableReportMs: 50})
+
+    /** @type {Array<{stage: string}>} */
+    const frameworkErrors = []
+
+    configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push({stage: payload.context.stage}))
+
+    await configuration.connectBeacon({peerType: "test"})
+
+    await timeout({timeout: 2000}, async () => {
+      while (frameworkErrors.length === 0) await wait(0.01)
+    })
+
+    expect(frameworkErrors[0].stage).toBe("beacon-connect")
+
+    // Past at least one reconnect attempt the sustained outage must not be re-reported.
+    await wait(1.2)
+
+    expect(frameworkErrors.length).toBe(1)
+
+    await configuration.disconnectBeacon()
   })
 })

--- a/spec/beacon/error-reporting-spec.js
+++ b/spec/beacon/error-reporting-spec.js
@@ -49,17 +49,71 @@ async function reservedPort() {
   return port
 }
 
+/**
+ * Starts a BeaconServer on the given port (0 picks an ephemeral port) and returns it.
+ * @param {number} [port] - Port to listen on.
+ * @returns {Promise<BeaconServer>} - The started broker.
+ */
+async function startBeaconServer(port = 0) {
+  const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port})
+
+  await beacon.start()
+
+  return beacon
+}
+
+/**
+ * Collects `framework-error` payloads emitted on a configuration's error channel.
+ * @param {import("../../src/configuration.js").default} configuration - Configuration to listen on.
+ * @returns {Array<{stage: string, error: Error}>} - Mutable list populated as errors arrive.
+ */
+function collectFrameworkErrors(configuration) {
+  /** @type {Array<{stage: string, error: Error}>} */
+  const frameworkErrors = []
+
+  configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push({stage: payload.context.stage, error: payload.error}))
+
+  return frameworkErrors
+}
+
+/**
+ * Waits until the configuration's Beacon client reports a live connection.
+ * @param {import("../../src/configuration.js").default} configuration - Configuration to poll.
+ * @param {number} [timeoutMs] - Max time to wait.
+ * @returns {Promise<void>}
+ */
+async function waitUntilConnected(configuration, timeoutMs = 1000) {
+  await timeout({timeout: timeoutMs}, async () => {
+    while (!configuration.getBeaconClient()?.isConnected()) await wait(0.01)
+  })
+}
+
+/**
+ * Connects a raw BeaconClient to a broker and collects its `disconnect` reasons.
+ * @param {BeaconServer} beacon - Broker to connect to.
+ * @returns {Promise<{client: BeaconClient, reasons: Array<Error>}>} - The connected client and its disconnect-reason list.
+ */
+async function connectClientCollectingDisconnects(beacon) {
+  const client = new BeaconClient({host: "127.0.0.1", port: beacon.getPort(), peerType: "test"})
+
+  await client.connect()
+
+  /** @type {Array<Error>} */
+  const reasons = []
+
+  client.on("disconnect", (reason) => reasons.push(reason))
+
+  return {client, reasons}
+}
+
 describe("Beacon error reporting", {databaseCleaning: {transaction: false, truncate: false}}, () => {
   it("emits framework-error and all-error when the initial connect fails", async () => {
     const port = await reservedPort()
     const configuration = buildConfiguration({host: "127.0.0.1", port})
-
-    /** @type {Array<{stage: string, error: Error}>} */
-    const frameworkErrors = []
+    const frameworkErrors = collectFrameworkErrors(configuration)
     /** @type {Array<{stage: string, errorType: string, error: Error}>} */
     const allErrors = []
 
-    configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push({stage: payload.context.stage, error: payload.error}))
     configuration.getErrorEvents().on("all-error", (payload) => allErrors.push({stage: payload.context.stage, errorType: payload.errorType, error: payload.error}))
 
     await configuration.connectBeacon({peerType: "test"})
@@ -77,16 +131,9 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
   })
 
   it("emits framework-error with stage `beacon-disconnect` when the broker drops mid-session", async () => {
-    const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port: 0})
-
-    await beacon.start()
-
+    const beacon = await startBeaconServer()
     const configuration = buildConfiguration({host: "127.0.0.1", port: beacon.getPort()})
-
-    /** @type {Array<{stage: string, error: Error}>} */
-    const errors = []
-
-    configuration.getErrorEvents().on("framework-error", (payload) => errors.push({stage: payload.context.stage, error: payload.error}))
+    const errors = collectFrameworkErrors(configuration)
 
     await configuration.connectBeacon({peerType: "test"})
 
@@ -181,18 +228,8 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
   })
 
   it("BeaconClient `disconnect` event fires with an Error reason when the broker drops", async () => {
-    const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port: 0})
-
-    await beacon.start()
-
-    const client = new BeaconClient({host: "127.0.0.1", port: beacon.getPort(), peerType: "test"})
-
-    await client.connect()
-
-    /** @type {Array<Error>} */
-    const reasons = []
-
-    client.on("disconnect", (reason) => reasons.push(reason))
+    const beacon = await startBeaconServer()
+    const {client, reasons} = await connectClientCollectingDisconnects(beacon)
 
     await timeout({timeout: 1000}, async () => {
       while (beacon.getPeerCount() < 1) await wait(0.01)
@@ -212,18 +249,8 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
   })
 
   it("does not emit disconnect when the client is closed by the application", async () => {
-    const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port: 0})
-
-    await beacon.start()
-
-    const client = new BeaconClient({host: "127.0.0.1", port: beacon.getPort(), peerType: "test"})
-
-    await client.connect()
-
-    /** @type {Array<Error>} */
-    const reasons = []
-
-    client.on("disconnect", (reason) => reasons.push(reason))
+    const beacon = await startBeaconServer()
+    const {client, reasons} = await connectClientCollectingDisconnects(beacon)
 
     await client.close()
     await wait(0.05)
@@ -241,10 +268,7 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
     // client *after* awaiting `client.connect()`, so under this contract
     // a regression would either delay the client registration or block on
     // the OS TCP timeout.
-    const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port: 0})
-
-    await beacon.start()
-
+    const beacon = await startBeaconServer()
     const configuration = buildConfiguration({host: "127.0.0.1", port: beacon.getPort()})
     const start = Date.now()
 
@@ -259,9 +283,7 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
     expect(configuration.getBeaconClient()).toBeTruthy()
 
     // Eventually the connect lands.
-    await timeout({timeout: 1000}, async () => {
-      while (!configuration.getBeaconClient()?.isConnected()) await wait(0.01)
-    })
+    await waitUntilConnected(configuration)
 
     expect(configuration.getBeaconClient()?.isConnected()).toBe(true)
 
@@ -271,34 +293,20 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
 
   it("does not report a transient beacon blip that reconnects within the grace window", async () => {
     const port = await reservedPort()
-    const beacon = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port})
-
-    await beacon.start()
-
+    const beacon = await startBeaconServer(port)
     // Long grace window: a reconnect should land well before it would report.
     const configuration = buildConfiguration({host: "127.0.0.1", port, unreachableReportMs: 5000})
-
-    /** @type {Array<{stage: string}>} */
-    const frameworkErrors = []
-
-    configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push({stage: payload.context.stage}))
+    const frameworkErrors = collectFrameworkErrors(configuration)
 
     await configuration.connectBeacon({peerType: "test"})
-
-    await timeout({timeout: 1000}, async () => {
-      while (!configuration.getBeaconClient()?.isConnected()) await wait(0.01)
-    })
+    await waitUntilConnected(configuration)
 
     // Broker drops (e.g. a deploy restart) and comes back on the same port; the client auto-reconnects.
     await beacon.stop()
 
-    const beaconAgain = new BeaconServer({configuration: buildConfiguration({host: "127.0.0.1", port: 0}), host: "127.0.0.1", port})
+    const beaconAgain = await startBeaconServer(port)
 
-    await beaconAgain.start()
-
-    await timeout({timeout: 4000}, async () => {
-      while (!configuration.getBeaconClient()?.isConnected()) await wait(0.01)
-    })
+    await waitUntilConnected(configuration, 4000)
 
     // Settle past the reconnect; the transient blip must not have been reported.
     await wait(0.3)
@@ -312,11 +320,7 @@ describe("Beacon error reporting", {databaseCleaning: {transaction: false, trunc
   it("reports a single framework-error when the beacon stays unreachable past the grace window", async () => {
     const port = await reservedPort()
     const configuration = buildConfiguration({host: "127.0.0.1", port, unreachableReportMs: 50})
-
-    /** @type {Array<{stage: string}>} */
-    const frameworkErrors = []
-
-    configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push({stage: payload.context.stage}))
+    const frameworkErrors = collectFrameworkErrors(configuration)
 
     await configuration.connectBeacon({peerType: "test"})
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -173,6 +173,7 @@
  * @property {string} [host] - Hostname of the Beacon broker daemon.
  * @property {number} [port] - Port of the Beacon broker daemon.
  * @property {string} [peerType] - Optional human-readable label for this peer (e.g. "server", "background-jobs-worker").
+ * @property {number} [unreachableReportMs] - Grace window (ms) a beacon connect/disconnect blip must persist before it is reported as a framework-error. Transient outages that recover within this window (e.g. a deploy restarting the broker) are not reported. Defaults to 30000.
  */
 
 /**

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -91,6 +91,12 @@ export default class VelociousConfiguration {
     this._beaconClient = undefined
     /** @type {Promise<import("./beacon/client.js").default | import("./beacon/in-process-client.js").default | undefined> | undefined} */
     this._beaconConnectPromise = undefined
+    /** @type {ReturnType<typeof setTimeout> | undefined} - Pending "beacon still unreachable" report timer. */
+    this._beaconReportTimer = undefined
+    /** @type {boolean} - Whether the current beacon outage has already been reported. */
+    this._beaconOutageReported = false
+    /** @type {{stage: "beacon-connect" | "beacon-disconnect", error: Error} | undefined} - Latest beacon-down details, reported only if the outage is sustained. */
+    this._beaconLastDownError = undefined
     this._scheduledBackgroundJobs = scheduledBackgroundJobs
     this._attachments = attachments || {}
     this._backendProjects = backendProjects || []
@@ -793,7 +799,7 @@ export default class VelociousConfiguration {
    * Setting `enabled: false` explicitly disables it even when env vars
    * are present (useful for tests). When `inProcess: true` is set,
    * env-var host/port are ignored — code-level config wins.
-   * @returns {{enabled: boolean, host: string, port: number, peerType?: string, inProcess: boolean}} - Beacon configuration with defaults applied.
+   * @returns {{enabled: boolean, host: string, port: number, peerType?: string, inProcess: boolean, unreachableReportMs: number}} - Beacon configuration with defaults applied.
    */
   getBeaconConfig() {
     const configured = this._beacon || {}
@@ -819,7 +825,11 @@ export default class VelociousConfiguration {
       enabled = Boolean(inProcess || configured.host || configured.port || envHost || envPort)
     }
 
-    return {enabled, host, port, peerType: configured.peerType, inProcess}
+    const unreachableReportMs = typeof configured.unreachableReportMs === "number" && Number.isFinite(configured.unreachableReportMs)
+      ? configured.unreachableReportMs
+      : 30_000
+
+    return {enabled, host, port, peerType: configured.peerType, inProcess, unreachableReportMs}
   }
 
   /**
@@ -886,18 +896,28 @@ export default class VelociousConfiguration {
         this._deliverBroadcastFromBeacon(message)
       })
 
+      // Beacon connect/disconnect blips are expected during deploys (the broker
+      // restarts) and the BeaconClient auto-reconnects in the background, so a
+      // single transient failure is NOT reported. Only a sustained outage (still
+      // down after `unreachableReportMs`) is surfaced on the framework-error
+      // channel; a (re)connect within the grace window clears it silently.
+
       // `connect-error` fires when the *initial* TCP/handshake fails.
-      // We report it via the framework error channel; the BeaconClient's
-      // reconnect loop keeps trying in the background.
       client.on("connect-error", (error) => {
-        this._reportBeaconError({stage: "beacon-connect", error})
+        this._handleBeaconDown({stage: "beacon-connect", error, reportAfterMs: config.unreachableReportMs})
       })
 
-      // `disconnect` fires when an established connection drops. The
-      // payload is the underlying socket error if there was one, or a
-      // synthetic Error("Beacon broker disconnected") otherwise.
+      // `disconnect` fires when an established connection drops. The payload is
+      // the underlying socket error if there was one, or a synthetic
+      // Error("Beacon broker disconnected") otherwise.
       client.on("disconnect", (reason) => {
-        this._reportBeaconError({stage: "beacon-disconnect", error: reason})
+        this._handleBeaconDown({stage: "beacon-disconnect", error: reason, reportAfterMs: config.unreachableReportMs})
+      })
+
+      // `connect` fires on every (re)connect; clear any pending outage state so
+      // a transient blip that recovers within the grace window stays silent.
+      client.on("connect", () => {
+        this._handleBeaconUp()
       })
 
       // Register the client *before* kicking off connect so subsequent
@@ -962,6 +982,54 @@ export default class VelociousConfiguration {
   }
 
   /**
+   * Records a Beacon connect/disconnect failure without reporting it immediately.
+   * The BeaconClient auto-reconnects, so brief outages (e.g. a deploy restarting
+   * the broker) are expected; only if the beacon is still unreachable after
+   * `reportAfterMs` is a single framework-error surfaced via `_reportBeaconError`.
+   * A subsequent `connect` (see `_handleBeaconUp`) cancels the pending report.
+   * @param {object} args - Options.
+   * @param {"beacon-connect" | "beacon-disconnect"} args.stage - Failure stage.
+   * @param {Error} args.error - Error instance.
+   * @param {number} args.reportAfterMs - Grace window before a sustained outage is reported.
+   * @returns {void}
+   */
+  _handleBeaconDown({stage, error, reportAfterMs}) {
+    this._beaconLastDownError = {stage, error}
+
+    // A report is already pending or already sent for this outage — keep the
+    // latest error but don't stack timers or re-report.
+    if (this._beaconReportTimer || this._beaconOutageReported) return
+
+    const timer = setTimeout(() => {
+      this._beaconReportTimer = undefined
+      this._beaconOutageReported = true
+
+      if (this._beaconLastDownError) this._reportBeaconError(this._beaconLastDownError)
+    }, reportAfterMs)
+
+    // Don't let the grace timer keep the process alive.
+    if (typeof timer.unref === "function") timer.unref()
+
+    this._beaconReportTimer = timer
+  }
+
+  /**
+   * Clears beacon-down state on a (re)connect. A blip that recovers within the
+   * grace window is never reported; if a sustained outage had already been
+   * reported, the state resets so a future outage can report again.
+   * @returns {void}
+   */
+  _handleBeaconUp() {
+    if (this._beaconReportTimer) {
+      clearTimeout(this._beaconReportTimer)
+      this._beaconReportTimer = undefined
+    }
+
+    this._beaconOutageReported = false
+    this._beaconLastDownError = undefined
+  }
+
+  /**
    * Surfaces a Beacon failure on the framework error channel. Mirrors
    * the pattern used by `request-runner.js` for HTTP errors. When no
    * listener is attached to either `framework-error` or `all-error`,
@@ -1010,6 +1078,14 @@ export default class VelociousConfiguration {
 
     this._beaconClient = undefined
     this._beaconConnectPromise = undefined
+
+    if (this._beaconReportTimer) {
+      clearTimeout(this._beaconReportTimer)
+      this._beaconReportTimer = undefined
+    }
+
+    this._beaconOutageReported = false
+    this._beaconLastDownError = undefined
 
     if (client) await client.close()
   }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -70,6 +70,17 @@ function mergeDatabaseConfiguration(databaseConfiguration, overrideConfiguration
   }
 }
 
+/**
+ * Resolves the grace window (ms) before a sustained beacon outage is reported.
+ * @param {unknown} value - Configured `unreachableReportMs`, if any.
+ * @returns {number} - The configured value when it's a finite number, otherwise the 30s default.
+ */
+function resolveBeaconUnreachableReportMs(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+
+  return 30_000
+}
+
 export default class VelociousConfiguration {
   /** @type {Promise<void> | null} */
   _closeDatabaseConnectionsPromise = null
@@ -825,9 +836,7 @@ export default class VelociousConfiguration {
       enabled = Boolean(inProcess || configured.host || configured.port || envHost || envPort)
     }
 
-    const unreachableReportMs = typeof configured.unreachableReportMs === "number" && Number.isFinite(configured.unreachableReportMs)
-      ? configured.unreachableReportMs
-      : 30_000
+    const unreachableReportMs = resolveBeaconUnreachableReportMs(configured.unreachableReportMs)
 
     return {enabled, host, port, peerType: configured.peerType, inProcess, unreachableReportMs}
   }


### PR DESCRIPTION
## Why

Beacon connect/disconnect blips are expected during deploys (the broker restarts) and the `BeaconClient` already auto-reconnects with exponential backoff (1s→30s) — background jobs are durable in the DB, so a brief beacon outage is fully self-healing. But the configuration wiring reported **every** transient `connect-error`/`disconnect` as a `framework-error`, so a single deploy emitted paired `beacon-connect` (ECONNREFUSED) + `beacon-disconnect` errors to the error tracker despite zero functional impact (noise).

## What

In `configuration.js` `connectBeacon()`, hold off reporting on a beacon-down event:
- `connect-error` / `disconnect` now go through `_handleBeaconDown(...)`, which starts a one-shot grace timer (unref'd) instead of reporting immediately.
- A new `connect` listener (`_handleBeaconUp()`) cancels the pending timer and clears the down state on (re)connect — so a blip that recovers within the grace window is **never** reported.
- Only if the beacon is still unreachable when the grace timer fires is a **single** `framework-error` surfaced (via the unchanged `_reportBeaconError`). The state resets on recovery so a later sustained outage reports again.
- Grace window is configurable: `beacon.unreachableReportMs` (default **30000**), added to `getBeaconConfig()` + `BeaconConfiguration`. Genuine sustained outages still report.
- Timer is cleared on `disconnectBeacon()` teardown.

## Tests (`spec/beacon/error-reporting-spec.js`)

- New: a transient blip that reconnects within the grace window emits **no** framework-error.
- New: a beacon that stays unreachable past the window emits **exactly one** framework-error (`beacon-connect`) and doesn't re-report on subsequent reconnect attempts.
- Existing reporting specs updated to set a tiny `unreachableReportMs` (they assert the report path on sustained-down). All beacon + background-jobs beacon specs pass; `typecheck` + `lint` green.

## Follow-up

This needs a release; ticket-server will bump `velocious` to consume it (the beacon runs there). It also adds a `restart` guard to the beacon in ticket-server's rollbridge config separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
