### PR TITLE
Detach websocket broadcasts from DB context

### DIFF
--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -22,6 +22,35 @@ class ReorderedDebugChannel extends WebsocketChannel {
   }
 }
 
+class ConnectionContextDebugChannel extends WebsocketChannel {
+  /** @type {Array<Record<string, unknown>>} */
+  static deliveries = []
+
+  /** @returns {boolean} Whether the subscription is allowed. */
+  canSubscribe() { return true }
+
+  /**
+   * @param {Record<string, unknown>} body - Broadcast body.
+   * @returns {Promise<void>} - Resolves when delivered.
+   */
+  async deliverBroadcast(body) {
+    const currentConnectionsBeforeEnsure = this.session.configuration.getCurrentConnections()
+    const defaultConnection = currentConnectionsBeforeEnsure.default
+    const defaultConnectionSnapshot = defaultConnection?.getDebugSnapshot()
+    const defaultPool = this.session.configuration.getDatabasePool("default")
+
+    ConnectionContextDebugChannel.deliveries.push({
+      body,
+      checkoutNameBeforeEnsure: defaultConnectionSnapshot?.checkoutName,
+      currentConnectionCountBeforeEnsure: Object.keys(currentConnectionsBeforeEnsure).length,
+      currentContextStoreBeforeEnsure: defaultPool.asyncLocalStorage?.getStore(),
+      defaultConnectionIdSeqBeforeEnsure: defaultConnection?.getIdSeq()
+    })
+
+    await super.deliverBroadcast(body)
+  }
+}
+
 function reconnectingClientWithManualNetwork(initialOnline = true) {
   let isOnline = initialOnline
   /** @type {Set<(isOnline: boolean) => void>} */
@@ -320,6 +349,40 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
       } finally {
         await clientA.close()
         await clientB.close()
+      }
+    })
+  })
+
+  it("does not inherit the publisher DB connection context for detached broadcast delivery", async () => {
+    await Dummy.run(async () => {
+      dummyConfiguration.registerWebsocketChannel("ConnectionContextDebug", ConnectionContextDebugChannel)
+      ConnectionContextDebugChannel.deliveries = []
+      const client = new WebsocketClient()
+
+      try {
+        await client.connect()
+
+        /** @type {any[]} */
+        const received = []
+        const subscription = client.subscribeChannel("ConnectionContextDebug", {
+          params: {allow: true},
+          onMessage: (body) => received.push(body)
+        })
+
+        await subscription.ready
+
+        const defaultPool = dummyConfiguration.getDatabasePool("default")
+        await defaultPool.withConnection({name: "Publisher request"}, async () => {
+          expect(Object.keys(dummyConfiguration.getCurrentConnections()).length).toBeGreaterThan(0)
+          dummyConfiguration.broadcastToChannel("ConnectionContextDebug", {}, {count: 1})
+        })
+
+        await waitFor(() => received.length >= 1)
+
+        expect(ConnectionContextDebugChannel.deliveries[0]?.body).toEqual({count: 1})
+        expect(ConnectionContextDebugChannel.deliveries[0]?.checkoutNameBeforeEnsure).not.toEqual("Publisher request")
+      } finally {
+        await client.close()
       }
     })
   })

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1970,12 +1970,14 @@ export default class VelociousConfiguration {
 
       if (!matches) continue
 
-      void Promise
-        .resolve()
-        .then(() => this._deliverWebsocketChannelBroadcast(subscription, body, {eventId: meta?.eventId}))
-        .catch((error) => {
-          console.error(`broadcastToChannel: ${name} subscription ${subscription.subscriptionId} deliverBroadcast threw`, error)
-        })
+      this.withoutCurrentConnectionContexts(() => {
+        void Promise
+          .resolve()
+          .then(() => this._deliverWebsocketChannelBroadcast(subscription, body, {eventId: meta?.eventId}))
+          .catch((error) => {
+            console.error(`broadcastToChannel: ${name} subscription ${subscription.subscriptionId} deliverBroadcast threw`, error)
+          })
+      })
     }
   }
 
@@ -2181,6 +2183,24 @@ export default class VelociousConfiguration {
     }
 
     return dbs
+  }
+
+  /**
+   * @template T
+   * @param {() => T} callback - Callback to run without inherited DB connection contexts.
+   * @returns {T} - Callback result.
+   */
+  withoutCurrentConnectionContexts(callback) {
+    let runCallback = callback
+
+    for (const identifier of this.getDatabaseIdentifiers()) {
+      const pool = this.getDatabasePool(identifier)
+      const previousRunCallback = runCallback
+
+      runCallback = () => pool.withoutCurrentConnectionContext(previousRunCallback)
+    }
+
+    return runCallback()
   }
 
   /**

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2193,8 +2193,8 @@ export default class VelociousConfiguration {
   withoutCurrentConnectionContexts(callback) {
     let runCallback = callback
 
-    for (const identifier of this.getDatabaseIdentifiers()) {
-      const pool = this.getDatabasePool(identifier)
+    for (const pool of Object.values(this.databasePools)) {
+      if (!pool) continue
       const previousRunCallback = runCallback
 
       runCallback = () => pool.withoutCurrentConnectionContext(previousRunCallback)

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -559,6 +559,15 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     return this.getCurrentConnection()
   }
 
+  /**
+   * @template T
+   * @param {() => T} callback - Callback to run without the current async DB connection context.
+   * @returns {T} - Callback result.
+   */
+  _withoutCurrentConnectionContext = (callback) => {
+    return this.asyncLocalStorage.run(undefined, callback)
+  }
+
   /** @returns {import("./base.js").DatabasePoolDebugSnapshot} - Diagnostic snapshot for this pool. */
   getDebugSnapshot() {
     const snapshot = super.getDebugSnapshot()

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -51,6 +51,9 @@ function stableStringify(value) {
 }
 
 class VelociousDatabasePoolBase {
+  /** @type {undefined | (<T>(callback: () => T) => T)} */
+  _withoutCurrentConnectionContext = undefined
+
   /**
    * @returns {VelociousDatabasePoolBase} - The current.
    */
@@ -113,6 +116,17 @@ class VelociousDatabasePoolBase {
    */
   getCurrentContextConnection() {
     return this.getCurrentConnection()
+  }
+
+  /**
+   * @template T
+   * @param {() => T} callback - Callback to run without any current connection context.
+   * @returns {T} - Callback result.
+   */
+  withoutCurrentConnectionContext(callback) {
+    if (this._withoutCurrentConnectionContext) return this._withoutCurrentConnectionContext(callback)
+
+    return callback()
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a configuration helper to run detached work without inherited database connection contexts
- schedule local websocket channel broadcast delivery outside publisher DB contexts
- add regression coverage for broadcast delivery started from a checked-out publisher connection

## Validation
- node scripts/run-tests.js -- spec/http-server/websocket-channel-spec.js
- node scripts/run-tests.js -- spec/http-server/websocket-session-close-spec.js spec/http-server/debug-snapshot-spec.js
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow
- git diff --check