### PR TITLE
Count via the subquery form for composite array primary keys

### DIFF
--- a/spec/database/query/model-class-query.browser-spec.js
+++ b/spec/database/query/model-class-query.browser-spec.js
@@ -1,6 +1,7 @@
 import Comment from "../../dummy/src/models/comment.js"
 import Project from "../../dummy/src/models/project.js"
 import ProjectDetail from "../../dummy/src/models/project-detail.js"
+import Record from "../../../src/database/record/index.js"
 import Task from "../../dummy/src/models/task.js"
 import UuidInteraction from "../../dummy/src/models/uuid-interaction.js"
 import UuidItem from "../../dummy/src/models/uuid-item.js"
@@ -85,6 +86,23 @@ describe("Database - query - model class query", {databaseCleaning: {transaction
     expect(limitedCount).toEqual(2)
     expect(offsetCount).toEqual(1)
     expect(pageCount).toEqual(1)
+  })
+
+  it("counts records on a model with a composite array primary key", async () => {
+    class CompositePkTask extends Record {}
+
+    CompositePkTask.setTableName("tasks")
+    CompositePkTask.setPrimaryKey(["name", "project_id"])
+
+    const project = await Project.create({nameEn: "Composite count", nameDe: "Zusammengesetzte Anzahl"})
+    await Task.create({name: "Composite count task 1", project})
+    await Task.create({name: "Composite count task 2", project})
+
+    // An array primary key cannot be quoted as a single COUNT(column), so count() must use the
+    // subquery form instead of generating COUNT(`tasks`.`name,project_id`).
+    const count = await CompositePkTask.count()
+
+    expect(count).toEqual(2)
   })
 
   it("orders records with a structured column descriptor", async () => {

--- a/spec/database/query/model-class-query.browser-spec.js
+++ b/spec/database/query/model-class-query.browser-spec.js
@@ -105,6 +105,54 @@ describe("Database - query - model class query", {databaseCleaning: {transaction
     expect(count).toEqual(2)
   })
 
+  it("sums grouped counts on a model with a composite array primary key", async () => {
+    class CompositePkTask extends Record {}
+
+    CompositePkTask.setTableName("tasks")
+    CompositePkTask.setPrimaryKey(["name", "project_id"])
+
+    const project1 = await Project.create({nameEn: "Composite group 1", nameDe: "Zusammengesetzte Gruppe 1"})
+    const project2 = await Project.create({nameEn: "Composite group 2", nameDe: "Zusammengesetzte Gruppe 2"})
+
+    await Task.create({name: "Composite group task 1", project: project1})
+    await Task.create({name: "Composite group task 2", project: project1})
+    await Task.create({name: "Composite group task 3", project: project2})
+    await Task.create({name: "Composite group task 4", project: project2})
+
+    // Starting a query chain with group() doesn't lazy-initialize the model like count() does.
+    await CompositePkTask.count()
+
+    // A grouped count must sum each group's row count (matching the single-primary-key behavior),
+    // not count one subquery row per group.
+    const count = await CompositePkTask.group("tasks.project_id").count()
+
+    expect(count).toEqual(4)
+  })
+
+  it("rejects grouped distinct counts on a model with a composite array primary key", async () => {
+    class CompositePkTask extends Record {}
+
+    CompositePkTask.setTableName("tasks")
+    CompositePkTask.setPrimaryKey(["name", "project_id"])
+
+    const project = await Project.create({nameEn: "Composite distinct group", nameDe: "Zusammengesetzte eindeutige Gruppe"})
+
+    await Task.create({name: "Composite distinct group task", project})
+
+    // Starting a query chain with group() doesn't lazy-initialize the model like count() does.
+    await CompositePkTask.count()
+
+    let countError
+
+    try {
+      await CompositePkTask.group("tasks.project_id").distinct().count()
+    } catch (error) {
+      countError = error
+    }
+
+    expect(countError?.message).toContain("Can't count a grouped distinct query on CompositePkTask")
+  })
+
   it("orders records with a structured column descriptor", async () => {
     const project = await Project.create({nameEn: "Structured order", nameDe: "Strukturierte Reihenfolge"})
     await Task.create({name: "Bravo structured order", project})

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -301,18 +301,30 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
    * @returns {Promise<number>} - Resolves with the count.
    */
   async count() {
-    // Pagination, or a model with no single primary-key column — setPrimaryKey(null) or a composite
-    // setPrimaryKey([...]) on legacy tables — counts via the subquery form. It references no
-    // primary-key column and preserves DISTINCT over joins — which a bare COUNT(*) would not (it
-    // would count joined duplicate rows instead of distinct root rows). primaryKey() falls back to
-    // "id" for the no-pk case, so hasPrimaryKey() is used to detect it, and an array primary key
-    // cannot be quoted as a single COUNT(column).
-    if (this._limit !== null || this._offset !== null || !this.getModelClass().hasPrimaryKey() || Array.isArray(this.getModelClass().primaryKey())) {
+    // A model without a single primary-key column — setPrimaryKey(null) or a composite
+    // setPrimaryKey([...]) on legacy tables — has no column COUNT can reference (an array primary key
+    // cannot be quoted as a single COUNT(column), and primaryKey() falls back to "id" for the no-pk
+    // case, so hasPrimaryKey() detects that one).
+    const hasSingleColumnPrimaryKey = this.getModelClass().hasPrimaryKey() && !Array.isArray(this.getModelClass().primaryKey())
+
+    // Pagination, or an ungrouped query on a model with no single primary-key column, counts via the
+    // subquery form. It references no primary-key column and preserves DISTINCT over joins — which a
+    // bare COUNT(*) would not (it would count joined duplicate rows instead of distinct root rows).
+    // A grouped query stays on the per-group flow below, because the subquery form would count one
+    // row per group instead of summing each group's row count.
+    if (this._limit !== null || this._offset !== null || (!hasSingleColumnPrimaryKey && this._groups.length == 0)) {
       return await this.paginatedCount()
     }
 
+    if (!hasSingleColumnPrimaryKey && this._distinct) {
+      throw new Error(`Can't count a grouped distinct query on ${this.getModelClass().name} because it has no single primary-key column to count distinct values of`)
+    }
+
     const distinctPrefix = this._distinct ? "DISTINCT " : ""
-    let sql = `COUNT(${distinctPrefix}${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(this.getModelClass().primaryKey())})`
+    const countExpression = hasSingleColumnPrimaryKey
+      ? `${this.driver.quoteTable(this.getModelClass().tableName())}.${this.driver.quoteColumn(this.getModelClass().primaryKey())}`
+      : "*"
+    let sql = `COUNT(${distinctPrefix}${countExpression})`
 
     if (this.driver.getType() == "pgsql") sql += "::int"
 

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -301,12 +301,13 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
    * @returns {Promise<number>} - Resolves with the count.
    */
   async count() {
-    // Pagination, or a model with no single primary key (setPrimaryKey(null), e.g. composite-key
-    // legacy tables with no id column), count via the subquery form. It references no primary-key
-    // column and preserves DISTINCT over joins — which a bare COUNT(*) would not (it would count
-    // joined duplicate rows instead of distinct root rows). primaryKey() falls back to "id" for the
-    // no-pk case, so hasPrimaryKey() is used to detect it.
-    if (this._limit !== null || this._offset !== null || !this.getModelClass().hasPrimaryKey()) {
+    // Pagination, or a model with no single primary-key column — setPrimaryKey(null) or a composite
+    // setPrimaryKey([...]) on legacy tables — counts via the subquery form. It references no
+    // primary-key column and preserves DISTINCT over joins — which a bare COUNT(*) would not (it
+    // would count joined duplicate rows instead of distinct root rows). primaryKey() falls back to
+    // "id" for the no-pk case, so hasPrimaryKey() is used to detect it, and an array primary key
+    // cannot be quoted as a single COUNT(column).
+    if (this._limit !== null || this._offset !== null || !this.getModelClass().hasPrimaryKey() || Array.isArray(this.getModelClass().primaryKey())) {
       return await this.paginatedCount()
     }
 


### PR DESCRIPTION
## Summary

`count()` only routed `setPrimaryKey(null)` models through `paginatedCount()`. A composite `setPrimaryKey([...])` (e.g. ticket-app's `Pyt18Artikelportalvariante` with `["ArtikelNr", "PortalNr", "VerkaufssystemNr", "Preiskategorie", "Rabattstufe"]`) passed the `hasPrimaryKey()` check and generated:

```sql
SELECT COUNT([ArtikelPortalVarianten].[ArtikelNr,PortalNr,VerkaufssystemNr,Preiskategorie,Rabattstufe]) AS count ...
```

quoting the array as a single column → `Invalid column name`. This failed ticket-app PR #1266's Admin app check when the admin frontend counts that model.

## Fix

Route array primary keys through the subquery `paginatedCount()` form too — same as the no-pk case, since an array primary key cannot be referenced as a single `COUNT(column)`.

## Validation

- New spec `counts records on a model with a composite array primary key` fails without the fix (`no such column: name,project_id`) and passes with it.
- `node scripts/run-tests.js spec/database/query/model-class-query.browser-spec.js` — 33/33 green (sqlite).
- `npm run typecheck` + `npm run eslint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)