### PR TITLE
Cross-realm Date SQL serialization + lint:relationships command

### DIFF
--- a/spec/cli/commands/lint/relationships-spec.js
+++ b/spec/cli/commands/lint/relationships-spec.js
@@ -1,0 +1,90 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../src/testing/test.js"
+import Cli from "../../../../src/cli/index.js"
+import Configuration from "../../../../src/configuration.js"
+import DatabaseRecord from "../../../../src/database/record/index.js"
+import dummyDirectory from "../../../dummy/dummy-directory.js"
+import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import path from "node:path"
+
+class LintProject extends DatabaseRecord {}
+class LintTask extends DatabaseRecord {}
+
+LintTask.belongsTo("project", {className: "LintProject"})
+LintProject.hasMany("lintTasks", {className: "LintTask"})
+
+class LintEvent extends DatabaseRecord {}
+class LintOrphanSetting extends DatabaseRecord {}
+
+LintOrphanSetting.belongsTo("lintEvent", {className: "LintEvent"})
+
+/**
+ * @param {Array<typeof DatabaseRecord>} modelClasses - Model classes to register.
+ * @returns {Configuration} - Configuration instance.
+ */
+function buildConfiguration(modelClasses) {
+  return new Configuration({
+    database: {test: {}},
+    directory: dummyDirectory(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async ({configuration}) => {
+      for (const modelClass of modelClasses) {
+        configuration.registerModelClass(modelClass)
+      }
+    },
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+}
+
+/**
+ * @param {Configuration} configuration - Configuration instance.
+ * @param {string[]} processArgs - CLI arguments.
+ * @returns {Promise<?>} - Resolves with the CLI result.
+ */
+async function runLint(configuration, processArgs = ["lint:relationships"]) {
+  const cli = new Cli({
+    configuration,
+    directory: dummyDirectory(),
+    environmentHandler: configuration.getEnvironmentHandler(),
+    processArgs,
+    testing: true
+  })
+
+  return await cli.execute()
+}
+
+describe("Cli - lint - relationships", () => {
+  it("passes when every belongs-to relationship has an inverse on the target model", async () => {
+    await runLint(buildConfiguration([LintProject, LintTask]))
+  })
+
+  it("fails when a belongs-to relationship has no inverse on the target model", async () => {
+    let lintError
+
+    try {
+      await runLint(buildConfiguration([LintEvent, LintOrphanSetting]))
+    } catch (error) {
+      lintError = error
+    }
+
+    expect(lintError?.message).toContain("Relationship lint failed with 1 offence(s)")
+    expect(lintError?.message).toContain("LintEvent is missing an inverse hasMany/hasOne relationship for LintOrphanSetting#lintEvent")
+  })
+
+  it("ignores relationships listed in the config file", async () => {
+    const configPath = path.join(dummyDirectory(), "tmp-relationship-lint.json")
+
+    await fs.writeFile(configPath, JSON.stringify({ignore: ["LintOrphanSetting#lintEvent"]}))
+
+    try {
+      await runLint(buildConfiguration([LintEvent, LintOrphanSetting]), ["lint:relationships", "--config", configPath])
+    } finally {
+      await fs.rm(configPath, {force: true})
+    }
+  })
+})

--- a/spec/database/record/cross-realm-date-spec.js
+++ b/spec/database/record/cross-realm-date-spec.js
@@ -1,0 +1,19 @@
+import {describe, expect, it} from "../../../src/testing/test.js"
+import Task from "../../dummy/src/models/task.js"
+import vm from "node:vm"
+
+describe("Record - cross-realm dates", {tags: ["dummy"]}, () => {
+  it("serializes a date created in another realm into SQL values", async () => {
+    // A Date from another realm (e.g. the velocious console REPL) fails `instanceof Date` and used
+    // to bypass date conversion, serializing as an empty SQL value.
+    const crossRealmDate = vm.runInNewContext("new Date('2026-01-02T03:04:05.000Z')")
+
+    expect(crossRealmDate instanceof Date).toEqual(false)
+
+    await Task.count() // trigger initialization
+
+    const sql = Task.where({createdAt: crossRealmDate}).toSql()
+
+    expect(sql).toContain("2026-01-02")
+  })
+})

--- a/spec/utils/is-date-spec.js
+++ b/spec/utils/is-date-spec.js
@@ -1,0 +1,24 @@
+import {describe, expect, it} from "../../src/testing/test.js"
+import isDate from "../../src/utils/is-date.js"
+import vm from "node:vm"
+
+describe("isDate", () => {
+  it("recognizes same-realm dates", () => {
+    expect(isDate(new Date())).toEqual(true)
+  })
+
+  it("recognizes dates created in another realm", () => {
+    const crossRealmDate = vm.runInNewContext("new Date('2026-01-02T03:04:05.000Z')")
+
+    expect(crossRealmDate instanceof Date).toEqual(false)
+    expect(isDate(crossRealmDate)).toEqual(true)
+  })
+
+  it("rejects non-dates", () => {
+    expect(isDate("2026-01-02T03:04:05.000Z")).toEqual(false)
+    expect(isDate(1234567890)).toEqual(false)
+    expect(isDate({})).toEqual(false)
+    expect(isDate(null)).toEqual(false)
+    expect(isDate(undefined)).toEqual(false)
+  })
+})

--- a/src/cli/commands/lint/relationships.js
+++ b/src/cli/commands/lint/relationships.js
@@ -1,0 +1,12 @@
+import BaseCommand from "../../base-command.js"
+
+/** Lints model relationships (e.g. belongs-to relationships missing an inverse on the target model). */
+export default class VelociousCliCommandsLintRelationships extends BaseCommand {
+  /**
+   * Runs execute.
+   * @returns {Promise<?>} - Resolves with the command result.
+   */
+  async execute() {
+    return await this.getConfiguration().getEnvironmentHandler().cliCommandsLintRelationships(this)
+  }
+}

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -103,6 +103,7 @@
 
 import BacktraceCleaner from "../../utils/backtrace-cleaner.js"
 import { getDatabaseAnnotations } from "../annotations.js"
+import isDate from "../../utils/is-date.js"
 import Logger from "../../logger.js"
 import Query from "../query/index.js"
 import Handler from "../handler.js"
@@ -644,7 +645,9 @@ export default class VelociousDatabaseDriversBase {
       return value ? 1 : 0
     }
 
-    if (value instanceof Date) {
+    // isDate instead of instanceof: a Date created in another realm (e.g. the console REPL) would
+    // fail instanceof, skip this conversion, and serialize as an empty SQL value downstream.
+    if (isDate(value)) {
       return strftime("%F %T.%L", value)
     }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -31,6 +31,7 @@ import HasOneRelationship from "./relationships/has-one.js"
 import RecordAttachmentHandle from "./attachments/handle.js"
 import * as inflection from "inflection"
 import deburrColumnName from "../../utils/deburr-column-name.js"
+import isDate from "../../utils/is-date.js"
 import ModelClassQuery from "../query/model-class-query.js"
 import Preloader from "../query/preloader.js"
 import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQueryData, setPayloadAssociationCount, setPayloadComputedAbility, setPayloadQueryData} from "../../record-payload-values.js"
@@ -2234,7 +2235,7 @@ class VelociousDatabaseRecord {
       normalizedValue = this._normalizeDateStringForInsert(normalizedValue)
     }
 
-    if (normalizedValue instanceof Date) {
+    if (isDate(normalizedValue)) {
       const configuration = this._getConfiguration()
       const offsetMinutes = configuration.getEnvironmentHandler().getTimezoneOffsetMinutes(configuration)
       const offsetMs = offsetMinutes * 60 * 1000
@@ -3904,7 +3905,7 @@ class VelociousDatabaseRecord {
     const offsetMinutes = configuration.getEnvironmentHandler().getTimezoneOffsetMinutes(configuration)
     const offsetMs = offsetMinutes * 60 * 1000
 
-    if (value instanceof Date) {
+    if (isDate(value)) {
       return new Date(value.getTime() + offsetMs)
     }
 
@@ -4063,7 +4064,7 @@ class VelociousDatabaseRecord {
 
       const value = data[columnName]
 
-      if (!(value instanceof Date)) continue
+      if (!isDate(value)) continue
 
       data[columnName] = new Date(value.getTime() - offsetMs)
     }

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -244,6 +244,16 @@ export default class VelociousEnvironmentHandlerBase {
   }
 
   /**
+   * Runs cli commands lint relationships.
+   * @abstract
+   * @param {import("../cli/base-command.js").default} _command - Command.
+   * @returns {Promise<?>} - Resolves with the command result.
+   */
+  async cliCommandsLintRelationships(_command) {
+    throw new Error("cliCommandsLintRelationships not implemented")
+  }
+
+  /**
    * Runs cli commands routes.
    * @abstract
    * @param {import("../cli/base-command.js").default} _command - Command.

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -8,6 +8,7 @@ import CliCommandsGenerateBaseModels from "./node/cli/commands/generate/base-mod
 import CliCommandsGenerateFrontendModels from "./node/cli/commands/generate/frontend-models.js"
 import CliCommandsGenerateMigration from "./node/cli/commands/generate/migration.js"
 import CliCommandsGenerateModel from "./node/cli/commands/generate/model.js"
+import CliCommandsLintRelationships from "./node/cli/commands/lint/relationships.js"
 import CliCommandsRoutes from "./node/cli/commands/routes.js"
 import CliCommandsServer from "./node/cli/commands/server.js"
 import CliCommandsTest from "./node/cli/commands/test.js"
@@ -507,6 +508,15 @@ export default class VelociousEnvironmentHandlerNode extends Base{
    */
   async cliCommandsGenerateModel(command) {
     return await this.forwardCommand(command, CliCommandsGenerateModel)
+  }
+
+  /**
+   * Runs cli commands lint relationships.
+   * @param {import("../cli/base-command.js").default} command - Command.
+   * @returns {Promise<?>} - Resolves with the command result.
+   */
+  async cliCommandsLintRelationships(command) {
+    return await this.forwardCommand(command, CliCommandsLintRelationships)
   }
 
   /**

--- a/src/environment-handlers/node/cli/commands/lint/relationships.js
+++ b/src/environment-handlers/node/cli/commands/lint/relationships.js
@@ -1,0 +1,144 @@
+// @ts-check
+
+import BaseCommand from "../../../../../cli/base-command.js"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+/**
+ * Lints model relationships: every non-polymorphic belongs-to relationship should have an inverse
+ * has-many or has-one relationship declared on its target model class. A missing inverse usually
+ * means the target model was never told about the association (e.g. an Event model missing
+ * `hasMany("priceCategorySettings")` while PriceCategorySetting declares `belongsTo("event")`).
+ *
+ * Specific relationships can be ignored through a JSON config file (default:
+ * `relationship-lint.json` in the project directory, overridable with `--config <path>`):
+ *
+ *   {"ignore": ["PriceCategorySetting#event"]}
+ *
+ * where each entry is `<model class name>#<belongs-to relationship name>`.
+ */
+export default class VelociousCliCommandsLintRelationships extends BaseCommand {
+  /**
+   * Runs execute.
+   * @returns {Promise<{offences: Array<{ignoreKey: string, message: string}>}>} - Resolves with the found offences (empty when the lint passes).
+   */
+  async execute() {
+    // Relationship target resolution (getTargetModelClass) looks model classes up through the
+    // current configuration, so make this command's configuration the current one.
+    this.getConfiguration().setCurrent()
+
+    await this.getConfiguration().initializeModels()
+
+    const ignoredRelationships = await this._loadIgnoredRelationships()
+    const offences = []
+    const modelClasses = Object.values(this.getConfiguration().getModelClasses())
+
+    for (const modelClass of modelClasses) {
+      for (const relationship of modelClass.getRelationships()) {
+        if (relationship.getType() != "belongsTo") continue
+        if (relationship.getPolymorphic()) continue
+
+        const ignoreKey = `${modelClass.name}#${relationship.getRelationshipName()}`
+
+        if (ignoredRelationships.has(ignoreKey)) continue
+
+        let targetModelClass
+
+        try {
+          targetModelClass = relationship.getTargetModelClass()
+        } catch (error) {
+          offences.push({
+            ignoreKey,
+            message: `${ignoreKey}: couldn't resolve the target model class: ${error instanceof Error ? error.message : error}`
+          })
+
+          continue
+        }
+
+        if (!targetModelClass) {
+          offences.push({ignoreKey, message: `${ignoreKey}: couldn't resolve the target model class`})
+
+          continue
+        }
+
+        const inverseRelationship = targetModelClass.getRelationships().find((candidate) => {
+          if (candidate.getType() != "hasMany" && candidate.getType() != "hasOne") return false
+          if (candidate.through) return false
+
+          try {
+            return candidate.getTargetModelClass() === modelClass
+          } catch {
+            // A has-many/has-one with an unresolvable target can't be the inverse of this belongs-to.
+            // It is reported separately when its own model's belongs-to relationships are linted.
+            return false
+          }
+        })
+
+        if (inverseRelationship) continue
+
+        offences.push({
+          ignoreKey,
+          message: `${targetModelClass.name} is missing an inverse hasMany/hasOne relationship for ${ignoreKey} (belongsTo). ` +
+            `Declare the inverse on ${targetModelClass.name} or add "${ignoreKey}" to the ignore config.`
+        })
+      }
+    }
+
+    for (const offence of offences) {
+      console.error(offence.message)
+    }
+
+    if (offences.length > 0) {
+      throw new Error(`Relationship lint failed with ${offences.length} offence(s):\n${offences.map((offence) => offence.message).join("\n")}`)
+    }
+
+    console.log(`Relationship lint passed for ${modelClasses.length} model(s).`)
+
+    return {offences}
+  }
+
+  /**
+   * Loads the ignored relationship keys from the lint config file. The file is optional; when the
+   * default path doesn't exist, no relationships are ignored. An explicitly passed `--config` path
+   * must exist.
+   * @returns {Promise<Set<string>>} - Ignored `<model>#<relationship>` keys.
+   */
+  async _loadIgnoredRelationships() {
+    const configArgIndex = this.processArgs?.indexOf("--config") ?? -1
+    const explicitConfigPath = configArgIndex >= 0 ? this.processArgs?.[configArgIndex + 1] : undefined
+
+    if (configArgIndex >= 0 && !explicitConfigPath) {
+      throw new Error("--config was given without a path argument")
+    }
+
+    const configPath = explicitConfigPath
+      ? path.resolve(this.directory(), explicitConfigPath)
+      : path.join(this.directory(), "relationship-lint.json")
+
+    let configContent
+
+    try {
+      configContent = await fs.readFile(configPath, "utf8")
+    } catch (error) {
+      if (!explicitConfigPath && /** @type {NodeJS.ErrnoException} */ (error).code == "ENOENT") {
+        return new Set()
+      }
+
+      throw error
+    }
+
+    const config = JSON.parse(configContent)
+
+    if (config === null || typeof config != "object" || Array.isArray(config)) {
+      throw new Error(`Relationship lint config must be a JSON object: ${configPath}`)
+    }
+
+    const ignore = config.ignore ?? []
+
+    if (!Array.isArray(ignore) || ignore.some((entry) => typeof entry != "string")) {
+      throw new Error(`Relationship lint config "ignore" must be an array of "<model>#<relationship>" strings: ${configPath}`)
+    }
+
+    return new Set(ignore)
+  }
+}

--- a/src/utils/is-date.js
+++ b/src/utils/is-date.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+/**
+ * Whether the value is a Date, including Dates created in another JS realm (e.g. the velocious
+ * console REPL context or a node:vm context), where `instanceof Date` is false because the other
+ * realm has its own Date constructor. Without this, such a Date bypasses date normalization and SQL
+ * value conversion and ends up as an empty value in the generated SQL.
+ * @param {?} value - Value to test.
+ * @returns {value is Date} - Whether the value is a Date from any realm.
+ */
+export default function isDate(value) {
+  return value instanceof Date || Object.prototype.toString.call(value) === "[object Date]"
+}


### PR DESCRIPTION
## Summary

Two changes:

### 1. Serialize Dates from other JS realms correctly in SQL values

A `Date` created in another JS realm — e.g. the **velocious console** (the REPL runs in its own context) or a `node:vm` context — fails `instanceof Date`, so it bypassed date normalization and the driver's `_convertValue`. On mysql/MariaDB the value then serialized as an **empty SQL value** (SqlString escapes an object with no own keys to nothing), producing a parse error like:

```
INSERT INTO `price_category_settings` (..., `valid_from_at`, `valid_to_at`, ...) VALUES (..., , , ...)
ER_PARSE_ERROR: You have an error in your SQL syntax
```

On sqlite it stringified as the verbose `toString` form. Hit in production while creating records with Date attributes from the console.

**Fix:** new `src/utils/is-date.js` — cross-realm-safe Date check (`instanceof` || `Object.prototype.toString` tag; browser-safe, no `node:util`), used in the database read/write paths: `drivers/base.js` `_convertValue`, `record/index.js` `_normalizeDateValueForInsert`/`_normalizeDateValueForRead`, and the timezone-offset loop.

### 2. New `lint:relationships` command

`npx velocious lint:relationships` checks that every non-polymorphic `belongsTo` has an inverse `hasMany`/`hasOne` declared on its target model. A missing inverse usually means the target model was never told about the association — e.g. ticket-app's scanner Event model missing `hasMany("priceCategorySettings")` while `PriceCategorySetting` declares `belongsTo("event")`, which this command catches:

```
Event is missing an inverse hasMany/hasOne relationship for PriceCategorySetting#event (belongsTo).
Declare the inverse on Event or add "PriceCategorySetting#event" to the ignore config.
```

It initializes the app's models, reports every missing inverse, and exits non-zero, so it can be included in a project's linter/checker setup. Relationships can be ignored through a JSON config — default `relationship-lint.json` in the project directory, overridable with `--config <path>`:

```json
{"ignore": ["PriceCategorySetting#event"]}
```

## Validation

- `spec/utils/is-date-spec.js` + `spec/database/record/cross-realm-date-spec.js` — the cross-realm spec fails without the fix and passes with it; `spec/database` 397/397 green.
- `spec/cli/commands/lint/relationships-spec.js` — passing graph, missing-inverse failure (message content asserted), and ignore-config cases.
- Ran `lint:relationships` against all five ticket-app projects: it found the real scanner-app missing relationship plus 2 in ticket-app's local models; stagemap-app/admin-app pass clean.
- `npm run typecheck` + `npm run eslint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
