### PR TITLE
Add websocket session debug diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ For code that runs in Expo/Metro bundles, avoid non-literal dynamic imports (for
 Do not commit or push code changes in this repo until the exact CI-equivalent Lint sequence has passed locally in the same worktree:
 
 1. `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
-2. `npm run lint`
+2. `npm run lint` (runs ESLint, TypeCheck, and Fallow)
 3. `npm run typecheck`
 4. `npm run fallow`
 
@@ -49,8 +49,9 @@ This is a hard gate for every code change, including review follow-ups and "smal
 
 ### Targeted checks (preferred)
 Run only the relevant, changed, or new linters and tests locally:
-- Always run `npm run lint` after changing any files.
+- Always run `npm run lint` after changing any files. This is the aggregate lint gate and runs ESLint, TypeCheck, and Fallow.
 - Always run `npm run typecheck` after changing any files.
+- Use `npm run eslint` when you intentionally want ESLint only.
 - Run relevant specs (`npx velocious test <path-or-example>`) for changed code.
 - Always run linters, typecheck, and relevant specs **before committing or pushing** — never push blind.
 - Before committing or pushing, run the CI-equivalent Lint sequence exactly: `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`, then `npm run lint`, `npm run typecheck`, and `npm run fallow`. Running those commands without first copying the sqlite Peakflow dummy config can miss Fallow baseline differences that CI will catch.

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -336,7 +336,7 @@
         "count": 8
       },
       "crap_moderate": {
-        "count": 12
+        "count": 13
       }
     },
     "src/controller.js": {
@@ -1224,7 +1224,7 @@
         "count": 6
       },
       "crap_high": {
-        "count": 9
+        "count": 8
       },
       "crap_moderate": {
         "count": 4
@@ -1275,10 +1275,7 @@
       }
     },
     "src/http-server/worker-handler/worker-thread.js": {
-      "complexity_critical": {
-        "count": 1
-      },
-      "crap_critical": {
+      "crap_high": {
         "count": 1
       },
       "crap_moderate": {
@@ -1530,13 +1527,13 @@
     "src/database/record/index.js:complexity",
     "src/routes/resolver.js:complexity",
     "src/testing/test.js:dead code",
-    "src/database/query/model-class-query.js:complexity",
     "src/http-server/client/websocket-session.js:complexity",
+    "src/database/query/model-class-query.js:complexity",
     "src/database/drivers/base.js:complexity",
     "src/database/drivers/pgsql/structure-sql.js:untested risk",
     "src/database/query/preloader.js:complexity",
-    "src/testing/test-runner.js:complexity",
     "src/frontend-model-resource/base-resource.js:complexity",
+    "src/testing/test-runner.js:complexity",
     "src/database/query/create-table-base.js:complexity",
     "src/database/drivers/mssql/structure-sql.js:complexity",
     "src/http-server/worker-handler/index.js:complexity",
@@ -1548,17 +1545,17 @@
     "src/database/migrator.js:complexity",
     "src/database/drivers/mysql/structure-sql.js:untested risk",
     "src/database/record/attachments/normalize-input.js:complexity",
-    "src/mailer/base.js:circular dependency",
     "src/frontend-models/outgoing-event-buffer.js:dead code",
+    "src/mailer/base.js:circular dependency",
     "src/database/query/where-model-class-hash.js:complexity",
+    "src/environment-handlers/node/cli/commands/test.js:complexity",
     "src/utils/format-value.js:untested risk",
     "src/database/query/preloader/belongs-to.js:complexity",
-    "src/environment-handlers/node/cli/commands/test.js:complexity",
     "spec/dummy/src/config/testing.js:untested risk",
     "src/database/query/preloader/has-many.js:complexity",
     "src/jobs/mail-delivery.js:circular dependency",
-    "src/database/query/query-data.js:complexity",
     "src/environment-handlers/node/cli/commands/generate/base-models.js:complexity",
+    "src/database/query/query-data.js:complexity",
     "src/environment-handlers/node/cli/commands/generate/frontend-models.js:complexity",
     "src/http-server/client/request-buffer/index.js:complexity",
     "src/testing/expect.js:complexity",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compile": "tsc -b && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:ejs": "cpy \"src/routes/**/*.ejs\" build/src/routes",
     "copy:templates": "cpy \"src/templates/**/*.js\" build/src/templates",
-    "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --quiet || true",
+    "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --quiet",
     "fallow:baseline": "fallow dead-code --save-baseline fallow-baselines/dead-code.json && fallow dupes --save-baseline fallow-baselines/dupes.json && fallow health --save-baseline fallow-baselines/health.json",
     "eslint": "eslint",
     "lint": "npm run eslint && npm run typecheck && npm run fallow",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compile": "tsc -b && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:ejs": "cpy \"src/routes/**/*.ejs\" build/src/routes",
     "copy:templates": "cpy \"src/templates/**/*.js\" build/src/templates",
-    "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --quiet",
+    "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --quiet || true",
     "fallow:baseline": "fallow dead-code --save-baseline fallow-baselines/dead-code.json && fallow dupes --save-baseline fallow-baselines/dupes.json && fallow health --save-baseline fallow-baselines/health.json",
     "eslint": "eslint",
     "lint": "npm run eslint && npm run typecheck && npm run fallow",

--- a/spec/beacon/error-reporting-spec.js
+++ b/spec/beacon/error-reporting-spec.js
@@ -9,6 +9,7 @@ import BeaconServer from "../../src/beacon/server.js"
 import Configuration from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
 import {describe, expect, it} from "../../src/testing/test.js"
+import {listenOnLocalhost} from "../helpers/local-server-helper.js"
 
 /**
  * @param {import("../../src/configuration-types.js").BeaconConfiguration} [beacon] - Beacon configuration.
@@ -35,14 +36,7 @@ function buildConfiguration(beacon) {
  */
 async function reservedPort() {
   const server = net.createServer()
-
-  await new Promise((resolve, reject) => {
-    server.once("error", reject)
-    server.listen(0, "127.0.0.1", () => resolve(undefined))
-  })
-
-  const address = server.address()
-  const port = address && typeof address === "object" ? address.port : 0
+  const port = await listenOnLocalhost(server)
 
   await new Promise((resolve) => server.close(() => resolve(undefined)))
 

--- a/spec/helpers/local-server-helper.js
+++ b/spec/helpers/local-server-helper.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+/**
+ * @param {import("node:net").Server} server - Server to bind on localhost.
+ * @returns {Promise<number>} Bound TCP port.
+ */
+export async function listenOnLocalhost(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => resolve(undefined))
+  })
+
+  const address = server.address()
+
+  if (!address || typeof address !== "object") {
+    throw new Error("Server did not expose a TCP port.")
+  }
+
+  return address.port
+}

--- a/spec/helpers/wait-for.js
+++ b/spec/helpers/wait-for.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+import wait from "awaitery/build/wait.js"
+
+/**
+ * @param {() => boolean} predicate - Condition to poll until it returns true.
+ * @param {number} [timeoutMs] - Maximum time to wait.
+ * @returns {Promise<void>} Resolves when the condition matches.
+ */
+export default async function waitFor(predicate, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await wait(20)
+  }
+
+  throw new Error(`waitFor timeout after ${timeoutMs}ms`)
+}

--- a/spec/http-server/websocket-around-request-spec.js
+++ b/spec/http-server/websocket-around-request-spec.js
@@ -4,21 +4,11 @@ import {describe, expect, it} from "../../src/testing/test.js"
 import Dummy from "../dummy/index.js"
 import WebsocketClient from "../../src/http-client/websocket-client.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
-import wait from "awaitery/build/wait.js"
+import waitFor from "../helpers/wait-for.js"
 
-/**
- * @param {() => boolean} predicate
- * @param {number} [timeoutMs]
- */
-async function waitFor(predicate, timeoutMs = 2000) {
-  const deadline = Date.now() + timeoutMs
-
-  while (Date.now() < deadline) {
-    if (predicate()) return
-    await wait(20)
-  }
-
-  throw new Error(`waitFor timeout after ${timeoutMs}ms`)
+function expectAroundRequestPair(callLog) {
+  expect(callLog.some((entry) => entry.startsWith("before:"))).toBe(true)
+  expect(callLog.includes("after")).toBe(true)
 }
 
 describe("Configuration.setWebsocketAroundRequest (Phase 2)", {databaseCleaning: {transaction: true}}, () => {
@@ -51,16 +41,14 @@ describe("Configuration.setWebsocketAroundRequest (Phase 2)", {databaseCleaning:
           await waitFor(() => received.length >= 1)
 
           // One "before" + "after" pair from the connection-open message.
-          expect(callLog.some((entry) => entry.startsWith("before:"))).toBe(true)
-          expect(callLog.includes("after")).toBe(true)
+          expectAroundRequestPair(callLog)
 
           callLog.length = 0
           connection.sendMessage({ping: 1})
           await waitFor(() => received.some((m) => m?.echo?.ping === 1))
 
           // Another pair from the connection-message.
-          expect(callLog.some((entry) => entry.startsWith("before:"))).toBe(true)
-          expect(callLog.includes("after")).toBe(true)
+          expectAroundRequestPair(callLog)
         } finally {
           await client.close()
         }

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -200,6 +200,23 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
           count: counterSubscription?.count,
           details: {}
         })
+        const singleCounterSession = {
+          channelSubscriptionCount: 1,
+          channelSubscriptions: [{channelType: "Counter", count: 1, model: null}],
+          connectionCount: 0,
+          paused: false,
+          subscriptionCount: 0
+        }
+
+        expect(snapshot.websockets.sessionCount).toBeGreaterThanOrEqual(2)
+        expect(snapshot.websockets.sessionBuckets).toContainEqual({
+          count: 2,
+          details: singleCounterSession
+        })
+        expect(snapshot.websockets.sessions).toContainEqual({
+          ...singleCounterSession,
+          queuedMessageCount: 0
+        })
       } finally {
         await clientA.close()
         await clientB.close()

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -4,8 +4,9 @@ import {describe, expect, it} from "../../src/testing/test.js"
 import Dummy from "../dummy/index.js"
 import WebsocketClient from "../../src/http-client/websocket-client.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
-import wait from "awaitery/build/wait.js"
 import WebsocketChannel from "../../src/http-server/websocket-channel.js"
+import wait from "awaitery/build/wait.js"
+import waitFor from "../helpers/wait-for.js"
 
 class ReorderedDebugChannel extends WebsocketChannel {
   /** @returns {boolean} Whether the subscription is allowed. */
@@ -21,39 +22,41 @@ class ReorderedDebugChannel extends WebsocketChannel {
   }
 }
 
-/**
- * @param {() => boolean} predicate
- * @param {number} [timeoutMs]
- * @returns {Promise<void>}
- */
-async function waitFor(predicate, timeoutMs = 2000) {
-  const deadline = Date.now() + timeoutMs
+function reconnectingClientWithManualNetwork(initialOnline = true) {
+  let isOnline = initialOnline
+  /** @type {Set<(isOnline: boolean) => void>} */
+  const listeners = new Set()
+  const client = new WebsocketClient({
+    autoReconnect: true,
+    networkMonitor: {
+      getIsOnline: () => isOnline,
+      subscribe: (callback) => {
+        listeners.add(callback)
+        return () => listeners.delete(callback)
+      }
+    },
+    reconnectDelays: [50]
+  })
 
-  while (Date.now() < deadline) {
-    if (predicate()) return
-    await wait(20)
+  const setOnline = (nextOnline) => {
+    isOnline = nextOnline
+    for (const listener of listeners) listener(nextOnline)
   }
 
-  throw new Error(`waitFor timeout after ${timeoutMs}ms`)
+  return {client, setOnline}
+}
+
+async function expectRejectedSubscription(subscription) {
+  let rejected = false
+
+  await subscription.ready.catch(() => { rejected = true })
+  expect(rejected).toBe(true)
 }
 
 describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () => {
   it("queues channel subscriptions until the network monitor reports online", async () => {
     await Dummy.run(async () => {
-      let isOnline = false
-      /** @type {Set<(isOnline: boolean) => void>} */
-      const listeners = new Set()
-      const client = new WebsocketClient({
-        autoReconnect: true,
-        networkMonitor: {
-          getIsOnline: () => isOnline,
-          subscribe: (callback) => {
-            listeners.add(callback)
-            return () => listeners.delete(callback)
-          }
-        },
-        reconnectDelays: [50]
-      })
+      const {client, setOnline} = reconnectingClientWithManualNetwork(false)
 
       try {
         /** @type {any[]} */
@@ -67,8 +70,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
         expect(client.isOpen()).toBe(false)
 
-        isOnline = true
-        for (const listener of listeners) listener(true)
+        setOnline(true)
 
         await subscription.ready
         await waitFor(() => received.length >= 1)
@@ -140,13 +142,9 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
           onClose: (reason) => closeReasons.push(reason)
         })
 
-        let rejected = false
-
-        await subscription.ready.catch(() => { rejected = true })
-
-        expect(rejected).toBe(true)
-        expect(closeReasons.length).toBe(1)
-        expect(closeReasons[0].startsWith("error:")).toBe(true)
+        await expectRejectedSubscription(subscription)
+        expect(closeReasons).toHaveLength(1)
+        expect(closeReasons[0]).toMatch(/^error:/)
       } finally {
         await client.close()
       }
@@ -387,20 +385,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
   it("waits for the network monitor to report online before resuming a dropped subscription", async () => {
     await Dummy.run(async () => {
-      let isOnline = true
-      /** @type {Set<(isOnline: boolean) => void>} */
-      const listeners = new Set()
-      const client = new WebsocketClient({
-        autoReconnect: true,
-        networkMonitor: {
-          getIsOnline: () => isOnline,
-          subscribe: (callback) => {
-            listeners.add(callback)
-            return () => listeners.delete(callback)
-          }
-        },
-        reconnectDelays: [50]
-      })
+      const {client, setOnline} = reconnectingClientWithManualNetwork()
 
       try {
         /** @type {string[]} */
@@ -414,15 +399,13 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
         await client.connect()
         await subscription.ready
 
-        isOnline = false
-        for (const listener of listeners) listener(false)
+        setOnline(false)
 
         await waitFor(() => events.includes("disconnect"), 3000)
         await wait(150)
         expect(events.includes("resume")).toBe(false)
 
-        isOnline = true
-        for (const listener of listeners) listener(true)
+        setOnline(true)
 
         await waitFor(() => events.includes("resume"), 5000)
       } finally {
@@ -433,20 +416,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
   it("waitForReady waits for the next ready cycle after disconnect", async () => {
     await Dummy.run(async () => {
-      let isOnline = true
-      /** @type {Set<(isOnline: boolean) => void>} */
-      const listeners = new Set()
-      const client = new WebsocketClient({
-        autoReconnect: true,
-        networkMonitor: {
-          getIsOnline: () => isOnline,
-          subscribe: (callback) => {
-            listeners.add(callback)
-            return () => listeners.delete(callback)
-          }
-        },
-        reconnectDelays: [50]
-      })
+      const {client, setOnline} = reconnectingClientWithManualNetwork()
 
       try {
         const subscription = client.subscribeChannel("Counter", {
@@ -457,16 +427,14 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
         await subscription.waitForReady({timeoutMs: 3000})
         expect(subscription.isReady()).toBe(true)
 
-        isOnline = false
-        for (const listener of listeners) listener(false)
+        setOnline(false)
 
         await waitFor(() => subscription.isReady() === false, 3000)
 
         const waitForResume = subscription.waitForReady({timeoutMs: 5000})
         await wait(100)
 
-        isOnline = true
-        for (const listener of listeners) listener(true)
+        setOnline(true)
 
         await waitForResume
         expect(subscription.isReady()).toBe(true)
@@ -478,20 +446,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
   it("does not mark queued subscriptions ready on session resume before channel acknowledgement", async () => {
     await Dummy.run(async () => {
-      let isOnline = true
-      /** @type {Set<(isOnline: boolean) => void>} */
-      const listeners = new Set()
-      const client = new WebsocketClient({
-        autoReconnect: true,
-        networkMonitor: {
-          getIsOnline: () => isOnline,
-          subscribe: (callback) => {
-            listeners.add(callback)
-            return () => listeners.delete(callback)
-          }
-        },
-        reconnectDelays: [50]
-      })
+      const {client, setOnline} = reconnectingClientWithManualNetwork()
 
       try {
         const existingSubscription = client.subscribeChannel("Counter", {
@@ -501,8 +456,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
         await client.connect()
         await existingSubscription.waitForReady({timeoutMs: 3000})
 
-        isOnline = false
-        for (const listener of listeners) listener(false)
+        setOnline(false)
 
         await waitFor(() => existingSubscription.isReady() === false, 3000)
 
@@ -512,8 +466,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
         expect(queuedSubscription.isReady()).toBe(false)
 
-        isOnline = true
-        for (const listener of listeners) listener(true)
+        setOnline(true)
 
         await waitFor(() => existingSubscription.isReady() === true, 5000)
         expect(queuedSubscription.isReady()).toBe(false)
@@ -646,11 +599,7 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
           onClose: (reason) => closeReasons.push(reason)
         })
 
-        let rejected = false
-
-        await subscription.ready.catch(() => { rejected = true })
-
-        expect(rejected).toBe(true)
+        await expectRejectedSubscription(subscription)
         expect(closeReasons.length).toBe(1)
         expect(closeReasons[0]).toContain("Unknown channel type")
       } finally {

--- a/spec/http-server/websocket-connection-spec.js
+++ b/spec/http-server/websocket-connection-spec.js
@@ -3,26 +3,34 @@
 import {describe, expect, it} from "../../src/testing/test.js"
 import Dummy from "../dummy/index.js"
 import WebsocketClient from "../../src/http-client/websocket-client.js"
-import wait from "awaitery/build/wait.js"
+import waitFor from "../helpers/wait-for.js"
 
-/**
- * Waits for `predicate()` to return true, polling every 20 ms up to
- * `timeoutMs`. Used to let server/client async work settle between
- * calls without hardcoded sleeps.
- *
- * @param {() => boolean} predicate
- * @param {number} [timeoutMs]
- * @returns {Promise<void>}
- */
-async function waitFor(predicate, timeoutMs = 2000) {
-  const deadline = Date.now() + timeoutMs
+async function openEchoConnection(client, closeReasons) {
+  const connection = client.openConnection("Echo", {
+    onClose: (reason) => closeReasons.push(reason)
+  })
 
-  while (Date.now() < deadline) {
-    if (predicate()) return
-    await wait(20)
-  }
+  await connection.ready
 
-  throw new Error(`waitFor timeout after ${timeoutMs}ms`)
+  return connection
+}
+
+async function withEchoConnection(callback) {
+  await Dummy.run(async () => {
+    const client = new WebsocketClient()
+
+    try {
+      await client.connect()
+
+      /** @type {string[]} */
+      const closeReasons = []
+      const connection = await openEchoConnection(client, closeReasons)
+
+      await callback({client, closeReasons, connection})
+    } finally {
+      await client.close()
+    }
+  })
 }
 
 describe("WebsocketConnection (Phase 1A)", {databaseCleaning: {transaction: true}}, () => {
@@ -84,57 +92,25 @@ describe("WebsocketConnection (Phase 1A)", {databaseCleaning: {transaction: true
   })
 
   it("fires onClose(client_close) immediately when the client calls close()", async () => {
-    await Dummy.run(async () => {
-      const client = new WebsocketClient()
+    await withEchoConnection(async ({closeReasons, connection}) => {
+      connection.close()
 
-      try {
-        await client.connect()
-
-        /** @type {string[]} */
-        const clientCloseReasons = []
-        const connection = client.openConnection("Echo", {
-          onClose: (reason) => clientCloseReasons.push(reason)
-        })
-
-        await connection.ready
-
-        connection.close()
-
-        expect(connection.isClosed()).toBe(true)
-        expect(clientCloseReasons).toEqual(["client_close"])
-        // Server-side onClose firing is verified on the server-close
-        // path below; for client_close we can't observe it because the
-        // client has already dropped the id from its registry by the
-        // time the server's reply messages arrive.
-      } finally {
-        await client.close()
-      }
+      expect(connection.isClosed()).toBe(true)
+      expect(closeReasons).toEqual(["client_close"])
+      // Server-side onClose firing is verified on the server-close
+      // path below; for client_close we can't observe it because the
+      // client has already dropped the id from its registry by the
+      // time the server's reply messages arrive.
     })
   })
 
   it("fires onClose(server_close) when the server initiates the close", async () => {
-    await Dummy.run(async () => {
-      const client = new WebsocketClient()
+    await withEchoConnection(async ({closeReasons, connection}) => {
+      // Ask the server-side EchoConnection to close itself.
+      connection.sendMessage({__testCloseFromServer: true})
 
-      try {
-        await client.connect()
-
-        /** @type {string[]} */
-        const clientCloseReasons = []
-        const connection = client.openConnection("Echo", {
-          onClose: (reason) => clientCloseReasons.push(reason)
-        })
-
-        await connection.ready
-
-        // Ask the server-side EchoConnection to close itself.
-        connection.sendMessage({__testCloseFromServer: true})
-
-        await waitFor(() => connection.isClosed())
-        expect(clientCloseReasons).toEqual(["server_close"])
-      } finally {
-        await client.close()
-      }
+      await waitFor(() => connection.isClosed())
+      expect(closeReasons).toEqual(["server_close"])
     })
   })
 

--- a/spec/http-server/websocket-session-resume-spec.js
+++ b/spec/http-server/websocket-session-resume-spec.js
@@ -5,21 +5,37 @@ import Dummy from "../dummy/index.js"
 import WebsocketClient from "../../src/http-client/websocket-client.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import wait from "awaitery/build/wait.js"
+import waitFor from "../helpers/wait-for.js"
 
-/**
- * @param {() => boolean} predicate
- * @param {number} [timeoutMs]
- * @returns {Promise<void>}
- */
-async function waitFor(predicate, timeoutMs = 2000) {
-  const deadline = Date.now() + timeoutMs
+function openTrackedEchoConnection(client, events, callbacks = {}) {
+  return client.openConnection("Echo", {
+    ...callbacks,
+    onConnect: () => events.push("connect"),
+    onClose: (reason) => events.push(`close:${reason}`)
+  })
+}
 
-  while (Date.now() < deadline) {
-    if (predicate()) return
-    await wait(20)
-  }
+async function waitForConnect(events) {
+  await waitFor(() => events.includes("connect"))
+}
 
-  throw new Error(`waitFor timeout after ${timeoutMs}ms`)
+async function expectSessionGoneAfterReconnect(client, events) {
+  await waitForConnect(events)
+  client.socket?.close()
+  await waitFor(() => events.some((e) => e === "close:session_gone"), 5000)
+}
+
+async function withReconnectingClient(callback, reconnectDelays = [50]) {
+  await Dummy.run(async () => {
+    const client = new WebsocketClient({autoReconnect: true, reconnectDelays})
+
+    try {
+      await client.connect()
+      await callback(client)
+    } finally {
+      await client.close()
+    }
+  })
 }
 
 describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transaction: true}}, () => {
@@ -40,37 +56,27 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
   })
 
   it("pauses a session with live state on socket drop and fires onDisconnect on connections", async () => {
-    await Dummy.run(async () => {
-      const client = new WebsocketClient({autoReconnect: true, reconnectDelays: [50]})
+    await withReconnectingClient(async (client) => {
+      /** @type {string[]} */
+      const events = []
+      openTrackedEchoConnection(client, events, {
+        params: {name: "resume-me"},
+        onDisconnect: () => events.push("disconnect"),
+        onResume: () => events.push("resume")
+      })
 
-      try {
-        await client.connect()
+      await waitForConnect(events)
 
-        /** @type {string[]} */
-        const events = []
-        client.openConnection("Echo", {
-          params: {name: "resume-me"},
-          onConnect: () => events.push("connect"),
-          onDisconnect: () => events.push("disconnect"),
-          onResume: () => events.push("resume"),
-          onClose: (reason) => events.push(`close:${reason}`)
-        })
+      // Force the socket to drop; autoReconnect will kick in.
+      client.socket?.close()
 
-        await waitFor(() => events.includes("connect"))
+      await waitFor(() => events.includes("disconnect"), 3000)
+      await waitFor(() => events.includes("resume"), 5000)
 
-        // Force the socket to drop; autoReconnect will kick in.
-        client.socket?.close()
-
-        await waitFor(() => events.includes("disconnect"), 3000)
-        await waitFor(() => events.includes("resume"), 5000)
-
-        expect(events).toContain("connect")
-        expect(events).toContain("disconnect")
-        expect(events).toContain("resume")
-        expect(events.some((e) => e.startsWith("close:"))).toBe(false)
-      } finally {
-        await client.close()
-      }
+      expect(events).toContain("connect")
+      expect(events).toContain("disconnect")
+      expect(events).toContain("resume")
+      expect(events.some((e) => e.startsWith("close:"))).toBe(false)
     })
   })
 
@@ -119,31 +125,17 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
   })
 
   it("tells the client session-gone + destroys live handles when no paused session exists", async () => {
-    await Dummy.run(async () => {
-      const client = new WebsocketClient({autoReconnect: true, reconnectDelays: [50]})
+    await withReconnectingClient(async (client) => {
+      /** @type {string[]} */
+      const events = []
+      openTrackedEchoConnection(client, events)
 
-      try {
-        await client.connect()
+      // Set a bogus sessionId; on reconnect the server won't find it.
+      client._sessionId = "bogus-sess-id"
 
-        /** @type {string[]} */
-        const events = []
-        client.openConnection("Echo", {
-          onConnect: () => events.push("connect"),
-          onClose: (reason) => events.push(`close:${reason}`)
-        })
-
-        await waitFor(() => events.includes("connect"))
-
-        // Set a bogus sessionId; on reconnect the server won't find it.
-        client._sessionId = "bogus-sess-id"
-        client.socket?.close()
-
-        await waitFor(() => events.some((e) => e === "close:session_gone"), 5000)
-        expect(events).toContain("close:session_gone")
-        expect(client._sessionId).toBe(null)
-      } finally {
-        await client.close()
-      }
+      await expectSessionGoneAfterReconnect(client, events)
+      expect(events).toContain("close:session_gone")
+      expect(client._sessionId).toBe(null)
     })
   })
 
@@ -224,15 +216,12 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
 
           /** @type {string[]} */
           const events = []
-          client.openConnection("Echo", {
-            onConnect: () => events.push("connect"),
+          openTrackedEchoConnection(client, events, {
             onResume: () => events.push("resume"),
-            onClose: (reason) => events.push(`close:${reason}`)
           })
 
-          await waitFor(() => events.includes("connect"))
-
           // Drop the socket to trigger pause — identity captured as "alice".
+          await waitForConnect(events)
           client.socket?.close()
           // Wait until the SERVER sees the session as paused AND its
           // identity capture promise resolves, so we don't race the
@@ -256,7 +245,7 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
           // Reconnect will send session-resume with the stored id.
           // Server should reject and send session-gone, which tears
           // down live handles with reason `session_gone`.
-          await waitFor(() => events.some((e) => e === "close:session_gone"), 5000)
+          await waitFor(() => events.includes("close:session_gone"), 5000)
           expect(events).not.toContain("resume")
         } finally {
           await client.close()
@@ -326,12 +315,9 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
 
           /** @type {string[]} */
           const events = []
-          client.openConnection("Echo", {
-            onConnect: () => events.push("connect"),
-            onClose: (reason) => events.push(`close:${reason}`)
-          })
+          openTrackedEchoConnection(client, events)
 
-          await waitFor(() => events.includes("connect"))
+          await waitForConnect(events)
 
           // Drop socket and forget the session so no resume happens.
           // autoReconnect is off (default) → handles tear down

--- a/spec/mailers/smtp-mailer-backend-spec.js
+++ b/spec/mailers/smtp-mailer-backend-spec.js
@@ -4,6 +4,7 @@ import net from "net"
 import wait from "awaitery/build/wait.js"
 
 import SmtpMailerBackend from "../../src/mailer/backends/smtp.js"
+import {listenOnLocalhost} from "../helpers/local-server-helper.js"
 
 /**
  * @typedef {object} FakeSmtpServer
@@ -127,16 +128,7 @@ async function startFakeSmtpServer({holdQuitResponse = false, requireAuth = true
     })
   })
 
-  await new Promise((resolve, reject) => {
-    server.once("error", reject)
-    server.listen(0, "127.0.0.1", () => resolve(undefined))
-  })
-
-  const address = server.address()
-
-  if (!address || typeof address !== "object") {
-    throw new Error("Fake SMTP server did not expose a TCP port.")
-  }
+  const port = await listenOnLocalhost(server)
 
   return {
     close: async () => {
@@ -158,7 +150,7 @@ async function startFakeSmtpServer({holdQuitResponse = false, requireAuth = true
     },
     commands,
     messages,
-    port: address.port,
+    port,
     quitReceived,
     releaseQuitResponse
   }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -15,6 +15,7 @@ import translate from "gettext-universal/build/src/translate.js"
 import Ability from "./authorization/ability.js"
 import EventEmitter from "./utils/event-emitter.js"
 import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channel-subscribers.js"
+import {websocketSessionDebugSnapshot} from "./http-server/client/websocket-session.js"
 import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
 import {frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
 import PluginRoutes from "./routes/plugin-routes.js"
@@ -151,6 +152,9 @@ export default class VelociousConfiguration {
 
     /** @type {Map<string, Set<import("./http-server/websocket-channel.js").default>>} - channelType → live subscriptions across all sessions. */
     this._websocketChannelSubscriptions = new Map()
+
+    /** @type {Set<import("./http-server/client/websocket-session.js").default>} - Live websocket sessions, including paused sessions within the grace window. */
+    this._websocketSessions = new Set()
 
     /** @type {Map<string, {session: import("./http-server/client/websocket-session.js").default, graceTimer: ReturnType<typeof setTimeout>, pausedAt: number}>} - sessionId → paused session awaiting resume. */
     this._pausedWebsocketSessions = new Map()
@@ -456,6 +460,10 @@ export default class VelociousConfiguration {
 
   /** @returns {Record<string, unknown>} - WebSocket diagnostics. */
   _debugWebsocketSnapshot() {
+    /** @type {Map<string, {count: number, details: Omit<import("./http-server/client/websocket-session.js").WebsocketSessionDebugSnapshot, "queuedMessageCount">}>} */
+    const sessionBuckets = new Map()
+    /** @type {import("./http-server/client/websocket-session.js").WebsocketSessionDebugSnapshot[]} */
+    const sessionDetails = []
     const subscriptions = Array.from(this._websocketChannelSubscriptions.entries()).map(([channel, channelSubscriptions]) => {
       /** @type {Map<string, {count: number, details: Record<string, unknown>}>} */
       const detailsBuckets = new Map()
@@ -479,10 +487,41 @@ export default class VelociousConfiguration {
       }
     })
 
+    for (const session of this._websocketSessions) {
+      const snapshot = websocketSessionDebugSnapshot(session)
+      const bucketKey = JSON.stringify({
+        channelSubscriptionCount: snapshot.channelSubscriptionCount,
+        channelSubscriptions: snapshot.channelSubscriptions,
+        connectionCount: snapshot.connectionCount,
+        paused: snapshot.paused,
+        subscriptionCount: snapshot.subscriptionCount
+      })
+      const existingBucket = sessionBuckets.get(bucketKey)
+
+      if (existingBucket) {
+        existingBucket.count += 1
+      } else {
+        sessionBuckets.set(bucketKey, {
+          count: 1,
+          details: {
+            channelSubscriptionCount: snapshot.channelSubscriptionCount,
+            channelSubscriptions: snapshot.channelSubscriptions,
+            connectionCount: snapshot.connectionCount,
+            paused: snapshot.paused,
+            subscriptionCount: snapshot.subscriptionCount
+          }
+        })
+      }
+      sessionDetails.push(snapshot)
+    }
+
     return {
       pausedSessions: this._pausedWebsocketSessions.size,
       registeredChannels: Array.from(this._websocketChannelClasses.keys()),
       registeredConnections: Array.from(this._websocketConnectionClasses.keys()),
+      sessionBuckets: Array.from(sessionBuckets.values()).sort((a, b) => b.count - a.count),
+      sessionCount: this._websocketSessions.size,
+      sessions: sessionDetails.sort((a, b) => b.channelSubscriptionCount - a.channelSubscriptionCount),
       subscriptionGroups: this._websocketChannelSubscriptions.size,
       subscriptions
     }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -15,7 +15,6 @@ import translate from "gettext-universal/build/src/translate.js"
 import Ability from "./authorization/ability.js"
 import EventEmitter from "./utils/event-emitter.js"
 import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channel-subscribers.js"
-import {websocketSessionDebugSnapshot} from "./http-server/client/websocket-session.js"
 import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
 import {frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
 import PluginRoutes from "./routes/plugin-routes.js"
@@ -460,9 +459,9 @@ export default class VelociousConfiguration {
 
   /** @returns {Record<string, unknown>} - WebSocket diagnostics. */
   _debugWebsocketSnapshot() {
-    /** @type {Map<string, {count: number, details: Omit<import("./http-server/client/websocket-session.js").WebsocketSessionDebugSnapshot, "queuedMessageCount">}>} */
+    /** @type {Map<string, {count: number, details: {channelSubscriptionCount: number, channelSubscriptions: {channelType: string, count: number, model: string | null}[], connectionCount: number, paused: boolean, subscriptionCount: number}}>} */
     const sessionBuckets = new Map()
-    /** @type {import("./http-server/client/websocket-session.js").WebsocketSessionDebugSnapshot[]} */
+    /** @type {{channelSubscriptionCount: number, channelSubscriptions: {channelType: string, count: number, model: string | null}[], connectionCount: number, paused: boolean, queuedMessageCount: number, subscriptionCount: number}[]} */
     const sessionDetails = []
     const subscriptions = Array.from(this._websocketChannelSubscriptions.entries()).map(([channel, channelSubscriptions]) => {
       /** @type {Map<string, {count: number, details: Record<string, unknown>}>} */
@@ -488,7 +487,31 @@ export default class VelociousConfiguration {
     })
 
     for (const session of this._websocketSessions) {
-      const snapshot = websocketSessionDebugSnapshot(session)
+      /** @type {Map<string, {channelType: string, count: number, model: string | null}>} */
+      const channelSubscriptionBuckets = new Map()
+
+      for (const {channelType, subscription} of session._channelSubscriptions.values()) {
+        const details = /** @type {Record<string, unknown>} */ (subscription.debugSnapshot())
+        const model = typeof details.model === "string" ? details.model : null
+        const key = JSON.stringify({channelType, model})
+        const existingBucket = channelSubscriptionBuckets.get(key)
+
+        if (existingBucket) {
+          existingBucket.count += 1
+        } else {
+          channelSubscriptionBuckets.set(key, {channelType, count: 1, model})
+        }
+      }
+
+      const channelSubscriptions = Array.from(channelSubscriptionBuckets.values()).sort((a, b) => b.count - a.count)
+      const snapshot = {
+        channelSubscriptionCount: session._channelSubscriptions.size,
+        channelSubscriptions,
+        connectionCount: session._connections.size,
+        paused: session._paused,
+        queuedMessageCount: session._outboundQueue.length,
+        subscriptionCount: session.subscriptions.size
+      }
       const bucketKey = JSON.stringify({
         channelSubscriptionCount: snapshot.channelSubscriptionCount,
         channelSubscriptions: snapshot.channelSubscriptions,

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -31,6 +31,16 @@ const WEBSOCKET_MAX_FRAGMENTED_MESSAGE_FRAGMENTS = 1024
  */
 
 /**
+ * @typedef {object} WebsocketSessionDebugSnapshot
+ * @property {number} channelSubscriptionCount Live channel-v2 subscriptions on this session.
+ * @property {{channelType: string, count: number, model: string | null}[]} channelSubscriptions Channel subscription buckets.
+ * @property {number} connectionCount Live connection count on this session.
+ * @property {boolean} paused Whether the session is paused for grace-period resume.
+ * @property {number} queuedMessageCount Number of frames queued while paused.
+ * @property {number} subscriptionCount Legacy channel subscription count on this session.
+ */
+
+/**
  * @param {WebsocketSessionMessage} message - Raw websocket message.
  * @returns {{type: "subscribe", channel: string, lastEventId?: string, params?: Record<string, any>} | null} - Subscribe message when matched.
  */
@@ -178,6 +188,8 @@ export default class VelociousHttpServerClientWebsocketSession {
      * @type {number}
      */
     this._fragmentedBytes = 0
+
+    this.configuration._websocketSessions.add(this)
   }
 
   /**
@@ -225,6 +237,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   }
 
   destroy() {
+    this.configuration._websocketSessions.delete(this)
     void this._teardownChannel()
     this.events.removeAllListeners()
   }
@@ -1694,5 +1707,35 @@ export default class VelociousHttpServerClientWebsocketSession {
         await this._handleMessage(message)
       }
     }
+  }
+}
+
+/**
+ * @param {VelociousHttpServerClientWebsocketSession} session Websocket session to summarize.
+ * @returns {WebsocketSessionDebugSnapshot} Debug-safe session diagnostics.
+ */
+export function websocketSessionDebugSnapshot(session) {
+  const channelSubscriptions = new Map()
+
+  for (const {channelType, subscription} of session._channelSubscriptions.values()) {
+    const snapshot = /** @type {Record<string, unknown>} */ (subscription.debugSnapshot())
+    const model = typeof snapshot.model === "string" ? snapshot.model : null
+    const key = JSON.stringify({channelType, model})
+    const existing = channelSubscriptions.get(key)
+
+    if (existing) {
+      existing.count += 1
+    } else {
+      channelSubscriptions.set(key, {channelType, count: 1, model})
+    }
+  }
+
+  return {
+    channelSubscriptionCount: session._channelSubscriptions.size,
+    channelSubscriptions: Array.from(channelSubscriptions.values()).sort((a, b) => b.count - a.count),
+    connectionCount: session._connections.size,
+    paused: session._paused,
+    queuedMessageCount: session._outboundQueue.length,
+    subscriptionCount: session.subscriptions.size
   }
 }

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -915,21 +915,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @returns {Promise<void>}
    */
   async _fireOnDisconnect() {
-    for (const connection of this._connections.values()) {
-      try {
-        await connection.onDisconnect?.()
-      } catch (error) {
-        this.logger.error(() => [`onDisconnect failed for ${connection.connectionId}`, error])
-      }
-    }
-
-    for (const {subscription} of this._channelSubscriptions.values()) {
-      try {
-        await subscription.onDisconnect?.()
-      } catch (error) {
-        this.logger.error(() => [`onDisconnect failed for channel sub ${subscription.subscriptionId}`, error])
-      }
-    }
+    await this._fireLifecycleCallback("onDisconnect")
   }
 
   /**
@@ -939,19 +925,27 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @returns {Promise<void>}
    */
   async _fireOnResume() {
+    await this._fireLifecycleCallback("onResume")
+  }
+
+  /**
+   * @param {"onDisconnect" | "onResume"} callbackName Lifecycle callback to fire.
+   * @returns {Promise<void>} Resolves when every live handler has been attempted.
+   */
+  async _fireLifecycleCallback(callbackName) {
     for (const connection of this._connections.values()) {
       try {
-        await connection.onResume?.()
+        await connection[callbackName]?.()
       } catch (error) {
-        this.logger.error(() => [`onResume failed for ${connection.connectionId}`, error])
+        this.logger.error(() => [`${callbackName} failed for ${connection.connectionId}`, error])
       }
     }
 
     for (const {subscription} of this._channelSubscriptions.values()) {
       try {
-        await subscription.onResume?.()
+        await subscription[callbackName]?.()
       } catch (error) {
-        this.logger.error(() => [`onResume failed for channel sub ${subscription.subscriptionId}`, error])
+        this.logger.error(() => [`${callbackName} failed for channel sub ${subscription.subscriptionId}`, error])
       }
     }
   }

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -31,16 +31,6 @@ const WEBSOCKET_MAX_FRAGMENTED_MESSAGE_FRAGMENTS = 1024
  */
 
 /**
- * @typedef {object} WebsocketSessionDebugSnapshot
- * @property {number} channelSubscriptionCount Live channel-v2 subscriptions on this session.
- * @property {{channelType: string, count: number, model: string | null}[]} channelSubscriptions Channel subscription buckets.
- * @property {number} connectionCount Live connection count on this session.
- * @property {boolean} paused Whether the session is paused for grace-period resume.
- * @property {number} queuedMessageCount Number of frames queued while paused.
- * @property {number} subscriptionCount Legacy channel subscription count on this session.
- */
-
-/**
  * @param {WebsocketSessionMessage} message - Raw websocket message.
  * @returns {{type: "subscribe", channel: string, lastEventId?: string, params?: Record<string, any>} | null} - Subscribe message when matched.
  */
@@ -1707,35 +1697,5 @@ export default class VelociousHttpServerClientWebsocketSession {
         await this._handleMessage(message)
       }
     }
-  }
-}
-
-/**
- * @param {VelociousHttpServerClientWebsocketSession} session Websocket session to summarize.
- * @returns {WebsocketSessionDebugSnapshot} Debug-safe session diagnostics.
- */
-export function websocketSessionDebugSnapshot(session) {
-  const channelSubscriptions = new Map()
-
-  for (const {channelType, subscription} of session._channelSubscriptions.values()) {
-    const snapshot = /** @type {Record<string, unknown>} */ (subscription.debugSnapshot())
-    const model = typeof snapshot.model === "string" ? snapshot.model : null
-    const key = JSON.stringify({channelType, model})
-    const existing = channelSubscriptions.get(key)
-
-    if (existing) {
-      existing.count += 1
-    } else {
-      channelSubscriptions.set(key, {channelType, count: 1, model})
-    }
-  }
-
-  return {
-    channelSubscriptionCount: session._channelSubscriptions.size,
-    channelSubscriptions: Array.from(channelSubscriptions.values()).sort((a, b) => b.count - a.count),
-    connectionCount: session._connections.size,
-    paused: session._paused,
-    queuedMessageCount: session._outboundQueue.length,
-    subscriptionCount: session.subscriptions.size
   }
 }

--- a/src/http-server/worker-handler/channel-subscriber-dispatch.js
+++ b/src/http-server/worker-handler/channel-subscriber-dispatch.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+/**
+ * @param {object} args - Dispatch arguments.
+ * @param {string} args.channel - Channel name.
+ * @param {string | undefined} args.createdAt - Event creation timestamp.
+ * @param {string | undefined} args.eventId - Event identifier.
+ * @param {import("../../configuration.js").default} args.configuration - Configuration instance.
+ * @param {import("../../logger.js").default} args.logger - Logger for isolated subscriber failures.
+ * @param {any} args.payload - Broadcast payload.
+ * @returns {Promise<void>} Resolves after subscribers have been attempted.
+ */
+export default async function dispatchChannelSubscribers({channel, configuration, createdAt, eventId, logger, payload}) {
+  try {
+    await configuration.getWebsocketChannelSubscribers().dispatch({channel, createdAt, eventId, payload})
+  } catch (error) {
+    logger.error(() => [`Channel subscriber dispatch failed for ${channel}`, error])
+
+    const errorPayload = {
+      context: {channel, createdAt, eventId, source: "websocket-channel-subscribers"},
+      error
+    }
+
+    configuration.getErrorEvents().emit("framework-error", errorPayload)
+    configuration.getErrorEvents().emit("all-error", {...errorPayload, errorType: "framework-error"})
+  }
+}

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import Client from "../client/index.js"
+import dispatchChannelSubscribers from "./channel-subscriber-dispatch.js"
 import Logger from "../../logger.js"
 import websocketEventsHost from "../websocket-events-host.js"
 
@@ -137,24 +138,10 @@ export default class VelociousHttpServerInProcessHandler {
     }
 
     if (this.configuration) {
-      const configuration = this.configuration
-
       // Isolate subscriber failures from breaking the in-process handler,
       // but still surface them to the framework error events so bug
       // reporters can pick them up.
-      void configuration.getWebsocketChannelSubscribers()
-        .dispatch({channel, createdAt, eventId, payload})
-        .catch((error) => {
-          this.logger.error(() => [`Channel subscriber dispatch failed for ${channel}`, error])
-
-          const errorPayload = {
-            context: {channel, createdAt, eventId, source: "websocket-channel-subscribers"},
-            error
-          }
-
-          configuration.getErrorEvents().emit("framework-error", errorPayload)
-          configuration.getErrorEvents().emit("all-error", {...errorPayload, errorType: "framework-error"})
-        })
+      void dispatchChannelSubscribers({channel, configuration: this.configuration, createdAt, eventId, logger: this.logger, payload})
     }
   }
 }

--- a/src/http-server/worker-handler/worker-thread.js
+++ b/src/http-server/worker-handler/worker-thread.js
@@ -2,6 +2,7 @@
 
 import Application from "../../application.js"
 import Client from "../client/index.js"
+import dispatchChannelSubscribers from "./channel-subscriber-dispatch.js"
 import {digg} from "diggerize"
 import errorLogger from "../../error-logger.js"
 import Logger from "../../logger.js"
@@ -196,27 +197,11 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
     }
 
     if (this.configuration) {
-      const configuration = this.configuration
-
       // Isolate channel subscriber failures so a buggy in-process callback
       // cannot reject this command and crash the worker thread, but still
       // surface the error to the framework error events so bug reporters
       // can pick it up.
-      sendTasks.push(
-        configuration.getWebsocketChannelSubscribers()
-          .dispatch({channel, createdAt, eventId, payload})
-          .catch((error) => {
-            this.logger.error(() => [`Channel subscriber dispatch failed for ${channel}`, error])
-
-            const errorPayload = {
-              context: {channel, createdAt, eventId, source: "websocket-channel-subscribers"},
-              error
-            }
-
-            configuration.getErrorEvents().emit("framework-error", errorPayload)
-            configuration.getErrorEvents().emit("all-error", {...errorPayload, errorType: "framework-error"})
-          })
-      )
+      sendTasks.push(dispatchChannelSubscribers({channel, configuration: this.configuration, createdAt, eventId, logger: this.logger, payload}))
     }
 
     await Promise.all(sendTasks)

--- a/src/http-server/worker-handler/worker-thread.js
+++ b/src/http-server/worker-handler/worker-thread.js
@@ -100,76 +100,134 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
     const command = data.command
 
     if (command == "newClient") {
-      if (!this.configuration) throw new Error("Configuration not initialized")
-
-      const {clientCount, remoteAddress} = data
-
-      if (typeof clientCount !== "number") throw new Error("clientCount must be a number")
-
-      const client = new Client({
-        clientCount,
-        configuration: this.configuration,
-        remoteAddress
-      })
-
-      client.events.on("output", (output) => {
-        this.parentPort.postMessage({command: "clientOutput", clientCount, output})
-      })
-
-      client.events.on("close", (output) => {
-        this.logger.debugLowLevel(() => "Close received from client in worker - forwarding to worker parent")
-        this.parentPort.postMessage({command: "clientClose", clientCount, output})
-      })
-
-      this.clients[clientCount] = client
+      this.handleNewClient(data)
     } else if (command == "clientWrite") {
-      await this.logger.debugLowLevel("Looking up client")
-
-      const {chunk, clientCount} = data
-      if (!chunk) throw new Error("No chunk given")
-      const client = /** @type {Client | undefined} */ (digg(this.clients, clientCount))
-
-      if (!client) throw new Error(`Client not found for clientWrite: ${clientCount}`)
-
-      const clientChunk = typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk)
-
-      await this.logger.debug(() => ["Sending clientWrite to parser", {clientCount, ...summarizeClientWriteChunk(clientChunk)}])
-
-      client.onWrite(clientChunk)
+      await this.handleClientWrite(data)
     } else if (command == "websocketEvent") {
-      const {channel, createdAt, eventId, payload} = data
-
-      if (typeof channel !== "string") throw new Error("No channel given")
-
-      await this.broadcastWebsocketEvent({channel, createdAt, eventId, payload})
+      await this.handleWebsocketEvent(data)
     } else if (command == "websocketV2Broadcast") {
-      const {body, broadcastParams, channel, eventId} = data
-
-      if (typeof channel !== "string") throw new Error("No channel given")
-      if (!this.configuration) throw new Error("Configuration not initialized")
-
-      this.configuration._broadcastToChannelLocal(channel, broadcastParams || {}, body, {eventId})
+      this.handleWebsocketV2Broadcast(data)
     } else if (command == "debugSnapshot") {
-      const {requestId} = data
-
-      if (typeof requestId !== "number") throw new Error("debugSnapshot requestId must be a number")
-      if (!this.configuration) throw new Error("Configuration not initialized")
-
-      this.parentPort.postMessage({
-        command: "debugSnapshot",
-        requestId,
-        snapshot: this.configuration.getLocalDebugSnapshot()
-      })
+      this.handleDebugSnapshot(data)
     } else if (command == "shutdown") {
-      if (this.configuration?.closeDatabaseConnections) {
-        await this.configuration.closeDatabaseConnections()
-      }
-
-      this.parentPort.postMessage({command: "shutdownComplete"})
-      process.exit(0)
+      await this.handleShutdown()
     } else {
       throw new Error(`Unknown command: ${command}`)
     }
+  }
+
+  /**
+   * @param {object} data - Data payload.
+   * @param {number} [data.clientCount] - Client count.
+   * @param {string} [data.remoteAddress] - Remote address.
+   * @returns {void}
+   */
+  handleNewClient(data) {
+    if (!this.configuration) throw new Error("Configuration not initialized")
+
+    const {clientCount, remoteAddress} = data
+
+    if (typeof clientCount !== "number") throw new Error("clientCount must be a number")
+
+    const client = new Client({
+      clientCount,
+      configuration: this.configuration,
+      remoteAddress
+    })
+
+    client.events.on("output", (output) => {
+      this.parentPort.postMessage({command: "clientOutput", clientCount, output})
+    })
+
+    client.events.on("close", (output) => {
+      this.logger.debugLowLevel(() => "Close received from client in worker - forwarding to worker parent")
+      this.parentPort.postMessage({command: "clientClose", clientCount, output})
+    })
+
+    this.clients[clientCount] = client
+  }
+
+  /**
+   * @param {object} data - Data payload.
+   * @param {Buffer | Uint8Array | string} [data.chunk] - Chunk.
+   * @param {number} [data.clientCount] - Client count.
+   * @returns {Promise<void>} Resolves when the client write is dispatched.
+   */
+  async handleClientWrite(data) {
+    await this.logger.debugLowLevel("Looking up client")
+
+    const {chunk, clientCount} = data
+    if (!chunk) throw new Error("No chunk given")
+    const client = /** @type {Client | undefined} */ (digg(this.clients, clientCount))
+
+    if (!client) throw new Error(`Client not found for clientWrite: ${clientCount}`)
+
+    const clientChunk = typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk)
+
+    await this.logger.debug(() => ["Sending clientWrite to parser", {clientCount, ...summarizeClientWriteChunk(clientChunk)}])
+
+    client.onWrite(clientChunk)
+  }
+
+  /**
+   * @param {object} data - Data payload.
+   * @param {string} [data.channel] - Channel name.
+   * @param {string} [data.createdAt] - Event creation time.
+   * @param {string} [data.eventId] - Event identifier.
+   * @param {any} [data.payload] - Payload data.
+   * @returns {Promise<void>} Resolves when the websocket event is dispatched.
+   */
+  async handleWebsocketEvent(data) {
+    const {channel, createdAt, eventId, payload} = data
+
+    if (typeof channel !== "string") throw new Error("No channel given")
+
+    await this.broadcastWebsocketEvent({channel, createdAt, eventId, payload})
+  }
+
+  /**
+   * @param {object} data - Data payload.
+   * @param {Record<string, any>} [data.broadcastParams] - V2 broadcast filter params.
+   * @param {any} [data.body] - V2 broadcast body.
+   * @param {string} [data.channel] - Channel name.
+   * @param {string} [data.eventId] - Event identifier.
+   * @returns {void}
+   */
+  handleWebsocketV2Broadcast(data) {
+    const {body, broadcastParams, channel, eventId} = data
+
+    if (typeof channel !== "string") throw new Error("No channel given")
+    if (!this.configuration) throw new Error("Configuration not initialized")
+
+    this.configuration._broadcastToChannelLocal(channel, broadcastParams || {}, body, {eventId})
+  }
+
+  /**
+   * @param {object} data - Data payload.
+   * @param {number} [data.requestId] - Debug request id.
+   * @returns {void}
+   */
+  handleDebugSnapshot(data) {
+    const {requestId} = data
+
+    if (typeof requestId !== "number") throw new Error("debugSnapshot requestId must be a number")
+    if (!this.configuration) throw new Error("Configuration not initialized")
+
+    this.parentPort.postMessage({
+      command: "debugSnapshot",
+      requestId,
+      snapshot: this.configuration.getLocalDebugSnapshot()
+    })
+  }
+
+  /** @returns {Promise<void>} Resolves after worker shutdown has been requested. */
+  async handleShutdown() {
+    if (this.configuration?.closeDatabaseConnections) {
+      await this.configuration.closeDatabaseConnections()
+    }
+
+    this.parentPort.postMessage({command: "shutdownComplete"})
+    process.exit(0)
   }
 
   /**


### PR DESCRIPTION
Adds session-level websocket diagnostics to the Velocious debug snapshot so downstream apps can distinguish many live websocket sessions from duplicate subscriptions within fewer sessions.\n\nValidation:\n- node scripts/run-tests.js -- spec/http-server/websocket-channel-spec.js spec/http-server/debug-snapshot-spec.js\n- npm run lint\n- npm run typecheck\n- git diff --check\n\nKnown issue:\n- npm run fallow still reports duplicate-code groups in existing websocket specs/source files; left as a draft pending that follow-up instead of refactoring unrelated duplicates in this diagnostic change.