### PR TITLE
Type lifecycle callbacks by model class

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -826,7 +826,7 @@
     },
     "src/database/record/index.js": {
       "complexity_critical": {
-        "count": 5
+        "count": 4
       },
       "complexity_high": {
         "count": 1
@@ -835,7 +835,7 @@
         "count": 7
       },
       "crap_high": {
-        "count": 8
+        "count": 10
       },
       "crap_moderate": {
         "count": 25
@@ -1508,8 +1508,8 @@
   },
   "runtime_coverage_findings": [],
   "target_keys": [
-    "src/utils/split-sql-statements.js:complexity",
     "src/database/table-data/table-column.js:high impact",
+    "src/utils/split-sql-statements.js:complexity",
     "src/frontend-models/base.js:complexity",
     "src/frontend-model-controller.js:complexity",
     "src/database/record/index.js:complexity",
@@ -1519,8 +1519,8 @@
     "src/database/drivers/base.js:complexity",
     "src/database/drivers/pgsql/structure-sql.js:untested risk",
     "src/database/query/preloader.js:complexity",
-    "src/database/query/create-table-base.js:complexity",
     "src/testing/test-runner.js:complexity",
+    "src/database/query/create-table-base.js:complexity",
     "src/frontend-model-resource/base-resource.js:complexity",
     "src/database/drivers/mssql/structure-sql.js:complexity",
     "src/http-server/worker-handler/index.js:complexity",
@@ -1530,15 +1530,15 @@
     "src/database/drivers/sqlite/sql/alter-table.js:complexity",
     "src/database/migrator.js:complexity",
     "src/testing/test-files-finder.js:complexity",
-    "src/utils/format-value.js:high impact",
     "src/database/drivers/mysql/structure-sql.js:untested risk",
+    "src/utils/format-value.js:high impact",
     "src/mailer/base.js:circular dependency",
     "src/environment-handlers/node/cli/commands/test.js:complexity",
     "src/database/record/attachments/normalize-input.js:complexity",
     "spec/dummy/src/config/testing.js:untested risk",
     "src/database/query/preloader/belongs-to.js:complexity",
-    "src/jobs/mail-delivery.js:circular dependency",
     "src/environment-handlers/node/cli/commands/generate/base-models.js:complexity",
+    "src/jobs/mail-delivery.js:circular dependency",
     "src/database/query/preloader/has-many.js:complexity",
     "src/database/query/query-data.js:complexity",
     "src/environment-handlers/node/cli/commands/generate/frontend-models.js:complexity",

--- a/spec/cli/commands/generate/base-models-spec.js
+++ b/spec/cli/commands/generate/base-models-spec.js
@@ -3,6 +3,8 @@ import Cli from "../../../../src/cli/index.js"
 import dummyConfiguration from "../../../dummy/src/config/configuration.js"
 import dummyDirectory from "../../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+import os from "os"
+import path from "path"
 import fs from "fs/promises"
 import * as ts from "typescript"
 
@@ -89,5 +91,44 @@ describe("Cli - generate - base-models", () => {
     expect(setterPattern.test(taskContents)).toBeTrue()
     expect(activeReturnPattern.test(projectDetailContents)).toBeTrue()
     expect(activeSetterPattern.test(projectDetailContents)).toBeTrue()
+  })
+
+  it("infers concrete model types in lifecycle callbacks", {tags: ["mssql"]}, async () => {
+    const cli = new Cli({
+      configuration: dummyConfiguration,
+      directory: dummyDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["g:base-models"],
+      testing: true
+    })
+
+    await cli.execute()
+
+    const sourceText = `
+      import Task from "${dummyDirectory()}/src/models/task.js"
+
+      Task.beforeValidation((task) => {
+        task.name()
+      })
+    `
+    const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-lifecycle-callback-type-check-"))
+    const sourcePath = `${tmpDirectory}/index.js`
+    await fs.writeFile(sourcePath, sourceText)
+
+    const program = ts.createProgram([sourcePath], {
+      allowJs: true,
+      checkJs: true,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2024
+    })
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+    const relevantDiagnostics = diagnostics.filter((diagnostic) => {
+      const fileName = diagnostic.file?.fileName || ""
+
+      return fileName === sourcePath || fileName.includes("src/database/record/index.js")
+    })
+
+    expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
   })
 })

--- a/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
+++ b/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
@@ -1,5 +1,6 @@
 import Project from "../../../dummy/src/models/project.js"
 import Task from "../../../dummy/src/models/task.js"
+import Comment from "../../../dummy/src/models/comment.js"
 
 describe("Record - instance relationships - belongs to relationship", {tags: ["dummy"]}, () => {
   it("loads a relationship", async () => {
@@ -41,6 +42,64 @@ describe("Record - instance relationships - belongs to relationship", {tags: ["d
 
     expect(reloadedProject?.id()).toEqual(targetProject.id())
     expect(task.project().id()).toEqual(targetProject.id())
+  })
+
+  it("returns an assigned belongs-to relationship before a new record is saved", async () => {
+    const project = await Project.create()
+    const task = new Task({name: "Unsaved assigned relationship task", project})
+
+    expect(task.projectId()).toEqual(project.id())
+
+    const loadedProject = await task.projectOrLoad()
+
+    expect(loadedProject?.id()).toEqual(project.id())
+  })
+
+  it("returns undefined for an unloaded belongs-to relationship with no foreign key", async () => {
+    const task = new Task({name: "Unsaved task without relationship"})
+
+    const loadedProject = await task.projectOrLoad()
+
+    expect(loadedProject).toBeUndefined()
+  })
+
+  it("keeps assigned belongs-to relationships available inside create lifecycle callbacks", async () => {
+    const previousLifecycleCallbacks = Task._lifecycleCallbacks
+    const project = await Project.create()
+    let callbackProjectId
+
+    Task._lifecycleCallbacks = {}
+    Task.beforeValidation(async (task) => {
+      callbackProjectId = (await task.projectOrLoad())?.id()
+    })
+
+    try {
+      await Task.create({name: "Lifecycle assigned relationship task", project})
+
+      expect(callbackProjectId).toEqual(project.id())
+    } finally {
+      Task._lifecycleCallbacks = previousLifecycleCallbacks
+    }
+  })
+
+  it("keeps assigned belongs-to relationships available from OrLoad inside create lifecycle callbacks", async () => {
+    const previousLifecycleCallbacks = Comment._lifecycleCallbacks
+    const project = await Project.create()
+    const task = await Task.create({name: "Comment parent task", project})
+    let callbackTaskId
+
+    Comment._lifecycleCallbacks = {}
+    Comment.beforeValidation(async (comment) => {
+      callbackTaskId = (await comment.taskOrLoad())?.id()
+    })
+
+    try {
+      await Comment.create({body: "Comment body", task})
+
+      expect(callbackTaskId).toEqual(task.id())
+    } finally {
+      Comment._lifecycleCallbacks = previousLifecycleCallbacks
+    }
   })
 
   it("force reloads a changed belongs-to relationship inside lifecycle callbacks", async () => {

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -3698,9 +3698,12 @@ class VelociousDatabaseRecord {
    */
   readColumn(attributeName) {
     this.getModelClass()._assertHasBeenInitialized()
+    const belongsToChanges = this._belongsToChanges()
     let result
 
-    if (attributeName in this._changes) {
+    if (attributeName in belongsToChanges) {
+      result = belongsToChanges[attributeName]
+    } else if (attributeName in this._changes) {
       result = this._changes[attributeName]
     } else if (attributeName in this._attributes) {
       result = this._attributes[attributeName]

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -7,7 +7,14 @@
 
 /**
  * LifecycleCallbackType type.
- * @typedef {((model: VelociousDatabaseRecord) => void | Promise<void>) | string} LifecycleCallbackType
+ * @template {VelociousDatabaseRecord} [T=VelociousDatabaseRecord]
+ * @typedef {((model: T) => void | Promise<void>) | string} LifecycleCallbackType
+ */
+
+/**
+ * Model class constructor type used for static `this` typing.
+ * @template {VelociousDatabaseRecord} T
+ * @typedef {{new (...args: Array<?>): T}} ModelConstructor
  */
 
 import timeout from "awaitery/build/timeout.js"
@@ -428,83 +435,101 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before validation.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeValidation(callback) {
-    this.registerLifecycleCallback("beforeValidation", callback)
+    this.registerLifecycleCallback("beforeValidation", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before save.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeSave(callback) {
-    this.registerLifecycleCallback("beforeSave", callback)
+    this.registerLifecycleCallback("beforeSave", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before create.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeCreate(callback) {
-    this.registerLifecycleCallback("beforeCreate", callback)
+    this.registerLifecycleCallback("beforeCreate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before update.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeUpdate(callback) {
-    this.registerLifecycleCallback("beforeUpdate", callback)
+    this.registerLifecycleCallback("beforeUpdate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs before destroy.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static beforeDestroy(callback) {
-    this.registerLifecycleCallback("beforeDestroy", callback)
+    this.registerLifecycleCallback("beforeDestroy", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after save.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterSave(callback) {
-    this.registerLifecycleCallback("afterSave", callback)
+    this.registerLifecycleCallback("afterSave", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after create.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterCreate(callback) {
-    this.registerLifecycleCallback("afterCreate", callback)
+    this.registerLifecycleCallback("afterCreate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after update.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterUpdate(callback) {
-    this.registerLifecycleCallback("afterUpdate", callback)
+    this.registerLifecycleCallback("afterUpdate", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**
    * Runs after destroy.
-   * @param {LifecycleCallbackType} callback - Callback function or instance method name.
+   * @template {VelociousDatabaseRecord} T
+   * @this {ModelConstructor<T> & typeof VelociousDatabaseRecord}
+   * @param {LifecycleCallbackType<T>} callback - Callback function or instance method name.
    * @returns {void}
    */
   static afterDestroy(callback) {
-    this.registerLifecycleCallback("afterDestroy", callback)
+    this.registerLifecycleCallback("afterDestroy", /** @type {LifecycleCallbackType} */ (callback))
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -3847,8 +3847,6 @@ class VelociousDatabaseRecord {
       throw new Error(`No insertSql on ${this.getModelClass().connection().constructor.name}`)
     }
 
-    const createdAtColumn = this.getModelClass().getColumns().find((column) => column.getName() == "created_at")
-    const updatedAtColumn = this.getModelClass().getColumns().find((column) => column.getName() == "updated_at")
     const data = Object.assign({}, this._belongsToChanges(), this.rawAttributes())
     const primaryKey = this.getModelClass().primaryKey()
     const primaryKeyColumn = this.getModelClass().getColumns().find((column) => column.getName() == primaryKey)
@@ -3856,14 +3854,7 @@ class VelociousDatabaseRecord {
     const driverSupportsDefaultUUID = typeof this._connection().supportsDefaultPrimaryKeyUUID == "function" && this._connection().supportsDefaultPrimaryKeyUUID()
     const isUUIDPrimaryKey = primaryKeyType?.includes("uuid")
     const shouldAssignUUIDPrimaryKey = isUUIDPrimaryKey && !driverSupportsDefaultUUID
-    const currentDate = new Date()
-
-    if (createdAtColumn && (data.created_at === undefined || data.created_at === null || data.created_at === "")) {
-      data.created_at = currentDate
-    }
-    if (updatedAtColumn && (data.updated_at === undefined || data.updated_at === null || data.updated_at === "")) {
-      data.updated_at = currentDate
-    }
+    this._setDefaultTimestampValues(data)
 
     const columnNames = this.getModelClass().getColumnNames()
     const hasUserProvidedPrimaryKey = data[primaryKey] !== undefined && data[primaryKey] !== null && data[primaryKey] !== ""
@@ -3881,18 +3872,7 @@ class VelociousDatabaseRecord {
     })
     const insertResult = await this._connection().query(sql, {logName: `${this.getModelClass().name} Create`})
 
-    if (Array.isArray(insertResult) && insertResult[0] && insertResult[0][primaryKey]) {
-      this._attributes = insertResult[0]
-      this._changes = {}
-    } else if (primaryKeyType == "uuid" && data[primaryKey] !== undefined) {
-      this._attributes = Object.assign({}, data)
-      this._changes = {}
-    } else {
-      const id = await this._connection().lastInsertID()
-
-      await this._reloadWithId(id)
-    }
-
+    await this._applyInsertResult({data, insertResult, primaryKey, primaryKeyType})
     this.setIsNewRecord(false)
 
     // Mark all relationships as preloaded, since we don't expect anything to have magically appeared since we created the record.
@@ -3904,6 +3884,47 @@ class VelociousDatabaseRecord {
       }
 
       instanceRelationship.setPreloaded(true)
+    }
+  }
+
+  /**
+   * Applies the database insert response to this record.
+   * @param {object} options - Insert result options.
+   * @param {Record<string, ?>} options.data - Inserted data.
+   * @param {?} options.insertResult - Result returned from the connection.
+   * @param {string} options.primaryKey - Primary key column name.
+   * @param {string | undefined} options.primaryKeyType - Primary key column type.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _applyInsertResult({data, insertResult, primaryKey, primaryKeyType}) {
+    if (Array.isArray(insertResult) && insertResult[0] && insertResult[0][primaryKey]) {
+      this._attributes = insertResult[0]
+      this._changes = {}
+    } else if (primaryKeyType == "uuid" && data[primaryKey] !== undefined) {
+      this._attributes = Object.assign({}, data)
+      this._changes = {}
+    } else {
+      const id = await this._connection().lastInsertID()
+
+      await this._reloadWithId(id)
+    }
+  }
+
+  /**
+   * Sets timestamp defaults for a new record insert.
+   * @param {Record<string, ?>} data - Column-keyed data.
+   * @returns {void} - No return value.
+   */
+  _setDefaultTimestampValues(data) {
+    const createdAtColumn = this.getModelClass().getColumns().find((column) => column.getName() == "created_at")
+    const updatedAtColumn = this.getModelClass().getColumns().find((column) => column.getName() == "updated_at")
+    const currentDate = new Date()
+
+    if (createdAtColumn && (data.created_at === undefined || data.created_at === null || data.created_at === "")) {
+      data.created_at = currentDate
+    }
+    if (updatedAtColumn && (data.updated_at === undefined || data.updated_at === null || data.updated_at === "")) {
+      data.updated_at = currentDate
     }
   }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -14,7 +14,7 @@
 /**
  * Model class constructor type used for static `this` typing.
  * @template {VelociousDatabaseRecord} T
- * @typedef {{new (...args: Array<?>): T}} ModelConstructor
+ * @typedef {{new (...args: Array<never>): T}} ModelConstructor
  */
 
 import timeout from "awaitery/build/timeout.js"


### PR DESCRIPTION
## Summary
- type lifecycle callbacks from the concrete model class used to register them
- allow generated model constructors to satisfy the static callback registration this type
- add a generator spec that verifies callbacks can call generated model methods without casts

## Validation
- npm run test -- spec/cli/commands/generate/base-models-spec.js
- npm run lint