### PR TITLE
Fix DB context helper declaration

### DIFF
--- a/changelog.d/20260609090000-db-connection-cleanup-sweep.md
+++ b/changelog.d/20260609090000-db-connection-cleanup-sweep.md
@@ -1,0 +1,1 @@
+Hardened database connection cleanup when async-tracked pool check-in rollback or checkout-name cleanup fails, and tightened CLI/global connection teardown paths.

--- a/spec/configuration/connection-checkout-name-spec.js
+++ b/spec/configuration/connection-checkout-name-spec.js
@@ -57,9 +57,11 @@ describe("connection checkout names", () => {
 
       const connection = await pool.checkout({name: "direct checkout spec"})
 
-      expect(connection._connectionCheckoutName).toBe("direct checkout spec")
-
-      await pool.checkin(connection)
+      try {
+        expect(connection._connectionCheckoutName).toBe("direct checkout spec")
+      } finally {
+        await pool.checkin(connection)
+      }
 
       expect(connection._connectionCheckoutName).toBeUndefined()
     }, {fresh: true})

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -20,42 +20,48 @@ class QueryCapturingMysqlDriver extends DatabaseDriversMysql {
   }
 }
 
+/**
+ * @param {(mysql: DatabaseDriversMysql) => Promise<void>} callback - Callback that receives a connected driver.
+ * @returns {Promise<void>} - Resolves when the driver has been closed.
+ */
+async function withMysqlConnection(callback) {
+  if (configuration.getDatabaseType() == "sqlite" || configuration.getDatabaseType() == "mssql" || configuration.getDatabaseType() == "pgsql") return
+
+  const mysql = new DatabaseDriversMysql(mysqlConfig, configuration)
+
+  try {
+    await mysql.connect()
+    await callback(mysql)
+  } finally {
+    await mysql.close()
+  }
+}
+
 describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transaction: true}}, () => {
   it("connects", async () => {
-    if (configuration.getDatabaseType() != "sqlite" && configuration.getDatabaseType() != "mssql" && configuration.getDatabaseType() != "pgsql") {
-      const mysql = new DatabaseDriversMysql(mysqlConfig, configuration)
-
-      await mysql.connect()
-
+    await withMysqlConnection(async (mysql) => {
       const result = await mysql.query("SELECT \"1\" AS test1, \"2\" AS test2")
 
       expect(result).toEqual([{
         test1: "1",
         test2: "2"
       }])
-    }
+    })
   })
 
   it("stores the active checkout name in a session variable", async () => {
-    if (configuration.getDatabaseType() != "sqlite" && configuration.getDatabaseType() != "mssql" && configuration.getDatabaseType() != "pgsql") {
-      const mysql = new DatabaseDriversMysql(mysqlConfig, configuration)
+    await withMysqlConnection(async (mysql) => {
+      await mysql.setConnectionCheckoutName("mysql checkout spec")
 
-      try {
-        await mysql.connect()
-        await mysql.setConnectionCheckoutName("mysql checkout spec")
+      let result = await mysql.query("SELECT @velocious_connection_checkout_name AS checkout_name")
 
-        let result = await mysql.query("SELECT @velocious_connection_checkout_name AS checkout_name")
+      expect(result).toEqual([{checkout_name: "mysql checkout spec"}])
 
-        expect(result).toEqual([{checkout_name: "mysql checkout spec"}])
+      await mysql.clearConnectionCheckoutName()
+      result = await mysql.query("SELECT @velocious_connection_checkout_name AS checkout_name")
 
-        await mysql.clearConnectionCheckoutName()
-        result = await mysql.query("SELECT @velocious_connection_checkout_name AS checkout_name")
-
-        expect(result).toEqual([{checkout_name: null}])
-      } finally {
-        await mysql.close()
-      }
-    }
+      expect(result).toEqual([{checkout_name: null}])
+    })
   })
 
   it("does not tag checkout-name session variable queries with process-list comments", async () => {

--- a/spec/database/drivers/schema-cache-spec.js
+++ b/spec/database/drivers/schema-cache-spec.js
@@ -94,8 +94,9 @@ describe("Database drivers - schema cache", {databaseCleaning: {truncate: false}
       expect(firstLoads).toBe(2)
       expect(secondLoads).toBe(2)
     } finally {
-      pool.checkin(firstConnection)
-      pool.checkin(secondConnection)
+      await pool.checkin(firstConnection)
+      await pool.checkin(secondConnection)
+      await pool.closeAll()
     }
   })
 

--- a/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
@@ -71,6 +71,22 @@ class FailingConnectSqliteDriver extends SqliteDriver {
   }
 }
 
+class FailingRollbackSqliteDriver extends SqliteDriver {
+  /** @type {boolean} */
+  static closed = false
+
+  /** @returns {Promise<void>} - Rejects while rolling back a transaction. */
+  async _rollbackTransactionAction() {
+    throw new Error("Rollback failed during checkin")
+  }
+
+  /** @returns {Promise<void>} - Resolves when the opened connection is closed. */
+  async close() {
+    FailingRollbackSqliteDriver.closed = true
+    await super.close()
+  }
+}
+
 /**
  * @param {string} prefix - Temp-path prefix.
  * @returns {Promise<{cleanup: () => Promise<void>, configuration: Configuration}>} - Test configuration and cleanup.
@@ -190,6 +206,45 @@ async function createFailingConnectConfiguration(prefix) {
     localeFallbacks: {en: ["en"]},
     locales: ["en"]
   })
+
+  return {
+    cleanup: async () => {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    },
+    configuration
+  }
+}
+
+/**
+ * @param {string} prefix - Temp-path prefix.
+ * @returns {Promise<{cleanup: () => Promise<void>, configuration: Configuration}>} - Test configuration and cleanup.
+ */
+async function createFailingRollbackConfiguration(prefix) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`))
+  const configuration = new Configuration({
+    database: {
+      test: {
+        default: {
+          driver: FailingRollbackSqliteDriver,
+          migrations: false,
+          name: `${prefix}-default`,
+          pool: {max: 1},
+          poolType: AsyncTrackedMultiConnection,
+          type: "sqlite"
+        }
+      }
+    },
+    directory,
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+
+  FailingRollbackSqliteDriver.closed = false
 
   return {
     cleanup: async () => {
@@ -647,5 +702,50 @@ describe("database - pool - async tracked multi connection reuse", () => {
 
       await pool.checkin(pendingConnection)
     })
+  })
+
+  it("closes a checked-out connection when rollback fails during checkin", async () => {
+    const {cleanup, configuration} = await createFailingRollbackConfiguration("velocious-pool-checkin-rollback-failure")
+
+    try {
+      const pool = configuration.getDatabasePool("default")
+
+      if (!(pool instanceof AsyncTrackedMultiConnection)) throw new Error("Expected an AsyncTrackedMultiConnection pool")
+
+      const connection = await pool.checkout()
+      await connection.startTransaction()
+
+      let checkoutRejected = false
+      const pendingCheckout = pool.checkout().catch((error) => {
+        checkoutRejected = true
+        throw error
+      })
+
+      await wait(0.02)
+
+      try {
+        await pool.checkin(connection)
+        throw new Error("Checkin unexpectedly resolved")
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect(/** @type {Error} */ (error).message).toBe("Rollback failed during checkin")
+      }
+
+      await wait(0.02)
+
+      expect(FailingRollbackSqliteDriver.closed).toBe(true)
+      expect(Object.values(pool.connectionsInUse).includes(connection)).toBe(false)
+      expect(pool.connections.includes(connection)).toBe(false)
+      expect(pool.pendingCheckouts.length).toBe(0)
+      expect(checkoutRejected).toBe(false)
+
+      const pendingConnection = await pendingCheckout
+
+      expect(pendingConnection).not.toBe(connection)
+
+      await pool.checkin(pendingConnection)
+    } finally {
+      await cleanup()
+    }
   })
 })

--- a/spec/http-server/request-behavior-spec.js
+++ b/spec/http-server/request-behavior-spec.js
@@ -2,6 +2,7 @@
 
 import {describe, expect, it} from "../../src/testing/test.js"
 import Dummy from "../dummy/index.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
 import net from "net"
 import timeout from "awaitery/build/timeout.js"
 
@@ -78,6 +79,14 @@ const readResponse = async (socket, initialBuffer = "") => {
 }
 
 describe("HttpServer - request behavior", {databaseCleaning: {transaction: false, truncate: true}}, async () => {
+  /** @returns {number} - Number of HTTP controller action checkouts currently in use. */
+  const activeControllerActionConnectionCount = () => {
+    const defaultPool = dummyConfiguration.getDatabasePool("default")
+    const snapshot = defaultPool.getDebugSnapshot()
+
+    return snapshot.connections.filter((connection) => connection.state === "in-use" && connection.checkoutName === "RootController.ping").length
+  }
+
   it("closes HTTP/1.1 connections when requested", async () => {
     await Dummy.run(async () => {
       const response = await sendRawRequest([
@@ -223,6 +232,44 @@ describe("HttpServer - request behavior", {databaseCleaning: {transaction: false
         ]
 
         expect(statusLines.length).toBe(2)
+      } finally {
+        socket.destroy()
+      }
+    })
+  })
+
+  it("checks database connections back in between keep-alive requests", async () => {
+    await Dummy.run(async () => {
+      const socket = new net.Socket()
+
+      socket.connect(3006, "127.0.0.1", () => {
+        socket.write([
+          "GET /ping HTTP/1.1",
+          "Host: localhost",
+          "Connection: keep-alive",
+          "",
+          ""
+        ].join("\r\n"))
+      })
+
+      try {
+        const firstResponse = await readResponse(socket)
+
+        expect(firstResponse.response).toContain("HTTP/1.1 200 OK")
+        expect(activeControllerActionConnectionCount()).toBe(0)
+
+        socket.write([
+          "GET /ping HTTP/1.1",
+          "Host: localhost",
+          "Connection: close",
+          "",
+          ""
+        ].join("\r\n"))
+
+        const secondResponse = await readResponse(socket, firstResponse.remaining)
+
+        expect(secondResponse.response).toContain("HTTP/1.1 200 OK")
+        expect(activeControllerActionConnectionCount()).toBe(0)
       } finally {
         socket.destroy()
       }

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -5,6 +5,7 @@ import Dummy from "../dummy/index.js"
 import WebsocketClient from "../../src/http-client/websocket-client.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import WebsocketChannel from "../../src/http-server/websocket-channel.js"
+import {websocketEventLogStoreForConfiguration} from "../../src/http-server/websocket-event-log-store.js"
 import wait from "awaitery/build/wait.js"
 import waitFor from "../helpers/wait-for.js"
 
@@ -371,10 +372,15 @@ describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () =>
 
         await subscription.ready
 
+        const store = websocketEventLogStoreForConfiguration(dummyConfiguration)
+
+        await store.markChannelInterested("ConnectionContextDebug")
+
         const defaultPool = dummyConfiguration.getDatabasePool("default")
         await defaultPool.withConnection({name: "Publisher request"}, async () => {
           expect(Object.keys(dummyConfiguration.getCurrentConnections()).length).toBeGreaterThan(0)
           dummyConfiguration.broadcastToChannel("ConnectionContextDebug", {}, {count: 1})
+          await dummyConfiguration.awaitPendingBroadcasts()
         })
 
         await waitFor(() => received.length >= 1)

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -156,7 +156,13 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
     const originalHandlers = new Set(websocketEventsHost.handlers)
     const sentMessages = []
-    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+    const handler = new WorkerHandler({
+      configuration: {
+        debug: false,
+        withoutCurrentConnectionContexts: (callback) => callback()
+      },
+      workerCount: 1
+    })
 
     websocketEventsHost.handlers.clear()
     handler.worker = {

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -88,28 +88,50 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    */
   async checkin(connection) {
     const id = connection.getIdSeq()
-
-    this.untrackConnectionInUse(connection, id)
-
     const trackedConnection = /** @type {import("../drivers/base.js").default & {[CLOSED_CONNECTION]?: boolean, [CONNECTION_CHECKED_OUT_AT]?: number, [IDLE_CONNECTION_CHECKED_IN_AT]?: number}} */ (connection)
 
-    if (trackedConnection[CLOSED_CONNECTION]) return
-
-    await this.rollbackLeftOpenTransaction(connection)
+    if (trackedConnection[CLOSED_CONNECTION]) {
+      this.untrackConnectionInUse(connection, id)
+      await this.drainPendingCheckouts()
+      return
+    }
 
     try {
+      await this.rollbackLeftOpenTransaction(connection)
       await connection.clearConnectionCheckoutName()
     } catch (error) {
-      await this.closeConnection(connection)
-
+      await this.closeCheckedOutConnectionAfterCheckinFailure(connection, id, error)
       throw error
     }
 
+    this.untrackConnectionInUse(connection, id)
     trackedConnection[IDLE_CONNECTION_CHECKED_IN_AT] = Date.now()
     delete trackedConnection[CONNECTION_CHECKED_OUT_AT]
     this.connections.push(connection)
     await this.drainPendingCheckouts()
     if (this.connections.includes(connection)) await this.handleCheckedInIdleConnection()
+  }
+
+  /**
+   * @param {import("../drivers/base.js").default} connection - Connection that failed check-in cleanup.
+   * @param {number | undefined} id - Connection checkout id.
+   * @param {unknown} originalError - Error that caused check-in cleanup to fail.
+   * @returns {Promise<void>} - Resolves when cleanup has been attempted.
+   */
+  async closeCheckedOutConnectionAfterCheckinFailure(connection, id, originalError) {
+    this.untrackConnectionInUse(connection, id)
+
+    try {
+      await this.closeConnection(connection)
+    } catch (error) {
+      this.logger.warn("Failed to close database connection after check-in cleanup failed", {error, originalError})
+    }
+
+    try {
+      await this.drainPendingCheckouts()
+    } catch (error) {
+      this.logger.warn("Failed to drain pending database checkouts after check-in cleanup failed", {error, originalError})
+    }
   }
 
   /**

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -51,7 +51,7 @@ function stableStringify(value) {
 }
 
 class VelociousDatabasePoolBase {
-  /** @type {undefined | (<T>(callback: () => T) => T)} */
+  /** @type {undefined | ((callback: () => unknown) => unknown)} */
   _withoutCurrentConnectionContext = undefined
 
   /**
@@ -124,7 +124,7 @@ class VelociousDatabasePoolBase {
    * @returns {T} - Callback result.
    */
   withoutCurrentConnectionContext(callback) {
-    if (this._withoutCurrentConnectionContext) return this._withoutCurrentConnectionContext(callback)
+    if (this._withoutCurrentConnectionContext) return /** @type {T} */ (this._withoutCurrentConnectionContext(callback))
 
     return callback()
   }

--- a/src/environment-handlers/node/cli/commands/cli-command-context.js
+++ b/src/environment-handlers/node/cli/commands/cli-command-context.js
@@ -1,0 +1,27 @@
+/**
+ * @typedef {object} CliCommandContext
+ * @property {import("../../../../configuration.js").default} configuration - Configuration instance.
+ * @property {import("../../../../database/drivers/base.js").default | undefined} db - Default database connection.
+ * @property {Record<string, import("../../../../database/drivers/base.js").default>} dbs - Database connections keyed by identifier.
+ * @property {string[]} args - CLI args after command-specific leading arguments.
+ */
+
+/**
+ * @param {import("../../../../cli/base-command.js").default} command - Command building the context.
+ * @param {number} argsOffset - Number of process args to omit.
+ * @returns {CliCommandContext} - Runtime context passed to CLI command scripts.
+ */
+export default function buildCliCommandContext(command, argsOffset) {
+  const configuration = command.getConfiguration()
+  const dbs = configuration.getCurrentConnections()
+  const identifiers = Object.keys(dbs)
+  /** @type {string[]} */
+  const processArgs = command.processArgs || []
+
+  return {
+    configuration,
+    db: dbs.default || (identifiers.length > 0 ? dbs[identifiers[0]] : undefined),
+    dbs,
+    args: processArgs.slice(argsOffset)
+  }
+}

--- a/src/environment-handlers/node/cli/commands/console.js
+++ b/src/environment-handlers/node/cli/commands/console.js
@@ -117,11 +117,12 @@ export default class VelociousCliCommandsConsole extends BaseCommand{
     })
 
     await application.initialize()
-    await configuration.ensureGlobalConnections()
-
-    const context = buildConsoleContext({application, configuration})
 
     try {
+      await configuration.ensureGlobalConnections()
+
+      const context = buildConsoleContext({application, configuration})
+
       if (this.cli.getTesting()) {
         return {modelNames: Object.keys(context.models || {})}
       }

--- a/src/environment-handlers/node/cli/commands/db/seed.js
+++ b/src/environment-handlers/node/cli/commands/db/seed.js
@@ -1,13 +1,10 @@
 import BaseCommand from "../../../../../cli/base-command.js"
+import buildCliCommandContext from "../cli-command-context.js"
 import path from "node:path"
 import toImportSpecifier from "../../../../../utils/to-import-specifier.js"
 
 /**
- * @typedef {object} RunnerContext
- * @property {import("../../../../../configuration.js").default} configuration - Configuration instance.
- * @property {import("../../../../../database/drivers/base.js").default | undefined} db - Default database connection.
- * @property {Record<string, import("../../../../../database/drivers/base.js").default>} dbs - Database connections keyed by identifier.
- * @property {string[]} args - CLI args after the command name.
+ * @typedef {import("../cli-command-context.js").CliCommandContext} RunnerContext
  */
 
 /**
@@ -32,9 +29,10 @@ export default class DbSeed extends BaseCommand {
     const configuration = this.getConfiguration()
 
     await this.initializeRuntime()
-    await configuration.ensureGlobalConnections()
 
     try {
+      await configuration.ensureGlobalConnections()
+
       const seedPath = this.seedFilePath()
       const runnerFunction = await importRunnerFunction(seedPath)
 
@@ -62,17 +60,6 @@ export default class DbSeed extends BaseCommand {
 
   /** @returns {RunnerContext} - Runtime context passed to the script function. */
   buildRunnerContext() {
-    const configuration = this.getConfiguration()
-    const dbs = configuration.getCurrentConnections()
-    const identifiers = Object.keys(dbs)
-    /** @type {string[]} */
-    const processArgs = this.processArgs || []
-
-    return {
-      configuration,
-      db: dbs.default || (identifiers.length > 0 ? dbs[identifiers[0]] : undefined),
-      dbs,
-      args: processArgs.slice(1)
-    }
+    return buildCliCommandContext(this, 1)
   }
 }

--- a/src/environment-handlers/node/cli/commands/run-script.js
+++ b/src/environment-handlers/node/cli/commands/run-script.js
@@ -1,13 +1,10 @@
 import BaseCommand from "../../../../cli/base-command.js"
+import buildCliCommandContext from "./cli-command-context.js"
 import path from "node:path"
 import toImportSpecifier from "../../../../utils/to-import-specifier.js"
 
 /**
- * @typedef {object} RunScriptContext
- * @property {import("../../../../configuration.js").default} configuration - Configuration instance.
- * @property {import("../../../../database/drivers/base.js").default | undefined} db - Default database connection.
- * @property {Record<string, import("../../../../database/drivers/base.js").default>} dbs - Database connections keyed by identifier.
- * @property {string[]} args - CLI args after the script path.
+ * @typedef {import("./cli-command-context.js").CliCommandContext} RunScriptContext
  */
 
 /**
@@ -33,9 +30,10 @@ export default class RunScriptCommand extends BaseCommand {
     const scriptPath = this.scriptFilePath()
 
     await this.initializeRuntime()
-    await configuration.ensureGlobalConnections()
 
     try {
+      await configuration.ensureGlobalConnections()
+
       const runScriptFunction = await importRunScriptFunction(scriptPath)
 
       return await runScriptFunction(this.buildRunScriptContext())
@@ -68,17 +66,6 @@ export default class RunScriptCommand extends BaseCommand {
 
   /** @returns {RunScriptContext} - Runtime context passed to the script function. */
   buildRunScriptContext() {
-    const configuration = this.getConfiguration()
-    const dbs = configuration.getCurrentConnections()
-    const identifiers = Object.keys(dbs)
-    /** @type {string[]} */
-    const processArgs = this.processArgs || []
-
-    return {
-      configuration,
-      db: dbs.default || (identifiers.length > 0 ? dbs[identifiers[0]] : undefined),
-      dbs,
-      args: processArgs.slice(2)
-    }
+    return buildCliCommandContext(this, 2)
   }
 }

--- a/src/environment-handlers/node/cli/commands/runner.js
+++ b/src/environment-handlers/node/cli/commands/runner.js
@@ -1,11 +1,8 @@
 import BaseCommand from "../../../../cli/base-command.js"
+import buildCliCommandContext from "./cli-command-context.js"
 
 /**
- * @typedef {object} RunnerContext
- * @property {import("../../../../configuration.js").default} configuration - Configuration instance.
- * @property {import("../../../../database/drivers/base.js").default | undefined} db - Default database connection.
- * @property {Record<string, import("../../../../database/drivers/base.js").default>} dbs - Database connections keyed by identifier.
- * @property {string[]} args - CLI args after the code expression.
+ * @typedef {import("./cli-command-context.js").CliCommandContext} RunnerContext
  */
 
 /** Node command for evaluating inline JavaScript in initialized app/DB context. */
@@ -16,9 +13,10 @@ export default class RunnerCommand extends BaseCommand {
     const code = this.runnerCode()
 
     await this.initializeRuntime()
-    await configuration.ensureGlobalConnections()
 
     try {
+      await configuration.ensureGlobalConnections()
+
       return await this.evaluateCode(code)
     } finally {
       await configuration.closeDatabaseConnections()
@@ -49,18 +47,7 @@ export default class RunnerCommand extends BaseCommand {
 
   /** @returns {RunnerContext} - Runtime context passed to evaluated code. */
   buildRunnerContext() {
-    const configuration = this.getConfiguration()
-    const dbs = configuration.getCurrentConnections()
-    const identifiers = Object.keys(dbs)
-    /** @type {string[]} */
-    const processArgs = this.processArgs || []
-
-    return {
-      configuration,
-      db: dbs.default || (identifiers.length > 0 ? dbs[identifiers[0]] : undefined),
-      dbs,
-      args: processArgs.slice(2)
-    }
+    return buildCliCommandContext(this, 2)
   }
 
   /**

--- a/src/http-server/websocket-event-log-store.js
+++ b/src/http-server/websocket-event-log-store.js
@@ -52,8 +52,8 @@ export default class VelociousHttpServerWebsocketEventLogStore {
     this.logger = new Logger(this)
     this._isReady = false
     this._readyPromise = null
-    /** @type {Set<string>} */
-    this._interestedChannels = new Set()
+    /** @type {Map<string, number>} */
+    this._interestedChannels = new Map()
   }
 
   /**
@@ -135,8 +135,9 @@ export default class VelociousHttpServerWebsocketEventLogStore {
   async markChannelInterested(channel) {
     await this.ensureReady()
 
-    this._interestedChannels.add(channel)
     const interestedUntil = new Date(Date.now() + this.retentionMs)
+
+    this._interestedChannels.set(channel, interestedUntil.getTime())
 
     await this._withDb(async (db) => {
       await this._upsertReplayChannelInterest(db, {channel, interestedUntil})
@@ -148,6 +149,10 @@ export default class VelociousHttpServerWebsocketEventLogStore {
    * @returns {Promise<boolean>} - Whether the channel should be persisted for replay.
    */
   async shouldPersistChannel(channel) {
+    const interestedUntil = this._interestedChannels.get(channel)
+
+    if (interestedUntil && interestedUntil > Date.now()) return true
+    if (interestedUntil) this._interestedChannels.delete(channel)
     if (this._interestedChannels.size === 0) return false
 
     await this.ensureReady()

--- a/src/http-server/websocket-events-host.js
+++ b/src/http-server/websocket-events-host.js
@@ -44,23 +44,18 @@ export class VelociousHttpServerWebsocketEventsHost {
     const channel = publishArgs.channel
     const payload = publishArgs.payload
 
-    this.publishQueue = this.publishQueue
-      .then(async () => {
-        const persistedEvent = await this._persistEventIfNeeded({channel, payload})
+    this._queuePublish(async () => {
+      const persistedEvent = await this._persistEventIfNeeded({channel, payload})
 
-        for (const handler of this.handlers) {
-          handler.dispatchWebsocketEvent({
-            channel,
-            createdAt: persistedEvent?.createdAt,
-            eventId: persistedEvent?.id,
-            payload
-          })
-        }
-      })
-      .catch((error) => {
-        console.error("Failed to publish websocket event", error)
-        throw error
-      })
+      for (const handler of this.handlers) {
+        handler.dispatchWebsocketEvent({
+          channel,
+          createdAt: persistedEvent?.createdAt,
+          eventId: persistedEvent?.id,
+          payload
+        })
+      }
+    }, "Failed to publish websocket event")
   }
 
   /**
@@ -79,22 +74,40 @@ export class VelociousHttpServerWebsocketEventsHost {
     // the next broadcast — without this, a subscriber that connects
     // immediately after a broadcast could miss the just-persisted
     // event when replaying from lastEventId on a slow DB.
+    this._queuePublish(async () => {
+      const persistedEvent = await this._persistV2EventIfNeeded({body, channel})
+
+      for (const handler of this.handlers) {
+        handler.dispatchWebsocketV2Broadcast({
+          body,
+          broadcastParams,
+          channel,
+          eventId: persistedEvent?.id,
+          createdAt: persistedEvent?.createdAt
+        })
+      }
+    }, "Failed to persist/broadcast V2 event")
+  }
+
+  /**
+   * @param {() => Promise<void>} callback - Publish work to run in order.
+   * @param {string} errorMessage - Message logged when publish work fails.
+   * @returns {void}
+   */
+  _queuePublish(callback, errorMessage) {
+    const handler = this.handlers.values().next().value
+    const configuration = handler?.configuration
+
     this.publishQueue = this.publishQueue
       .then(async () => {
-        const persistedEvent = await this._persistV2EventIfNeeded({body, channel})
-
-        for (const handler of this.handlers) {
-          handler.dispatchWebsocketV2Broadcast({
-            body,
-            broadcastParams,
-            channel,
-            eventId: persistedEvent?.id,
-            createdAt: persistedEvent?.createdAt
-          })
+        if (configuration) {
+          return await configuration.withoutCurrentConnectionContexts(callback)
         }
+
+        return await callback()
       })
       .catch((error) => {
-        console.error("Failed to persist/broadcast V2 event", error)
+        console.error(errorMessage, error)
         throw error
       })
   }
@@ -106,16 +119,7 @@ export class VelociousHttpServerWebsocketEventsHost {
    * @returns {Promise<{createdAt: string, id: string} | null>}
    */
   async _persistV2EventIfNeeded({body, channel}) {
-    const handler = this.handlers.values().next().value
-
-    if (!handler?.configuration) return null
-
-    const websocketEventLogStore = websocketEventLogStoreForConfiguration(handler.configuration)
-    const shouldPersist = await websocketEventLogStore.shouldPersistChannel(channel)
-
-    if (!shouldPersist) return null
-
-    return await websocketEventLogStore.appendEvent({channel, payload: body})
+    return await this._persistChannelEventIfNeeded({channel, payload: body})
   }
 
   /**
@@ -125,6 +129,16 @@ export class VelociousHttpServerWebsocketEventsHost {
    * @returns {Promise<{createdAt: string, id: string} | null>} - Persisted event metadata.
    */
   async _persistEventIfNeeded({channel, payload}) {
+    return await this._persistChannelEventIfNeeded({channel, payload})
+  }
+
+  /**
+   * @param {object} args - Options object.
+   * @param {string} args.channel - Channel name.
+   * @param {any} args.payload - Payload data.
+   * @returns {Promise<{createdAt: string, id: string} | null>} - Persisted event metadata.
+   */
+  async _persistChannelEventIfNeeded({channel, payload}) {
     const handler = this.handlers.values().next().value
 
     if (!handler?.configuration) return null


### PR DESCRIPTION
## Summary
- avoid generic function syntax in the optional DB context helper field
- keep the public helper generic while casting the hook result at the call site

## Validation
- node scripts/run-tests.js -- spec/http-server/websocket-channel-spec.js spec/beacon/configuration-integration-spec.js
- npm run typecheck
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow
- git diff --check