### PR TITLE
Fix lifecycle typings and bound async DB pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,7 +1453,7 @@ database: {
 }
 ```
 
-`pool.max` caps live async-tracked connections for that pool. When the cap is reached, new checkouts wait until a matching checked-in connection can be handed over or capacity is freed. The built-in debug endpoint reports each in-use connection's `checkedOutForMs`, each idle connection's `idleForMs`, and queued `pendingCheckouts[].waitingForMs` so production diagnostics can distinguish long-held checkouts from pool-capacity waits.
+`pool.max` caps live async-tracked connections for that pool and defaults to `10` when omitted. When the cap is reached, new checkouts wait until a matching checked-in connection can be handed over or capacity is freed. Set `pool.max` to `null` only when a process is deliberately allowed to open an unbounded number of database connections. The built-in debug endpoint reports each in-use connection's `checkedOutForMs`, each idle connection's `idleForMs`, and queued `pendingCheckouts[].waitingForMs` so production diagnostics can distinguish long-held checkouts from pool-capacity waits.
 
 # Websockets
 

--- a/changelog.d/20260613222938-db-pool-default-cap.md
+++ b/changelog.d/20260613222938-db-pool-default-cap.md
@@ -1,0 +1,1 @@
+Default `AsyncTrackedMultiConnection` pools to a bounded max connection cap and skip database/tenant/ability resolution for built-in 404 responses.

--- a/changelog.d/20260613223704-lifecycle-callback-concrete-types.md
+++ b/changelog.d/20260613223704-lifecycle-callback-concrete-types.md
@@ -1,0 +1,1 @@
+Fix generated backend model lifecycle callback typing so callbacks infer the concrete model class.

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -20,6 +20,8 @@ await configuration.ensureConnections({name: "invoice cleanup"}, async (dbs) => 
 
 When a current connection scope already exists, `ensureConnections` reuses it and keeps the existing checkout name.
 
+`AsyncTrackedMultiConnection` pools default to a maximum of `10` live database connections per configured pool. Configure `database.<environment>.<identifier>.pool.max` when a process needs a different cap. Set `pool.max` to `null` only for deliberately unbounded pools; leaving the value out keeps the default cap and protects long-running processes from exhausting the database server.
+
 Velocious adds checkout names and active database annotations to SQL comments while a query is executing. This makes active queries easier to identify in process/activity views such as `SHOW FULL PROCESSLIST`, PostgreSQL `pg_stat_activity.query`, and SQL Server request SQL text:
 
 ```sql

--- a/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
@@ -352,6 +352,26 @@ describe("database - pool - async tracked multi connection reuse", () => {
     })
   })
 
+  it("defaults to a bounded max connection cap", async () => {
+    await withIsolatedPool(async (pool) => {
+      delete pool.getConfiguration().pool
+
+      expect(pool.maxConnections()).toEqual(10)
+    })
+  })
+
+  it("uses configured max connection caps and allows explicit unbounded pools", async () => {
+    await withIsolatedPool(async (pool) => {
+      pool.getConfiguration().pool = {max: 3}
+
+      expect(pool.maxConnections()).toEqual(3)
+
+      pool.getConfiguration().pool = {max: null}
+
+      expect(pool.maxConnections()).toEqual(undefined)
+    })
+  })
+
   it("hands a matching idle connection to pending checkouts before waiting for spawn capacity", async () => {
     await withIsolatedPool(async (pool) => {
       pool.getConfiguration().pool = {idleTimeoutMillis: 0, max: 1}

--- a/spec/routes/not-found-spec.js
+++ b/spec/routes/not-found-spec.js
@@ -1,0 +1,136 @@
+// @ts-check
+
+import Configuration, {CurrentConfigurationNotSetError} from "../../src/configuration.js"
+import BasePool from "../../src/database/pool/base.js"
+import dummyDirectory from "../dummy/dummy-directory.js"
+import dummyRoutes from "../dummy/src/config/routes.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import Request from "../../src/http-server/client/request.js"
+import Response from "../../src/http-server/client/response.js"
+import RoutesResolver from "../../src/routes/resolver.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/** Test pool that fails if the not-found route tries to resolve database connections. */
+class NotFoundFailingPool extends BasePool {
+  /** @type {boolean} */
+  static resolvedConnections = false
+
+  /** @param {import("../../src/database/drivers/base.js").default} _connection - Connection. */
+  checkin(_connection) {
+    throw new Error("Not-found responses should not check in database connections")
+  }
+
+  /**
+   * @param {import("../../src/database/pool/base.js").ConnectionCheckoutOptions} [_options] - Checkout options.
+   * @returns {Promise<import("../../src/database/drivers/base.js").default>} - Rejected checkout.
+   */
+  async checkout(_options) {
+    NotFoundFailingPool.resolvedConnections = true
+
+    throw new Error("Not-found responses should not check out database connections")
+  }
+
+  /** @returns {import("../../src/database/drivers/base.js").default} - Current connection. */
+  getCurrentConnection() {
+    throw new Error("Not-found responses should not read current database connections")
+  }
+
+  /** @returns {string} - Primary key type. */
+  primaryKeyType() {
+    return "integer"
+  }
+
+  /**
+   * @template T
+   * @param {import("../../src/database/pool/base.js").ConnectionCheckoutOptions | ((connection: import("../../src/database/drivers/base.js").default) => Promise<T>)} _optionsOrCallback - Options or callback.
+   * @param {(connection: import("../../src/database/drivers/base.js").default) => Promise<T>} [_callback] - Callback.
+   * @returns {Promise<T>} - Rejected connection callback.
+   */
+  async withConnection(_optionsOrCallback, _callback) {
+    NotFoundFailingPool.resolvedConnections = true
+
+    throw new Error("Not-found responses should not resolve database connections")
+  }
+}
+
+/**
+ * @returns {Configuration | undefined} - Current configuration when one has been set.
+ */
+function currentConfigurationOrUndefined() {
+  try {
+    return Configuration.current()
+  } catch (error) {
+    if (error instanceof CurrentConfigurationNotSetError) return
+
+    throw error
+  }
+}
+
+/**
+ * Resolves one GET request through the route resolver.
+ * @param {Configuration} configuration - Configuration instance.
+ * @param {string} path - Request path.
+ * @returns {Promise<Response>} - Resolved response.
+ */
+async function resolveGet(configuration, path) {
+  const previousConfiguration = currentConfigurationOrUndefined()
+  configuration.setCurrent()
+  configuration.setRoutes(dummyRoutes.routes)
+
+  const response = new Response({configuration})
+  const request = new Request({client: {remoteAddress: "127.0.0.1"}, configuration})
+  const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+
+  try {
+    request.feed(Buffer.from(`GET ${path} HTTP/1.1\r\nHost: example.com\r\n\r\n`, "utf8"))
+    await donePromise
+
+    await new RoutesResolver({configuration, request, response}).resolve()
+  } finally {
+    if (previousConfiguration) previousConfiguration.setCurrent()
+  }
+
+  return response
+}
+
+describe("routes - not found", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("renders the built-in not-found response without resolving database connections, tenant, or ability", async () => {
+    let resolvedAbility = false
+    let resolvedTenant = false
+    NotFoundFailingPool.resolvedConnections = false
+    const configuration = new Configuration({
+      abilityResolver: () => {
+        resolvedAbility = true
+        throw new Error("Ability resolver should not run for built-in not-found responses")
+      },
+      database: {
+        test: {
+          default: {
+            poolType: NotFoundFailingPool,
+            type: "fake"
+          }
+        }
+      },
+      directory: dummyDirectory(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      logging: {console: true, file: false, levels: ["info", "warn", "error"]},
+      tenantResolver: () => {
+        resolvedTenant = true
+        throw new Error("Tenant resolver should not run for built-in not-found responses")
+      }
+    })
+
+    const response = await resolveGet(configuration, "/application.yaml")
+
+    expect(response.getStatusCode()).toEqual(404)
+    expect(response.getBody()).toEqual("Path not found: /application.yaml\n")
+    expect(resolvedAbility).toEqual(false)
+    expect(NotFoundFailingPool.resolvedConnections).toEqual(false)
+    expect(resolvedTenant).toEqual(false)
+  })
+})

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -44,7 +44,7 @@
  * @property {boolean} [options.trustServerCertificate] - Whether to trust the server certificate (MSSQL).
  * @property {string} [password] - Password for the SQL user.
  * @property {object} [pool] - Connection pool configuration.
- * @property {number} [pool.max] - Maximum number of connections.
+ * @property {number | null} [pool.max] - Maximum number of connections. Set null to disable the cap.
  * @property {number} [pool.min] - Minimum number of connections.
  * @property {number} [pool.idleTimeoutMillis] - Idle timeout before releasing a connection.
  * @property {string} [server] - SQL server hostname.
@@ -54,7 +54,7 @@
 /**
  * @typedef {object} DatabasePoolConfiguration
  * @property {number | null} [idleTimeoutMillis] - Idle timeout before closing a checked-in async-tracked connection. Set null to disable idle reaping. Default: 5000.
- * @property {number} [max] - Maximum live async-tracked connections for this pool. Extra checkouts wait until a matching connection is checked in or capacity is freed.
+ * @property {number | null} [max] - Maximum live async-tracked connections for this pool. Defaults to 10. Extra checkouts wait until a matching connection is checked in or capacity is freed. Set null to disable the cap.
  */
 
 /**

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -6,6 +6,7 @@ import BasePool, {POOL_CONFIGURATION_KEY} from "./base.js"
 export const CLOSED_CONNECTION = Symbol("velociousClosedConnection")
 const IDLE_CONNECTION_CHECKED_IN_AT = Symbol("velociousIdleConnectionCheckedInAt")
 const CONNECTION_CHECKED_OUT_AT = Symbol("velociousConnectionCheckedOutAt")
+const DEFAULT_MAX_CONNECTIONS = 10
 const DEFAULT_IDLE_TIMEOUT_MILLIS = 5000
 
 /**
@@ -285,9 +286,10 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   maxConnections() {
     const value = this.getConfiguration().pool?.max
 
+    if (value === null) return
     if (this.validMaxConnections(value)) return value
 
-    return
+    return DEFAULT_MAX_CONNECTIONS
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -507,8 +507,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before validation.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -518,8 +518,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before save.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -529,8 +529,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before create.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -540,8 +540,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before update.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -551,8 +551,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before destroy.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -562,8 +562,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after save.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -573,8 +573,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after create.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -584,8 +584,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after update.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */
@@ -595,8 +595,8 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after destroy.
-   * @template R
-   * @this {new (...args: Array<?>) => R}
+   * @template {VelociousDatabaseRecord} R
+   * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
    */

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -13,7 +13,7 @@
 
 /**
  * Model class constructor type used for static `this` typing.
- * @template {VelociousDatabaseRecord} T
+ * @template T
  * @typedef {{new (changes?: Record<string, unknown>): T}} ModelConstructor
  */
 
@@ -507,7 +507,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before validation.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -518,7 +518,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before save.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -529,7 +529,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before create.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -540,7 +540,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before update.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -551,7 +551,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs before destroy.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -562,7 +562,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after save.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -573,7 +573,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after create.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -584,7 +584,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after update.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}
@@ -595,7 +595,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Runs after destroy.
-   * @template {VelociousDatabaseRecord} R
+   * @template R
    * @this {ModelConstructor<R>}
    * @param {LifecycleCallbackType<R>} callback - Callback function or instance method name.
    * @returns {void}

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -33,6 +33,14 @@ import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQuer
  * @typedef {{attributes?: string[], builtInCollectionCommands?: string[], builtInMemberCommands?: string[], collectionCommands?: string[], commands?: string[], memberCommands?: string[], attachments?: Record<string, FrontendModelAttachmentDefinition>, modelName?: string, nestedAttributes?: Record<string, {allowDestroy?: boolean, limit?: number}>, primaryKey?: string, relationships?: string[]}} FrontendModelResourceConfig
  */
 /**
+ * Frontend model constructor type.
+ * @typedef {{new (attributes?: Record<string, ?>): FrontendModelBase}} FrontendModelConstructor
+ */
+/**
+ * Frontend model static side without generated per-model create overloads.
+ * @typedef {FrontendModelConstructor & Omit<typeof FrontendModelBase, "create">} FrontendModelClass
+ */
+/**
  * FrontendModelTransportConfig type.
  * @typedef {object} FrontendModelTransportConfig
  * @property {string | (() => string | undefined | null)} [url] - Optional frontend-model URL. This should be the shared endpoint (for example `"/frontend-models"` or `"https://example.com/frontend-models"`).
@@ -61,7 +69,7 @@ const QUERY_DATA_KEY = "__queryData"
 const ABILITIES_KEY = "__abilities"
 /**
  * Pending shared frontend model requests.
-  @type {Array<{commandName?: string, commandType: FrontendModelRequestCommandType, customPath?: string, modelClass: typeof FrontendModelBase, payload: Record<string, ?>, requestId: string, resolve: (response: Record<string, ?>) => void, reject: (error: ?) => void, resourcePath?: string | null}>} */
+  @type {Array<{commandName?: string, commandType: FrontendModelRequestCommandType, customPath?: string, modelClass: FrontendModelClass, payload: Record<string, ?>, requestId: string, resolve: (response: Record<string, ?>) => void, reject: (error: ?) => void, resourcePath?: string | null}>} */
 let pendingSharedFrontendModelRequests = []
 let sharedFrontendModelRequestId = 0
 let sharedFrontendModelFlushScheduled = false
@@ -208,7 +216,7 @@ async function flushBufferedOutgoingEventsAfterReconnect() {
 
 /**
  * Runs default frontend model resource path.
- * @param {typeof FrontendModelBase} modelClass - Frontend model class.
+ * @param {FrontendModelClass} modelClass - Frontend model class.
  * @returns {string} - Default resource path for the model class.
  */
 function defaultFrontendModelResourcePath(modelClass) {
@@ -230,8 +238,8 @@ export class AttributeNotSelectedError extends Error {
 
 /**
  * Lightweight singular relationship state holder for frontend model instances.
- * @template {typeof FrontendModelBase} S
- * @template {typeof FrontendModelBase} T
+ * @template {FrontendModelClass} S
+ * @template {FrontendModelClass} T
  */
 export class FrontendModelSingularRelationship {
   /**
@@ -300,8 +308,8 @@ export class FrontendModelSingularRelationship {
 
 /**
  * Lightweight has-many relationship state holder for frontend model instances.
- * @template {typeof FrontendModelBase} S
- * @template {typeof FrontendModelBase} T
+ * @template {FrontendModelClass} S
+ * @template {FrontendModelClass} T
  */
 export class FrontendModelHasManyRelationship {
   /**
@@ -621,12 +629,12 @@ function frontendModelPayloadContainsAttachmentUpload(value) {
 /**
  * Returns the concrete frontend-model class for an instance.
  * @param {FrontendModelBase} model - Frontend model instance.
- * @returns {typeof FrontendModelBase} Concrete frontend-model class.
+ * @returns {FrontendModelClass} Concrete frontend-model class.
  */
 function frontendModelClassFor(model) {
   const constructorValue = model.constructor
 
-  return /** @type {typeof FrontendModelBase} */ (constructorValue)
+  return /** @type {FrontendModelClass} */ (constructorValue)
 }
 
 /**
@@ -901,7 +909,7 @@ const FRONTEND_MODELS_CHANNEL_NAME = "frontend-models"
 
 /**
  * Defines this typedef.
- * @typedef {{callback: (payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void, eventFilterKey: string | null, eventFilterPayload: import("./query.js").FrontendModelEventFilterPayload | null, projectionPayload: import("./query.js").FrontendModelProjectionPayload}} FrontendModelModelEventCallbackEntry
+ * @typedef {{callback: (payload: {id: string, model: FrontendModelBase}) => void, eventFilterKey: string | null, eventFilterPayload: import("./query.js").FrontendModelEventFilterPayload | null, projectionPayload: import("./query.js").FrontendModelProjectionPayload}} FrontendModelModelEventCallbackEntry
  */
 /**
  * Defines this typedef.
@@ -1051,7 +1059,7 @@ function frontendModelEventEntryMatches(entry, matchedEventFilterKeys) {
 
 /**
  * Runs assert no destroy event filter.
- * @param {typeof FrontendModelBase} ModelClass - Event model class.
+ * @param {FrontendModelClass} ModelClass - Event model class.
  * @param {import("./query.js").FrontendModelEventOptions} options - Event options.
  * @returns {void}
  */
@@ -1077,7 +1085,7 @@ function assertNoDestroyEventFilter(ModelClass, options) {
 class FrontendModelEventSubscription {
   /**
    * Runs constructor.
-   * @param {typeof FrontendModelBase} ModelClass - Frontend model class for this subscription bucket.
+   * @param {FrontendModelClass} ModelClass - Frontend model class for this subscription bucket.
    */
   constructor(ModelClass) {
     this.ModelClass = ModelClass
@@ -1095,7 +1103,7 @@ class FrontendModelEventSubscription {
     this.classDestroyCallbacks = new Set()
     /**
      * Narrows the runtime value to the documented type.
-      @type {Map<string, {instance: InstanceType<typeof FrontendModelBase>, updateCallbacks: Set<FrontendModelModelEventCallbackEntry>, destroyCallbacks: Set<FrontendModelDestroyEventCallbackEntry>}>} */
+      @type {Map<string, {instance: FrontendModelBase, updateCallbacks: Set<FrontendModelModelEventCallbackEntry>, destroyCallbacks: Set<FrontendModelDestroyEventCallbackEntry>}>} */
     this.instanceListeners = new Map()
     /**
      * Narrows the runtime value to the documented type.
@@ -1333,12 +1341,12 @@ class FrontendModelEventSubscription {
 
 /**
  * Frontend model event subscriptions.
-  @type {WeakMap<typeof FrontendModelBase, FrontendModelEventSubscription>} */
+  @type {WeakMap<FrontendModelClass, FrontendModelEventSubscription>} */
 const frontendModelEventSubscriptions = new WeakMap()
 
 /**
  * Runs ensure frontend model event subscription.
- * @param {typeof FrontendModelBase} ModelClass - Model class.
+ * @param {FrontendModelClass} ModelClass - Model class.
  * @returns {FrontendModelEventSubscription} - Per-class subscription helper.
  */
 function ensureFrontendModelEventSubscription(ModelClass) {
@@ -1356,8 +1364,8 @@ function ensureFrontendModelEventSubscription(ModelClass) {
  * Runs ensure frontend model instance listener.
  * @param {FrontendModelEventSubscription} sub - Event subscription bucket.
  * @param {string} id - Model id.
- * @param {InstanceType<typeof FrontendModelBase>} instance - Listener instance.
- * @returns {{instance: InstanceType<typeof FrontendModelBase>, updateCallbacks: Set<FrontendModelModelEventCallbackEntry>, destroyCallbacks: Set<FrontendModelDestroyEventCallbackEntry>}} - Instance listener bucket.
+ * @param {FrontendModelBase} instance - Listener instance.
+ * @returns {{instance: FrontendModelBase, updateCallbacks: Set<FrontendModelModelEventCallbackEntry>, destroyCallbacks: Set<FrontendModelDestroyEventCallbackEntry>}} - Instance listener bucket.
  */
 function ensureFrontendModelInstanceListener(sub, id, instance) {
   let listener = sub.instanceListeners.get(id)
@@ -1718,7 +1726,7 @@ export default class FrontendModelBase {
   _attributes
   /**
    * Narrows the runtime value to the documented type.
-    @type {Record<string, FrontendModelHasManyRelationship<typeof FrontendModelBase, typeof FrontendModelBase> | FrontendModelSingularRelationship<typeof FrontendModelBase, typeof FrontendModelBase>>} */
+    @type {Record<string, FrontendModelHasManyRelationship<FrontendModelClass, FrontendModelClass> | FrontendModelSingularRelationship<FrontendModelClass, FrontendModelClass>>} */
   _relationships
   /**
    * Narrows the runtime value to the documented type.
@@ -1772,7 +1780,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs ensure generated attachment methods.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {void} - Ensures attachment helper methods exist on the prototype.
    */
   static ensureGeneratedAttachmentMethods() {
@@ -1806,8 +1814,8 @@ export default class FrontendModelBase {
 
   /**
    * Runs relationship model classes.
-   * @this {typeof FrontendModelBase}
-   * @returns {Record<string, typeof FrontendModelBase | string>} - Relationship model classes (or class name strings) keyed by relationship name.
+   * @this {FrontendModelClass}
+   * @returns {Record<string, FrontendModelClass | string>} - Relationship model classes (or class name strings) keyed by relationship name.
    */
   static relationshipModelClasses() {
     return {}
@@ -1815,7 +1823,7 @@ export default class FrontendModelBase {
 
   /**
    * Register a frontend model class so it can be resolved by name in relationship lookups.
-   * @param {typeof FrontendModelBase} modelClass - Model class to register.
+   * @param {FrontendModelClass} modelClass - Model class to register.
    * @returns {void}
    */
   static registerModel(modelClass) {
@@ -1825,7 +1833,7 @@ export default class FrontendModelBase {
   /**
    * Runs define scope.
    * @param {(...args: Array<?>) => ?} callback - Scope callback.
-   * @returns {((...args: Array<?>) => import("./query.js").default<typeof FrontendModelBase>) & {scope: (...args: Array<?>) => import("../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
+   * @returns {((...args: Array<?>) => import("./query.js").default<FrontendModelClass>) & {scope: (...args: Array<?>) => import("../utils/model-scope.js").ModelScopeDescriptor}} - Scope helper.
    */
   static defineScope(callback) {
     return defineModelScope({
@@ -1837,8 +1845,8 @@ export default class FrontendModelBase {
 
   /**
    * Resolve a relationship model class value that may be a class reference or a string name.
-   * @param {typeof FrontendModelBase | string | null | undefined} value - Class or class name.
-   * @returns {typeof FrontendModelBase | null} - Resolved model class.
+   * @param {FrontendModelClass | string | null | undefined} value - Class or class name.
+   * @returns {FrontendModelClass | null} - Resolved model class.
    */
   static resolveModelClass(value) {
     return resolveFrontendModelClass(value)
@@ -1846,7 +1854,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs relationship definitions.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {Record<string, {type: "belongsTo" | "hasOne" | "hasMany", autoload?: boolean}>} - Relationship definitions keyed by relationship name.
    */
   static relationshipDefinitions() {
@@ -1855,7 +1863,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs attachment definitions.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {Record<string, FrontendModelAttachmentDefinition>} - Attachment definitions keyed by attachment name.
    */
   static attachmentDefinitions() {
@@ -1864,7 +1872,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs attachment definition.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {string} attachmentName - Attachment name.
    * @returns {FrontendModelAttachmentDefinition | null} - Attachment definition.
    */
@@ -1874,7 +1882,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs relationship definition.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {string} relationshipName - Relationship name.
    * @returns {{type: "belongsTo" | "hasOne" | "hasMany", autoload?: boolean} | null} - Relationship definition.
    */
@@ -1886,7 +1894,7 @@ export default class FrontendModelBase {
 
   /**
    * Resolves a Rails-style nested attributes key to a configured relationship.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {string} attributeName - Candidate attribute name, such as `tasksAttributes`.
    * @returns {string | null} Relationship name when nested attributes are configured.
    */
@@ -1903,9 +1911,9 @@ export default class FrontendModelBase {
 
   /**
    * Runs relationship model class.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {string} relationshipName - Relationship name.
-   * @returns {typeof FrontendModelBase | null} - Target relationship model class.
+   * @returns {FrontendModelClass | null} - Target relationship model class.
    */
   static relationshipModelClass(relationshipName) {
     const relationshipModelClasses = this.relationshipModelClasses()
@@ -2002,7 +2010,7 @@ export default class FrontendModelBase {
   /**
    * Runs get relationship by name.
    * @param {string} relationshipName - Relationship name.
-   * @returns {FrontendModelHasManyRelationship<typeof FrontendModelBase, typeof FrontendModelBase> | FrontendModelSingularRelationship<typeof FrontendModelBase, typeof FrontendModelBase>} - Relationship state object.
+   * @returns {FrontendModelHasManyRelationship<FrontendModelClass, FrontendModelClass> | FrontendModelSingularRelationship<FrontendModelClass, FrontendModelClass>} - Relationship state object.
    */
   getRelationshipByName(relationshipName) {
     if (!this._relationships[relationshipName]) {
@@ -2068,7 +2076,7 @@ export default class FrontendModelBase {
    * required columns present are left untouched unless `force` is set. Carries
    * the query's preload graph, select, selectsExtra, withCount, abilities, and
    * queryData when re-fetching.
-   * @param {import("./query.js").default<typeof FrontendModelBase> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - Preload source.
+   * @param {import("./query.js").default<FrontendModelClass> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - Preload source.
    * @param {{force?: boolean}} [options] - Options.
    * @returns {Promise<void>} - Resolves when preloading completes.
    */
@@ -2221,7 +2229,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs primary key.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {string} - Primary key name.
    */
   static primaryKey() {
@@ -2442,7 +2450,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs resource path.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {string} - Derived resource path.
    */
   static resourcePath() {
@@ -2454,7 +2462,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs command name.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {FrontendModelCommandType} commandType - Command type.
    * @returns {string} - Resolved command name.
    */
@@ -2475,7 +2483,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs normalize custom command payload arguments.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {Array<?>} args - Command arguments.
    * @returns {Record<string, ?>} - Command payload.
    */
@@ -2510,7 +2518,7 @@ export default class FrontendModelBase {
    * Returns the model name, preferring an explicit `static modelName` declaration
    * over the JavaScript class `.name` property. This allows minified builds to
    * preserve correct model names without relying on `keep_classnames`.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {string} - The model name.
    */
   static getModelName() {
@@ -2802,7 +2810,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs attributes from response.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {object} response - Response payload.
    * @returns {Record<string, ?>} - Attributes from payload.
    */
@@ -2814,7 +2822,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs model data from response.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {object} response - Response payload.
    * @returns {{abilities: Record<string, boolean>, attributes: Record<string, ?>, associationCounts: Record<string, number>, queryData: Record<string, ?>, preloadedRelationships: Record<string, ?>, selectedAttributes: Set<string>}} - Attributes, preloaded relationships, association counts, queryData, abilities, and the selected-attributes set.
    */
@@ -2884,7 +2892,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs apply preloaded relationships.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {FrontendModelBase} model - Model instance.
    * @param {Record<string, ?>} preloadedRelationships - Preloaded relationship payload.
    * @returns {void}
@@ -2905,9 +2913,9 @@ export default class FrontendModelBase {
 
   /**
    * Runs instantiate relationship value.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {?} relationshipPayload - Relationship payload value.
-   * @param {typeof FrontendModelBase | null} targetModelClass - Target model class.
+   * @param {FrontendModelClass | null} targetModelClass - Target model class.
    * @returns {?} - Instantiated relationship value.
    */
   static instantiateRelationshipValue(relationshipPayload, targetModelClass) {
@@ -2920,7 +2928,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs instantiate from response.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?> | InstanceType<T>} response - Response payload, or an already-hydrated instance of this class.
    * @returns {InstanceType<T>} - New model instance, or the same instance unchanged if it was already hydrated.
@@ -2973,7 +2981,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {number | string} id - Record identifier.
    * @returns {Promise<InstanceType<T>>} - Resolved model.
@@ -2984,7 +2992,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find by.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} conditions - Attribute match conditions.
    * @returns {Promise<InstanceType<T> | null>} - Found model or null.
@@ -2995,7 +3003,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find by or fail.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} conditions - Attribute match conditions.
    * @returns {Promise<InstanceType<T>>} - Found model.
@@ -3006,7 +3014,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs to array.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {Promise<InstanceType<T>[]>} - Loaded model instances.
    */
@@ -3016,7 +3024,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs load.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {Promise<InstanceType<T>[]>} - Loaded model instances.
    */
@@ -3026,7 +3034,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs all.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {FrontendModelQuery<T>} - Query builder.
    */
@@ -3036,7 +3044,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs where.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} conditions - Root-model where conditions.
    * @returns {import("./query.js").default<T>} - Query with where conditions.
@@ -3047,7 +3055,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs joins.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?> | Array<Record<string, ?>>} joins - Relationship descriptor joins.
    * @returns {import("./query.js").default<T>} - Query with joins.
@@ -3058,7 +3066,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs limit.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {number} value - Maximum number of records.
    * @returns {import("./query.js").default<T>} - Query with limit.
@@ -3069,7 +3077,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs offset.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {number} value - Number of records to skip.
    * @returns {import("./query.js").default<T>} - Query with offset.
@@ -3080,7 +3088,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs page.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {number} pageNumber - 1-based page number.
    * @returns {import("./query.js").default<T>} - Query with page applied.
@@ -3091,7 +3099,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs per page.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {number} value - Number of records per page.
    * @returns {import("./query.js").default<T>} - Query with page size.
@@ -3102,7 +3110,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs count.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {Promise<number>} - Number of loaded model instances.
    */
@@ -3116,8 +3124,8 @@ export default class FrontendModelBase {
    * accepted, future `create` events for this model are delivered
    * without re-checking per-record visibility. Query options can still
    * narrow which events reach this callback.
-   * @this {typeof FrontendModelBase}
-   * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
+   * @this {FrontendModelClass}
+   * @param {(payload: {id: string, model: FrontendModelBase}) => void} callback - Event callback.
    * @param {import("./query.js").FrontendModelEventOptions} [options] - Event query or record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
@@ -3136,8 +3144,8 @@ export default class FrontendModelBase {
 
   /**
    * Class-level hook fired when any record of this model is updated.
-   * @this {typeof FrontendModelBase}
-   * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
+   * @this {FrontendModelClass}
+   * @param {(payload: {id: string, model: FrontendModelBase}) => void} callback - Event callback.
    * @param {import("./query.js").FrontendModelEventOptions} [options] - Event query or record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
@@ -3156,7 +3164,7 @@ export default class FrontendModelBase {
 
   /**
    * Class-level hook fired when any record of this model is destroyed.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {(payload: {id: string}) => void} callback - Event callback.
    * @param {import("./query.js").FrontendModelEventOptions} [options] - Accepted for API symmetry; destroy events carry ids only.
    * @returns {Promise<() => void>} - Unsubscribe callback.
@@ -3181,7 +3189,7 @@ export default class FrontendModelBase {
    * instance's attributes are auto-merged with the broadcast payload
    * before the callback runs, so callers can read fresh values via
    * `this.someAttr()` without re-fetching.
-   * @param {(payload: {id: string, model: InstanceType<typeof FrontendModelBase>}) => void} callback - Event callback.
+   * @param {(payload: {id: string, model: FrontendModelBase}) => void} callback - Event callback.
    * @param {import("./query.js").FrontendModelEventOptions} [options] - Event query or record projection options.
    * @returns {Promise<() => void>} - Unsubscribe callback.
    */
@@ -3248,7 +3256,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs pluck.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {...(string | string[] | Record<string, ?> | Array<Record<string, ?>>)} columns - Pluck definition(s).
    * @returns {Promise<Array<?>>} - Plucked values.
@@ -3259,7 +3267,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs search.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {string[]} path - Relationship path.
    * @param {string} column - Column or attribute name.
@@ -3273,7 +3281,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs ransack.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} params - Ransack-style params hash.
    * @returns {FrontendModelQuery<T>} - Query builder with Ransack filters applied.
@@ -3284,7 +3292,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs sort.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {string | string[] | string[][] | [string, string] | Array<[string, string]> | Record<string, ?> | Array<Record<string, ?>>} sort - Sort definition(s).
    * @returns {FrontendModelQuery<T>} - Query builder with sort definitions.
@@ -3295,7 +3303,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs order.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {string | string[] | string[][] | [string, string] | Array<[string, string]> | Record<string, ?> | Array<Record<string, ?>>} sort - Sort definition(s).
    * @returns {FrontendModelQuery<T>} - Query builder with sort definitions.
@@ -3306,7 +3314,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs group.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {string | string[] | Record<string, ?> | Array<Record<string, ?>>} group - Group definition(s).
    * @returns {FrontendModelQuery<T>} - Query builder with group definitions.
@@ -3317,7 +3325,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs distinct.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {boolean} [value] - Whether to request distinct rows.
    * @returns {FrontendModelQuery<T>} - Query builder with distinct flag.
@@ -3328,7 +3336,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs query.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {FrontendModelQuery<T>} - Query builder.
    */
@@ -3338,7 +3346,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs preload.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} preload - Preload graph.
    * @returns {FrontendModelQuery<T>} - Query with preload.
@@ -3349,7 +3357,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs select.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, string[] | string> | string | string[]} select - Model-aware attribute select map or root-model shorthand.
    * @returns {FrontendModelQuery<T>} - Query with selected attributes.
@@ -3360,7 +3368,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs selects extra.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, string[] | string> | string | string[]} select - Extra attributes to load in addition to the defaults, keyed by model name or root-model shorthand.
    * @returns {FrontendModelQuery<T>} - Query with extra selected attributes.
@@ -3371,7 +3379,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs first.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {Promise<InstanceType<T> | null>} - First model or null.
    */
@@ -3381,7 +3389,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs last.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @returns {Promise<InstanceType<T> | null>} - Last model or null.
    */
@@ -3391,7 +3399,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find or initialize by.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} conditions - Attribute match conditions.
    * @returns {Promise<InstanceType<T>>} - Existing or initialized model.
@@ -3402,7 +3410,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find or create by.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} conditions - Attribute match conditions.
    * @param {(model: InstanceType<T>) => Promise<void> | void} [callback] - Optional callback before save when created.
@@ -3414,7 +3422,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs create.
-   * @template {typeof FrontendModelBase} T
+   * @template {FrontendModelClass} T
    * @this {T}
    * @param {Record<string, ?>} [attributes] - Initial attributes.
    * @returns {Promise<InstanceType<T>>} - Persisted model.
@@ -3431,7 +3439,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs assert find by conditions.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {Record<string, ?>} conditions - findBy conditions.
    * @returns {void}
    */
@@ -3445,7 +3453,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs matches find by conditions.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {FrontendModelBase} model - Candidate model.
    * @param {Record<string, ?>} conditions - Match conditions.
    * @returns {boolean} - Whether the model matches all conditions.
@@ -3475,7 +3483,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find by condition value matches.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {?} actualValue - Actual model value.
    * @param {?} expectedValue - Expected find condition value.
    * @returns {boolean} - Whether values match.
@@ -3543,7 +3551,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find by primitive values match.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {?} actualValue - Actual model value.
    * @param {?} expectedValue - Expected find condition value.
    * @returns {boolean} - Whether primitive values match after safe coercion.
@@ -3574,7 +3582,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs find by numeric string matches number.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {string} numericString - Numeric string value.
    * @param {number} expectedNumber - Number value.
    * @returns {boolean} - Whether values represent the same number.
@@ -3862,7 +3870,7 @@ export default class FrontendModelBase {
 
   /**
    * Builds nested entries from a Rails-style submitted `*Attributes` value.
-   * @param {typeof FrontendModelBase} ModelClass - Parent model class.
+   * @param {FrontendModelClass} ModelClass - Parent model class.
    * @param {string} relationshipName - Nested relationship name.
    * @param {?} value - Submitted nested attributes value.
    * @returns {Promise<Array<Record<string, ?>>>} Nested entries for the transport payload.
@@ -3898,7 +3906,7 @@ export default class FrontendModelBase {
 
   /**
    * Converts one submitted Rails-style nested attributes object into transport payload shape.
-   * @param {typeof FrontendModelBase} ModelClass - Nested child model class.
+   * @param {FrontendModelClass} ModelClass - Nested child model class.
    * @param {?} submittedEntry - Submitted nested attributes entry.
    * @returns {Promise<Record<string, ?>>} Transport nested-attributes entry.
    */
@@ -3950,7 +3958,7 @@ export default class FrontendModelBase {
 
   /**
    * Normalizes a submitted attachment value for transport.
-   * @param {typeof FrontendModelBase} ModelClass - Model class owning the attachment.
+   * @param {FrontendModelClass} ModelClass - Model class owning the attachment.
    * @param {string} attachmentName - Attachment name.
    * @param {?} value - Submitted attachment value.
    * @returns {Promise<Record<string, ?> | Record<string, ?>[]>} Normalized attachment payload.
@@ -4014,7 +4022,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs execute command.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {FrontendModelCommandType} commandType - Command type.
    * @param {Record<string, ?>} payload - Command payload.
    * @returns {Promise<Record<string, ?>>} - Parsed JSON response.
@@ -4091,7 +4099,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs execute custom command.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {object} args - Command arguments.
    * @param {string} args.commandName - Raw command path segment.
    * @param {FrontendModelRequestCommandType} args.commandType - Logical command type for error handling.
@@ -4139,7 +4147,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs throw on error frontend model response.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @param {object} args - Arguments.
    * @param {FrontendModelRequestCommandType} args.commandType - Command type.
    * @param {Record<string, ?>} args.response - Decoded response.
@@ -4198,7 +4206,7 @@ export default class FrontendModelBase {
 
   /**
    * Runs configured frontend model attribute names.
-   * @this {typeof FrontendModelBase}
+   * @this {FrontendModelClass}
    * @returns {Set<string>} - Configured frontend model attribute names.
    */
   static configuredFrontendModelAttributeNames() {

--- a/src/frontend-models/preloader.js
+++ b/src/frontend-models/preloader.js
@@ -15,7 +15,7 @@ export default class FrontendModelPreloader {
   /**
    * Runs preload.
    * @param {Array<import("./base.js").default>} models - Frontend model instances to preload onto.
-   * @param {import("./query.js").default<typeof import("./base.js").default> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - A query built via `Model.preload(...).select(...)`, or a raw preload spec.
+   * @param {import("./query.js").default<import("./base.js").FrontendModelClass> | import("../database/query/index.js").NestedPreloadRecord | string | Array<string | import("../database/query/index.js").NestedPreloadRecord>} queryOrSpec - A query built via `Model.preload(...).select(...)`, or a raw preload spec.
    * @param {{force?: boolean}} [options] - Options.
    * @returns {Promise<void>} - Resolves when preloading completes.
    */
@@ -24,12 +24,12 @@ export default class FrontendModelPreloader {
 
     const modelClass = /**
                         * Narrows the runtime value to the documented type.
-                         @type {typeof import("./base.js").default} */ (models[0].constructor)
+                         @type {import("./base.js").FrontendModelClass} */ (models[0].constructor)
     const isQuery = Boolean(queryOrSpec) && typeof queryOrSpec === "object" && "_preload" in queryOrSpec
     const query = isQuery
       ? /**
          * Narrows the runtime value to the documented type.
-          @type {import("./query.js").default<typeof import("./base.js").default>} */ (queryOrSpec)
+          @type {import("./query.js").default<import("./base.js").FrontendModelClass>} */ (queryOrSpec)
       : modelClass.preload(/**
                             * Narrows the runtime value to the documented type.
                              @type {?} */ (queryOrSpec))
@@ -85,10 +85,10 @@ export default class FrontendModelPreloader {
   /**
    * Runs model needs reload.
    * @param {object} args - Options object.
-   * @param {typeof import("./base.js").default} args.modelClass - Model class the preload graph is rooted at.
+   * @param {import("./base.js").FrontendModelClass} args.modelClass - Model class the preload graph is rooted at.
    * @param {import("./base.js").default} args.model - Model instance.
    * @param {import("../database/query/index.js").NestedPreloadRecord} args.preload - Preload sub-graph to satisfy.
-   * @param {import("./query.js").default<typeof import("./base.js").default>} args.query - Source query carrying select/selectsExtra.
+   * @param {import("./query.js").default<import("./base.js").FrontendModelClass>} args.query - Source query carrying select/selectsExtra.
    * @param {boolean} args.force - Whether to reload regardless of cached state.
    * @returns {boolean} - Whether the model needs a reload request.
    */
@@ -110,11 +110,11 @@ export default class FrontendModelPreloader {
    * client-unknown default attributes plus the extras), so it always reloads.
    * With no select and no nested preload, being preloaded is enough.
    * @param {object} args - Options object.
-   * @param {typeof import("./base.js").default} args.modelClass - Model class owning the relationship.
+   * @param {import("./base.js").FrontendModelClass} args.modelClass - Model class owning the relationship.
    * @param {import("./base.js").default} args.model - Model instance.
    * @param {string} args.relationshipName - Relationship name.
    * @param {import("../database/query/index.js").NestedPreloadRecord[string]} args.subPreload - Preload value for this relationship (`true` or a nested record).
-   * @param {import("./query.js").default<typeof import("./base.js").default>} args.query - Source query carrying select/selectsExtra.
+   * @param {import("./query.js").default<import("./base.js").FrontendModelClass>} args.query - Source query carrying select/selectsExtra.
    * @returns {boolean} - Whether the relationship is already satisfied.
    */
   static _relationshipSatisfied({modelClass, model, relationshipName, subPreload, query}) {

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -37,11 +37,11 @@ import isPlainObject from "../utils/plain-object.js"
  */
 /**
  * Defines this typedef.
- * @typedef {FrontendModelProjectionOptions & {query?: FrontendModelQuery<typeof import("./base.js").default>}} FrontendModelEventOptionsObject
+ * @typedef {FrontendModelProjectionOptions & {query?: FrontendModelQuery<import("./base.js").FrontendModelClass>}} FrontendModelEventOptionsObject
  */
 /**
  * FrontendModelEventOptions type.
- * @typedef {FrontendModelEventOptionsObject | FrontendModelQuery<typeof import("./base.js").default>} FrontendModelEventOptions
+ * @typedef {FrontendModelEventOptionsObject | FrontendModelQuery<import("./base.js").FrontendModelClass>} FrontendModelEventOptions
  */
 /**
  * FrontendModelProjectionPayload type.
@@ -955,7 +955,7 @@ export function normalizePluck(pluck) {
 
 /**
  * Runs frontend model resource attributes.
- * @param {typeof import("./base.js").default} modelClass - Model class.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Model class.
  * @returns {Set<string>} - Resource attribute names.
  */
 function frontendModelResourceAttributes(modelClass) {
@@ -977,9 +977,9 @@ function frontendModelResourceAttributes(modelClass) {
 
 /**
  * Runs frontend model pluck target model class.
- * @param {typeof import("./base.js").default} modelClass - Root model class.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Root model class.
  * @param {string[]} path - Relationship path.
- * @returns {typeof import("./base.js").default} - Target model class for path.
+ * @returns {import("./base.js").FrontendModelClass} - Target model class for path.
  */
 function frontendModelPluckTargetModelClass(modelClass, path) {
   let targetModelClass = modelClass
@@ -1011,7 +1011,7 @@ function frontendModelPluckTargetModelClass(modelClass, path) {
 /**
  * Runs validate pluck definitions.
  * @param {object} args - Pluck validation args.
- * @param {typeof import("./base.js").default} args.modelClass - Root model class.
+ * @param {import("./base.js").FrontendModelClass} args.modelClass - Root model class.
  * @param {FrontendModelPluck[]} args.pluck - Pluck descriptors.
  * @returns {FrontendModelPluck[]} - Validated pluck descriptors.
  */
@@ -1075,7 +1075,7 @@ function reverseSortDirection(direction) {
 
 /**
  * Query wrapper for frontend model commands.
- * @template {typeof import("./base.js").default} T
+ * @template {import("./base.js").FrontendModelClass} T
  */
 export default class FrontendModelQuery {
   /**
@@ -2145,7 +2145,7 @@ function frontendModelEventFilterKey(payload) {
 
 /**
  * Runs apply frontend model projection options.
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Query receiving projection options.
+ * @param {FrontendModelQuery<import("./base.js").FrontendModelClass>} query - Query receiving projection options.
  * @param {FrontendModelProjectionOptions} options - Projection options.
  * @returns {void}
  */
@@ -2160,8 +2160,8 @@ function applyFrontendModelProjectionOptions(query, options) {
 
 /**
  * Runs assert frontend model event query class.
- * @param {typeof import("./base.js").default} modelClass - Expected frontend model class.
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Expected frontend model class.
+ * @param {FrontendModelQuery<import("./base.js").FrontendModelClass>} query - Event query.
  * @returns {void}
  */
 function assertFrontendModelEventQueryClass(modelClass, query) {
@@ -2183,9 +2183,9 @@ function assertFrontendModelEventOptionsObject(options) {
 
 /**
  * Runs cloned frontend model event query.
- * @param {typeof import("./base.js").default} modelClass - Frontend model class.
- * @param {FrontendModelQuery<typeof import("./base.js").default>} query - Event query.
- * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Cloned query used by event subscriptions.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Frontend model class.
+ * @param {FrontendModelQuery<import("./base.js").FrontendModelClass>} query - Event query.
+ * @returns {FrontendModelQuery<import("./base.js").FrontendModelClass>} - Cloned query used by event subscriptions.
  */
 function clonedFrontendModelEventQuery(modelClass, query) {
   assertFrontendModelEventQueryClass(modelClass, query)
@@ -2195,9 +2195,9 @@ function clonedFrontendModelEventQuery(modelClass, query) {
 
 /**
  * Runs frontend model event query from options object.
- * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Frontend model class.
  * @param {FrontendModelEventOptionsObject} options - Event options object.
- * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Query used by event subscriptions.
+ * @returns {FrontendModelQuery<import("./base.js").FrontendModelClass>} - Query used by event subscriptions.
  */
 function frontendModelEventQueryFromOptionsObject(modelClass, options) {
   if (options.query !== undefined && !(options.query instanceof FrontendModelQuery)) {
@@ -2215,9 +2215,9 @@ function frontendModelEventQueryFromOptionsObject(modelClass, options) {
 
 /**
  * Runs frontend model event query.
- * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Frontend model class.
  * @param {FrontendModelEventOptions} [options] - Event query or projection options.
- * @returns {FrontendModelQuery<typeof import("./base.js").default>} - Normalized query used by event subscriptions.
+ * @returns {FrontendModelQuery<import("./base.js").FrontendModelClass>} - Normalized query used by event subscriptions.
  */
 function frontendModelEventQuery(modelClass, options = {}) {
   if (options instanceof FrontendModelQuery) return clonedFrontendModelEventQuery(modelClass, options)
@@ -2236,7 +2236,7 @@ function frontendModelEventQuery(modelClass, options = {}) {
 
 /**
  * Runs the frontendModelEventOptionsPayload helper.
- * @param {typeof import("./base.js").default} modelClass - Frontend model class.
+ * @param {import("./base.js").FrontendModelClass} modelClass - Frontend model class.
  * @param {FrontendModelEventOptions} [options] - Event query or projection options.
  * @returns {FrontendModelEventOptionsPayload} - Normalized event subscription payload.
  */

--- a/src/frontend-models/use-created-event.js
+++ b/src/frontend-models/use-created-event.js
@@ -2,7 +2,7 @@
 
 import useModelClassEvent from "./use-model-class-event.js"
 
-/** @typedef {typeof import("./base.js").default} FrontendModelClass */
+/** @typedef {import("./base.js").FrontendModelClass} FrontendModelClass */
 /** @typedef {import("./use-model-class-event.js").FrontendModelCreateUpdateEventPayload} FrontendModelCreateEventPayload */
 /** @typedef {import("./use-model-class-event.js").UseModelClassEventOptions} UseCreatedEventOptions */
 /** @typedef {(payload: FrontendModelCreateEventPayload) => void} FrontendModelCreateEventCallback */

--- a/src/frontend-models/use-destroyed-event.js
+++ b/src/frontend-models/use-destroyed-event.js
@@ -9,7 +9,7 @@ import useModelClassEvent from "./use-model-class-event.js"
 
 /**
  * FrontendModelClass type.
-  @typedef {typeof import("./base.js").default} FrontendModelClass */
+  @typedef {import("./base.js").FrontendModelClass} FrontendModelClass */
 /**
  * FrontendModelInstance type.
   @typedef {import("./base.js").default} FrontendModelInstance */

--- a/src/frontend-models/use-model-class-event.js
+++ b/src/frontend-models/use-model-class-event.js
@@ -7,7 +7,7 @@ import clearPendingDebouncedCallback from "./clear-pending-debounced-callback.js
 
 /**
  * FrontendModelClass type.
-  @typedef {typeof import("./base.js").default} FrontendModelClass */
+  @typedef {import("./base.js").FrontendModelClass} FrontendModelClass */
 /**
  * FrontendModelInstance type.
   @typedef {InstanceType<FrontendModelClass>} FrontendModelInstance */

--- a/src/frontend-models/use-updated-event.js
+++ b/src/frontend-models/use-updated-event.js
@@ -9,7 +9,7 @@ import useModelClassEvent from "./use-model-class-event.js"
 
 /**
  * FrontendModelClass type.
-  @typedef {typeof import("./base.js").default} FrontendModelClass */
+  @typedef {import("./base.js").FrontendModelClass} FrontendModelClass */
 /**
  * FrontendModelInstance type.
   @typedef {import("./base.js").default} FrontendModelInstance */

--- a/src/routes/resolver.js
+++ b/src/routes/resolver.js
@@ -120,9 +120,9 @@ export default class VelociousRoutesResolver {
     }
 
     const routeResolverHookMatch = await this.resolveRouteResolverHooks(currentPath, {hasMatchingCustomRoute})
-    const skipControllerConnections = routeResolverHookMatch?.skipControllerConnections === true
-    const skipAbilityResolution = routeResolverHookMatch?.skipAbilityResolution === true
-    const skipTenantResolution = routeResolverHookMatch?.skipTenantResolution === true
+    let skipControllerConnections = routeResolverHookMatch?.skipControllerConnections === true
+    let skipAbilityResolution = routeResolverHookMatch?.skipAbilityResolution === true
+    let skipTenantResolution = routeResolverHookMatch?.skipTenantResolution === true
     const matchResult = routeResolverHookMatch || !currentRoute ? undefined : this.matchPathWithRoutes(currentRoute, currentPath)
     const actionParam = this.params.action
     const controllerParam = this.params.controller
@@ -151,21 +151,24 @@ export default class VelociousRoutesResolver {
       viewPath = routeHookViewPath || `${this.configuration.getDirectory()}/src/routes/${controller}`
       this.routeHookControllerClass = routeHookControllerClass
     } else if (!matchResult) {
-        const __filename = fileURLToPath(import.meta.url)
-        const __dirname = dirname(__filename)
-        const requestedPath = currentPath.replace(/^\//, "") || "_root"
-        const attemptedControllerPath = `${this.configuration.getDirectory()}/src/routes/${requestedPath}/controller.js`
+      const __filename = fileURLToPath(import.meta.url)
+      const __dirname = dirname(__filename)
+      const requestedPath = currentPath.replace(/^\//, "") || "_root"
+      const attemptedControllerPath = `${this.configuration.getDirectory()}/src/routes/${requestedPath}/controller.js`
 
-        const logger = this.logger
+      const logger = this.logger
 
-        if (!logger) throw new Error("Logger not initialized")
+      if (!logger) throw new Error("Logger not initialized")
 
-        await logger.warn(`No route matched for ${rawPath}. Tried controller at ${attemptedControllerPath}`)
+      await logger.warn(`No route matched for ${rawPath}. Tried controller at ${attemptedControllerPath}`)
 
-        controller = "errors"
-        controllerPath = "./built-in/errors/controller.js"
-        action = "notFound"
-        viewPath = await fs.realpath(`${__dirname}/built-in/errors`)
+      controller = "errors"
+      controllerPath = "./built-in/errors/controller.js"
+      action = "notFound"
+      skipAbilityResolution = true
+      skipControllerConnections = true
+      skipTenantResolution = true
+      viewPath = await fs.realpath(`${__dirname}/built-in/errors`)
     } else if (action) {
       if (!controller) controller = "_root"
 

--- a/src/utils/model-scope.js
+++ b/src/utils/model-scope.js
@@ -7,7 +7,7 @@ const MODEL_SCOPE_DESCRIPTOR_MARKER = "velociousModelScopeDescriptor"
  * @typedef {object} ModelScopeDescriptor
  * @property {true} [velociousModelScopeDescriptor] - Internal marker.
  * @property {(...args: Array<?>) => ?} callback - Scope callback.
- * @property {typeof import("../database/record/index.js").default | typeof import("../frontend-models/base.js").default} modelClass - Owning model class.
+ * @property {typeof import("../database/record/index.js").default | import("../frontend-models/base.js").FrontendModelClass} modelClass - Owning model class.
  * @property {Array<?>} scopeArgs - Scope arguments.
  */
 
@@ -15,7 +15,7 @@ const MODEL_SCOPE_DESCRIPTOR_MARKER = "velociousModelScopeDescriptor"
  * Runs the defineModelScope helper.
  * @param {object} args - Definition arguments.
  * @param {(...args: Array<?>) => ?} args.callback - Scope callback.
- * @param {typeof import("../database/record/index.js").default | typeof import("../frontend-models/base.js").default} args.modelClass - Owning model class.
+ * @param {typeof import("../database/record/index.js").default | import("../frontend-models/base.js").FrontendModelClass} args.modelClass - Owning model class.
  * @param {() => ?} args.startQuery - Factory that returns a fresh query for the owning model class.
  * @returns {((...args: Array<?>) => ?) & {scope: (...args: Array<?>) => ModelScopeDescriptor}} - Scope helper.
  */

--- a/src/utils/ransack.js
+++ b/src/utils/ransack.js
@@ -16,7 +16,7 @@ import {resolveFrontendModelClass} from "../frontend-models/model-registry.js"
 
 /**
  * RansackModelClass type.
- * @typedef {typeof import("../database/record/index.js").default | typeof import("../frontend-models/base.js").default} RansackModelClass
+ * @typedef {typeof import("../database/record/index.js").default | import("../frontend-models/base.js").FrontendModelClass} RansackModelClass
  */
 
 /**


### PR DESCRIPTION
## Summary
- Bound static lifecycle callback generics to VelociousDatabaseRecord
- Use ModelConstructor<R> for lifecycle callback this types so model constructors with optional changes are assignable
- Added a FrontendModelClass bound that excludes generated per-model static create overloads from generic frontend-model query/static method constraints
- Default AsyncTrackedMultiConnection pools to a bounded `pool.max` of 10, with `pool.max: null` as the explicit unbounded opt-out
- Skip database connection, tenant, and ability resolution for built-in 404 responses so bot/noise paths do not consume DB checkouts

## Validation
- `npm run lint`
- `npm run build`
- `./run-tests.sh spec/database/pool/async-tracked-multi-connection-reuse-spec.js spec/routes/not-found-spec.js`
- AwesomeTasks backend npm run typecheck against the local Velocious build
- AwesomeTasks frontend npm run typecheck against the local Velocious build

## Downstream
- ticket-app PR kaspernj/ticket-app#1275 adds TensorBuzz DB pool diagnostics for connection exhaustion reports. After this Velocious PR is reviewed and released, ticket-app should bump `velocious` across its projects through the normal release/version flow.