### PR TITLE
Fix authorization query declaration types

### DIFF
--- a/src/authorization/ability.js
+++ b/src/authorization/ability.js
@@ -4,7 +4,7 @@ import BaseResource from "./base-resource.js"
 
 /**
  * Defines this typedef.
-  @typedef {Record<string, ?> | string | ((query: import("../database/query/model-class-query.js").default<?>, args: {ability: VelociousAuthorizationAbility, action: string, modelClass: typeof import("../database/record/index.js").default}) => void | import("../database/query/model-class-query.js").default<?>)} AbilityConditionsType */
+  @typedef {Record<string, ?> | string | ((query: import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>, args: {ability: VelociousAuthorizationAbility, action: string, modelClass: typeof import("../database/record/index.js").default}) => void | import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>)} AbilityConditionsType */
 
 /**
  * AbilityRuleType type.
@@ -191,8 +191,8 @@ export default class VelociousAuthorizationAbility {
    * @param {object} args - Query args.
    * @param {string} args.action - Requested action.
    * @param {typeof import("../database/record/index.js").default} args.modelClass - Model class.
-   * @param {import("../database/query/model-class-query.js").default<?>} args.query - Query.
-   * @returns {import("../database/query/model-class-query.js").default<?>} - Authorized query.
+   * @param {import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} args.query - Query.
+   * @returns {import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} - Authorized query.
    */
   applyToQuery({action, modelClass, query}) {
     this.loadAbilitiesForModelClass(modelClass)
@@ -242,7 +242,7 @@ export default class VelociousAuthorizationAbility {
    * @param {object} args - SQL args.
    * @param {string} args.action - Action.
    * @param {typeof import("../database/record/index.js").default} args.modelClass - Model class.
-   * @param {import("../database/query/model-class-query.js").default<?>} args.query - Base query.
+   * @param {import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} args.query - Base query.
    * @param {AbilityRuleType[]} args.rules - Rules.
    * @returns {string[]} - SQL condition parts.
    */
@@ -283,7 +283,7 @@ export default class VelociousAuthorizationAbility {
    * @param {string} args.action - Action.
    * @param {AbilityRuleType[]} args.denyRules - Deny rules.
    * @param {typeof import("../database/record/index.js").default} args.modelClass - Model class.
-   * @param {import("../database/query/model-class-query.js").default<?>} args.query - Query.
+   * @param {import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} args.query - Query.
    * @returns {void} - No return value.
    */
   applyDenyRules({action, denyRules, modelClass, query}) {
@@ -307,8 +307,8 @@ export default class VelociousAuthorizationAbility {
    * @param {string} args.action - Action.
    * @param {AbilityConditionsType} args.conditions - Rule conditions.
    * @param {typeof import("../database/record/index.js").default} args.modelClass - Model class.
-   * @param {import("../database/query/model-class-query.js").default<?>} args.query - Query.
-   * @returns {void | import("../database/query/model-class-query.js").default<?>} - Optional replacement query.
+   * @param {import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} args.query - Query.
+   * @returns {void | import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} - Optional replacement query.
    */
   applyRuleCondition({action, conditions, modelClass, query}) {
     if (typeof conditions === "string") {

--- a/src/authorization/base-resource.js
+++ b/src/authorization/base-resource.js
@@ -31,7 +31,7 @@ export default class AuthorizationBaseResource {
   /**
    * Runs can.
    * @param {string | string[]} actions - Ability action(s).
-   * @param {Record<string, ?> | string | ((query: import("../database/query/model-class-query.js").default<?>, args: {ability: import("./ability.js").default, action: string, modelClass: typeof import("../database/record/index.js").default}) => void | import("../database/query/model-class-query.js").default<?>)} [conditions] - Conditions.
+   * @param {import("./ability.js").AbilityConditionsType} [conditions] - Conditions.
    * @returns {void} - No return value.
    */
   can(actions, conditions) {
@@ -42,7 +42,7 @@ export default class AuthorizationBaseResource {
   /**
    * Runs cannot.
    * @param {string | string[]} actions - Ability action(s).
-   * @param {Record<string, ?> | string | ((query: import("../database/query/model-class-query.js").default<?>, args: {ability: import("./ability.js").default, action: string, modelClass: typeof import("../database/record/index.js").default}) => void | import("../database/query/model-class-query.js").default<?>)} [conditions] - Conditions.
+   * @param {import("./ability.js").AbilityConditionsType} [conditions] - Conditions.
    * @returns {void} - No return value.
    */
   cannot(actions, conditions) {

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -262,7 +262,7 @@ class VelociousDatabaseRecord {
   /**
    * Runs define scope.
    * @param {(...args: Array<?>) => ?} callback - Scope callback.
-   * @returns {((...args: Array<?>) => import("../query/model-class-query.js").default<?>) & {scope: (...args: Array<?>) => import("../../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
+   * @returns {((...args: Array<?>) => import("../query/model-class-query.js").default<typeof VelociousDatabaseRecord>) & {scope: (...args: Array<?>) => import("../../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
    */
   static defineScope(callback) {
     return defineModelScope({
@@ -527,7 +527,7 @@ class VelociousDatabaseRecord {
 
   /**
    * RelationshipScopeCallback type.
-   * @typedef {(query: import("../query/model-class-query.js").default) => (import("../query/model-class-query.js").default | void)} RelationshipScopeCallback
+   * @typedef {(query: import("../query/model-class-query.js").default<typeof VelociousDatabaseRecord>) => (import("../query/model-class-query.js").default<typeof VelociousDatabaseRecord> | void)} RelationshipScopeCallback
    */
   /**
    * RelationshipDataArgumentType type.

--- a/src/database/record/relationships/base.js
+++ b/src/database/record/relationships/base.js
@@ -5,7 +5,7 @@ import * as inflection from "inflection"
 
 /**
  * RelationshipScopeCallback type.
- * @typedef {(query: import("../../query/model-class-query.js").default<?>) => (import("../../query/model-class-query.js").default<?> | void)} RelationshipScopeCallback
+ * @typedef {(query: import("../../query/model-class-query.js").default<typeof import("../index.js").default>) => (import("../../query/model-class-query.js").default<typeof import("../index.js").default> | void)} RelationshipScopeCallback
  */
 /**
  * RelationshipBaseArgsType type.
@@ -128,7 +128,7 @@ export default class VelociousDatabaseRecordBaseRelationship {
                          * Narrows the runtime value to the documented type.
                           @type {T | void} */ (scope.call(query, /**
                                                                   * Narrows the runtime value to the documented type.
-                                                                   @type {import("../../query/model-class-query.js").default<?>} */ (query)))
+                                                                    @type {import("../../query/model-class-query.js").default<typeof import("../index.js").default>} */ (query)))
 
     return scopedQuery || query
   }

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -954,7 +954,7 @@ export default class FrontendModelController extends Controller {
   /**
    * Runs frontend model authorized query.
    * @param {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url"} action - Frontend action.
-   * @returns {import("./database/query/model-class-query.js").default<?>} - Authorized query for the action.
+   * @returns {import("./database/query/model-class-query.js").default<typeof import("./database/record/index.js").default>} - Authorized query for the action.
    */
   frontendModelAuthorizedQuery(action) {
     const abilityAction = this.frontendModelAbilityAction(action)

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -2029,8 +2029,8 @@ export default class FrontendModelController extends Controller {
   /**
    * Runs apply frontend model translated attribute preloads.
    * @param {object} args - Args.
-   * @param {import("./database/query/model-class-query.js").default<?>} args.query - Query instance.
-   * @returns {import("./database/query/model-class-query.js").default<?>} - Query with translations preloaded if needed.
+   * @param {import("./database/query/model-class-query.js").default<typeof import("./database/record/index.js").default>} args.query - Query instance.
+   * @returns {import("./database/query/model-class-query.js").default<typeof import("./database/record/index.js").default>} - Query with translations preloaded if needed.
    */
   applyFrontendModelTranslatedAttributePreloads({query}) {
     const modelClass = this.frontendModelClass()

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -93,8 +93,8 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   /**
    * Runs typed controller instance.
    * @returns {import("../controller.js").default & {
-   *   frontendModelAuthorizedQuery: (action: "index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url") => import("../database/query/model-class-query.js").default<unknown>,
-   *   frontendModelIndexQuery: () => import("../database/query/model-class-query.js").default<unknown>,
+   *   frontendModelAuthorizedQuery: (action: "index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url") => import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>,
+   *   frontendModelIndexQuery: () => import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>,
    *   frontendModelPreload: () => import("../database/query/index.js").NestedPreloadRecord | null,
    *   serializeFrontendModel: (model: import("../database/record/index.js").default) => Promise<Record<string, unknown>>
    * }} - Controller instance with frontend-model helpers.
@@ -227,7 +227,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   /**
    * Runs authorized query.
    * @param {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url"} action - Ability action.
-   * @returns {import("../database/query/model-class-query.js").default<?>} - Authorized query.
+   * @returns {import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>} - Authorized query.
    */
   authorizedQuery(action) {
     return this.typedControllerInstance().frontendModelAuthorizedQuery(action)

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -1626,7 +1626,7 @@ export default class FrontendModelBase {
   _attributes
   /**
    * Narrows the runtime value to the documented type.
-    @type {Record<string, FrontendModelHasManyRelationship<?, ?> | FrontendModelSingularRelationship<?, ?>>} */
+    @type {Record<string, FrontendModelHasManyRelationship<typeof FrontendModelBase, typeof FrontendModelBase> | FrontendModelSingularRelationship<typeof FrontendModelBase, typeof FrontendModelBase>>} */
   _relationships
   /**
    * Narrows the runtime value to the documented type.
@@ -1889,7 +1889,7 @@ export default class FrontendModelBase {
   /**
    * Runs get relationship by name.
    * @param {string} relationshipName - Relationship name.
-   * @returns {FrontendModelHasManyRelationship<?, ?> | FrontendModelSingularRelationship<?, ?>} - Relationship state object.
+   * @returns {FrontendModelHasManyRelationship<typeof FrontendModelBase, typeof FrontendModelBase> | FrontendModelSingularRelationship<typeof FrontendModelBase, typeof FrontendModelBase>} - Relationship state object.
    */
   getRelationshipByName(relationshipName) {
     if (!this._relationships[relationshipName]) {
@@ -1961,7 +1961,7 @@ export default class FrontendModelBase {
    * required columns present are left untouched unless `force` is set. Carries
    * the query's preload graph, select, selectsExtra, withCount, abilities, and
    * queryData when re-fetching.
-   * @param {import("./query.js").default<?> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - Preload source.
+   * @param {import("./query.js").default<typeof FrontendModelBase> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - Preload source.
    * @param {{force?: boolean}} [options] - Options.
    * @returns {Promise<void>} - Resolves when preloading completes.
    */

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -1729,7 +1729,7 @@ export default class FrontendModelBase {
   /**
    * Runs define scope.
    * @param {(...args: Array<?>) => ?} callback - Scope callback.
-   * @returns {((...args: Array<?>) => import("./query.js").default<?>) & {scope: (...args: Array<?>) => import("../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
+   * @returns {((...args: Array<?>) => import("./query.js").default<typeof FrontendModelBase>) & {scope: (...args: Array<?>) => import("../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
    */
   static defineScope(callback) {
     return defineModelScope({

--- a/src/frontend-models/preloader.js
+++ b/src/frontend-models/preloader.js
@@ -15,7 +15,7 @@ export default class FrontendModelPreloader {
   /**
    * Runs preload.
    * @param {Array<import("./base.js").default>} models - Frontend model instances to preload onto.
-   * @param {import("./query.js").default<?> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - A query built via `Model.preload(...).select(...)`, or a raw preload spec.
+   * @param {import("./query.js").default<typeof import("./base.js").default> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - A query built via `Model.preload(...).select(...)`, or a raw preload spec.
    * @param {{force?: boolean}} [options] - Options.
    * @returns {Promise<void>} - Resolves when preloading completes.
    */
@@ -29,7 +29,7 @@ export default class FrontendModelPreloader {
     const query = isQuery
       ? /**
          * Narrows the runtime value to the documented type.
-          @type {import("./query.js").default<?>} */ (queryOrSpec)
+          @type {import("./query.js").default<typeof import("./base.js").default>} */ (queryOrSpec)
       : modelClass.preload(/**
                             * Narrows the runtime value to the documented type.
                              @type {?} */ (queryOrSpec))
@@ -88,7 +88,7 @@ export default class FrontendModelPreloader {
    * @param {typeof import("./base.js").default} args.modelClass - Model class the preload graph is rooted at.
    * @param {import("./base.js").default} args.model - Model instance.
    * @param {import("../database/query/index.js").NestedPreloadRecord} args.preload - Preload sub-graph to satisfy.
-   * @param {import("./query.js").default<?>} args.query - Source query carrying select/selectsExtra.
+   * @param {import("./query.js").default<typeof import("./base.js").default>} args.query - Source query carrying select/selectsExtra.
    * @param {boolean} args.force - Whether to reload regardless of cached state.
    * @returns {boolean} - Whether the model needs a reload request.
    */
@@ -114,7 +114,7 @@ export default class FrontendModelPreloader {
    * @param {import("./base.js").default} args.model - Model instance.
    * @param {string} args.relationshipName - Relationship name.
    * @param {import("../database/query/index.js").NestedPreloadRecord[string]} args.subPreload - Preload value for this relationship (`true` or a nested record).
-   * @param {import("./query.js").default<?>} args.query - Source query carrying select/selectsExtra.
+   * @param {import("./query.js").default<typeof import("./base.js").default>} args.query - Source query carrying select/selectsExtra.
    * @returns {boolean} - Whether the relationship is already satisfied.
    */
   static _relationshipSatisfied({modelClass, model, relationshipName, subPreload, query}) {


### PR DESCRIPTION
## Summary
- replace authorization wildcard query generics with the concrete database record model class
- reuse the ability condition typedef from authorization resources
- keep generated declarations from emitting ModelClassQuery<unknown>

## Validation
- npm run typecheck
- npm run build
- npm run lint
- npm run fallow