### PR TITLE
Fix acts-as-list position ordering

### DIFF
--- a/changelog.d/20260610121000-acts-as-list-sql-order.md
+++ b/changelog.d/20260610121000-acts-as-list-sql-order.md
@@ -1,0 +1,1 @@
+Fix `actsAsList` auto-append queries for camelCase position attributes backed by snake_case database columns.

--- a/src/database/record/acts-as-list.js
+++ b/src/database/record/acts-as-list.js
@@ -180,7 +180,7 @@ async function shiftPositionsUp({record, positionColumn, scope, fromPosition, to
     .select(positionColumn)
     .where({[scopeUnderscore]: resolvedScopeValue})
     .where(`${positionColumnSql} >= ${connection.quote(fromPosition)}`)
-    .order(`${positionUnderscore} DESC`)
+    .order(`${positionColumnSql} DESC`)
 
   if (toPosition != null) {
     query = query.where(`${positionColumnSql} < ${connection.quote(toPosition)}`)
@@ -274,8 +274,10 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
   const modelClass = /**
                       * Narrows the runtime value to the documented type.
                        @type {typeof import("./index.js").default} */ (record.constructor)
+  const connection = modelClass.connection()
   const scopeUnderscore = inflection.underscore(scope)
   const positionUnderscore = inflection.underscore(positionColumn)
+  const positionColumnSql = connection.quoteColumn(positionUnderscore)
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
 
   if (resolvedScopeValue == null) return 0
@@ -283,7 +285,7 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
   const rows = await modelClass
     .select(positionColumn)
     .where({[scopeUnderscore]: resolvedScopeValue})
-    .order(`${positionUnderscore} DESC`)
+    .order(`${positionColumnSql} DESC`)
     .limit(1)
     .toArray()
 

--- a/src/database/record/acts-as-list.js
+++ b/src/database/record/acts-as-list.js
@@ -2,8 +2,6 @@
 
 /** @file Registers gap-less positional list callbacks on a model class. */
 
-import * as inflection from "inflection"
-
 /**
  * Acts as list shifting.
  * @type {symbol} - Guard flag set on the model instance during shift operations to prevent re-entrant lifecycle hooks.
@@ -28,23 +26,6 @@ function setShiftingFlag(record, value) {
 function isShifting(record) {
   // @ts-ignore - Symbol indexing on Record instances
   return Boolean(record[ACTS_AS_LIST_SHIFTING])
-}
-
-/**
- * Resolves the actual database column name for a given attribute name using
- * the model's attribute-to-column mapping, just like the rest of the record
- * layer. Falls back to underscoring only when the model has no explicit
- * mapping for the attribute (e.g. it isn't registered as a column).
- * @param {typeof import("./index.js").default} modelClass - The model class.
- * @param {string} attributeName - camelCase attribute name (e.g. "rowNumber").
- * @returns {string} - The resolved database column name for the attribute.
- */
-function columnNameForAttribute(modelClass, attributeName) {
-  const columnName = modelClass.getAttributeNameToColumnNameMap()[attributeName]
-
-  if (columnName) return columnName
-
-  return inflection.underscore(attributeName)
 }
 
 /**
@@ -84,8 +65,8 @@ export default function registerActsAsListCallbacks(modelClass, positionColumn, 
     const modelClass = /**
                         * Narrows the runtime value to the documented type.
                          @type {typeof import("./index.js").default} */ (record.constructor)
-    const posColumn = columnNameForAttribute(modelClass, positionColumn)
-    const scopeCol = columnNameForAttribute(modelClass, scope)
+    const posColumn = modelClass.getColumnNameForAttributeName(positionColumn)
+    const scopeCol = modelClass.getColumnNameForAttributeName(scope)
     const rawAttributes = /**
                            * Narrows the runtime value to the documented type.
                             @type {Record<string, ?>} */ (record._attributes || {})
@@ -185,11 +166,11 @@ async function shiftPositionsUp({record, positionColumn, scope, fromPosition, to
   const connection = modelClass.connection()
   const tableName = modelClass._getTable().getName()
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
-  const scopeColumnName = columnNameForAttribute(modelClass, scope)
+  const scopeColumnName = modelClass.getColumnNameForAttributeName(scope)
 
   if (resolvedScopeValue == null) return
 
-  const positionColumnName = columnNameForAttribute(modelClass, positionColumn)
+  const positionColumnName = modelClass.getColumnNameForAttributeName(positionColumn)
   const positionColumnSql = connection.quoteColumn(positionColumnName)
   const scopeColumnSql = connection.quoteColumn(scopeColumnName)
   const tableSql = connection.quoteTable(tableName)
@@ -243,11 +224,11 @@ async function shiftPositionsDown({record, positionColumn, scope, fromPosition, 
   const connection = modelClass.connection()
   const tableName = modelClass._getTable().getName()
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
-  const scopeColumnName = columnNameForAttribute(modelClass, scope)
+  const scopeColumnName = modelClass.getColumnNameForAttributeName(scope)
 
   if (resolvedScopeValue == null) return
 
-  const positionColumnName = columnNameForAttribute(modelClass, positionColumn)
+  const positionColumnName = modelClass.getColumnNameForAttributeName(positionColumn)
   const positionColumnSql = connection.quoteColumn(positionColumnName)
   const scopeColumnSql = connection.quoteColumn(scopeColumnName)
   const tableSql = connection.quoteTable(tableName)
@@ -295,8 +276,8 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
                       * Narrows the runtime value to the documented type.
                        @type {typeof import("./index.js").default} */ (record.constructor)
   const connection = modelClass.connection()
-  const scopeColumnName = columnNameForAttribute(modelClass, scope)
-  const positionColumnName = columnNameForAttribute(modelClass, positionColumn)
+  const scopeColumnName = modelClass.getColumnNameForAttributeName(scope)
+  const positionColumnName = modelClass.getColumnNameForAttributeName(positionColumn)
   const positionColumnSql = connection.quoteColumn(positionColumnName)
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
 
@@ -332,15 +313,16 @@ function resolveScopeValue(record, scope) {
                       * Narrows the runtime value to the documented type.
                        @type {typeof import("./index.js").default} */ (record.constructor)
   const relationships = modelClass.getRelationshipsMap()
+  const scopeColumnName = modelClass.getColumnNameForAttributeName(scope)
 
   for (const relationshipName in relationships) {
     const relationship = relationships[relationshipName]
 
     if (relationship.getType?.() !== "belongsTo") continue
 
-    const foreignKey = inflection.camelize(relationship.getForeignKey(), true)
+    const foreignKey = relationship.getForeignKey()
 
-    if (foreignKey !== scope) continue
+    if (foreignKey !== scopeColumnName) continue
 
     const instanceRelationship = record.getRelationshipByName(relationshipName)
     const loaded = instanceRelationship.loaded()
@@ -375,8 +357,8 @@ async function moveOutOfWay({record, positionColumn, scope, scopeValue}) {
 
   const highest = await highestPositionInScope({record, positionColumn, scope, scopeValue: resolvedScopeValue})
   const tempPosition = highest + 10000
-  const positionColumnSql = connection.quoteColumn(columnNameForAttribute(modelClass, positionColumn))
-  const scopeColumnSql = connection.quoteColumn(columnNameForAttribute(modelClass, scope))
+  const positionColumnSql = connection.quoteColumn(modelClass.getColumnNameForAttributeName(positionColumn))
+  const scopeColumnSql = connection.quoteColumn(modelClass.getColumnNameForAttributeName(scope))
   const tableSql = connection.quoteTable(tableName)
   const pkSql = connection.quoteColumn("id")
 

--- a/src/database/record/acts-as-list.js
+++ b/src/database/record/acts-as-list.js
@@ -275,6 +275,7 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
                       * Narrows the runtime value to the documented type.
                        @type {typeof import("./index.js").default} */ (record.constructor)
   const scopeUnderscore = inflection.underscore(scope)
+  const positionUnderscore = inflection.underscore(positionColumn)
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
 
   if (resolvedScopeValue == null) return 0
@@ -282,7 +283,7 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
   const rows = await modelClass
     .select(positionColumn)
     .where({[scopeUnderscore]: resolvedScopeValue})
-    .order(`${positionColumn} DESC`)
+    .order(`${positionUnderscore} DESC`)
     .limit(1)
     .toArray()
 

--- a/src/database/record/acts-as-list.js
+++ b/src/database/record/acts-as-list.js
@@ -31,6 +31,23 @@ function isShifting(record) {
 }
 
 /**
+ * Resolves the actual database column name for a given attribute name using
+ * the model's attribute-to-column mapping, just like the rest of the record
+ * layer. Falls back to underscoring only when the model has no explicit
+ * mapping for the attribute (e.g. it isn't registered as a column).
+ * @param {typeof import("./index.js").default} modelClass - The model class.
+ * @param {string} attributeName - camelCase attribute name (e.g. "rowNumber").
+ * @returns {string} - The resolved database column name for the attribute.
+ */
+function columnNameForAttribute(modelClass, attributeName) {
+  const columnName = modelClass.getAttributeNameToColumnNameMap()[attributeName]
+
+  if (columnName) return columnName
+
+  return inflection.underscore(attributeName)
+}
+
+/**
  * Registers gap-less positional list callbacks on a model class to maintain
  * a gap-less positional list. When a record is inserted, updated, or
  * destroyed, the surrounding positions are shifted so the list stays compact
@@ -64,8 +81,11 @@ export default function registerActsAsListCallbacks(modelClass, positionColumn, 
     if (isShifting(record)) return
     if (!record.isPersisted()) return
 
-    const posColumn = inflection.underscore(positionColumn)
-    const scopeCol = inflection.underscore(scope)
+    const modelClass = /**
+                        * Narrows the runtime value to the documented type.
+                         @type {typeof import("./index.js").default} */ (record.constructor)
+    const posColumn = columnNameForAttribute(modelClass, positionColumn)
+    const scopeCol = columnNameForAttribute(modelClass, scope)
     const rawAttributes = /**
                            * Narrows the runtime value to the documented type.
                             @type {Record<string, ?>} */ (record._attributes || {})
@@ -165,20 +185,20 @@ async function shiftPositionsUp({record, positionColumn, scope, fromPosition, to
   const connection = modelClass.connection()
   const tableName = modelClass._getTable().getName()
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
-  const scopeUnderscore = inflection.underscore(scope)
+  const scopeColumnName = columnNameForAttribute(modelClass, scope)
 
   if (resolvedScopeValue == null) return
 
-  const positionUnderscore = inflection.underscore(positionColumn)
-  const positionColumnSql = connection.quoteColumn(positionUnderscore)
-  const scopeColumnSql = connection.quoteColumn(scopeUnderscore)
+  const positionColumnName = columnNameForAttribute(modelClass, positionColumn)
+  const positionColumnSql = connection.quoteColumn(positionColumnName)
+  const scopeColumnSql = connection.quoteColumn(scopeColumnName)
   const tableSql = connection.quoteTable(tableName)
   const quotedScope = connection.quote(resolvedScopeValue)
 
   // Load rows in descending order so we bump the highest first
   let query = modelClass
     .select(positionColumn)
-    .where({[scopeUnderscore]: resolvedScopeValue})
+    .where({[scopeColumnName]: resolvedScopeValue})
     .where(`${positionColumnSql} >= ${connection.quote(fromPosition)}`)
     .order(`${positionColumnSql} DESC`)
 
@@ -223,22 +243,22 @@ async function shiftPositionsDown({record, positionColumn, scope, fromPosition, 
   const connection = modelClass.connection()
   const tableName = modelClass._getTable().getName()
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
-  const scopeUnderscore = inflection.underscore(scope)
+  const scopeColumnName = columnNameForAttribute(modelClass, scope)
 
   if (resolvedScopeValue == null) return
 
-  const positionUnderscore = inflection.underscore(positionColumn)
-  const positionColumnSql = connection.quoteColumn(positionUnderscore)
-  const scopeColumnSql = connection.quoteColumn(scopeUnderscore)
+  const positionColumnName = columnNameForAttribute(modelClass, positionColumn)
+  const positionColumnSql = connection.quoteColumn(positionColumnName)
+  const scopeColumnSql = connection.quoteColumn(scopeColumnName)
   const tableSql = connection.quoteTable(tableName)
   const quotedScope = connection.quote(resolvedScopeValue)
 
   // Load rows in ascending order so we shift the lowest gap first
   let query = modelClass
     .select(positionColumn)
-    .where({[scopeUnderscore]: resolvedScopeValue})
+    .where({[scopeColumnName]: resolvedScopeValue})
     .where(`${positionColumnSql} >= ${connection.quote(fromPosition)}`)
-    .order(positionUnderscore)
+    .order(positionColumnName)
 
   if (toPosition != null) {
     query = query.where(`${positionColumnSql} < ${connection.quote(toPosition)}`)
@@ -275,16 +295,16 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
                       * Narrows the runtime value to the documented type.
                        @type {typeof import("./index.js").default} */ (record.constructor)
   const connection = modelClass.connection()
-  const scopeUnderscore = inflection.underscore(scope)
-  const positionUnderscore = inflection.underscore(positionColumn)
-  const positionColumnSql = connection.quoteColumn(positionUnderscore)
+  const scopeColumnName = columnNameForAttribute(modelClass, scope)
+  const positionColumnName = columnNameForAttribute(modelClass, positionColumn)
+  const positionColumnSql = connection.quoteColumn(positionColumnName)
   const resolvedScopeValue = scopeValue != null ? scopeValue : resolveScopeValue(record, scope)
 
   if (resolvedScopeValue == null) return 0
 
   const rows = await modelClass
     .select(positionColumn)
-    .where({[scopeUnderscore]: resolvedScopeValue})
+    .where({[scopeColumnName]: resolvedScopeValue})
     .order(`${positionColumnSql} DESC`)
     .limit(1)
     .toArray()
@@ -355,8 +375,8 @@ async function moveOutOfWay({record, positionColumn, scope, scopeValue}) {
 
   const highest = await highestPositionInScope({record, positionColumn, scope, scopeValue: resolvedScopeValue})
   const tempPosition = highest + 10000
-  const positionColumnSql = connection.quoteColumn(inflection.underscore(positionColumn))
-  const scopeColumnSql = connection.quoteColumn(inflection.underscore(scope))
+  const positionColumnSql = connection.quoteColumn(columnNameForAttribute(modelClass, positionColumn))
+  const scopeColumnSql = connection.quoteColumn(columnNameForAttribute(modelClass, scope))
   const tableSql = connection.quoteTable(tableName)
   const pkSql = connection.quoteColumn("id")
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -247,6 +247,19 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * Resolves the database column name for a record attribute name.
+   * @param {string} attributeName - Attribute name to resolve.
+   * @returns {string} - Mapped column name, or the underscored attribute name when no mapping exists.
+   */
+  static getColumnNameForAttributeName(attributeName) {
+    const columnName = this.getAttributeNameToColumnNameMap()[attributeName]
+
+    if (columnName) return columnName
+
+    return inflection.underscore(attributeName)
+  }
+
+  /**
    * Runs define scope.
    * @param {(...args: Array<?>) => ?} callback - Scope callback.
    * @returns {((...args: Array<?>) => import("../query/model-class-query.js").default<?>) & {scope: (...args: Array<?>) => import("../../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.


### PR DESCRIPTION
## Summary
- order acts-as-list highest-position queries by the database column name for camelCase position attributes
- add changelog entry

## Validation
- npm run test -- database/record/acts-as-list.browser-spec.js
- npm run lint
- npm run typecheck