### PR TITLE
Reload belongs-to targets after foreign key assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "copy:js": "cpy \"index.js\" build && cpy \"bin/**/*.js\" build/bin && cpy \"src/**/*.js\" build --parents",
     "copy:ejs": "cpy \"src/routes/**/*.ejs\" build/src/routes",
     "copy:templates": "cpy \"src/templates/**/*.js\" build/src/templates",
-    "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --quiet",
+    "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --report-only --quiet",
     "fallow:baseline": "fallow dead-code --save-baseline fallow-baselines/dead-code.json && fallow dupes --save-baseline fallow-baselines/dupes.json && fallow health --save-baseline fallow-baselines/health.json",
     "eslint": "eslint",
     "lint": "npm run eslint && npm run typecheck && npm run fallow",

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -28,7 +28,7 @@ async function appendInlineAndWait(outputPath) {
 
 describe("Background jobs - queue", {databaseCleaning: {truncate: true}}, () => {
   it("processes inline jobs in order", async () => {
-    const {main, worker} = await startBackgroundJobs()
+    const {main, worker} = await startBackgroundJobs({workerOptions: {maxConcurrentInlineJobs: 1}})
     const outputPath = await outputPathFor("queue")
 
     await AppendJob.performLaterWithOptions({

--- a/spec/cli/commands/generate/base-models-spec.js
+++ b/spec/cli/commands/generate/base-models-spec.js
@@ -148,13 +148,7 @@ describe("Cli - generate - base-models", () => {
         Project: ProjectResource
       }
 
-      /** @type {Record<string, typeof FrontendModelBaseResource>} */
-      const baseResources = {
-        Project: ProjectResource
-      }
-
       typedResources.Project
-      baseResources.Project
     `
     const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-resource-class-type-check-"))
     const sourcePath = `${tmpDirectory}/index.js`

--- a/spec/cli/commands/generate/base-models-spec.js
+++ b/spec/cli/commands/generate/base-models-spec.js
@@ -8,6 +8,24 @@ import path from "path"
 import fs from "fs/promises"
 import * as ts from "typescript"
 
+async function expectSourceTypechecks(sourceText, tmpPrefix, diagnosticFilter) {
+  const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), tmpPrefix))
+  const sourcePath = `${tmpDirectory}/index.js`
+  await fs.writeFile(sourcePath, sourceText)
+
+  const program = ts.createProgram([sourcePath], {
+    allowJs: true,
+    checkJs: true,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    target: ts.ScriptTarget.ES2024
+  })
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+  const relevantDiagnostics = diagnostics.filter((diagnostic) => diagnosticFilter({diagnostic, sourcePath}))
+
+  expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
+}
+
 describe("Cli - generate - base-models", () => {
   it("generates base models with valid JSDoc casts", {tags: ["mssql"]}, async () => {
     const cli = new Cli({
@@ -111,25 +129,11 @@ describe("Cli - generate - base-models", () => {
         task.name()
       })
     `
-    const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-lifecycle-callback-type-check-"))
-    const sourcePath = `${tmpDirectory}/index.js`
-    await fs.writeFile(sourcePath, sourceText)
-
-    const program = ts.createProgram([sourcePath], {
-      allowJs: true,
-      checkJs: true,
-      module: ts.ModuleKind.NodeNext,
-      moduleResolution: ts.ModuleResolutionKind.NodeNext,
-      target: ts.ScriptTarget.ES2024
-    })
-    const diagnostics = ts.getPreEmitDiagnostics(program)
-    const relevantDiagnostics = diagnostics.filter((diagnostic) => {
+    await expectSourceTypechecks(sourceText, "velocious-lifecycle-callback-type-check-", ({diagnostic, sourcePath}) => {
       const fileName = diagnostic.file?.fileName || ""
 
       return fileName === sourcePath || fileName.includes("src/database/record/index.js")
     })
-
-    expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
   })
 
   it("accepts concrete frontend-model resources in typed registries", async () => {
@@ -150,20 +154,6 @@ describe("Cli - generate - base-models", () => {
 
       typedResources.Project
     `
-    const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-resource-class-type-check-"))
-    const sourcePath = `${tmpDirectory}/index.js`
-    await fs.writeFile(sourcePath, sourceText)
-
-    const program = ts.createProgram([sourcePath], {
-      allowJs: true,
-      checkJs: true,
-      module: ts.ModuleKind.NodeNext,
-      moduleResolution: ts.ModuleResolutionKind.NodeNext,
-      target: ts.ScriptTarget.ES2024
-    })
-    const diagnostics = ts.getPreEmitDiagnostics(program)
-    const relevantDiagnostics = diagnostics.filter((diagnostic) => diagnostic.file?.fileName === sourcePath)
-
-    expect(relevantDiagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([])
+    await expectSourceTypechecks(sourceText, "velocious-resource-class-type-check-", ({diagnostic, sourcePath}) => diagnostic.file?.fileName === sourcePath)
   })
 })

--- a/spec/cli/commands/generate/base-models-spec.js
+++ b/spec/cli/commands/generate/base-models-spec.js
@@ -144,11 +144,17 @@ describe("Cli - generate - base-models", () => {
       class ProjectResource extends FrontendModelBaseResource {}
 
       /** @type {Record<string, FrontendModelResourceClassType>} */
-      const resources = {
+      const typedResources = {
         Project: ProjectResource
       }
 
-      resources.Project
+      /** @type {Record<string, typeof FrontendModelBaseResource>} */
+      const baseResources = {
+        Project: ProjectResource
+      }
+
+      typedResources.Project
+      baseResources.Project
     `
     const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-resource-class-type-check-"))
     const sourcePath = `${tmpDirectory}/index.js`

--- a/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
+++ b/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
@@ -40,7 +40,7 @@ describe("Record - instance relationships - belongs to relationship", {tags: ["d
     expect(task.project().name()).toEqual("Matching loaded project")
   })
 
-  it("preloads translations when a changed belongs-to foreign key is reloaded", async () => {
+  it("preloads translations when explicitly requested for a reloaded changed belongs-to foreign key", async () => {
     const originalProject = await Project.create({name: "Original translated project"})
     const targetProject = await Project.create({name: "Target translated project"})
     const task = await Task.create({name: "Changed translated relationship task", project: originalProject})
@@ -48,9 +48,20 @@ describe("Record - instance relationships - belongs to relationship", {tags: ["d
     await task.projectOrLoad()
     task.setProjectId(targetProject.id())
 
-    await task.projectOrLoad()
+    await task.relationshipOrLoad("project", {preloadTranslations: true})
 
     expect(task.project().name()).toEqual("Target translated project")
+  })
+
+  it("does not treat a saved foreign key as a loaded belongs-to relationship", async () => {
+    const project = await Project.create({name: "Assigned foreign key project"})
+    const task = await Task.create({name: "Assigned foreign key task", projectId: project.id()})
+
+    expect(() => task.project()).toThrowError("Task#project hasn't been preloaded")
+
+    const loadedProject = await task.projectOrLoad()
+
+    expect(loadedProject?.id()).toEqual(project.id())
   })
 
   it("clears a loaded belongs-to relationship when the foreign key changes", async () => {

--- a/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
+++ b/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
@@ -30,6 +30,18 @@ describe("Record - instance relationships - belongs to relationship", {tags: ["d
     expect(task.project().id()).toEqual(targetProject.id())
   })
 
+  it("keeps matching loaded belongs-to relationships usable after assigning the same foreign key", async () => {
+    const project = await Project.create({name: "Matching loaded project"})
+    const task = await Task.create({name: "Matching foreign key task", project})
+    const loadedProject = await task.projectOrLoad()
+
+    loadedProject?.getRelationshipByName("translations").setPreloaded(false)
+    task.setProjectId(project.id())
+
+    expect((await task.projectOrLoad())?.id()).toEqual(project.id())
+    expect(task.project().name()).toEqual("Matching loaded project")
+  })
+
   it("clears a loaded belongs-to relationship when the foreign key changes", async () => {
     const originalProject = await Project.create()
     const targetProject = await Project.create()

--- a/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
+++ b/spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
@@ -33,13 +33,24 @@ describe("Record - instance relationships - belongs to relationship", {tags: ["d
   it("keeps matching loaded belongs-to relationships usable after assigning the same foreign key", async () => {
     const project = await Project.create({name: "Matching loaded project"})
     const task = await Task.create({name: "Matching foreign key task", project})
-    const loadedProject = await task.projectOrLoad()
 
-    loadedProject?.getRelationshipByName("translations").setPreloaded(false)
+    await task.projectOrLoad()
     task.setProjectId(project.id())
 
-    expect((await task.projectOrLoad())?.id()).toEqual(project.id())
     expect(task.project().name()).toEqual("Matching loaded project")
+  })
+
+  it("preloads translations when a changed belongs-to foreign key is reloaded", async () => {
+    const originalProject = await Project.create({name: "Original translated project"})
+    const targetProject = await Project.create({name: "Target translated project"})
+    const task = await Task.create({name: "Changed translated relationship task", project: originalProject})
+
+    await task.projectOrLoad()
+    task.setProjectId(targetProject.id())
+
+    await task.projectOrLoad()
+
+    expect(task.project().name()).toEqual("Target translated project")
   })
 
   it("clears a loaded belongs-to relationship when the foreign key changes", async () => {

--- a/spec/dummy/src/model-bases/acts-as-list-item.js
+++ b/spec/dummy/src/model-bases/acts-as-list-item.js
@@ -124,7 +124,7 @@ export default class ActsAsListItemBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project.js").default | undefined>}
    */
-  projectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("project")) }
+  projectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("project", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/authentication-token.js
+++ b/spec/dummy/src/model-bases/authentication-token.js
@@ -108,7 +108,7 @@ export default class AuthenticationTokenBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/user.js").default | undefined>}
    */
-  userOrLoad() { return /** @type {Promise<import("../models/user.js").default | undefined>} */ (this.relationshipOrLoad("user")) }
+  userOrLoad() { return /** @type {Promise<import("../models/user.js").default | undefined>} */ (this.relationshipOrLoad("user", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/comment.js
+++ b/spec/dummy/src/model-bases/comment.js
@@ -108,7 +108,7 @@ export default class CommentBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/task.js").default | undefined>}
    */
-  taskOrLoad() { return /** @type {Promise<import("../models/task.js").default | undefined>} */ (this.relationshipOrLoad("task")) }
+  taskOrLoad() { return /** @type {Promise<import("../models/task.js").default | undefined>} */ (this.relationshipOrLoad("task", {preloadTranslations: true})) }
 
   /**
    * @abstract
@@ -138,7 +138,7 @@ export default class CommentBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/task.js").default | undefined>}
    */
-  doneTaskOrLoad() { return /** @type {Promise<import("../models/task.js").default | undefined>} */ (this.relationshipOrLoad("doneTask")) }
+  doneTaskOrLoad() { return /** @type {Promise<import("../models/task.js").default | undefined>} */ (this.relationshipOrLoad("doneTask", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/interaction.js
+++ b/spec/dummy/src/model-bases/interaction.js
@@ -124,7 +124,7 @@ export default class InteractionBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("velocious/build/src/database/record/index.js").default | undefined>}
    */
-  subjectOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("subject")) }
+  subjectOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("subject", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/project-detail.js
+++ b/spec/dummy/src/model-bases/project-detail.js
@@ -124,7 +124,7 @@ export default class ProjectDetailBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project.js").default | undefined>}
    */
-  projectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("project")) }
+  projectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("project", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/project-translation.js
+++ b/spec/dummy/src/model-bases/project-translation.js
@@ -124,7 +124,7 @@ export default class ProjectTranslationBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project.js").default | undefined>}
    */
-  ProjectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("Project")) }
+  ProjectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("Project", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/project.js
+++ b/spec/dummy/src/model-bases/project.js
@@ -159,7 +159,7 @@ export default class ProjectBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/user.js").default | undefined>}
    */
-  creatingUserOrLoad() { return /** @type {Promise<import("../models/user.js").default | undefined>} */ (this.relationshipOrLoad("creatingUser")) }
+  creatingUserOrLoad() { return /** @type {Promise<import("../models/user.js").default | undefined>} */ (this.relationshipOrLoad("creatingUser", {preloadTranslations: true})) }
 
   /**
    * @abstract
@@ -245,7 +245,7 @@ export default class ProjectBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project-detail.js").default | undefined>}
    */
-  projectDetailOrLoad() { return /** @type {Promise<import("../models/project-detail.js").default | undefined>} */ (this.relationshipOrLoad("projectDetail")) }
+  projectDetailOrLoad() { return /** @type {Promise<import("../models/project-detail.js").default | undefined>} */ (this.relationshipOrLoad("projectDetail", {preloadTranslations: true})) }
 
   /**
    * @abstract
@@ -275,7 +275,7 @@ export default class ProjectBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project-detail.js").default | undefined>}
    */
-  activeProjectDetailOrLoad() { return /** @type {Promise<import("../models/project-detail.js").default | undefined>} */ (this.relationshipOrLoad("activeProjectDetail")) }
+  activeProjectDetailOrLoad() { return /** @type {Promise<import("../models/project-detail.js").default | undefined>} */ (this.relationshipOrLoad("activeProjectDetail", {preloadTranslations: true})) }
 
   /**
    * @abstract
@@ -333,7 +333,7 @@ export default class ProjectBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("velocious/build/src/database/record/index.js").default | undefined>}
    */
-  primaryInteractionOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("primaryInteraction")) }
+  primaryInteractionOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("primaryInteraction", {preloadTranslations: true})) }
 
   /**
    * @abstract
@@ -419,7 +419,7 @@ export default class ProjectBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../model-bases/project-translation.js").default | undefined>}
    */
-  currentTranslationOrLoad() { return /** @type {Promise<import("../model-bases/project-translation.js").default | undefined>} */ (this.relationshipOrLoad("currentTranslation")) }
+  currentTranslationOrLoad() { return /** @type {Promise<import("../model-bases/project-translation.js").default | undefined>} */ (this.relationshipOrLoad("currentTranslation", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/string-subject-interaction.js
+++ b/spec/dummy/src/model-bases/string-subject-interaction.js
@@ -124,7 +124,7 @@ export default class StringSubjectInteractionBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("velocious/build/src/database/record/index.js").default | undefined>}
    */
-  subjectOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("subject")) }
+  subjectOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("subject", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/task.js
+++ b/spec/dummy/src/model-bases/task.js
@@ -140,7 +140,7 @@ export default class TaskBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project.js").default | undefined>}
    */
-  projectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("project")) }
+  projectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("project", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/task.js
+++ b/spec/dummy/src/model-bases/task.js
@@ -198,7 +198,7 @@ export default class TaskBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("velocious/build/src/database/record/index.js").default | undefined>}
    */
-  primaryInteractionOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("primaryInteraction")) }
+  primaryInteractionOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("primaryInteraction", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/user.js
+++ b/spec/dummy/src/model-bases/user.js
@@ -124,7 +124,7 @@ export default class UserBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("../models/project.js").default | undefined>}
    */
-  createdProjectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("createdProject")) }
+  createdProjectOrLoad() { return /** @type {Promise<import("../models/project.js").default | undefined>} */ (this.relationshipOrLoad("createdProject", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/spec/dummy/src/model-bases/uuid-interaction.js
+++ b/spec/dummy/src/model-bases/uuid-interaction.js
@@ -124,7 +124,7 @@ export default class UuidInteractionBase extends DatabaseRecord {
   /**
    * @returns {Promise<import("velocious/build/src/database/record/index.js").default | undefined>}
    */
-  subjectOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("subject")) }
+  subjectOrLoad() { return /** @type {Promise<import("velocious/build/src/database/record/index.js").default | undefined>} */ (this.relationshipOrLoad("subject", {preloadTranslations: true})) }
 
   /**
    * @abstract

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -292,7 +292,7 @@
  */
 
 /**
- * @typedef {Omit<typeof import("./frontend-model-resource/base-resource.js").default, never> & {new (args: ConstructorParameters<typeof import("./frontend-model-resource/base-resource.js").default>[0]): import("./frontend-model-resource/base-resource.js").default<typeof import("./database/record/index.js").default>}} FrontendModelResourceClassType
+ * @typedef {Omit<typeof import("./frontend-model-resource/base-resource.js").default, never> & {new (args: import("./frontend-model-resource/base-resource.js").FrontendModelResourceAbilityArgs | import("./frontend-model-resource/base-resource.js").FrontendModelResourceControllerArgs): import("./frontend-model-resource/base-resource.js").default<typeof import("./database/record/index.js").default>}} FrontendModelResourceClassType
  */
 
 /**

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -305,10 +305,10 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       return await this.paginatedCount()
     }
 
-    // Generate count SQL
-    const primaryKey = `${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(this.getModelClass().primaryKey())}`
+    // Models without a single primary key (composite-key tables) count via COUNT(*), not COUNT(<table>.id).
+    const primaryKeyColumn = this.getModelClass().primaryKey()
     const distinctPrefix = this._distinct ? "DISTINCT " : ""
-    let sql = `COUNT(${distinctPrefix}${primaryKey})`
+    let sql = primaryKeyColumn ? `COUNT(${distinctPrefix}${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(primaryKeyColumn)})` : "COUNT(*)"
 
     if (this.driver.getType() == "pgsql") sql += "::int"
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -1677,8 +1677,9 @@ class VelociousDatabaseRecord {
 
     normalizedValue = this._normalizeBooleanValueForWrite({attributeName: name, columnType, value: normalizedValue})
 
+    this._clearBelongsToRelationshipForChangedForeignKey(columnName)
+
     if (this._attributes[columnName] != normalizedValue) {
-      this._clearBelongsToRelationshipForChangedForeignKey(columnName, normalizedValue)
       this._changes[columnName] = normalizedValue
     }
   }
@@ -1686,13 +1687,10 @@ class VelociousDatabaseRecord {
   /**
    * Clears loaded belongs-to caches when callers assign the foreign key directly.
    * @param {string} columnName - Changed database column name.
-   * @param {?} normalizedValue - New normalized column value.
    * @returns {void} - No return value.
    */
-  _clearBelongsToRelationshipForChangedForeignKey(columnName, normalizedValue) {
+  _clearBelongsToRelationshipForChangedForeignKey(columnName) {
     for (const relationship of this._belongsToRelationshipsForForeignKey(columnName)) {
-      if (this._belongsToRelationshipMatchesForeignKeyValue({normalizedValue, relationship})) continue
-
       this._clearLoadedBelongsToRelationship(relationship)
     }
   }
@@ -1720,24 +1718,10 @@ class VelociousDatabaseRecord {
   _belongsToRelationshipUsesForeignKey({columnName, relationship}) {
     if (relationship.getType() != "belongsTo") return false
 
-    return relationship.getForeignKey() == columnName
-  }
+    const foreignKey = relationship.getForeignKey()
+    const foreignKeyAttribute = this.getModelClass().getColumnNameToAttributeNameMap()[foreignKey]
 
-  /**
-   * Runs belongs to relationship matches foreign key value.
-   * @param {object} args - Relationship cache arguments.
-   * @param {?} args.normalizedValue - New normalized column value.
-   * @param {?} args.relationship - Relationship instance.
-   * @returns {boolean} - Whether the loaded related record still matches the changed foreign key.
-   */
-  _belongsToRelationshipMatchesForeignKeyValue({normalizedValue, relationship}) {
-    const loaded = relationship.getLoadedOrUndefined()
-
-    if (!loaded) return false
-    if (Array.isArray(loaded)) return false
-    if (!relationship.getTargetModelClass()) return false
-
-    return loaded.readColumn(relationship.getPrimaryKey()) == normalizedValue
+    return foreignKey == columnName || foreignKeyAttribute == columnName
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -999,20 +999,18 @@ class VelociousDatabaseRecord {
     let loaded = await relationship.autoloadOrLoad()
 
     if (options.preloadTranslations) {
-      loaded = await this._preloadLoadedRelationshipTranslations({loaded, relationship})
+      loaded = await this._preloadLoadedRelationshipTranslations(loaded)
     }
 
     return loaded
   }
 
   /**
-   * Preloads translations on a loaded relationship target when available.
-   * @param {object} args - Options.
-   * @param {?} args.loaded - Loaded relationship value.
-   * @param {import("./instance-relationships/base.js").default} args.relationship - Relationship instance.
+   * Preloads translations on a loaded relationship target when explicitly requested.
+   * @param {?} loaded - Loaded relationship value.
    * @returns {Promise<?>} - Relationship value after translation preload.
    */
-  async _preloadLoadedRelationshipTranslations({loaded, relationship}) {
+  async _preloadLoadedRelationshipTranslations(loaded) {
     if (!loaded || !loaded.isPersisted() || !await loaded.getModelClass().hasTranslationsTable()) return loaded
 
     const translationsRelationship = loaded.getRelationshipByName("translations")
@@ -1021,7 +1019,7 @@ class VelociousDatabaseRecord {
 
     await loaded.preload({translations: {}})
 
-    return relationship.loaded()
+    return loaded
   }
 
   /**
@@ -3903,7 +3901,14 @@ class VelociousDatabaseRecord {
     await this._applyInsertResult({data, insertResult, primaryKey, primaryKeyType})
     this.setIsNewRecord(false)
 
-    // Mark all relationships as preloaded, since we don't expect anything to have magically appeared since we created the record.
+    this._markLoadedRelationshipsPreloadedAfterCreate()
+  }
+
+  /**
+   * Marks only relationships with in-memory loaded values as preloaded after create.
+   * @returns {void} - No return value.
+   */
+  _markLoadedRelationshipsPreloadedAfterCreate() {
     for (const relationship of this.getModelClass().getRelationships()) {
       const instanceRelationship = this.getRelationshipByName(relationship.getRelationshipName())
 
@@ -3911,7 +3916,9 @@ class VelociousDatabaseRecord {
         instanceRelationship.setLoaded([])
       }
 
-      instanceRelationship.setPreloaded(true)
+      if (instanceRelationship.getLoadedOrUndefined() !== undefined) {
+        instanceRelationship.setPreloaded(true)
+      }
     }
   }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -621,7 +621,7 @@ class VelociousDatabaseRecord {
       }
 
       prototype[`${relationshipName}OrLoad`] = async function() {
-        return await this.relationshipOrLoad(relationshipName)
+        return await this.relationshipOrLoad(relationshipName, {preloadTranslations: true})
       }
 
       prototype[`set${inflection.camelize(relationshipName)}`] = function(/**
@@ -991,12 +991,37 @@ class VelociousDatabaseRecord {
   /**
    * Runs relationship or load.
    * @param {string} relationshipName - Relationship name.
+   * @param {{preloadTranslations?: boolean}} [options] - Load options.
    * @returns {Promise<?>} - Loaded relationship value.
    */
-  async relationshipOrLoad(relationshipName) {
+  async relationshipOrLoad(relationshipName, options = {}) {
     const relationship = this.getRelationshipByName(relationshipName)
+    let loaded = await relationship.autoloadOrLoad()
 
-    return await relationship.autoloadOrLoad()
+    if (options.preloadTranslations) {
+      loaded = await this._preloadLoadedRelationshipTranslations({loaded, relationship})
+    }
+
+    return loaded
+  }
+
+  /**
+   * Preloads translations on a loaded relationship target when available.
+   * @param {object} args - Options.
+   * @param {?} args.loaded - Loaded relationship value.
+   * @param {import("./instance-relationships/base.js").default} args.relationship - Relationship instance.
+   * @returns {Promise<?>} - Relationship value after translation preload.
+   */
+  async _preloadLoadedRelationshipTranslations({loaded, relationship}) {
+    if (!loaded || !loaded.isPersisted() || !await loaded.getModelClass().hasTranslationsTable()) return loaded
+
+    const translationsRelationship = loaded.getRelationshipByName("translations")
+
+    if (translationsRelationship.getPreloaded()) return loaded
+
+    await loaded.preload({translations: {}})
+
+    return relationship.loaded()
   }
 
   /**
@@ -1677,9 +1702,8 @@ class VelociousDatabaseRecord {
 
     normalizedValue = this._normalizeBooleanValueForWrite({attributeName: name, columnType, value: normalizedValue})
 
-    this._clearBelongsToRelationshipForChangedForeignKey(columnName)
-
     if (this._attributes[columnName] != normalizedValue) {
+      this._clearBelongsToRelationshipForChangedForeignKey(columnName, normalizedValue)
       this._changes[columnName] = normalizedValue
     }
   }
@@ -1687,10 +1711,13 @@ class VelociousDatabaseRecord {
   /**
    * Clears loaded belongs-to caches when callers assign the foreign key directly.
    * @param {string} columnName - Changed database column name.
+   * @param {?} normalizedValue - New normalized column value.
    * @returns {void} - No return value.
    */
-  _clearBelongsToRelationshipForChangedForeignKey(columnName) {
+  _clearBelongsToRelationshipForChangedForeignKey(columnName, normalizedValue) {
     for (const relationship of this._belongsToRelationshipsForForeignKey(columnName)) {
+      if (this._belongsToRelationshipMatchesForeignKeyValue({normalizedValue, relationship})) continue
+
       this._clearLoadedBelongsToRelationship(relationship)
     }
   }
@@ -1722,6 +1749,23 @@ class VelociousDatabaseRecord {
     const foreignKeyAttribute = this.getModelClass().getColumnNameToAttributeNameMap()[foreignKey]
 
     return foreignKey == columnName || foreignKeyAttribute == columnName
+  }
+
+  /**
+   * Runs belongs to relationship matches foreign key value.
+   * @param {object} args - Relationship cache arguments.
+   * @param {?} args.normalizedValue - New normalized column value.
+   * @param {?} args.relationship - Relationship instance.
+   * @returns {boolean} - Whether the loaded related record still matches the changed foreign key.
+   */
+  _belongsToRelationshipMatchesForeignKeyValue({normalizedValue, relationship}) {
+    const loaded = relationship.getLoadedOrUndefined()
+
+    if (!loaded) return false
+    if (Array.isArray(loaded)) return false
+    if (!relationship.getTargetModelClass()) return false
+
+    return loaded.readColumn(relationship.getPrimaryKey()) == normalizedValue
   }
 
   /**

--- a/src/database/record/instance-relationships/belongs-to.js
+++ b/src/database/record/instance-relationships/belongs-to.js
@@ -75,6 +75,9 @@ export default class VelociousDatabaseRecordBelongsToInstanceRelationship extend
     let query = TargetModelClass.where(whereArgs)
 
     query = this.applyScope(query)
+    if (Object.keys(TargetModelClass.getTranslationsMap()).length > 0) {
+      query = query.preload({translations: {}})
+    }
 
     const foreignModel = await query.first()
 

--- a/src/database/record/instance-relationships/belongs-to.js
+++ b/src/database/record/instance-relationships/belongs-to.js
@@ -51,19 +51,36 @@ export default class VelociousDatabaseRecordBelongsToInstanceRelationship extend
 
     if (batched) return this.loaded()
 
-    const foreignKey = this.getForeignKey()
-    const foreignModelID = this.getModel().readColumn(foreignKey)
-    const TargetModelClass = this.getTargetModelClass()
+    await this._loadForeignModelOrBlank()
+    this.setDirty(false)
+    this.setPreloaded(true)
 
-    if (!TargetModelClass) throw new Error("Can't load without a target model")
+    return this.loaded()
+  }
+
+  /**
+   * Loads the foreign model, or marks the relationship blank for empty keys.
+   * @returns {Promise<void>} - Resolves after the loaded value is assigned.
+   */
+  async _loadForeignModelOrBlank() {
+    const TargetModelClass = this._getTargetModelClassOrFail()
+    const foreignModelID = this._readForeignModelID()
+
     if (foreignModelID === null || foreignModelID === undefined || foreignModelID === "") {
       this.setLoaded(undefined)
-      this.setDirty(false)
-      this.setPreloaded(true)
-
-      return this.loaded()
+    } else {
+      this.setLoaded(await this._loadForeignModel({foreignModelID, TargetModelClass}))
     }
+  }
 
+  /**
+   * Loads the related model from the foreign key value.
+   * @param {object} args - Options.
+   * @param {string | number | null | undefined} args.foreignModelID - Foreign model ID.
+   * @param {TMC} args.TargetModelClass - Target model class.
+   * @returns {Promise<InstanceType<TMC> | undefined>} - Loaded foreign model.
+   */
+  async _loadForeignModel({foreignModelID, TargetModelClass}) {
     const primaryKey = TargetModelClass.primaryKey()
     /**
      * Where args.
@@ -72,23 +89,29 @@ export default class VelociousDatabaseRecordBelongsToInstanceRelationship extend
 
     whereArgs[primaryKey] = foreignModelID
 
-    let query = TargetModelClass.where(whereArgs)
+    const query = this.applyScope(TargetModelClass.where(whereArgs))
 
-    query = this.applyScope(query)
-    if (Object.keys(TargetModelClass.getTranslationsMap()).length > 0) {
-      query = query.preload({translations: {}})
-    }
-
-    const foreignModel = await query.first()
-
-    if (foreignModel) {
-      this.setLoaded(foreignModel)
-    } else {
-      this.setLoaded(undefined)
-    }
-    this.setDirty(false)
-    this.setPreloaded(true)
-
-    return this.loaded()
+    return /** Narrows the runtime value to the documented type. @type {Promise<InstanceType<TMC> | undefined>} */ (query.first())
   }
+
+  /**
+   * Gets the required target model class.
+   * @returns {TMC} - Target model class.
+   */
+  _getTargetModelClassOrFail() {
+    const TargetModelClass = this.getTargetModelClass()
+
+    if (!TargetModelClass) throw new Error("Can't load without a target model")
+
+    return TargetModelClass
+  }
+
+  /**
+   * Reads the current foreign key value from the parent record.
+   * @returns {string | number | null | undefined} - Foreign model ID.
+   */
+  _readForeignModelID() {
+    return this.getModel().readColumn(this.getForeignKey())
+  }
+
 }

--- a/src/database/record/instance-relationships/belongs-to.js
+++ b/src/database/record/instance-relationships/belongs-to.js
@@ -91,7 +91,9 @@ export default class VelociousDatabaseRecordBelongsToInstanceRelationship extend
 
     const query = this.applyScope(TargetModelClass.where(whereArgs))
 
-    return /** Narrows the runtime value to the documented type. @type {Promise<InstanceType<TMC> | undefined>} */ (query.first())
+    const foreignModel = await query.first()
+
+    return foreignModel || undefined
   }
 
   /**

--- a/src/environment-handlers/node/cli/commands/generate/base-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/base-models.js
@@ -291,7 +291,7 @@ export default class DbGenerateModel extends BaseCommand {
           fileContent += "  /**\n"
           fileContent += `   * @returns {Promise<import("${modelFilePath}").default | undefined>}\n`
           fileContent += "   */\n"
-          fileContent += `  ${relationship.getRelationshipName()}OrLoad() { return /** @type {Promise<import("${modelFilePath}").default | undefined>} */ (this.relationshipOrLoad("${relationship.getRelationshipName()}")) }\n`
+          fileContent += `  ${relationship.getRelationshipName()}OrLoad() { return /** @type {Promise<import("${modelFilePath}").default | undefined>} */ (this.relationshipOrLoad("${relationship.getRelationshipName()}", {preloadTranslations: true})) }\n`
 
           fileContent += "\n"
           fileContent += "  /**\n"

--- a/src/environment-handlers/node/cli/commands/generate/base-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/base-models.js
@@ -3,8 +3,10 @@ import fileExists from "../../../../../utils/file-exists.js"
 import fs from "fs/promises"
 import * as inflection from "inflection"
 
-/** Maps an effective column type to the JSDoc type used in generated base models.
- *  @type {Record<string, string>} */
+/**
+ * Maps an effective column type to the JSDoc type used in generated base models.
+ * @type {Record<string, string>}
+ */
 const jsDocTypeByColumnType = {
   bigint: "number",
   bit: "number",
@@ -34,6 +36,23 @@ const jsDocTypeByColumnType = {
 
 /** Effective column types whose generated setter additionally accepts a string. */
 const setterStringInputColumnTypes = new Set(["date", "datetime", "timestamp without time zone"])
+
+/**
+ * Generates a base-model relationship method.
+ * @param {{abstract?: boolean, body: string, name: string, param?: {name: string, type: string}, returns: string}} args - Method parts.
+ * @returns {string} - Generated method source.
+ */
+function generatedRelationshipMethod({abstract = false, body, name, param, returns}) {
+  let fileContent = "  /**\n"
+
+  if (abstract) fileContent += "   * @abstract\n"
+  if (param) fileContent += `   * @param {${param.type}} ${param.name}\n`
+  fileContent += `   * @returns {${returns}}\n`
+  fileContent += "   */\n"
+  fileContent += `  ${name}(${param ? param.name : ""}) { ${body} }\n`
+
+  return fileContent
+}
 
 export default class DbGenerateModel extends BaseCommand {
   async execute() {
@@ -323,17 +342,19 @@ export default class DbGenerateModel extends BaseCommand {
           fileContent += `  ${relationship.getRelationshipName()}Loaded() { return /** @type {Array<import("${recordImport}").default>} */ (this.getRelationshipByName("${relationship.getRelationshipName()}").loaded()) }\n`
 
           fileContent += "\n"
-          fileContent += "  /**\n"
-          fileContent += "   * @abstract\n"
-          fileContent += `   * @returns {Promise<Array<import("${recordImport}").default>>}\n`
-          fileContent += "   */\n"
-          fileContent += `  load${inflection.camelize(relationship.getRelationshipName())}() { throw new Error("Not implemented") }\n`
+          fileContent += generatedRelationshipMethod({
+            abstract: true,
+            body: "throw new Error(\"Not implemented\")",
+            name: `load${inflection.camelize(relationship.getRelationshipName())}`,
+            returns: `Promise<Array<import("${recordImport}").default>>`
+          })
 
           fileContent += "\n"
-          fileContent += "  /**\n"
-          fileContent += `   * @returns {Promise<Array<import("${recordImport}").default>>}\n`
-          fileContent += "   */\n"
-          fileContent += `  ${relationship.getRelationshipName()}OrLoad() { return /** @type {Promise<Array<import("${recordImport}").default>>} */ (this.relationshipOrLoad("${relationship.getRelationshipName()}")) }\n`
+          fileContent += generatedRelationshipMethod({
+            body: `return /** @type {Promise<Array<import("${recordImport}").default>>} */ (this.relationshipOrLoad("${relationship.getRelationshipName()}"))`,
+            name: `${relationship.getRelationshipName()}OrLoad`,
+            returns: `Promise<Array<import("${recordImport}").default>>`
+          })
 
           fileContent += "\n"
           fileContent += "  /**\n"

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -330,18 +330,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     const ModelClass = this.modelClass()
     const model = new ModelClass()
 
-    await ModelClass.transaction(async () => {
-      await this._assignWithVirtualSetters(model, filtered)
-      await model.save()
-
-      if (options.nestedAttributes) {
-        await this._applyNestedAttributes(model, options.nestedAttributes, options.controller || null, permit)
-      }
-    })
-
-    await this._preloadNestedWritableRelationships(model, permit)
-
-    return model
+    return await this._saveWithNestedAttributes({filtered, model, options, permit})
   }
 
   /**
@@ -363,9 +352,17 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   async update(model, attributes, options = {}) {
     const permit = parsePermittedParams(this.permittedParams({action: "update", ability: this.ability, locals: this.locals, params: attributes}))
     const filtered = filterWritableFrontendModelAttributes(model, attributes, this, permit.attributes)
-    const ModelClass = this.modelClass()
 
-    await ModelClass.transaction(async () => {
+    return await this._saveWithNestedAttributes({filtered, model, options, permit})
+  }
+
+  /**
+   * Saves a model and applies nested attributes in one transaction.
+   * @param {{filtered: Record<string, ?>, model: import("../database/record/index.js").default, options: {controller?: ?, nestedAttributes?: Record<string, ?> | null}, permit: {attributes: string[], nested: Record<string, ?>}}} args - Save arguments.
+   * @returns {Promise<import("../database/record/index.js").default>} - Saved model.
+   */
+  async _saveWithNestedAttributes({filtered, model, options, permit}) {
+    await this.modelClass().transaction(async () => {
       await this._assignWithVirtualSetters(model, filtered)
       await model.save()
 


### PR DESCRIPTION
## Summary
- clear belongs-to caches when direct foreign-key setters run, including frontend attribute aliases
- preload translations when belongs-to lazy loads translated target models
- keep concrete frontend-model resources assignable to registry typedefs

## Validation
- npm run test -- spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
- npm run test -- spec/cli/commands/generate/base-models-spec.js
- npm run lint