### PR TITLE
Fix async pool context declaration output

### DIFF
--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -80,6 +80,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    */
   constructor({configuration, identifier}) {
     super({configuration, identifier})
+    this._withoutCurrentConnectionContext = /** @type {(callback: () => unknown) => unknown} */ ((callback) => this.asyncLocalStorage.run(undefined, callback))
   }
 
   /**
@@ -579,11 +580,6 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (id === undefined) return this._testSharedConnection
 
     return this.getCurrentConnection()
-  }
-
-  /** @type {(callback: () => unknown) => unknown} */
-  _withoutCurrentConnectionContext = (callback) => {
-    return this.asyncLocalStorage.run(undefined, callback)
   }
 
   /** @returns {import("./base.js").DatabasePoolDebugSnapshot} - Diagnostic snapshot for this pool. */

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -581,11 +581,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     return this.getCurrentConnection()
   }
 
-  /**
-   * @template T
-   * @param {() => T} callback - Callback to run without the current async DB connection context.
-   * @returns {T} - Callback result.
-   */
+  /** @type {(callback: () => unknown) => unknown} */
   _withoutCurrentConnectionContext = (callback) => {
     return this.asyncLocalStorage.run(undefined, callback)
   }


### PR DESCRIPTION
## Summary
- changes the async-tracked pool context-detach field to a non-generic function type so TypeScript emits valid declarations
- preserves the public generic wrapper on the base pool API

## Validation
- node scripts/run-tests.js -- spec/database/pool/async-tracked-multi-connection-reuse-spec.js
- git diff --check
- npm run typecheck
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow