### PR TITLE
Fix relationship helper declaration type

### DIFF
--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2512,7 +2512,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Resolves a relationship foreign-key column to this model's public attribute name.
-   * @param {import("./instance-relationships/base.js").default<?, ?>} instanceRelationship - Relationship instance.
+   * @param {import("./instance-relationships/base.js").default<typeof VelociousDatabaseRecord, typeof VelociousDatabaseRecord>} instanceRelationship - Relationship instance.
    * @returns {string} Attribute name accepted by setAttribute/assign.
    */
   _relationshipForeignKeyAttribute(instanceRelationship) {


### PR DESCRIPTION
## Summary
- tighten the private relationship FK helper JSDoc so generated declaration files do not emit invalid unknown generics

## Validation
- npm run test -- spec/database/record/instance-relationships/belongs-to-relationship.browser-spec.js
- npm run lint && npm run typecheck

Note: unrelated local changes in spec/dummy/src/config/configuration.js and spec/dummy/src/frontend-models/user.js were left uncommitted.