### PR TITLE
Type lifecycle callbacks by model class

### DIFF
--- a/spec/cli/commands/generate/base-models-spec.js
+++ b/spec/cli/commands/generate/base-models-spec.js
@@ -3,6 +3,8 @@ import Cli from "../../../../src/cli/index.js"
 import dummyConfiguration from "../../../dummy/src/config/configuration.js"
 import dummyDirectory from "../../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+import os from "os"
+import path from "path"
 import fs from "fs/promises"
 import * as ts from "typescript"
 
@@ -89,5 +91,44 @@ describe("Cli - generate - base-models", () => {
     expect(setterPattern.test(taskContents)).toBeTrue()
     expect(activeReturnPattern.test(projectDetailContents)).toBeTrue()
     expect(activeSetterPattern.test(projectDetailContents)).toBeTrue()
+  })
+
+  it("infers concrete model types in lifecycle callbacks", {tags: ["mssql"]}, async () => {
+    const cli = new Cli({
+      configuration: dummyConfiguration,
+      directory: dummyDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["g:base-models"],
+      testing: true
+    })
+
+    await cli.execute()
+
+    const sourceText = `
+      import Task from "${dummyDirectory()}/src/models/task.js"
+
+      Task.beforeValidation((task) => {
+        task.name()
+      })
+    `
+    const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-lifecycle-callback-type-check-"))
+    const sourcePath = `${tmpDirectory}/index.js`
+    await fs.writeFile(sourcePath, sourceText)
+
+    const program = ts.createProgram([sourcePath], {
+      allowJs: true,
+      checkJs: true,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2024
+    })
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+    const relevantDiagnostics = diagnostics.filter((diagnostic) => {
+      const fileName = diagnostic.file?.fileName || ""
+
+      return fileName === sourcePath || fileName.includes("src/database/record/index.js")
+    })
+
+    expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
   })
 })

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -292,7 +292,7 @@
  */
 
 /**
- * @typedef {typeof import("./frontend-model-resource/base-resource.js").default} FrontendModelResourceClassType
+ * @typedef {Omit<typeof import("./frontend-model-resource/base-resource.js").default, never> & {new (args: ConstructorParameters<typeof import("./frontend-model-resource/base-resource.js").default>[0]): import("./frontend-model-resource/base-resource.js").default}} FrontendModelResourceClassType
  */
 
 /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -7,7 +7,14 @@
 
 /**
  * LifecycleCallbackType type.
- * @typedef {((model: VelociousDatabaseRecord) => void | Promise<void>) | string} LifecycleCallbackType
+ * @template {VelociousDatabaseRecord} [T=VelociousDatabaseRecord]
+ * @typedef {((model: T) => void | Promise<void>) | string} LifecycleCallbackType
+ */
+
+/**
+ * Model class constructor type used for static `this` typing.
+ * @template {VelociousDatabaseRecord} T
+ * @typedef {{new (...args: Array<?>): T}} ModelConstructor
  */
 
 import timeout from "awaitery/build/timeout.js"
@@ -428,83 +435,101 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before validation.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeValidation(callback) {
-    this.registerLifecycleCallback("beforeValidation", callback)
+    this.registerLifecycleCallback("beforeValidation", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before save.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeSave(callback) {
-    this.registerLifecycleCallback("beforeSave", callback)
+    this.registerLifecycleCallback("beforeSave", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before create.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeCreate(callback) {
-    this.registerLifecycleCallback("beforeCreate", callback)
+    this.registerLifecycleCallback("beforeCreate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before update.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeUpdate(callback) {
-    this.registerLifecycleCallback("beforeUpdate", callback)
+    this.registerLifecycleCallback("beforeUpdate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before destroy.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeDestroy(callback) {
-    this.registerLifecycleCallback("beforeDestroy", callback)
+    this.registerLifecycleCallback("beforeDestroy", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after save.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterSave(callback) {
-    this.registerLifecycleCallback("afterSave", callback)
+    this.registerLifecycleCallback("afterSave", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after create.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterCreate(callback) {
-    this.registerLifecycleCallback("afterCreate", callback)
+    this.registerLifecycleCallback("afterCreate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after update.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterUpdate(callback) {
-    this.registerLifecycleCallback("afterUpdate", callback)
+    this.registerLifecycleCallback("afterUpdate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after destroy.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterDestroy(callback) {
-    this.registerLifecycleCallback("afterDestroy", callback)
+    this.registerLifecycleCallback("afterDestroy", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -14,7 +14,7 @@
 /**
  * Model class constructor type used for static `this` typing.
  * @template {VelociousDatabaseRecord} T
- * @typedef {{new (...args: Array<?>): T}} ModelConstructor
+ * @typedef {{new (...args: Array<never>): T}} ModelConstructor
  */
 
 import timeout from "awaitery/build/timeout.js"

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -125,7 +125,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    * @param {Set<string>} args.availableFrontendModelClassNames - Available frontend model class names in backend project.
    * @param {string} args.className - Model class name.
    * @param {Record<string, ?>} args.modelConfig - Model configuration.
-   * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} [args.resourceClass]
+   * @param {import("../../../../../configuration-types.js").FrontendModelResourceClassType | null} [args.resourceClass]
    * @returns {void} - No return value.
    */
   validateModelConfig({availableFrontendModelClassNames, className, modelConfig, resourceClass}) {
@@ -218,7 +218,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    * @param {string} args.importPath - Base class import path.
    * @param {typeof import("../../../../../database/record/index.js").default | undefined} args.modelClass - Backend model class.
    * @param {Record<string, ?>} args.modelConfig - Model configuration.
-   * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} [args.resourceClass]
+   * @param {import("../../../../../configuration-types.js").FrontendModelResourceClassType | null} [args.resourceClass]
    * @returns {string} - Generated file content.
    */
   buildModelFileContent({className, importPath, modelClass, modelConfig, resourceClass}) {
@@ -531,7 +531,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    *
    * Constructed with no controller/ability so resource overrides must
    * support being called without a request context.
-   * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} resourceClass - Resource class.
+   * @param {import("../../../../../configuration-types.js").FrontendModelResourceClassType | null} resourceClass - Resource class.
    * @returns {string[]} - Relationship names that accept nested writes (empty when none).
    */
   nestedRelationshipNamesForGenerator(resourceClass) {
@@ -804,7 +804,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    * @param {object} args - Arguments.
    * @param {string} args.className - Model class name.
    * @param {Record<string, ?>} args.modelConfig - Model configuration.
-   * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} [args.resourceClass]
+   * @param {import("../../../../../configuration-types.js").FrontendModelResourceClassType | null} [args.resourceClass]
    * @returns {Array<{autoload: boolean, relationshipName: string, targetClassName: string, targetFileName: string, type: "belongsTo" | "hasOne" | "hasMany"}>} - Relationships.
    */
   relationshipsForModel({className, modelConfig, resourceClass}) {
@@ -826,7 +826,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    * @param {object} args - Arguments.
    * @param {string} args.className - Model class name.
    * @param {string} args.relationshipName - Relationship name.
-   * @param {typeof import("../../../../../frontend-model-resource/base-resource.js").default | null} [args.resourceClass]
+   * @param {import("../../../../../configuration-types.js").FrontendModelResourceClassType | null} [args.resourceClass]
    * @returns {{autoload: boolean, relationshipName: string, targetClassName: string, targetFileName: string, type: "belongsTo" | "hasOne" | "hasMany"}} Inferred relationship definition.
    */
   inferredRelationshipDefinition({className, relationshipName, resourceClass}) {

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -27,6 +27,7 @@ import * as inflection from "inflection"
 
 /**
  * Base class for backend frontend-model resources.
+ * @template {typeof import("../database/record/index.js").default} [out TModelClass=typeof import("../database/record/index.js").default]
  */
 export default class FrontendModelBaseResource extends AuthorizationBaseResource {
   /**
@@ -99,6 +100,8 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * Runs typed controller instance.
    * @returns {import("../controller.js").default & {
    *   frontendModelAuthorizedQuery: (action: "index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url") => import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>,
+   *   frontendModelAbilityAction: (action: string) => string,
+   *   currentAbility: () => import("../authorization/ability.js").default | undefined,
    *   frontendModelIndexQuery: () => import("../database/query/model-class-query.js").default<typeof import("../database/record/index.js").default>,
    *   frontendModelPreload: () => import("../database/query/index.js").NestedPreloadRecord | null,
    *   serializeFrontendModel: (model: import("../database/record/index.js").default) => Promise<Record<string, unknown>>
@@ -151,14 +154,14 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
 
   /**
    * Runs model class.
-   * @returns {typeof import("../database/record/index.js").default} - Model class.
+   * @returns {TModelClass} - Model class.
    */
   modelClass() {
     if (!this.modelClassValue) {
       throw new Error(`${this.constructor.name} requires a model class.`)
     }
 
-    return this.modelClassValue
+    return /** @type {TModelClass} */ (this.modelClassValue)
   }
 
   /**
@@ -246,6 +249,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   authorizedQuery(action) {
     return /** Narrows the authorized query to the resource's model class. @type {import("../database/query/model-class-query.js").default<MC>} */ (this.typedControllerInstance().frontendModelAuthorizedQuery(action))
   }
+
 
   /**
    * Runs supports pluck.

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -8,7 +8,7 @@ import {validateFrontendModelResourceCommandName} from "./resource-config-valida
 /**
  * Runs the frontendModelResourcesForBackendProject helper.
  * @param {import("../configuration-types.js").BackendProjectConfiguration} backendProject - Backend project config.
- * @returns {Record<string, typeof FrontendModelBaseResource>} - Resource definitions keyed by model name.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelResourceClassType>} - Resource definitions keyed by model name.
  */
 export function frontendModelResourcesForBackendProject(backendProject) {
   const resources = backendProject.frontendModels
@@ -27,7 +27,7 @@ export function frontendModelResourcesForBackendProject(backendProject) {
 /**
  * Runs the frontendModelResourceDefinitionIsClass helper.
  * @param {?} value - Candidate resource definition.
- * @returns {value is typeof FrontendModelBaseResource} - Whether value is a resource class.
+ * @returns {value is import("../configuration-types.js").FrontendModelResourceClassType} - Whether value is a resource class.
  */
 export function frontendModelResourceDefinitionIsClass(value) {
   return typeof value === "function" && (value === FrontendModelBaseResource || value.prototype instanceof FrontendModelBaseResource)
@@ -36,7 +36,7 @@ export function frontendModelResourceDefinitionIsClass(value) {
 /**
  * Runs the frontendModelResourceClassFromDefinition helper.
  * @param {?} resourceDefinition - Resource definition.
- * @returns {typeof FrontendModelBaseResource | null} - Resource class when definition is class-based.
+ * @returns {import("../configuration-types.js").FrontendModelResourceClassType | null} - Resource class when definition is class-based.
  */
 export function frontendModelResourceClassFromDefinition(resourceDefinition) {
   return frontendModelResourceDefinitionIsClass(resourceDefinition) ? resourceDefinition : null

--- a/src/frontend-models/websocket-publishers.js
+++ b/src/frontend-models/websocket-publishers.js
@@ -24,7 +24,7 @@ export function frontendModelBroadcastChannelName(modelName) {
  * Builds a frontend models map from the configuration's ability resources.
  * Each resource class with a static ModelClass property is keyed by model name.
  * @param {import("../configuration.js").default} configuration - Configuration instance.
- * @returns {Record<string, typeof FrontendModelBaseResource>} - Resource definitions keyed by model name.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelResourceClassType>} - Resource definitions keyed by model name.
  */
 /**
  * Runs resolve ability resources list.
@@ -59,12 +59,12 @@ async function resolveAbilityResourcesList(configuration) {
 /**
  * Runs frontend model resources from ability resources list.
  * @param {import("../configuration-types.js").AbilityResourceClassType[]} abilityResources - Ability resource classes.
- * @returns {Record<string, typeof FrontendModelBaseResource>} - Resource definitions keyed by model name.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelResourceClassType>} - Resource definitions keyed by model name.
  */
 function frontendModelResourcesFromAbilityResourcesList(abilityResources) {
   /**
    * Resources.
-    @type {Record<string, typeof FrontendModelBaseResource>} */
+    @type {Record<string, import("../configuration-types.js").FrontendModelResourceClassType>} */
   const resources = {}
 
   if (!abilityResources || abilityResources.length === 0) return resources
@@ -81,7 +81,7 @@ function frontendModelResourcesFromAbilityResourcesList(abilityResources) {
     if (resourceClass.prototype instanceof FrontendModelBaseResource) {
       const modelClass = /**
                           * Narrows the runtime value to the documented type.
-                           @type {typeof FrontendModelBaseResource} */ (resourceClass).ModelClass
+                           @type {import("../configuration-types.js").FrontendModelResourceClassType} */ (resourceClass).ModelClass
 
       if (!modelClass) {
         throw new Error(`Resource class ${resourceClass.name} is missing a static ModelClass property`)
@@ -95,7 +95,7 @@ function frontendModelResourcesFromAbilityResourcesList(abilityResources) {
 
       resources[modelName] = /**
                               * Narrows the runtime value to the documented type.
-                               @type {typeof FrontendModelBaseResource} */ (resourceClass)
+                               @type {import("../configuration-types.js").FrontendModelResourceClassType} */ (resourceClass)
     } else if (resourceClass.prototype instanceof AuthorizationBaseResource) {
       // Authorization-only resource — valid but not relevant for WebSocket publishing
     } else {
@@ -116,7 +116,7 @@ export async function ensureFrontendModelWebsocketPublishersRegistered(configura
 
   /**
    * All frontend models.
-    @type {Record<string, typeof FrontendModelBaseResource>} */
+    @type {Record<string, import("../configuration-types.js").FrontendModelResourceClassType>} */
   let allFrontendModels = {}
 
   for (const backendProject of configuration.getBackendProjects()) {


### PR DESCRIPTION
## Summary
- type lifecycle callbacks from the concrete model class used to register them
- add a generator spec that verifies callbacks can call generated model methods without casts

## Validation
- npm run test -- spec/cli/commands/generate/base-models-spec.js
- npm run lint