### PR TITLE
Clean up resumed websocket session shells

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ The `Lint` Peakflow build first copies `spec/dummy/src/config/configuration.peak
 
 **Default to actually FIXING a Fallow offence, not ignoring it.** Delete the dead code, remove the duplication, or refactor the complexity that Fallow flags — that is the intended response. Refreshing the baseline (`npm run fallow:baseline`) and inline `// fallow-ignore-*` comments are last resorts, only for findings that are genuinely intended and reviewed (e.g. a new public API Fallow can't see is consumed, or a deliberate, justified complexity increase); explain why in the PR. Do not refresh the baseline or add ignore comments merely to make the gate pass — that hides real dead code/duplication instead of removing it.
 
+When a Fallow failure is confusing, inspect current JSON output against the checked-in baseline before refactoring broad unrelated code. Use `npx fallow health --baseline fallow-baselines/health.json --quiet --format json > tmp/fallow-health.json; status=$?; printf 'status=%s\n' "$status"` to preserve the exit status while capturing details. If Fallow itself changed target keys/report shape or the baseline is stale, save a fresh baseline with the owning command (for health: `npx fallow health --quiet --save-baseline tmp/health-current.json`, inspect the diff, then copy it to `fallow-baselines/health.json` only if the accepted baseline update is intentional) and rerun the full strict sequence. Never use `|| true` or a script change to make Fallow informational.
+
 If any command fails:
 - Read the error output, fix the underlying issue, and re-run the same command.
 - Repeat until the command succeeds (or clearly explain why it cannot be made to pass).

--- a/spec/http-server/websocket-session-resume-spec.js
+++ b/spec/http-server/websocket-session-resume-spec.js
@@ -201,6 +201,45 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
     })
   })
 
+  it("removes the paused session shell from debug tracking after resume", async () => {
+    await Dummy.run(async () => {
+      /** @type {{value: string | null}} */
+      const storage = {value: null}
+      const sessionStore = {
+        get: () => storage.value,
+        set: (/** @type {string} */ id) => { storage.value = id },
+        clear: () => { storage.value = null }
+      }
+      const firstClient = new WebsocketClient({sessionStore})
+      const secondClient = new WebsocketClient({sessionStore})
+
+      try {
+        await firstClient.connect()
+        const subscription = firstClient.subscribeChannel("Counter", {params: {allow: true, topic: "resume-debug"}})
+
+        await subscription.ready
+        await waitFor(() => storage.value !== null, 2000)
+        const snapshotBeforeDrop = dummyConfiguration.getLocalDebugSnapshot()
+        const sessionCountBeforeDrop = snapshotBeforeDrop.websockets.sessionCount
+
+        firstClient.socket?.close()
+        await waitFor(() => !firstClient.isOpen(), 2000)
+
+        await secondClient.connect()
+        await waitFor(() => secondClient._sessionId === storage.value, 3000)
+
+        const snapshot = dummyConfiguration.getLocalDebugSnapshot()
+        const counterSubscription = snapshot.websockets.subscriptions.find((entry) => entry.channel === "Counter")
+
+        expect(snapshot.websockets.sessionCount).toEqual(sessionCountBeforeDrop)
+        expect(counterSubscription?.count).toEqual(1)
+      } finally {
+        await firstClient.close().catch(() => {})
+        await secondClient.close().catch(() => {})
+      }
+    })
+  })
+
   it("rejects resume with session-gone when the identity resolver reports a different user", async () => {
     /** @type {{identity: string | null}} */
     const authState = {identity: "alice"}

--- a/spec/http-server/websocket-session-resume-spec.js
+++ b/spec/http-server/websocket-session-resume-spec.js
@@ -214,6 +214,9 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
       const secondClient = new WebsocketClient({sessionStore})
 
       try {
+        const snapshotBeforeSubscribe = dummyConfiguration.getLocalDebugSnapshot()
+        const counterCountBeforeSubscribe = snapshotBeforeSubscribe.websockets.subscriptions.find((entry) => entry.channel === "Counter")?.count || 0
+
         await firstClient.connect()
         const subscription = firstClient.subscribeChannel("Counter", {params: {allow: true, topic: "resume-debug"}})
 
@@ -232,7 +235,7 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
         const counterSubscription = snapshot.websockets.subscriptions.find((entry) => entry.channel === "Counter")
 
         expect(snapshot.websockets.sessionCount).toEqual(sessionCountBeforeDrop)
-        expect(counterSubscription?.count).toEqual(1)
+        expect(counterSubscription?.count).toEqual(counterCountBeforeSubscribe + 1)
       } finally {
         await firstClient.close().catch(() => {})
         await secondClient.close().catch(() => {})

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -228,7 +228,10 @@ export default class VelociousHttpServerClientWebsocketSession {
 
   destroy() {
     this.configuration._websocketSessions.delete(this)
+    this._paused = false
     void this._teardownChannel()
+    void this._teardownConnections("session_destroyed")
+    void this._teardownChannelSubscriptions()
     this.events.removeAllListeners()
   }
 
@@ -1026,6 +1029,7 @@ export default class VelociousHttpServerClientWebsocketSession {
     paused._connections.clear()
     paused._channelSubscriptions.clear()
     paused._paused = false
+    paused.destroy()
 
     this.sendJson({type: "session-resumed", sessionId: resumeSessionId})
     for (const body of queued) this.sendJson(body)


### PR DESCRIPTION
## Summary
- Remove paused websocket session shells from debug tracking after successful session resume
- Make websocket session destroy tear down channel-v2 subscriptions and live connections
- Add regression coverage for resumed sessions not increasing debug session counts
- Document Fallow troubleshooting guidance in AGENTS.md

## Validation
- node scripts/run-tests.js -- spec/http-server/websocket-session-resume-spec.js
- node scripts/run-tests.js -- spec/http-server/websocket-channel-spec.js spec/http-server/websocket-session-close-spec.js spec/http-server/debug-snapshot-spec.js
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow