### PR TITLE
Make migration primary key type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Database models with migrations and validations
 * Database models that work almost the same in frontend and backend
 * Declarative state machines for models (see [docs/state-machine.md](docs/state-machine.md))
-* Migrations for schema changes
+* Migrations for schema changes (see [docs/database-migrations.md](docs/database-migrations.md))
 * Controllers and views for HTTP endpoints
 * Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))
@@ -1006,7 +1006,20 @@ npx velocious g:migration create-tasks
 ```
 
 ## Write a migration
-Implicit `id` primary keys and `references(...)` columns use UUIDs by default. Use an explicit numeric `id` or reference `type` only for legacy schemas or external compatibility.
+Implicit `id` primary keys and `references(...)` columns use UUIDs by default. Set `primaryKeyType` on a database config to change the implicit type for that database, or pass an explicit `id` / reference `type` for legacy schemas and external compatibility.
+
+```js
+export default new Configuration({
+  database: {
+    production: {
+      default: {
+        type: "pgsql",
+        primaryKeyType: "bigint"
+      }
+    }
+  }
+})
+```
 
 ```js
 import Migration from "velocious/build/src/database/migration/index.js"

--- a/changelog.d/20260616075702-configurable-primary-key-type.md
+++ b/changelog.d/20260616075702-configurable-primary-key-type.md
@@ -1,0 +1,1 @@
+Allow database configs to override the default migration primary-key type with `primaryKeyType`, keeping UUID as the default and applying the configured type to implicit `references(...)` columns.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder contains implementation learnings and practical guidance discovered 
 ## Index
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
 - `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
+- `docs/database-migrations.md`: Migration helpers, implicit primary keys, and reference column defaults.
 - `docs/http-server.md`: HTTP server worker configuration and socket distribution behavior.
 - `docs/expo-metro-compatibility.md`: Expo/Metro integration rules and the repository Expo export check.
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,39 @@
+# Database Migrations
+
+Velocious migration helpers default new tables to UUID primary keys:
+
+```js
+await this.createTable("tasks", (table) => {
+  table.string("name")
+  table.references("project")
+  table.timestamps()
+})
+```
+
+The implicit `id` column and implicit `table.references(...)` column use the current database's `primaryKeyType`. When omitted, `primaryKeyType` defaults to `"uuid"`.
+
+Set `primaryKeyType` on a database configuration to change the default for that database:
+
+```js
+export default new Configuration({
+  database: {
+    production: {
+      default: {
+        type: "mysql",
+        primaryKeyType: "bigint"
+      }
+    }
+  }
+})
+```
+
+Explicit migration types still take precedence:
+
+```js
+await this.createTable("legacy_events", {id: {type: "bigint"}}, (table) => {
+  table.references("task", {type: "bigint"})
+  table.references("external_user", {type: "uuid"})
+})
+```
+
+SQLite stores auto-increment primary keys through its special `INTEGER PRIMARY KEY` form even when a migration asks for `bigint`, while non-primary reference columns keep the configured `bigint` type. PostgreSQL emits `BIGSERIAL` for auto-increment `bigint` primary keys.

--- a/spec/database/migration/uuid-primary-key.browser-spec.js
+++ b/spec/database/migration/uuid-primary-key.browser-spec.js
@@ -68,6 +68,75 @@ describe("database - migration - uuid primary key", {tags: ["dummy"]}, () => {
     })
   })
 
+  it("uses configured primary key types for implicit primary keys and references", async () => {
+    const configuration = Configuration.current()
+    const databaseConfiguration = configuration.getDatabaseConfiguration().default
+    const originalPrimaryKeyType = databaseConfiguration.primaryKeyType
+
+    databaseConfiguration.primaryKeyType = "bigint"
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const driver = dbs.default
+        const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+        try {
+          await driver.dropTable("configured_primary_key_children", {cascade: true, ifExists: true})
+          await driver.dropTable("configured_primary_key_parents", {cascade: true, ifExists: true})
+          await migration.createTable("configured_primary_key_parents", (table) => {
+            table.string("name")
+          })
+          await migration.createTable("configured_primary_key_children", (table) => {
+            table.references("configured_primary_key_parent", {null: true})
+            table.references("configured_primary_key_parent_uuid", {null: true, type: "uuid"})
+          })
+
+          const parentTable = await driver.getTableByNameOrFail("configured_primary_key_parents")
+          const childTable = await driver.getTableByNameOrFail("configured_primary_key_children")
+          const parentIdColumn = await parentTable.getColumnByNameOrFail("id")
+          const parentReferenceColumn = await childTable.getColumnByNameOrFail("configured_primary_key_parent_id")
+          const explicitUuidReferenceColumn = await childTable.getColumnByNameOrFail("configured_primary_key_parent_uuid_id")
+          const expectedParentIdType = driver.getType() == "sqlite" ? "integer" : "bigint"
+
+          expect(parentIdColumn.getType()?.toLowerCase()).toEqual(expectedParentIdType)
+          expect(parentReferenceColumn.getType()?.toLowerCase()).toEqual("bigint")
+          expect(["uuid", "varchar"].includes(explicitUuidReferenceColumn.getType()?.toLowerCase() || "")).toEqual(true)
+        } finally {
+          await driver.dropTable("configured_primary_key_children", {cascade: true, ifExists: true})
+          await driver.dropTable("configured_primary_key_parents", {cascade: true, ifExists: true})
+        }
+      })
+    } finally {
+      if (originalPrimaryKeyType === undefined) {
+        delete databaseConfiguration.primaryKeyType
+      } else {
+        databaseConfiguration.primaryKeyType = originalPrimaryKeyType
+      }
+    }
+  })
+
+  it("keeps reference defaults tied to the database primary key type when table IDs are explicit", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const configuration = Configuration.current()
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      try {
+        await driver.dropTable("explicit_id_reference_defaults", {cascade: true, ifExists: true})
+        await migration.createTable("explicit_id_reference_defaults", {id: {type: "bigint"}}, (table) => {
+          table.references("implicit_uuid_parent", {null: true})
+        })
+
+        const table = await driver.getTableByNameOrFail("explicit_id_reference_defaults")
+        const referenceColumn = await table.getColumnByNameOrFail("implicit_uuid_parent_id")
+
+        expect(["uuid", "varchar"].includes(referenceColumn.getType()?.toLowerCase() || "")).toEqual(true)
+      } finally {
+        await driver.dropTable("explicit_id_reference_defaults", {cascade: true, ifExists: true})
+      }
+    })
+  })
+
   it("uses driver default UUIDs when supported", async () => {
     await Configuration.current().ensureConnections(async (dbs) => {
       const table = await dbs.default.getTableByNameOrFail("uuid_items")

--- a/spec/database/migration/uuid-primary-key.browser-spec.js
+++ b/spec/database/migration/uuid-primary-key.browser-spec.js
@@ -137,6 +137,37 @@ describe("database - migration - uuid primary key", {tags: ["dummy"]}, () => {
     })
   })
 
+  it("uses the explicit migration driver for primary key defaults outside a pool checkout", async () => {
+    const configuration = Configuration.current()
+    const pool = configuration.getDatabasePool("default")
+    const outsideContextConnection = pool.withoutCurrentConnectionContext(() => pool.getCurrentContextConnection())
+    const outsideContextConnectionIsShared = Boolean(outsideContextConnection && outsideContextConnection.getArgs().getConnection)
+
+    if (outsideContextConnection && !outsideContextConnectionIsShared) await pool.closeAll()
+    const driver = await pool.spawnConnection()
+    const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+    const sharesConnection = Boolean(driver.getArgs().getConnection)
+
+    try {
+      await driver.dropTable("explicit_driver_primary_keys", {cascade: true, ifExists: true})
+      await configuration.withoutCurrentConnectionContexts(async () => {
+        await migration.createTable("explicit_driver_primary_keys", {id: {type: "bigint"}}, (table) => {
+          table.string("name")
+        })
+      })
+
+      const table = await driver.getTableByNameOrFail("explicit_driver_primary_keys")
+      const idColumn = await table.getColumnByNameOrFail("id")
+      const expectedIdType = driver.getType() == "sqlite" ? "integer" : "bigint"
+
+      expect(idColumn.getType()?.toLowerCase()).toEqual(expectedIdType)
+    } finally {
+      await driver.dropTable("explicit_driver_primary_keys", {cascade: true, ifExists: true})
+
+      if (!sharesConnection) await driver.close()
+    }
+  })
+
   it("uses driver default UUIDs when supported", async () => {
     await Configuration.current().ensureConnections(async (dbs) => {
       const table = await dbs.default.getTableByNameOrFail("uuid_items")

--- a/spec/database/query/create-table-foreign-key-sql-spec.js
+++ b/spec/database/query/create-table-foreign-key-sql-spec.js
@@ -83,4 +83,14 @@ describe("database - query - create-table foreign-key SQL", {databaseCleaning: {
     expect(sqls[0]).toContain("REFERENCES `authors`(`id`)")
     expect(sqls[0]).not.toContain("CONSTRAINT")
   })
+
+  it("uses bigserial for PostgreSQL auto-increment bigint primary keys", async () => {
+    const tableData = new TableData("posts")
+
+    tableData.addColumn("id", {autoIncrement: true, null: false, primaryKey: true, type: "bigint"})
+
+    const sqls = await new CreateTableBase({driver: buildDriver("pgsql"), tableData}).toSql()
+
+    expect(sqls[0]).toContain("`id` BIGSERIAL PRIMARY KEY NOT NULL")
+  })
 })

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -71,6 +71,7 @@
  * @property {boolean} [migrations] - Whether migrations are enabled for this database.
  * @property {string} [password] - Password for the database user.
  * @property {number} [port] - Database port.
+ * @property {string} [primaryKeyType] - Default type for implicit migration primary keys and references. Defaults to `uuid`.
  * @property {DatabasePoolConfiguration} [pool] - Velocious database pool lifecycle configuration.
  * @property {string} [name] - Friendly name for the configuration.
  * @property {(file: string) => string} [locateFile] - Optional sqlite-web sql.js wasm resolver (`initSqlJs({locateFile})`).

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -407,6 +407,14 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Runs primary key type.
+   * @returns {string} - Configured primary key type, defaulting to UUID.
+   */
+  primaryKeyType() {
+    return this.getArgs().primaryKeyType || "uuid"
+  }
+
+  /**
    * Clears cached schema metadata for this driver instance.
    * @returns {void} - No return value.
    */

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -200,12 +200,6 @@ export default class VelociousDatabaseDriversMssql extends Base{
   getType() { return "mssql" }
 
   /**
-   * Runs primary key type.
-   * @returns {string} - The primary key type.
-   */
-  primaryKeyType() { return "uuid" }
-
-  /**
    * Runs query actual.
    * @param {string} sql - SQL string.
    * @returns {Promise<import("../base.js").QueryResultType>} - Resolves with the query actual.

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -208,12 +208,6 @@ export default class VelociousDatabaseDriversMysql extends Base{
   getType() { return "mysql" }
 
   /**
-   * Runs primary key type.
-   * @returns {string} - The primary key type.
-   */
-  primaryKeyType() { return "uuid" }
-
-  /**
    * Runs retryable database error.
    * @param {Error} error - Error instance.
    * @returns {import("../base.js").RetryableDatabaseErrorResult} - Retry info.

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -177,7 +177,6 @@ export default class VelociousDatabaseDriversPgsql extends Base{
   }
 
   getType() { return "pgsql" }
-  primaryKeyType() { return "uuid" }
 
   /**
    * Runs query actual.

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -266,12 +266,6 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
   }
 
   /**
-   * Runs primary key type.
-   * @returns {string} - The type of the primary key for this driver.
-   */
-  primaryKeyType() { return "uuid" }
-
-  /**
    * Runs query to sql.
    * @param {import("../../query/index.js").default} query - Query instance.
    * @returns {string} - SQL string.

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -351,8 +351,8 @@ export default class VelociousDatabaseMigration {
     }
 
     const {id = {}, ifNotExists = false, ...restArgs} = args
-    const databaseIdentifier = this._getDatabaseIdentifier()
-    const databasePool = this.configuration.getDatabasePool(databaseIdentifier)
+    const driver = this.getDriver()
+    const defaultPrimaryKeyType = driver.primaryKeyType()
     let idDefault, idType, restArgsId
 
     if (id !== false) {
@@ -362,9 +362,9 @@ export default class VelociousDatabaseMigration {
     }
 
     if (!idType) {
-      idType = databasePool.primaryKeyType()
+      idType = defaultPrimaryKeyType
     }
-    const driverSupportsDefaultUUID = this.getDriver().supportsDefaultPrimaryKeyUUID?.()
+    const driverSupportsDefaultUUID = driver.supportsDefaultPrimaryKeyUUID?.()
     const lowerIdType = idType?.toLowerCase()
     const isUUIDPrimaryKey = lowerIdType == "uuid"
     const numericAutoIncrementTypes = ["int", "integer", "bigint", "smallint", "tinyint"]
@@ -384,7 +384,7 @@ export default class VelociousDatabaseMigration {
       // If driver doesn't support UUID() but the caller explicitly set a default, respect it.
     }
 
-    const tableData = new TableData(tableName, {ifNotExists, primaryKeyType: databasePool.primaryKeyType()})
+    const tableData = new TableData(tableName, {ifNotExists, primaryKeyType: defaultPrimaryKeyType})
 
     restArgsError(restArgs)
 
@@ -398,7 +398,7 @@ export default class VelociousDatabaseMigration {
       callback(tableData)
     }
 
-    const sqls = await this.getDriver().createTableSql(tableData)
+    const sqls = await driver.createTableSql(tableData)
 
     for (const sql of sqls) {
       await this._db.query(sql)

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -384,7 +384,7 @@ export default class VelociousDatabaseMigration {
       // If driver doesn't support UUID() but the caller explicitly set a default, respect it.
     }
 
-    const tableData = new TableData(tableName, {ifNotExists})
+    const tableData = new TableData(tableName, {ifNotExists, primaryKeyType: databasePool.primaryKeyType()})
 
     restArgsError(restArgs)
 

--- a/src/database/table-data/index.js
+++ b/src/database/table-data/index.js
@@ -8,6 +8,7 @@ import TableReference from "./table-reference.js"
  * TableDataArgsType type.
  * @typedef {object} TableDataArgsType
  * @property {boolean} ifNotExists - Whether to create the table only if it does not exist.
+ * @property {string} [primaryKeyType] - Default type for implicit primary-key references.
  */
 
 export default class TableData {
@@ -188,7 +189,7 @@ export default class TableData {
     const referenceArgs = args || {}
     const reference = new TableReference(name, referenceArgs)
     const {index, polymorphic, ...restArgs} = referenceArgs
-    const columnArgs = Object.assign({isNewColumn: true, type: "uuid"}, restArgs)
+    const columnArgs = Object.assign({isNewColumn: true, type: this.args?.primaryKeyType || "uuid"}, restArgs)
     const column = new TableColumn(columnName, columnArgs)
     const indexArgs = typeof index == "object" ? {unique: index.unique === true} : undefined
     const tableIndex = new TableIndex([column], indexArgs)

--- a/src/database/table-data/table-column.js
+++ b/src/database/table-data/table-column.js
@@ -326,7 +326,13 @@ export default class TableColumn {
     }
 
     if (databaseType == "pgsql" && this.getAutoIncrement() && this.getPrimaryKey()) {
-      type = "SERIAL"
+      if (type == "BIGINT") {
+        type = "BIGSERIAL"
+      } else if (type == "SMALLINT") {
+        type = "SMALLSERIAL"
+      } else {
+        type = "SERIAL"
+      }
     }
 
     let sql = `${options.quoteColumnName(this.getActualName())} `


### PR DESCRIPTION
## Summary
- add database `primaryKeyType` config with UUID as the default
- make implicit migration IDs and `table.references(...)` use the configured database default
- keep explicit table ID types from changing reference defaults, and keep explicit reference types taking precedence
- emit `BIGSERIAL`/`SMALLSERIAL` for PostgreSQL auto-increment bigint/smallint primary keys
- document migration primary-key defaults and add a changelog fragment

## Validation
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/migration/uuid-primary-key.browser-spec.js`
- `VELOCIOUS_ENV=test VELOCIOUS_DISABLE_MSSQL=1 npm run test:browser -- spec/database/migration/uuid-primary-key.browser-spec.js`
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/query/create-table-foreign-key-sql-spec.js`
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/migration/all-column-types.browser-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint`
- `npm run typecheck`
- `npm run fallow`
- restored `spec/dummy/src/config/configuration.js` after validation
