### PR TITLE
Fix acts-as-list scope append

### DIFF
--- a/changelog.d/20260610112351-acts-as-list-scope-append.md
+++ b/changelog.d/20260610112351-acts-as-list-scope-append.md
@@ -1,0 +1,1 @@
+Fix `actsAsList` scope moves without an explicit position so the moved record appends to the new scope without shifting existing rows.

--- a/spec/database/record/acts-as-list.browser-spec.js
+++ b/spec/database/record/acts-as-list.browser-spec.js
@@ -163,6 +163,28 @@ describe("Record - acts as list", {tags: ["dummy"]}, () => {
     expect(itemsB[2].position()).toEqual(3)
   })
 
+  it("appends without shifting target rows when moving between scopes without a new position", async () => {
+    const projectA = await Project.create({name: "List Project I1"})
+    const projectB = await Project.create({name: "List Project I2"})
+
+    await ActsAsListItem.create({name: "A1", project: projectA})
+    const itemA2 = await ActsAsListItem.create({name: "A2", project: projectA})
+    await ActsAsListItem.create({name: "A3", project: projectA})
+
+    await ActsAsListItem.create({name: "B1", project: projectB})
+    await ActsAsListItem.create({name: "B2", project: projectB})
+
+    await itemA2.update({projectId: projectB.id()})
+
+    const itemsB = await ActsAsListItem
+      .where({projectId: projectB.id()})
+      .order("position")
+      .toArray()
+
+    expect(itemsB.map((item) => item.name())).toEqual(["B1", "B2", "A2"])
+    expect(itemsB.map((item) => item.position())).toEqual([1, 2, 3])
+  })
+
   it("shifts existing rows when inserting at an occupied position", async () => {
     const project = await Project.create({name: "List Project H"})
 

--- a/src/database/record/acts-as-list.js
+++ b/src/database/record/acts-as-list.js
@@ -110,14 +110,15 @@ export default function registerActsAsListCallbacks(modelClass, positionColumn, 
     if (scopeChanged && oldScopeValue !== newScopeValue) {
       let targetPosition = newPosition
 
-      // When only the scope changes without a new position, append to the
-      // end of the new scope.
+      // When only the scope changes without a new position, append to the end
+      // of the new scope. There is no target-scope row to shift out of the way.
       if (!posChanged) {
         const highestNew = await highestPositionInScope({record, positionColumn, scope, scopeValue: newScopeValue})
         const nextPos = highestNew + 1
 
-        targetPosition = nextPos
         record.setAttribute(positionColumn, nextPos)
+        await shiftPositionsDown({record, positionColumn, scope, scopeValue: oldScopeValue, fromPosition: oldPosition + 1})
+        return
       }
 
       await shiftPositionsDown({record, positionColumn, scope, scopeValue: oldScopeValue, fromPosition: oldPosition + 1})


### PR DESCRIPTION
## Summary
- fix acts-as-list scope moves without an explicit position so records append to the new scope
- add coverage for moving between scopes without shifting target rows
- add a changelog fragment

## Validation
- npm run test -- spec/database/record/acts-as-list.browser-spec.js
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow