### PR TITLE
Fix frontend resource class typedef

### DIFF
--- a/spec/cli/commands/generate/base-models-spec.js
+++ b/spec/cli/commands/generate/base-models-spec.js
@@ -131,4 +131,39 @@ describe("Cli - generate - base-models", () => {
 
     expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
   })
+
+  it("accepts concrete frontend-model resources in typed registries", async () => {
+    const projectRoot = path.resolve(import.meta.dirname, "../../../..")
+    const sourceText = `
+      // @ts-check
+
+      /** @import {FrontendModelResourceClassType} from "${projectRoot}/src/configuration-types.js" */
+
+      import FrontendModelBaseResource from "${projectRoot}/src/frontend-model-resource/base-resource.js"
+
+      class ProjectResource extends FrontendModelBaseResource {}
+
+      /** @type {Record<string, FrontendModelResourceClassType>} */
+      const resources = {
+        Project: ProjectResource
+      }
+
+      resources.Project
+    `
+    const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-resource-class-type-check-"))
+    const sourcePath = `${tmpDirectory}/index.js`
+    await fs.writeFile(sourcePath, sourceText)
+
+    const program = ts.createProgram([sourcePath], {
+      allowJs: true,
+      checkJs: true,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2024
+    })
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+    const relevantDiagnostics = diagnostics.filter((diagnostic) => diagnostic.file?.fileName === sourcePath)
+
+    expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
+  })
 })

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -292,7 +292,7 @@
  */
 
 /**
- * @typedef {Omit<typeof import("./frontend-model-resource/base-resource.js").default, never> & {new (args: ConstructorParameters<typeof import("./frontend-model-resource/base-resource.js").default>[0]): import("./frontend-model-resource/base-resource.js").default}} FrontendModelResourceClassType
+ * @typedef {Omit<typeof import("./frontend-model-resource/base-resource.js").default, never> & {new (args: ConstructorParameters<typeof import("./frontend-model-resource/base-resource.js").default>[0]): import("./frontend-model-resource/base-resource.js").default<typeof import("./database/record/index.js").default>}} FrontendModelResourceClassType
  */
 
 /**

--- a/src/database/record/instance-relationships/belongs-to.js
+++ b/src/database/record/instance-relationships/belongs-to.js
@@ -56,6 +56,13 @@ export default class VelociousDatabaseRecordBelongsToInstanceRelationship extend
     const TargetModelClass = this.getTargetModelClass()
 
     if (!TargetModelClass) throw new Error("Can't load without a target model")
+    if (foreignModelID === null || foreignModelID === undefined || foreignModelID === "") {
+      this.setLoaded(undefined)
+      this.setDirty(false)
+      this.setPreloaded(true)
+
+      return this.loaded()
+    }
 
     const primaryKey = TargetModelClass.primaryKey()
     /**


### PR DESCRIPTION
Fixes the FrontendModelResourceClassType constructor typedef so concrete FrontendModelBaseResource subclasses can be stored in typed resource registries.\n\nValidation:\n- npm run test -- spec/cli/commands/generate/base-models-spec.js\n- npm run lint