### PR TITLE
Preserve null pool max semantics

### DIFF
--- a/changelog.d/20260614050431-preserve-null-pool-max.md
+++ b/changelog.d/20260614050431-preserve-null-pool-max.md
@@ -1,0 +1,1 @@
+Preserve `pool.max: null` as the explicit unbounded database pool value instead of normalizing it to `undefined`.

--- a/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-reuse-spec.js
@@ -368,7 +368,7 @@ describe("database - pool - async tracked multi connection reuse", () => {
 
       pool.getConfiguration().pool = {max: null}
 
-      expect(pool.maxConnections()).toEqual(undefined)
+      expect(pool.maxConnections()).toEqual(null)
     })
   })
 

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -281,12 +281,12 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
   /**
    * Runs max connections.
-   * @returns {number | undefined} - Configured max live connections.
+   * @returns {number | null} - Configured max live connections.
    */
   maxConnections() {
     const value = this.getConfiguration().pool?.max
 
-    if (value === null) return
+    if (value === null) return null
     if (this.validMaxConnections(value)) return value
 
     return DEFAULT_MAX_CONNECTIONS
@@ -322,7 +322,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
   canSpawnConnection() {
     const maxConnections = this.maxConnections()
 
-    return maxConnections === undefined || this.liveConnectionCount() < maxConnections
+    return maxConnections === null || this.liveConnectionCount() < maxConnections
   }
 
   /**


### PR DESCRIPTION
## Summary
- preserve `pool.max: null` as `null` from `maxConnections()` instead of normalizing it to `undefined`
- keep `null` as the explicit unbounded sentinel in `canSpawnConnection()`
- update the focused pool spec and changelog fragment

## Tests
- `./run-tests.sh spec/database/pool/async-tracked-multi-connection-reuse-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`

After validation, `spec/dummy/src/config/configuration.js` was restored to its tracked config.