### PR TITLE
Improve frontend-model error reporter context

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ const configuration = new Configuration({
 
 This opt-in is ignored in `production`; production frontend-model responses never include internal exception details.
 
-Backends can append client-safe metadata to frontend-model error responses with `configuration.addClientErrorPayloadReporter(...)`. Reporters receive the caught `error`, the current `request`, and a small `context` object, and should only return fields that are safe for clients to see. This is useful for attaching an error-reporting URL while keeping the normal production error message generic:
+Backends can append client-safe metadata to frontend-model error responses with `configuration.addClientErrorPayloadReporter(...)`. Reporters receive the caught `error`, the current `request`, and a small `context` object, and should only return fields that are safe for clients to see. Frontend-model endpoint failures include `context.frontendModelEndpoint`, `action`, `commandType`, `model`, `requestId`, and `expectedError`. This is useful for attaching an error-reporting URL while keeping the normal production error message generic:
 
 ```js
 configuration.addClientErrorPayloadReporter(async ({error, request, context}) => {
@@ -1597,7 +1597,7 @@ configuration.getErrorEvents().on("all-error", ({error, errorType}) => {
 })
 ```
 
-Genuinely unexpected frontend-model command failures reach this bus too. The frontend-model controller catches them to return a client-safe `Request failed.` response, but it also emits them as `framework-error`/`all-error` (with `context.frontendModelEndpoint === true`) so they are reported instead of being silently swallowed. Expected user-flow errors are excluded: validation failures are forwarded with their real message (for example `Name can't be blank`) rather than the generic one, and `error.velocious`-annotated / `safeToExpose` errors keep their own message — none of these reach the error bus.
+Genuinely unexpected frontend-model command failures reach this bus too. The frontend-model controller catches them to return a client-safe `Request failed.` response, but it also emits them as `framework-error`/`all-error` (with `context.frontendModelEndpoint === true`) so they are reported instead of being silently swallowed. Expected user-flow errors are excluded: validation failures are forwarded with their real message (for example `Name can't be blank`) rather than the generic one, and `error.velocious`-annotated / `safeToExpose` / `errorType`-marked errors keep their expected-error status — none of these reach the error bus.
 
 ## Use the Websocket client API (HTTP-like)
 

--- a/changelog.d/20260615160930-frontend-model-error-context.md
+++ b/changelog.d/20260615160930-frontend-model-error-context.md
@@ -1,0 +1,1 @@
+Expose frontend-model endpoint metadata to client error payload reporters and keep `errorType`-marked frontend-model errors out of framework-error reporting.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -13,6 +13,8 @@
 - `development` and `test` responses also include `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` for faster browser/system-test diagnosis.
 - Other non-production environments, such as `staging`, can opt into the same debug fields with `exposeInternalErrorsToClients: true` on the app `Configuration`.
 - `production` always keeps the generic response, even if `exposeInternalErrorsToClients` is set.
+- `configuration.addClientErrorPayloadReporter(...)` can append client-safe metadata to the error payload. For frontend-model endpoint failures, the reporter `context` includes `frontendModelEndpoint`, `action`, `commandType`, `model`, `requestId`, and `expectedError`.
+- Unexpected frontend-model failures are emitted on `configuration.getErrorEvents()` as `framework-error` and `all-error`. Expected user-flow errors, including validation errors, `safeToExpose` errors, `error.velocious` metadata, and non-empty `error.errorType`, are not emitted as framework errors.
 
 ### Validation errors
 - When a record validation fails during `create` or `update`, the frontend-model response includes structured per-attribute validation errors.

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -17,6 +17,7 @@ import Request from "../../src/http-server/client/request.js"
 import Response from "../../src/http-server/client/response.js"
 import Task from "../dummy/src/models/task.js"
 import User from "../dummy/src/models/user.js"
+import VelociousError from "../../src/velocious-error.js"
 
 const FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE = "Request failed."
 
@@ -536,8 +537,11 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
 
   it("adds registered client error reporter payloads to shared frontend-model failures", async () => {
     const configuration = buildFrontendModelControllerConfiguration("production")
+    /** @type {import("../../src/configuration-types.js").ClientErrorPayloadContext[]} */
+    const reporterContexts = []
 
-    configuration.addClientErrorPayloadReporter(async ({error}) => {
+    configuration.addClientErrorPayloadReporter(async ({context, error}) => {
+      reporterContexts.push(context)
       expect(error.message).toMatch(/No frontend model resource configuration/)
 
       return {bugReportUrl: "https://tensorbuzz.test/bugs/1"}
@@ -552,6 +556,31 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
 
     expectGenericFrontendModelError(response)
     expect(response.bugReportUrl).toEqual("https://tensorbuzz.test/bugs/1")
+    expect(reporterContexts.length).toEqual(1)
+    expect(reporterContexts[0].action).toEqual("frontendApi")
+    expect(reporterContexts[0].commandType).toEqual("index")
+    expect(reporterContexts[0].expectedError).toEqual(false)
+    expect(reporterContexts[0].frontendModelEndpoint).toEqual(true)
+    expect(reporterContexts[0].model).toEqual("UnknownModel")
+    expect(reporterContexts[0].requestId).toEqual("request-1")
+  })
+
+  it("adds safe VelociousError codes to frontend-model client payload metadata", async () => {
+    const configuration = buildFrontendModelControllerConfiguration("production")
+    const controller = new FrontendModelController({
+      action: "frontendApi",
+      configuration,
+      controller: "frontend-models",
+      params: {},
+      request: new Request({client: {remoteAddress: "127.0.0.1"}, configuration}),
+      response: new Response({configuration}),
+      viewPath: `${dummyDirectory()}/src/routes/frontend-models`
+    })
+    const payload = await controller.frontendModelClientErrorPayloadForError(VelociousError.safe("Ticket scan failed", {code: "ticket-scan-pah-too-long"}))
+
+    expect(payload.status).toEqual("error")
+    expect(payload.errorMessage).toEqual("Ticket scan failed")
+    expect(payload.velocious).toEqual({code: "ticket-scan-pah-too-long"})
   })
 
   it("keeps unexpected shared frontend-model failures generic in production when debug details are enabled", async () => {

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -565,6 +565,49 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     expect(reporterContexts[0].requestId).toEqual("request-1")
   })
 
+  it("renders and emits direct frontend-model errors when params parsing fails", async () => {
+    const configuration = buildFrontendModelControllerConfiguration("production")
+    const request = new Request({client: {remoteAddress: "127.0.0.1"}, configuration})
+    const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+    /** @type {Array<{context: {frontendModelEndpoint?: boolean}, error: Error}>} */
+    const frameworkErrors = []
+
+    configuration.getErrorEvents().on("framework-error", (payload) => {
+      frameworkErrors.push(/** @type {{context: {frontendModelEndpoint?: boolean}, error: Error}} */ (payload))
+    })
+    request.feed(Buffer.from([
+      "GET /frontend-models?broken[x=1 HTTP/1.1",
+      "Host: example.com",
+      "",
+      ""
+    ].join("\r\n"), "utf8"))
+
+    await donePromise
+
+    const response = new Response({configuration})
+    const controller = new FrontendModelController({
+      action: "frontendIndex",
+      configuration,
+      controller: "frontend-models",
+      params: {model: "Task"},
+      request,
+      response,
+      viewPath: `${dummyDirectory()}/src/routes/frontend-models`
+    })
+
+    await controller.frontendIndex()
+
+    const body = response.getBody()
+    const responseText = typeof body === "string" ? body : Buffer.from(body).toString("utf8")
+    const responseJson = responseText.length > 0 ? JSON.parse(responseText) : {}
+    const payload = /** @type {Record<string, import("../../src/frontend-models/query.js").FrontendModelTransportValue>} */ (deserializeFrontendModelTransportValue(responseJson))
+
+    expectGenericFrontendModelError(payload)
+    expect(frameworkErrors.length).toEqual(1)
+    expect(frameworkErrors[0].context.frontendModelEndpoint).toEqual(true)
+    expect(frameworkErrors[0].error.message).toMatch(/Could not parse nested params key/)
+  })
+
   it("adds safe VelociousError codes to frontend-model client payload metadata", async () => {
     const configuration = buildFrontendModelControllerConfiguration("production")
     const controller = new FrontendModelController({

--- a/spec/controller/frontend-model-custom-command-spec.js
+++ b/spec/controller/frontend-model-custom-command-spec.js
@@ -32,6 +32,13 @@ class CustomFrontendModelCommandController extends Controller {
     error.velocious = {type: "UserError"}
     throw error
   }
+
+  /** @returns {Promise<void>} */
+  async rejectTypedInput() {
+    const error = /** @type {Error & {errorType?: string}} */ (new Error("Typed custom command rejection"))
+    error.errorType = "customCommandRejected"
+    throw error
+  }
 }
 
 describe("Controller frontend model custom commands", {databaseCleaning: {transaction: true}}, () => {
@@ -229,5 +236,66 @@ describe("Controller frontend model custom commands", {databaseCleaning: {transa
     // user-flow failures, not backend bugs.
     const combinedWrites = writes.join("")
     expect(combinedWrites).not.toMatch(/Frontend model endpoint request failed/)
+  })
+
+  it("suppresses framework-error events for frontend-model custom command errors with errorType", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: dummyDirectory(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+
+    configuration.routes((routes) => {
+      routes.post("/custom-frontend-models/users/reject-typed-input", {to: [CustomFrontendModelCommandController, "rejectTypedInput"]})
+    })
+
+    /** @type {Array<{errorType?: string}>} */
+    const allErrors = []
+    configuration.getErrorEvents().on("all-error", (payload) => allErrors.push(payload))
+
+    const client = {remoteAddress: "127.0.0.1"}
+    const request = new Request({client, configuration})
+    const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+
+    request.feed(Buffer.from([
+      "POST /frontend-models HTTP/1.1",
+      "Host: example.com",
+      "Content-Length: 0",
+      "",
+      ""
+    ].join("\r\n"), "utf8"))
+
+    await donePromise
+
+    const response = new Response({configuration})
+    const controller = new FrontendModelController({
+      action: "frontendApi",
+      configuration,
+      controller: "frontend-models",
+      params: {
+        requests: [{
+          commandType: "reject-typed-input",
+          customPath: "/custom-frontend-models/users/reject-typed-input",
+          model: "User",
+          payload: {},
+          requestId: "request-1"
+        }]
+      },
+      request,
+      response,
+      viewPath: `${dummyDirectory()}/src/routes/frontend-models`
+    })
+
+    await controller.frontendApi()
+    const responsePayload = JSON.parse(String(response.getBody()))
+
+    expect(responsePayload.responses[0].response.status).toEqual("error")
+    expect(responsePayload.responses[0].response.errorMessage).toEqual("Request failed.")
+    expect(allErrors.length).toEqual(0)
   })
 })

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -208,6 +208,10 @@
  */
 
 /**
+ * @typedef {Record<string, import("./frontend-models/query.js").FrontendModelTransportValue>} ClientErrorPayloadReporterPayload
+ */
+
+/**
  * @typedef {object} ClientErrorPayloadContext
  * @property {string} controller - Controller class name.
  * @property {string} [action] - Controller action or endpoint label.
@@ -223,7 +227,7 @@
  *   context: ClientErrorPayloadContext,
  *   error: Error,
  *   request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default | undefined
- * }): Promise<Record<string, ?> | void> | Record<string, ?> | void} ClientErrorPayloadReporterType
+ * }): Promise<ClientErrorPayloadReporterPayload | void> | ClientErrorPayloadReporterPayload | void} ClientErrorPayloadReporterType
  */
 
 /**

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -208,6 +208,25 @@
  */
 
 /**
+ * @typedef {object} ClientErrorPayloadContext
+ * @property {string} controller - Controller class name.
+ * @property {string} [action] - Controller action or endpoint label.
+ * @property {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url" | "custom-command"} [commandType] - Frontend-model command type.
+ * @property {boolean} [expectedError] - Whether the error is an expected user-flow failure.
+ * @property {boolean} [frontendModelEndpoint] - Whether the error came from the frontend-model endpoint.
+ * @property {string} [model] - Frontend-model name from the failed request.
+ * @property {string} [requestId] - Shared frontend-model request id.
+ */
+
+/**
+ * @typedef {function({
+ *   context: ClientErrorPayloadContext,
+ *   error: Error,
+ *   request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default | undefined
+ * }): Promise<Record<string, ?> | void> | Record<string, ?> | void} ClientErrorPayloadReporterType
+ */
+
+/**
  * @typedef {Record<string, unknown> & {configuration?: import("./configuration.js").default, currentUser?: unknown, params?: VelociousParams, request?: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default}} VelociousLooseObject
  */
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2396,10 +2396,10 @@ export default class VelociousConfiguration {
   /**
    * Runs registered client error payload reporters.
    * @param {{context: import("./configuration-types.js").ClientErrorPayloadContext, error: Error, request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default | undefined}} args - Reporter args.
-   * @returns {Promise<Record<string, ?>>} - Merged client-safe reporter payload.
+   * @returns {Promise<import("./configuration-types.js").ClientErrorPayloadReporterPayload>} - Merged client-safe reporter payload.
    */
   async clientErrorPayloadForError(args) {
-    /** @type {Record<string, ?>} */
+    /** @type {import("./configuration-types.js").ClientErrorPayloadReporterPayload} */
     const payload = {}
 
     for (const reporter of this._clientErrorPayloadReporters) {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -143,7 +143,7 @@ export default class VelociousConfiguration {
     this._scheduledBackgroundJobs = scheduledBackgroundJobs
     this._attachments = attachments || {}
     this._backendProjects = backendProjects || []
-    /** @type {Array<(args: {context: ?, error: Error, request: ?}) => Promise<Record<string, ?> | void> | Record<string, ?> | void>} */
+    /** @type {import("./configuration-types.js").ClientErrorPayloadReporterType[]} */
     this._clientErrorPayloadReporters = []
     this.cors = cors
     this._cookieSecret = cookieSecret
@@ -2386,7 +2386,7 @@ export default class VelociousConfiguration {
 
   /**
    * Registers a reporter that can add client-safe metadata to frontend-model error payloads.
-   * @param {(args: {context: ?, error: Error, request: ?}) => Promise<Record<string, ?> | void> | Record<string, ?> | void} reporter - Reporter callback.
+   * @param {import("./configuration-types.js").ClientErrorPayloadReporterType} reporter - Reporter callback.
    * @returns {void}
    */
   addClientErrorPayloadReporter(reporter) {
@@ -2395,7 +2395,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs registered client error payload reporters.
-   * @param {{context: ?, error: Error, request: ?}} args - Reporter args.
+   * @param {{context: import("./configuration-types.js").ClientErrorPayloadContext, error: Error, request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default | undefined}} args - Reporter args.
    * @returns {Promise<Record<string, ?>>} - Merged client-safe reporter payload.
    */
   async clientErrorPayloadForError(args) {

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -192,41 +192,35 @@ function frontendModelValidationErrorForError(error) {
  * developer for the frontend" — the framework treats it as
  * user-facing: surface the message, forward the metadata, and skip
  * the noisy endpoint-error log.
- * @param {?} error - Caught error.
+ * @param {unknown} error - Caught error.
  * @returns {boolean} Whether the error has Velocious frontend metadata.
  */
 function frontendModelErrorHasVelociousMetadata(error) {
   if (!error || typeof error !== "object") return false
 
-  /**
-   * Narrows the runtime value to an error metadata record.
-   * @type {{velocious?: Record<string, ?>}}
-   */
-  const errorRecord = error
+  // Runtime checks above narrow this caught value to the metadata record shape.
+  const errorRecord = /** @type {{velocious?: import("./configuration-types.js").ClientErrorPayloadReporterPayload}} */ (error)
 
   return isPlainObject(errorRecord.velocious)
 }
 
 /**
  * Whether the error has a frontend-model error type marker.
- * @param {?} error - Caught error.
+ * @param {unknown} error - Caught error.
  * @returns {boolean} Whether the error has an error type.
  */
 function frontendModelErrorHasErrorType(error) {
   if (!error || typeof error !== "object") return false
 
-  /**
-   * Narrows the runtime value to an error marker record.
-   * @type {{errorType?: string}}
-   */
-  const errorRecord = error
+  // Runtime checks above narrow this caught value to the marker record shape.
+  const errorRecord = /** @type {{errorType?: string}} */ (error)
 
   return typeof errorRecord.errorType === "string" && errorRecord.errorType.length > 0
 }
 
 /**
  * Whether the error is an expected frontend-model user-flow failure.
- * @param {?} error - Caught error.
+ * @param {unknown} error - Caught error.
  * @returns {boolean} Whether the error is expected.
  */
 function frontendModelExpectedError(error) {
@@ -239,8 +233,8 @@ function frontendModelExpectedError(error) {
 
 /**
  * Runs frontend model velocious metadata for error.
- * @param {?} error - Caught error.
- * @returns {Record<string, ?> | null} Frontend-model Velocious metadata when present.
+ * @param {unknown} error - Caught error.
+ * @returns {import("./configuration-types.js").ClientErrorPayloadReporterPayload | null} Frontend-model Velocious metadata when present.
  */
 function frontendModelVelociousMetadataForError(error) {
   const errorCode = error instanceof VelociousError && error.safeToExpose && typeof error.code === "string" && error.code.length > 0
@@ -251,11 +245,8 @@ function frontendModelVelociousMetadataForError(error) {
     return errorCode ? {code: errorCode} : null
   }
 
-  /**
-   * Narrows the runtime value to an error metadata record.
-   * @type {{velocious: Record<string, ?>}}
-   */
-  const errorRecord = error
+  // frontendModelErrorHasVelociousMetadata guards the caught value before this cast.
+  const errorRecord = /** @type {{velocious: import("./configuration-types.js").ClientErrorPayloadReporterPayload}} */ (error)
   const metadata = errorRecord.velocious
 
   return errorCode ? {...metadata, code: errorCode} : metadata
@@ -263,7 +254,7 @@ function frontendModelVelociousMetadataForError(error) {
 
 /**
  * Runs frontend model client message for error.
- * @param {?} error - Caught error.
+ * @param {unknown} error - Caught error.
  * @returns {string} - Message safe to return to API clients.
  */
 function frontendModelClientMessageForError(error) {
@@ -291,8 +282,8 @@ function frontendModelClientMessageForError(error) {
  * @param {object} args - Arguments.
  * @param {import("./configuration.js").default} args.configuration - Current configuration.
  * @param {string} args.environment - Current environment.
- * @param {?} args.error - Caught error.
- * @returns {Record<string, ?>} - Optional debug payload for non-production environments.
+ * @param {unknown} args.error - Caught error.
+ * @returns {import("./configuration-types.js").ClientErrorPayloadReporterPayload} - Optional debug payload for non-production environments.
  */
 function frontendModelDebugPayloadForError({configuration, environment, error}) {
   const debugAllowed = frontendModelDebugErrorEnvironments.has(environment) || environment !== "production" && configuration.getExposeInternalErrorsToClients()
@@ -2833,7 +2824,7 @@ export default class FrontendModelController extends Controller {
    * Builds frontend-model endpoint error context for logging and client payload reporters.
    * @param {object} args - Error context args.
    * @param {string} args.action - Endpoint/action label.
-   * @param {?} args.error - Caught error.
+   * @param {unknown} args.error - Caught error.
    * @param {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url" | "custom-command"} [args.commandType] - Frontend-model command type.
    * @param {string | undefined} [args.model] - Request model name when available.
    * @param {string | undefined} [args.requestId] - Batch request id when available.
@@ -2860,9 +2851,9 @@ export default class FrontendModelController extends Controller {
 
   /**
    * Runs frontend model client error payload for error.
-   * @param {?} error - Caught error.
+   * @param {unknown} error - Caught error.
    * @param {FrontendModelEndpointErrorContext | undefined} [endpointErrorContext] - Frontend-model endpoint error context.
-   * @returns {Promise<Record<string, ?>>} - Client payload for the current environment.
+   * @returns {Promise<import("./configuration-types.js").ClientErrorPayloadReporterPayload>} - Client payload for the current environment.
    */
   async frontendModelClientErrorPayloadForError(error, endpointErrorContext) {
     const velociousMetadata = frontendModelVelociousMetadataForError(error)

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -2834,7 +2834,8 @@ export default class FrontendModelController extends Controller {
     let resolvedModel = model
 
     if (!resolvedModel) {
-      const paramsModel = this.frontendModelParams().model
+      const cachedParams = this._frontendModelParamsOverride || this._frontendModelParams
+      const paramsModel = cachedParams ? cachedParams.model : undefined
       resolvedModel = typeof paramsModel === "string" && paramsModel.length > 0 ? paramsModel : undefined
     }
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -139,6 +139,14 @@ function normalizeFrontendModelSelect(select, rootModelName = null) {
  * @property {number | null} perPage - Page size.
  */
 
+/**
+ * @typedef {import("./configuration-types.js").ClientErrorPayloadContext & {
+ *   action: string,
+ *   expectedError: boolean,
+ *   frontendModelEndpoint: true
+ * }} FrontendModelEndpointErrorContext
+ */
+
 const frontendModelJoinedPathsSymbol = Symbol("frontendModelJoinedPaths")
 const frontendModelGroupedColumnsSymbol = Symbol("frontendModelGroupedColumns")
 const frontendModelWhereNoMatchSymbol = Symbol("frontendModelWhereNoMatch")
@@ -185,26 +193,72 @@ function frontendModelValidationErrorForError(error) {
  * user-facing: surface the message, forward the metadata, and skip
  * the noisy endpoint-error log.
  * @param {?} error - Caught error.
- * @returns {boolean}
+ * @returns {boolean} Whether the error has Velocious frontend metadata.
  */
 function frontendModelErrorHasVelociousMetadata(error) {
-  return Boolean(error && typeof error === "object" && /**
-                                                        * Types the following value.
-                                                        * @type {?} */ (error).velocious && typeof /**
-                                                                                                   * Types the following value.
-                                                                                                   * @type {?} */ (error).velocious === "object")
+  if (!error || typeof error !== "object") return false
+
+  /**
+   * Narrows the runtime value to an error metadata record.
+   * @type {{velocious?: Record<string, ?>}}
+   */
+  const errorRecord = error
+
+  return isPlainObject(errorRecord.velocious)
+}
+
+/**
+ * Whether the error has a frontend-model error type marker.
+ * @param {?} error - Caught error.
+ * @returns {boolean} Whether the error has an error type.
+ */
+function frontendModelErrorHasErrorType(error) {
+  if (!error || typeof error !== "object") return false
+
+  /**
+   * Narrows the runtime value to an error marker record.
+   * @type {{errorType?: string}}
+   */
+  const errorRecord = error
+
+  return typeof errorRecord.errorType === "string" && errorRecord.errorType.length > 0
+}
+
+/**
+ * Whether the error is an expected frontend-model user-flow failure.
+ * @param {?} error - Caught error.
+ * @returns {boolean} Whether the error is expected.
+ */
+function frontendModelExpectedError(error) {
+  if (error instanceof ValidationError) return true
+  if (error instanceof VelociousError && error.safeToExpose) return true
+  if (frontendModelErrorHasVelociousMetadata(error)) return true
+
+  return frontendModelErrorHasErrorType(error)
 }
 
 /**
  * Runs frontend model velocious metadata for error.
  * @param {?} error - Caught error.
- * @returns {Record<string, ?> | null}
+ * @returns {Record<string, ?> | null} Frontend-model Velocious metadata when present.
  */
 function frontendModelVelociousMetadataForError(error) {
-  if (!frontendModelErrorHasVelociousMetadata(error)) return null
-  return /** @type {Record<string, ?>} */ (/**
-                                            * Types the following value.
-                                            * @type {?} */ (error).velocious)
+  const errorCode = error instanceof VelociousError && error.safeToExpose && typeof error.code === "string" && error.code.length > 0
+    ? error.code
+    : null
+
+  if (!frontendModelErrorHasVelociousMetadata(error)) {
+    return errorCode ? {code: errorCode} : null
+  }
+
+  /**
+   * Narrows the runtime value to an error metadata record.
+   * @type {{velocious: Record<string, ?>}}
+   */
+  const errorRecord = error
+  const metadata = errorRecord.velocious
+
+  return errorCode ? {...metadata, code: errorCode} : metadata
 }
 
 /**
@@ -2776,11 +2830,41 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
+   * Builds frontend-model endpoint error context for logging and client payload reporters.
+   * @param {object} args - Error context args.
+   * @param {string} args.action - Endpoint/action label.
+   * @param {?} args.error - Caught error.
+   * @param {"index" | "find" | "create" | "update" | "destroy" | "attach" | "download" | "url" | "custom-command"} [args.commandType] - Frontend-model command type.
+   * @param {string | undefined} [args.model] - Request model name when available.
+   * @param {string | undefined} [args.requestId] - Batch request id when available.
+   * @returns {FrontendModelEndpointErrorContext} Frontend-model endpoint error context.
+   */
+  frontendModelEndpointErrorContext({action, commandType, error, model, requestId}) {
+    let resolvedModel = model
+
+    if (!resolvedModel) {
+      const paramsModel = this.frontendModelParams().model
+      resolvedModel = typeof paramsModel === "string" && paramsModel.length > 0 ? paramsModel : undefined
+    }
+
+    return {
+      action,
+      commandType,
+      controller: this.constructor.name,
+      expectedError: frontendModelExpectedError(error),
+      frontendModelEndpoint: true,
+      model: resolvedModel,
+      requestId
+    }
+  }
+
+  /**
    * Runs frontend model client error payload for error.
    * @param {?} error - Caught error.
+   * @param {FrontendModelEndpointErrorContext | undefined} [endpointErrorContext] - Frontend-model endpoint error context.
    * @returns {Promise<Record<string, ?>>} - Client payload for the current environment.
    */
-  async frontendModelClientErrorPayloadForError(error) {
+  async frontendModelClientErrorPayloadForError(error, endpointErrorContext) {
     const velociousMetadata = frontendModelVelociousMetadataForError(error)
     const normalizedError = error instanceof Error ? error : new Error(String(error))
 
@@ -2818,9 +2902,7 @@ export default class FrontendModelController extends Controller {
       ...(velociousMetadata ? {velocious: velociousMetadata} : {}),
       ...validationErrorsPayload,
       ...(await this.getConfiguration().clientErrorPayloadForError({
-        context: {
-          controller: this.constructor.name
-        },
+        context: endpointErrorContext || {controller: this.constructor.name},
         error: normalizedError,
         request: this.getRequest()
       }))
@@ -2838,23 +2920,12 @@ export default class FrontendModelController extends Controller {
    * @returns {Promise<void>} - Resolves after logging.
    */
   async frontendModelLogEndpointError({action, error, commandType, model, requestId}) {
-    // Errors annotated with `error.velocious = {...}` are user-flow
-    // failures the developer has marked as expected (bad password,
-    // validation message, etc.). Surface the message + metadata to
-    // the client (handled by frontendModelClientErrorPayloadForError),
-    // but skip the error log so monitoring stays focused on real
-    // backend failures.
-    if (frontendModelErrorHasVelociousMetadata(error)) return
+    const errorContext = this.frontendModelEndpointErrorContext({action, commandType, error, model, requestId})
 
-    let resolvedModel = model
-
-    if (!resolvedModel) {
-      try {
-        resolvedModel = this.frontendModelParams().model
-      } catch {
-        resolvedModel = undefined
-      }
-    }
+    // Expected user-flow errors are surfaced to clients by
+    // frontendModelClientErrorPayloadForError, but skipped here so monitoring
+    // stays focused on real backend failures.
+    if (errorContext.expectedError) return
 
     const errorMessage = error instanceof Error
       ? `${error.message}\n${error.stack || ""}`
@@ -2864,27 +2935,22 @@ export default class FrontendModelController extends Controller {
       action,
       commandType,
       error: errorMessage,
-      model: resolvedModel,
+      model: errorContext.model,
       requestId
     }])
 
     // Surface genuinely unexpected backend failures on the framework-error
     // channel so process-level bug reporters capture them, instead of the
     // controller silently swallowing them behind the generic "Request
-    // failed." client message. Developer-annotated user-flow errors
-    // (`error.velocious` metadata — handled by the early return above),
-    // validation errors, and deliberately client-safe VelociousErrors are
-    // expected and must NOT be reported as framework errors.
-    if (!(error instanceof ValidationError) && !(error instanceof VelociousError && error.safeToExpose)) {
-      const errorPayload = {
-        context: {action, commandType, frontendModelEndpoint: true, model: resolvedModel, requestId},
-        error: error instanceof Error ? error : new Error(String(error)),
-        request: this.getRequest()
-      }
-
-      this.getConfiguration().getErrorEvents().emit("framework-error", errorPayload)
-      this.getConfiguration().getErrorEvents().emit("all-error", {...errorPayload, errorType: "framework-error"})
+    // failed." client message.
+    const errorPayload = {
+      context: errorContext,
+      error: error instanceof Error ? error : new Error(String(error)),
+      request: this.getRequest()
     }
+
+    this.getConfiguration().getErrorEvents().emit("framework-error", errorPayload)
+    this.getConfiguration().getErrorEvents().emit("all-error", {...errorPayload, errorType: "framework-error"})
   }
 
   /**
@@ -2903,12 +2969,14 @@ export default class FrontendModelController extends Controller {
                * @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(responsePayload))
       })
     } catch (error) {
-      await this.frontendModelLogEndpointError({action, commandType: action, error})
+      const errorContext = this.frontendModelEndpointErrorContext({action, commandType: action, error})
+
+      await this.frontendModelLogEndpointError({action, commandType: action, error, model: errorContext.model})
 
       await this.render({
         json: /**
                * Types the following value.
-               * @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(await this.frontendModelClientErrorPayloadForError(error)))
+               * @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(await this.frontendModelClientErrorPayloadForError(error, errorContext)))
       })
     }
   }
@@ -3183,7 +3251,7 @@ export default class FrontendModelController extends Controller {
           response: responsePayload || this.frontendModelErrorPayload("Action halted by beforeAction.")
         })
       } catch (error) {
-        await this.frontendModelLogEndpointError({
+        const errorContext = this.frontendModelEndpointErrorContext({
           action: "frontendApi",
           commandType,
           error,
@@ -3191,9 +3259,17 @@ export default class FrontendModelController extends Controller {
           requestId
         })
 
+        await this.frontendModelLogEndpointError({
+          action: errorContext.action,
+          commandType: errorContext.commandType,
+          error,
+          model: errorContext.model,
+          requestId: errorContext.requestId
+        })
+
         responses.push({
           requestId,
-          response: await this.frontendModelClientErrorPayloadForError(error)
+          response: await this.frontendModelClientErrorPayloadForError(error, errorContext)
         })
       }
     }
@@ -3414,12 +3490,14 @@ export default class FrontendModelController extends Controller {
                * @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(responsePayload))
       })
     } catch (error) {
-      await this.frontendModelLogEndpointError({action: "frontendCustomCommand", commandType: "custom-command", error})
+      const errorContext = this.frontendModelEndpointErrorContext({action: "frontendCustomCommand", commandType: "custom-command", error})
+
+      await this.frontendModelLogEndpointError({action: errorContext.action, commandType: errorContext.commandType, error, model: errorContext.model})
 
       await this.render({
         json: /**
                * Types the following value.
-               * @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(await this.frontendModelClientErrorPayloadForError(error)))
+               * @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(await this.frontendModelClientErrorPayloadForError(error, errorContext)))
       })
     }
   }


### PR DESCRIPTION
## Summary
- enrich frontend-model client error payload reporter context with endpoint metadata
- keep validation, safe VelociousError, error.velocious, and errorType-marked frontend-model errors out of framework-error reporting
- expose safe VelociousError codes in frontend-model client payload metadata
- tighten the client error reporter payload typedef to the frontend-model transport payload contract instead of loose `Record<string, ?>`

## Verification
- `npm run test -- spec/controller/frontend-model-actions-spec.js spec/controller/frontend-model-custom-command-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow`
- `npm run build`

## CI Note
- Current commit `4bda37dfc6368af73bccbf3bb10796c76988a88b` has all Velocious TensorBuzz checks green except `MS-SQL (2/3)` and `MariaDB (1/3)`.
- Both red checks failed before tests ran with `Build service mssql failed health monitoring after 20 restart(s): healthcheck unhealthy`.
- The fetched MSSQL service log reports SQL Server aborting at startup with `Unable to create a new asynchronous I/O context. Please increase sysctl fs.aio-max-nr`, followed by repeated core dumps.
- GitHub check-run re-request calls for the two failed checks returned HTTP 404 with my token, so I could not rerun only those shards.