### PR TITLE
Use COUNT(*) for models without a single primary key

### DIFF
--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -305,10 +305,10 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
       return await this.paginatedCount()
     }
 
-    // Generate count SQL
-    const primaryKey = `${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(this.getModelClass().primaryKey())}`
+    // Models without a single primary key (composite-key tables) count via COUNT(*), not COUNT(<table>.id).
+    const primaryKeyColumn = this.getModelClass().primaryKey()
     const distinctPrefix = this._distinct ? "DISTINCT " : ""
-    let sql = `COUNT(${distinctPrefix}${primaryKey})`
+    let sql = primaryKeyColumn ? `COUNT(${distinctPrefix}${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(primaryKeyColumn)})` : "COUNT(*)"
 
     if (this.driver.getType() == "pgsql") sql += "::int"
 


### PR DESCRIPTION
`ModelClassQuery#count()` built `COUNT(<table>.<primaryKey()>)`. For composite-key models that declare `setPrimaryKey(null)`, `primaryKey()` is null and the SQL fell back to `COUNT(<table>.id)` — which throws **`Invalid column name 'id'`** on tables with no `id` column (legacy MSSQL link tables keyed on a composite of two FKs). Fix: fall back to `COUNT(*)` when there's no single primary key, matching `paginatedCount()`.

## Why
A ticket-app super-admin index over a composite-key article-artist link table (`Pyt18ArtikelKuenstler`, PK `(KuenstlerNr, ArtikelNr)`) crashed because its count ran `SELECT COUNT([ArtikelKuenstler].[id])`. Single-pk indexes were unaffected.

## Validation
build + typecheck + eslint clean; verified end-to-end against the ticket-app reproduction.

Note: `tensorbuzz/Lint` is red only from a pre-existing fallow dupes finding on master (`model-class-query.js` ↔ its browser-spec), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)