### PR TITLE
Fix has-many through target foreign key

### DIFF
--- a/spec/database/record/has-many-through.browser-spec.js
+++ b/spec/database/record/has-many-through.browser-spec.js
@@ -6,6 +6,8 @@ import Project from "../../dummy/src/models/project.js"
 import Task from "../../dummy/src/models/task.js"
 import Configuration from "../../../src/configuration.js"
 
+Project.hasMany("commentsThroughTasks", {className: "Comment", through: "tasks"})
+
 describe("database - record - hasMany through", {tags: ["dummy"]}, () => {
   it("loads comments through tasks", async () => {
     await Configuration.current().ensureConnections(async () => {
@@ -22,6 +24,21 @@ describe("database - record - hasMany through", {tags: ["dummy"]}, () => {
 
         expect(comments.length).toBe(2)
         expect(comments.map((comment) => comment.body())).toEqual(["first", "second"])
+    })
+  })
+
+  it("uses the target belongs-to foreign key for default through relationships", async () => {
+    await Configuration.current().ensureConnections(async () => {
+        const project = await Project.create({creatingUserReference: "creator-2"})
+        const task = await Task.create({projectId: project.id(), name: "Task C"})
+
+        await Comment.create({taskId: task.id(), body: "third"})
+        await project.getRelationshipByName("commentsThroughTasks").load()
+
+        const comments = project.getRelationshipByName("commentsThroughTasks").loaded()
+
+        expect(comments.length).toBe(1)
+        expect(comments[0].body()).toEqual("third")
     })
   })
 })

--- a/spec/database/record/has-many-through.browser-spec.js
+++ b/spec/database/record/has-many-through.browser-spec.js
@@ -5,8 +5,22 @@ import Comment from "../../dummy/src/models/comment.js"
 import Project from "../../dummy/src/models/project.js"
 import Task from "../../dummy/src/models/task.js"
 import Configuration from "../../../src/configuration.js"
+import {hasManyThroughTargetForeignKey} from "../../../src/database/query/preloader/has-many.js"
 
-Project.hasMany("commentsThroughTasks", {className: "Comment", through: "tasks"})
+describe("database - record - hasMany through - target foreign key resolution", {tags: ["dummy"]}, () => {
+  it("honors an explicit foreign key even when the target has another belongs-to to the through model", () => {
+    // Comment has two belongs-to to Task (task, doneTask); the explicit key must win over the first match.
+    const relationship = /** @type {any} */ ({getExplicitForeignKey: () => "done_task_id", getForeignKey: () => "task_id"})
+
+    expect(hasManyThroughTargetForeignKey(relationship, Task, Comment)).toEqual("done_task_id")
+  })
+
+  it("falls back to the target's belongs-to foreign key when no explicit key is given", () => {
+    const relationship = /** @type {any} */ ({getExplicitForeignKey: () => undefined, getForeignKey: () => "fallback_id"})
+
+    expect(hasManyThroughTargetForeignKey(relationship, Task, Comment)).toEqual("task_id")
+  })
+})
 
 describe("database - record - hasMany through", {tags: ["dummy"]}, () => {
   it("loads comments through tasks", async () => {

--- a/spec/database/record/preloader/has-many-through.browser-spec.js
+++ b/spec/database/record/preloader/has-many-through.browser-spec.js
@@ -2,6 +2,8 @@ import Comment from "../../../dummy/src/models/comment.js"
 import Project from "../../../dummy/src/models/project.js"
 import Task from "../../../dummy/src/models/task.js"
 
+Project.hasMany("commentsThroughTasks", {className: "Comment", through: "tasks"})
+
 describe("Record - preloader - has many through", {tags: ["dummy"]}, () => {
   it("preloads through-relationship models", async () => {
     const project = await Project.create({})
@@ -53,5 +55,18 @@ describe("Record - preloader - has many through", {tags: ["dummy"]}, () => {
     expect(p1Comments[0].body()).toEqual("comment for project 1")
     expect(p2Comments.length).toBe(1)
     expect(p2Comments[0].body()).toEqual("comment for project 2")
+  })
+
+  it("preloads through targets using the target belongs-to foreign key", async () => {
+    const project = await Project.create({})
+    const task = await Task.create({projectId: project.id(), name: "Task C"})
+
+    await Comment.create({taskId: task.id(), body: "third"})
+
+    const foundProject = /** @type {Project} */ (await Project.preload({commentsThroughTasks: true}).find(project.id()))
+    const comments = /** @type {Comment[]} */ (foundProject.getRelationshipByName("commentsThroughTasks").loaded())
+
+    expect(comments.length).toBe(1)
+    expect(comments[0].body()).toEqual("third")
   })
 })

--- a/spec/database/record/preloader/has-many-through.browser-spec.js
+++ b/spec/database/record/preloader/has-many-through.browser-spec.js
@@ -2,8 +2,6 @@ import Comment from "../../../dummy/src/models/comment.js"
 import Project from "../../../dummy/src/models/project.js"
 import Task from "../../../dummy/src/models/task.js"
 
-Project.hasMany("commentsThroughTasks", {className: "Comment", through: "tasks"})
-
 describe("Record - preloader - has many through", {tags: ["dummy"]}, () => {
   it("preloads through-relationship models", async () => {
     const project = await Project.create({})

--- a/spec/dummy/src/models/project.js
+++ b/spec/dummy/src/models/project.js
@@ -11,6 +11,7 @@ Project.hasOne("activeProjectDetail", function() { return this.where({isActive: 
 Project.hasMany("interactions", {className: "Interaction", foreignKey: "subject_id", polymorphic: true})
 Project.hasOne("primaryInteraction", {className: "Interaction", foreignKey: "subject_id", polymorphic: true})
 Project.hasMany("comments", {className: "Comment", through: "tasks", foreignKey: "task_id"})
+Project.hasMany("commentsThroughTasks", {className: "Comment", through: "tasks"})
 Project.translates("name")
 
 Project.beforeValidation((record) => {

--- a/src/database/query/preloader/has-many.js
+++ b/src/database/query/preloader/has-many.js
@@ -12,6 +12,13 @@ import restArgsError from "../../../utils/rest-args-error.js"
  * @returns {string} Target model foreign key column.
  */
 export function hasManyThroughTargetForeignKey(relationship, throughModelClass, targetModelClass) {
+  // An explicit foreign key on the has-many names the exact target column that references the
+  // through model — honor it. The target can have several belongs-to pointing at the through model
+  // (e.g. a default plus an alternate), so picking the first match would otherwise be ambiguous.
+  const explicitForeignKey = relationship.getExplicitForeignKey()
+
+  if (explicitForeignKey) return explicitForeignKey
+
   for (const targetRelationship of targetModelClass.getRelationships()) {
     if (targetRelationship.getType() != "belongsTo") continue
 

--- a/src/database/query/preloader/has-many.js
+++ b/src/database/query/preloader/has-many.js
@@ -4,6 +4,27 @@ import ensureModelClassInitialized from "./ensure-model-class-initialized.js"
 import PreloaderSelection from "./selection.js"
 import restArgsError from "../../../utils/rest-args-error.js"
 
+/**
+ * Resolves the target column that references the through model.
+ * @param {import("../../record/relationships/has-many.js").default} relationship - Has-many through relationship.
+ * @param {typeof import("../../record/index.js").default} throughModelClass - Model used by the through relationship.
+ * @param {typeof import("../../record/index.js").default} targetModelClass - Model loaded by the through relationship.
+ * @returns {string} Target model foreign key column.
+ */
+export function hasManyThroughTargetForeignKey(relationship, throughModelClass, targetModelClass) {
+  for (const targetRelationship of targetModelClass.getRelationships()) {
+    if (targetRelationship.getType() != "belongsTo") continue
+
+    const relationshipTargetModelClass = targetRelationship.getTargetModelClass()
+
+    if (relationshipTargetModelClass === throughModelClass) {
+      return targetRelationship.getForeignKey()
+    }
+  }
+
+  return relationship.getForeignKey()
+}
+
 export default class VelociousDatabaseQueryPreloaderHasMany {
   /**
    * Runs constructor.
@@ -90,7 +111,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
     if (!targetModelClass) throw new Error("No target model class could be gotten from relationship")
 
-    const targetForeignKey = this.relationship.getForeignKey()
+    const targetForeignKey = hasManyThroughTargetForeignKey(this.relationship, throughModelClass, targetModelClass)
     const {modelsToLoad, satisfiedTargets} = this._partition(targetModelClass, [targetForeignKey])
 
     if (modelsToLoad.length == 0) return satisfiedTargets

--- a/src/database/record/instance-relationships/has-many.js
+++ b/src/database/record/instance-relationships/has-many.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import BaseInstanceRelationship from "./base.js"
+import {hasManyThroughTargetForeignKey} from "../../query/preloader/has-many.js"
 
 /**
  * A generic query over some model type.
@@ -192,7 +193,11 @@ export default class VelociousDatabaseRecordHasManyInstanceRelationship extends 
 
       const throughForeignKey = throughRelationship.getForeignKey()
       const throughPrimaryKey = throughRelationship.getPrimaryKey()
-      const targetForeignKey = this.getForeignKey()
+      const targetForeignKey = hasManyThroughTargetForeignKey(
+        /** @type {import("../relationships/has-many.js").default} */ (this.getRelationship()),
+        throughModelClass,
+        TargetModelClass
+      )
       const targetTable = TargetModelClass.tableName()
       const throughTable = throughModelClass.tableName()
       const driver = TargetModelClass.connection()

--- a/src/database/record/relationships/base.js
+++ b/src/database/record/relationships/base.js
@@ -46,6 +46,7 @@ export default class VelociousDatabaseRecordBaseRelationship {
     this._counterCache = counterCache || false
     this._dependent = dependent
     this.foreignKey = foreignKey
+    this._explicitForeignKey = foreignKey
     this._inverseOf = inverseOf
     this.klass = klass
     this.modelClass = modelClass
@@ -76,6 +77,14 @@ export default class VelociousDatabaseRecordBaseRelationship {
    * @returns {string | undefined} What will be done when the parent record is destroyed. E.g. "destroy", "nullify", "restrict" etc.
    */
   getDependent() { return this._dependent }
+
+  /**
+   * The foreign key explicitly passed when the relationship was declared, if any. Unlike
+   * `getForeignKey()` this never falls back to a computed default, so callers can tell whether the
+   * developer named a specific column (e.g. to disambiguate multiple belongs-to on a through target).
+   * @returns {string | undefined} - The explicitly declared foreign key, or undefined.
+   */
+  getExplicitForeignKey() { return this._explicitForeignKey }
 
   /**
    * Runs get foreign key.


### PR DESCRIPTION
## Summary
- resolve has-many through target foreign keys from the target belongs-to relationship when available
- cover lazy loads and query preloads for default through relationships

## Validation
- npm run test -- spec/database/record/has-many-through.browser-spec.js
- npm run test -- spec/database/record/preloader/has-many-through.browser-spec.js
- npm run lint