### PR TITLE
Persist datetimes as UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Database models with migrations and validations
 * Database models that work almost the same in frontend and backend
 * Declarative state machines for models (see [docs/state-machine.md](docs/state-machine.md))
-* Migrations for schema changes (see [docs/database-migrations.md](docs/database-migrations.md))
+* Migrations for schema changes and UTC datetime storage (see [docs/database-migrations.md](docs/database-migrations.md))
 * Controllers and views for HTTP endpoints
 * Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))

--- a/changelog.d/20260616195407-utc-datetime-storage.md
+++ b/changelog.d/20260616195407-utc-datetime-storage.md
@@ -1,1 +1,1 @@
-Persist database datetimes as UTC instants, parse timezone-less datetime input as UTC, and add a migration helper for legacy local SQLite datetime rows.
+Persist database datetimes as UTC instants, parse timezone-less datetime input and frontend-model filters as UTC, and add a migration helper for legacy local SQLite datetime rows.

--- a/changelog.d/20260616195407-utc-datetime-storage.md
+++ b/changelog.d/20260616195407-utc-datetime-storage.md
@@ -1,0 +1,1 @@
+Persist database datetimes as UTC instants, parse timezone-less datetime input as UTC, and add a migration helper for legacy local SQLite datetime rows.

--- a/changelog.d/20260617054600-mysql-db-drop-maintenance-connection.md
+++ b/changelog.d/20260617054600-mysql-db-drop-maintenance-connection.md
@@ -1,0 +1,1 @@
+MySQL/MariaDB `db:drop` now opens its direct maintenance connection without selecting the `mysql` system database when the configured fallback database is the database being dropped.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains implementation learnings and practical guidance discovered 
 ## Index
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
 - `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
-- `docs/database-migrations.md`: Migration helpers, implicit primary keys, and reference column defaults.
+- `docs/database-migrations.md`: Migration helpers, UTC datetime storage, implicit primary keys, and reference column defaults.
 - `docs/http-server.md`: HTTP server worker configuration and socket distribution behavior.
 - `docs/expo-metro-compatibility.md`: Expo/Metro integration rules and the repository Expo export check.
 - `docs/frontend-models.md`: Frontend model transport, commands, lookup semantics, and pitfalls.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -37,3 +37,26 @@ await this.createTable("legacy_events", {id: {type: "bigint"}}, (table) => {
 ```
 
 SQLite stores auto-increment primary keys through its special `INTEGER PRIMARY KEY` form even when a migration asks for `bigint`, while non-primary reference columns keep the configured `bigint` type. PostgreSQL emits `BIGSERIAL` for auto-increment `bigint` primary keys.
+
+## Datetime Storage
+
+Velocious stores persisted `Date` values as UTC instants. Runtime-local timezone and `timezoneOffsetMinutes` are not applied when records are inserted, updated, or read back from storage.
+
+External datetime strings follow the same rule:
+
+- Strings with a timezone suffix, such as `2026-06-12T14:30:00+02:00`, are parsed as that exact instant and stored in UTC.
+- Timezone-less datetime strings, such as `2026-06-12 12:30:00`, are treated as UTC.
+
+SQLite stores new datetime rows with an explicit `Z` suffix. Legacy SQLite rows written by older Velocious versions may contain timezone-less local wall-clock strings. Use `migrateLegacyLocalDateTimesToUtcStorage(...)` in a migration to rewrite those rows:
+
+```js
+await this.migrateLegacyLocalDateTimesToUtcStorage({
+  tables: ["ticket_scans"],
+  columnsByTable: {
+    ticket_scans: ["scanned_at", "valid_from", "valid_until"]
+  },
+  legacyLocalOffsetMinutes: new Date().getTimezoneOffset()
+})
+```
+
+`legacyLocalOffsetMinutes` uses JavaScript's `Date#getTimezoneOffset()` sign convention: minutes to add to local wall-clock time to get UTC. Omit it to parse legacy values in the runtime's current local timezone, including that timezone's daylight-saving rules for each date.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -40,12 +40,14 @@ SQLite stores auto-increment primary keys through its special `INTEGER PRIMARY K
 
 ## Datetime Storage
 
-Velocious stores persisted `Date` values as UTC instants. Runtime-local timezone and `timezoneOffsetMinutes` are not applied when records are inserted, updated, or read back from storage.
+Velocious stores persisted `Date` values as UTC instants. Runtime-local timezone and `timezoneOffsetMinutes` are not applied when records are inserted, updated, queried, or read back from storage.
 
 External datetime strings follow the same rule:
 
 - Strings with a timezone suffix, such as `2026-06-12T14:30:00+02:00`, are parsed as that exact instant and stored in UTC.
 - Timezone-less datetime strings, such as `2026-06-12 12:30:00`, are treated as UTC.
+
+Frontend-model `where`/`findBy` datetime filters use the same parsing rule, so filtering with the same timezone-less datetime string that created a row matches the stored UTC instant.
 
 SQLite stores new datetime rows with an explicit `Z` suffix. Legacy SQLite rows written by older Velocious versions may contain timezone-less local wall-clock strings. Use `migrateLegacyLocalDateTimesToUtcStorage(...)` in a migration to rewrite those rows:
 

--- a/spec/cli/commands/db/drop-spec.js
+++ b/spec/cli/commands/db/drop-spec.js
@@ -9,7 +9,8 @@ class FakeDropDriver {
   static instances = []
   static failConnect = false
 
-  constructor() {
+  constructor(configuration) {
+    this.configuration = configuration
     this.closed = false
     this.connected = false
     FakeDropDriver.instances.push(this)
@@ -43,6 +44,24 @@ function fakeMssqlDropConfiguration() {
       })
     }),
     getDatabaseType: () => "mssql",
+    getEnvironment: () => "test",
+    getEnvironmentHandler: () => ({})
+  }
+}
+
+function fakeMysqlDropConfiguration() {
+  return {
+    getDatabaseConfiguration: () => ({default: {database: "velocious_test"}}),
+    getDatabaseIdentifiers: () => ["default"],
+    getDatabasePool: () => ({
+      getConfiguration: () => ({
+        database: "velocious_test",
+        driver: FakeDropDriver,
+        type: "mysql",
+        useDatabase: "velocious_test"
+      })
+    }),
+    getDatabaseType: () => "mysql",
     getEnvironment: () => "test",
     getEnvironmentHandler: () => ({})
   }
@@ -111,6 +130,21 @@ describe("Cli - Commands - db:drop", () => {
     await command.execute()
 
     expectSingleFakeDriverClosed(FakeDropDriver)
+  })
+
+  it("does not connect MySQL drop commands to the inaccessible mysql system database", async () => {
+    FakeDropDriver.reset()
+    const command = new DbDrop({
+      args: {
+        configuration: /** @type {import("../../../../src/configuration.js").default} */ (fakeMysqlDropConfiguration()),
+        testing: true
+      },
+      cli: /** @type {import("../../../../src/cli/index.js").default} */ ({})
+    })
+
+    await command.execute()
+
+    expect(FakeDropDriver.instances[0].configuration.database).toBeUndefined()
   })
 
   it("closes direct MSSQL connections when connect fails", async () => {

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -81,4 +81,17 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
       }
     ])
   })
+
+  it("sets the session time zone to UTC without process-list comments", async () => {
+    const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
+
+    await mysql.setSessionTimezoneToUtc()
+
+    expect(mysql.queries).toEqual([
+      {
+        options: {logName: "Set Session Time Zone", processListComment: false},
+        sql: "SET time_zone = '+00:00'"
+      }
+    ])
+  })
 })

--- a/spec/database/drivers/pgsql-connection-checkout-name-spec.js
+++ b/spec/database/drivers/pgsql-connection-checkout-name-spec.js
@@ -59,4 +59,17 @@ describe("Database - Drivers - PostgreSQL - checkout names", {databaseCleaning: 
       }
     ])
   })
+
+  it("sets the session time zone to UTC without process-list comments", async () => {
+    const pgsql = new QueryCapturingPgsqlDriver({}, buildConfiguration())
+
+    await pgsql.setSessionTimezoneToUtc()
+
+    expect(pgsql.queries).toEqual([
+      {
+        options: {logName: "Set Session Time Zone", processListComment: false},
+        sql: "SET TIME ZONE 'UTC'"
+      }
+    ])
+  })
 })

--- a/spec/database/migration/datetime-storage.browser-spec.js
+++ b/spec/database/migration/datetime-storage.browser-spec.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration - datetime storage", {tags: ["dummy"]}, () => {
+  it("converts legacy local SQLite datetime rows to UTC storage", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const tableName = "legacy_datetime_storage_records"
+      const migration = new Migration({configuration: Configuration.current(), db})
+
+      if (await migration.tableExists(tableName)) {
+        await migration.dropTable(tableName)
+      }
+
+      await migration.createTable(tableName, {id: false}, (table) => {
+        table.integer("id", {null: false, primaryKey: true})
+        table.datetime("created_at")
+        table.datetime("already_utc_at")
+      })
+
+      try {
+        await db.query(`
+          INSERT INTO ${db.quoteTable(tableName)}
+          (${db.quoteColumn("id")}, ${db.quoteColumn("created_at")}, ${db.quoteColumn("already_utc_at")})
+          VALUES (${db.quote(1)}, ${db.quote("2025-06-12 14:34:56.789")}, ${db.quote("2025-06-12T12:34:56.789Z")})
+        `)
+
+        await migration.migrateLegacyLocalDateTimesToUtcStorage({
+          tables: [tableName],
+          columnsByTable: {
+            [tableName]: ["created_at", "already_utc_at"]
+          },
+          legacyLocalOffsetMinutes: -120
+        })
+
+        const rows = await db.query(`SELECT * FROM ${db.quoteTable(tableName)}`)
+
+        expect(rows[0].created_at).toEqual("2025-06-12T12:34:56.789Z")
+        expect(rows[0].already_utc_at).toEqual("2025-06-12T12:34:56.789Z")
+      } finally {
+        await migration.dropTable(tableName)
+      }
+    })
+  })
+})

--- a/spec/database/migration/datetime-storage.browser-spec.js
+++ b/spec/database/migration/datetime-storage.browser-spec.js
@@ -10,6 +10,11 @@ describe("database - migration - datetime storage", {tags: ["dummy"]}, () => {
       const tableName = "legacy_datetime_storage_records"
       const migration = new Migration({configuration: Configuration.current(), db})
 
+      if (db.getType() != "sqlite") {
+        // Only SQLite preserves legacy local values as timezone-less strings.
+        return
+      }
+
       if (await migration.tableExists(tableName)) {
         await migration.dropTable(tableName)
       }

--- a/spec/database/record/create.browser-spec.js
+++ b/spec/database/record/create.browser-spec.js
@@ -228,21 +228,26 @@ describe("Record - create", {tags: ["dummy"]}, () => {
     const createdAt = "2025-12-26T16:18:50.641Z"
     const createdAtNoMs = "2025-12-26T16:18:50Z"
     const createdAtOffset = "2025-12-26T16:18:50+01:00"
+    const createdAtWithoutTimezone = "2025-12-26 16:18:50.641"
 
     const task = new Task({name: "ISO task", createdAt})
     const taskNoMs = new Task({name: "ISO task no ms", createdAt: createdAtNoMs})
     const taskOffset = new Task({name: "ISO task offset", createdAt: createdAtOffset})
+    const taskWithoutTimezone = new Task({name: "ISO task without timezone", createdAt: createdAtWithoutTimezone})
 
     const createdAtValue = task.createdAt()
     const createdAtNoMsValue = taskNoMs.createdAt()
     const createdAtOffsetValue = taskOffset.createdAt()
+    const createdAtWithoutTimezoneValue = taskWithoutTimezone.createdAt()
 
     expect(createdAtValue).toBeInstanceOf(Date)
     expect(createdAtNoMsValue).toBeInstanceOf(Date)
     expect(createdAtOffsetValue).toBeInstanceOf(Date)
+    expect(createdAtWithoutTimezoneValue).toBeInstanceOf(Date)
     expect(createdAtValue?.toISOString().slice(0, 19)).toEqual(createdAt.slice(0, 19))
     expect(createdAtNoMsValue?.toISOString().slice(0, 19)).toEqual(createdAtNoMs.slice(0, 19))
     expect(createdAtOffsetValue?.toISOString().slice(0, 19)).toEqual("2025-12-26T15:18:50")
+    expect(createdAtWithoutTimezoneValue?.toISOString().slice(0, 19)).toEqual("2025-12-26T16:18:50")
   })
 
   it("round-trips datetime values without timezone shifts", async () => {
@@ -287,9 +292,8 @@ describe("Record - create", {tags: ["dummy"]}, () => {
 
     await Configuration.current().getEnvironmentHandler().runWithTimezoneOffset(0, async () => {
       const reloaded = await Task.find(resolvedTaskId)
-      const expected = new Date(timestamp.getTime() - (120 * 60 * 1000))
 
-      expectTimestampMatches(reloaded.createdAt(), expected)
+      expectTimestampMatches(reloaded.createdAt(), timestamp)
     })
   })
 

--- a/spec/database/record/create.browser-spec.js
+++ b/spec/database/record/create.browser-spec.js
@@ -271,7 +271,7 @@ describe("Record - create", {tags: ["dummy"]}, () => {
     expectTimestampMatches(reloaded.createdAt(), timestamp)
   })
 
-  it("applies per-request timezone offsets on write and read", async () => {
+  it("does not apply per-request timezone offsets on write or read", async () => {
     const project = await Project.create({name: "Timezone offset project"})
     const timestamp = new Date("2025-12-26T12:34:56.789Z")
     /** @type {string | number | undefined} */

--- a/spec/database/record/datetime-persistence-spec.js
+++ b/spec/database/record/datetime-persistence-spec.js
@@ -2,7 +2,7 @@
 
 import Project from "../../dummy/src/models/project.js"
 import Task from "../../dummy/src/models/task.js"
-import process from "node:process"
+import runWithProcessTimezone from "../../helpers/process-timezone.js"
 import Configuration from "../../../src/configuration.js"
 
 describe("Record - datetime persistence", {tags: ["dummy"]}, () => {
@@ -25,28 +25,6 @@ describe("Record - datetime persistence", {tags: ["dummy"]}, () => {
       expect(Math.abs(actualTime - expectedTime)).toBeLessThanOrEqual(1)
     } else {
       expect(actualTime).toEqual(expectedTime)
-    }
-  }
-
-  /**
-   * Runs a callback with the Node process timezone temporarily changed.
-   * @param {string} timezone - IANA timezone name.
-   * @param {() => Promise<void>} callback - Callback to run.
-   * @returns {Promise<void>} - Resolves when the callback has completed.
-   */
-  async function runWithProcessTimezone(timezone, callback) {
-    const previousTimezone = process.env.TZ
-
-    process.env.TZ = timezone
-
-    try {
-      await callback()
-    } finally {
-      if (previousTimezone === undefined) {
-        delete process.env.TZ
-      } else {
-        process.env.TZ = previousTimezone
-      }
     }
   }
 

--- a/spec/database/record/datetime-persistence-spec.js
+++ b/spec/database/record/datetime-persistence-spec.js
@@ -1,0 +1,102 @@
+// @ts-check
+
+import Project from "../../dummy/src/models/project.js"
+import Task from "../../dummy/src/models/task.js"
+import process from "node:process"
+import Configuration from "../../../src/configuration.js"
+
+describe("Record - datetime persistence", {tags: ["dummy"]}, () => {
+  /**
+   * @param {Date | undefined} actual - Actual timestamp read from the database.
+   * @param {Date} expected - Expected timestamp.
+   * @returns {void} - No return value.
+   */
+  function expectTimestampMatches(actual, expected) {
+    const actualTime = actual?.getTime()
+    const expectedTime = expected.getTime()
+
+    if (actualTime === undefined) {
+      throw new Error("Expected timestamp to be set")
+    }
+
+    if (Task.getDatabaseType() == "mysql") {
+      expect(Math.floor(actualTime / 1000)).toEqual(Math.floor(expectedTime / 1000))
+    } else if (Task.getDatabaseType() == "mssql") {
+      expect(Math.abs(actualTime - expectedTime)).toBeLessThanOrEqual(1)
+    } else {
+      expect(actualTime).toEqual(expectedTime)
+    }
+  }
+
+  /**
+   * Runs a callback with the Node process timezone temporarily changed.
+   * @param {string} timezone - IANA timezone name.
+   * @param {() => Promise<void>} callback - Callback to run.
+   * @returns {Promise<void>} - Resolves when the callback has completed.
+   */
+  async function runWithProcessTimezone(timezone, callback) {
+    const previousTimezone = process.env.TZ
+
+    process.env.TZ = timezone
+
+    try {
+      await callback()
+    } finally {
+      if (previousTimezone === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = previousTimezone
+      }
+    }
+  }
+
+  it("round-trips datetime values across process timezones", async () => {
+    const project = await Project.create({name: "Process timezone project"})
+    const timestamp = new Date("2025-06-12T12:34:56.789Z")
+    /** @type {string | number | undefined} */
+    let taskId
+
+    await runWithProcessTimezone("Europe/Berlin", async () => {
+      const task = await Task.create({name: "Process timezone task", createdAt: timestamp, project})
+
+      taskId = task.id()
+    })
+
+    if (taskId === undefined) throw new Error("Expected task to be created")
+
+    await runWithProcessTimezone("UTC", async () => {
+      const reloaded = await Task.find(taskId)
+
+      expectTimestampMatches(reloaded.createdAt(), timestamp)
+    })
+  })
+
+  it("treats timezone-less datetime strings as UTC", async () => {
+    const task = new Task({name: "UTC string task", createdAt: "2025-06-12 12:34:56.789"})
+    const createdAt = task.createdAt()
+
+    expect(createdAt).toBeInstanceOf(Date)
+    expectTimestampMatches(createdAt, new Date("2025-06-12T12:34:56.789Z"))
+  })
+
+  it("does not apply timezoneOffsetMinutes to persisted datetime values", async () => {
+    const project = await Project.create({name: "Timezone offset persistence project"})
+    const timestamp = new Date("2025-06-12T12:34:56.789Z")
+    /** @type {string | number | undefined} */
+    let taskId
+
+    await Configuration.current().getEnvironmentHandler().runWithTimezoneOffset(120, async () => {
+      const task = await Task.create({name: "Timezone offset persistence task", createdAt: timestamp, project})
+
+      taskId = task.id()
+    })
+
+    if (taskId === undefined) throw new Error("Expected task to be created")
+
+    await Configuration.current().getEnvironmentHandler().runWithTimezoneOffset(0, async () => {
+      const reloaded = await Task.find(taskId)
+
+      expectTimestampMatches(reloaded.createdAt(), timestamp)
+    })
+  })
+})

--- a/spec/frontend-models/base.browser-spec.js
+++ b/spec/frontend-models/base.browser-spec.js
@@ -675,6 +675,25 @@ describe("Frontend models - base browser integration", {databaseCleaning: {trans
     }
   })
 
+  it("findBy treats timezone-less datetime strings as UTC over real browser HTTP requests", async () => {
+    if (!runBrowserHttpIntegration()) {
+      return
+    }
+
+    configureBrowserTransport()
+
+    try {
+      await seedUsers()
+
+      const model = await User.findBy({createdAt: "2026-02-18 08:00:00.000"})
+
+      expect(model?.id()).toEqual(1)
+      expect(model?.createdAt()?.toISOString()).toEqual("2026-02-18T08:00:00.000Z")
+    } finally {
+      resetFrontendModelTransport()
+    }
+  })
+
   it("findBy returns null when no backend record matches", async () => {
     if (!runBrowserHttpIntegration()) {
       return

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -8,6 +8,7 @@ import WebsocketClient from "../../src/http-client/websocket-client.js"
 import Dummy from "../dummy/index.js"
 import CommentRecord from "../dummy/src/models/comment.js"
 import ProjectRecord from "../dummy/src/models/project.js"
+import runWithProcessTimezone from "../helpers/process-timezone.js"
 import TaskRecord from "../dummy/src/models/task.js"
 import UserRecord from "../dummy/src/models/user.js"
 
@@ -963,6 +964,25 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
 
         expect(model?.id()).toEqual(jane.id())
         expect(model?.createdAt()?.toISOString()).toEqual("2026-02-18T08:00:00.000Z")
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("findBy treats timezone-less datetime strings as UTC over real Node HTTP requests", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        const {jane} = await seedHttpFrontendModels()
+
+        await runWithProcessTimezone("Europe/Berlin", async () => {
+          const model = await User.findBy({createdAt: "2026-02-18 08:00:00.000"})
+
+          expect(model?.id()).toEqual(jane.id())
+          expect(model?.createdAt()?.toISOString()).toEqual("2026-02-18T08:00:00.000Z")
+        })
       } finally {
         resetFrontendModelTransport()
       }

--- a/spec/helpers/process-timezone.js
+++ b/spec/helpers/process-timezone.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+import process from "node:process"
+
+/**
+ * Runs a callback with the Node process timezone temporarily changed.
+ * @param {string} timezone - IANA timezone name.
+ * @param {() => Promise<void>} callback - Callback to run.
+ * @returns {Promise<void>} - Resolves when the callback has completed.
+ */
+export default async function runWithProcessTimezone(timezone, callback) {
+  const previousTimezone = process.env.TZ
+
+  process.env.TZ = timezone
+
+  try {
+    await callback()
+  } finally {
+    if (previousTimezone === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = previousTimezone
+    }
+  }
+}

--- a/src/cli/commands/db/drop.js
+++ b/src/cli/commands/db/drop.js
@@ -32,9 +32,13 @@ export default class DbDrop extends DbBaseCommand {
         const configuredFallback = newConfiguration.useDatabase
         const useConfiguredFallback = typeof configuredFallback == "string" && configuredFallback.length > 0 && configuredFallback != targetDatabaseName
 
-        newConfiguration.database = useConfiguredFallback
-          ? configuredFallback
-          : this.systemFallbackDatabaseName(databaseType)
+        if (useConfiguredFallback) {
+          newConfiguration.database = configuredFallback
+        } else if (databaseType == "mysql") {
+          delete newConfiguration.database
+        } else {
+          newConfiguration.database = this.systemFallbackDatabaseName(databaseType)
+        }
 
         if (databaseType == "mssql" && newConfiguration.sqlConfig?.database) {
           delete newConfiguration.sqlConfig.database

--- a/src/database/datetime-storage.js
+++ b/src/database/datetime-storage.js
@@ -1,0 +1,188 @@
+// @ts-check
+
+import isDate from "../utils/is-date.js"
+
+const dateTimeWithTimezonePattern = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:[zZ]|[+-]\d{2}:\d{2})$/
+const dateTimeWithoutTimezonePattern = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?$/
+const timezoneSuffixPattern = /(?:[zZ]|[+-]\d{2}:\d{2})$/
+
+/**
+ * Pads a numeric date/time part.
+ * @param {number} value - Numeric part.
+ * @param {number} length - Target length.
+ * @returns {string} - Padded part.
+ */
+function pad(value, length = 2) {
+  return String(value).padStart(length, "0")
+}
+
+/**
+ * Replaces SQL-style datetime separators with ISO separators for parsing.
+ * @param {string} value - Datetime string.
+ * @returns {string} - Datetime string with a `T` separator.
+ */
+function normalizeDateTimeSeparator(value) {
+  return value.includes("T") ? value : value.replace(" ", "T")
+}
+
+/**
+ * Parses a datetime string with an explicit timezone.
+ * @param {string} value - Datetime string.
+ * @returns {Date | string} - Parsed date or the original string when it is not a recognized datetime.
+ */
+function parseTimezoneQualifiedDateTimeString(value) {
+  if (!dateTimeWithTimezonePattern.test(value)) return value
+
+  const timestamp = Date.parse(normalizeDateTimeSeparator(value))
+
+  if (Number.isNaN(timestamp)) return value
+
+  return new Date(timestamp)
+}
+
+/**
+ * Parses a timezone-less datetime string as UTC.
+ * @param {string} value - Datetime string.
+ * @returns {Date | string} - Parsed date or the original string when it is not a recognized datetime.
+ */
+function parseTimezoneLessDateTimeStringAsUtc(value) {
+  if (!dateTimeWithoutTimezonePattern.test(value)) return value
+
+  const timestamp = Date.parse(`${normalizeDateTimeSeparator(value)}Z`)
+
+  if (Number.isNaN(timestamp)) return value
+
+  return new Date(timestamp)
+}
+
+/**
+ * Parses a timezone-less datetime string as the current runtime's local wall-clock time.
+ * @param {string} value - Datetime string.
+ * @returns {Date | string} - Parsed date or the original string when it is not a recognized datetime.
+ */
+function parseTimezoneLessDateTimeStringAsLocal(value) {
+  if (!dateTimeWithoutTimezonePattern.test(value)) return value
+
+  const timestamp = Date.parse(normalizeDateTimeSeparator(value))
+
+  if (Number.isNaN(timestamp)) return value
+
+  return new Date(timestamp)
+}
+
+/**
+ * Parses a timezone-less legacy datetime string with an explicit local offset.
+ * The offset follows JavaScript's `Date#getTimezoneOffset()` sign convention.
+ * @param {string} value - Datetime string.
+ * @param {number} legacyLocalOffsetMinutes - UTC-minus-local offset in minutes.
+ * @returns {Date | string} - Parsed date or the original string when it is not a recognized datetime.
+ */
+function parseTimezoneLessDateTimeStringWithOffset(value, legacyLocalOffsetMinutes) {
+  const utcDate = parseTimezoneLessDateTimeStringAsUtc(value)
+
+  if (!isDate(utcDate)) return value
+
+  return new Date(utcDate.getTime() + (legacyLocalOffsetMinutes * 60 * 1000))
+}
+
+/**
+ * Checks whether a string has a datetime timezone suffix.
+ * @param {string} value - Value to check.
+ * @returns {boolean} - Whether the string ends with `Z` or an offset.
+ */
+export function hasDateTimeTimezone(value) {
+  return timezoneSuffixPattern.test(value)
+}
+
+/**
+ * Formats a Date for database storage as a UTC instant.
+ * @param {Date} value - Date value.
+ * @param {object} args - Options.
+ * @param {string} args.databaseType - Database driver type.
+ * @returns {string} - Database datetime string.
+ */
+export function formatDateForDatabase(value, {databaseType}) {
+  if (databaseType == "sqlite") return value.toISOString()
+
+  return [
+    value.getUTCFullYear(),
+    "-",
+    pad(value.getUTCMonth() + 1),
+    "-",
+    pad(value.getUTCDate()),
+    " ",
+    pad(value.getUTCHours()),
+    ":",
+    pad(value.getUTCMinutes()),
+    ":",
+    pad(value.getUTCSeconds()),
+    ".",
+    pad(value.getUTCMilliseconds(), 3)
+  ].join("")
+}
+
+/**
+ * Normalizes a record write string into a Date when it is a recognized datetime string.
+ * Timezone-less strings are external input and are treated as UTC.
+ * @param {string} value - Value to normalize.
+ * @returns {Date | string} - Normalized value.
+ */
+export function normalizeDateStringForWrite(value) {
+  if (hasDateTimeTimezone(value)) return parseTimezoneQualifiedDateTimeString(value)
+
+  return parseTimezoneLessDateTimeStringAsUtc(value)
+}
+
+/**
+ * Normalizes a record write value into a Date when it is a recognized datetime string.
+ * Timezone-less strings are external input and are treated as UTC.
+ * @param {Date | string | null | undefined} value - Value to normalize.
+ * @returns {Date | string | null | undefined} - Normalized value.
+ */
+export function normalizeDateValueForWrite(value) {
+  if (typeof value != "string") return value
+
+  return normalizeDateStringForWrite(value)
+}
+
+/**
+ * Normalizes a database value into a Date for record reads.
+ * SQLite timezone-less rows are legacy local wall-clock rows produced before
+ * UTC storage. New SQLite writes include `Z`, so they take the exact branch.
+ * @param {Date | string | null | undefined} value - Stored database value.
+ * @param {object} args - Options.
+ * @param {string} args.databaseType - Database driver type.
+ * @returns {Date | string | null | undefined} - Normalized value.
+ */
+export function normalizeDateValueForRead(value, {databaseType}) {
+  if (value === null || value === undefined) return value
+
+  if (isDate(value)) return new Date(value.getTime())
+  if (typeof value != "string") return value
+  if (hasDateTimeTimezone(value)) return parseTimezoneQualifiedDateTimeString(value)
+  if (databaseType == "sqlite") return parseTimezoneLessDateTimeStringAsLocal(value)
+
+  return parseTimezoneLessDateTimeStringAsUtc(value)
+}
+
+/**
+ * Converts a legacy timezone-less datetime value into the new UTC database storage format.
+ * The optional offset follows JavaScript's `Date#getTimezoneOffset()` sign convention.
+ * @param {Date | string | null | undefined} value - Legacy value.
+ * @param {object} args - Options.
+ * @param {string} args.databaseType - Database driver type.
+ * @param {number | undefined} [args.legacyLocalOffsetMinutes] - UTC-minus-local offset in minutes.
+ * @returns {Date | string | null | undefined} - Converted database value or the original value.
+ */
+export function convertLegacyDateValueToUtcStorage(value, {databaseType, legacyLocalOffsetMinutes}) {
+  if (typeof value != "string") return value
+  if (hasDateTimeTimezone(value)) return value
+
+  const parsedDate = legacyLocalOffsetMinutes === undefined
+    ? parseTimezoneLessDateTimeStringAsLocal(value)
+    : parseTimezoneLessDateTimeStringWithOffset(value, legacyLocalOffsetMinutes)
+
+  if (!isDate(parsedDate)) return value
+
+  return formatDateForDatabase(parsedDate, {databaseType})
+}

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -103,12 +103,12 @@
 
 import BacktraceCleaner from "../../utils/backtrace-cleaner.js"
 import { getDatabaseAnnotations } from "../annotations.js"
+import { formatDateForDatabase } from "../datetime-storage.js"
 import isDate from "../../utils/is-date.js"
 import Logger from "../../logger.js"
 import Query from "../query/index.js"
 import Handler from "../handler.js"
 import Mutex from "epic-locks/build/mutex.js"
-import strftime from "strftime"
 import UUID from "pure-uuid"
 import TableData from "../table-data/index.js"
 import TableColumn from "../table-data/table-column.js"
@@ -656,7 +656,7 @@ export default class VelociousDatabaseDriversBase {
     // isDate instead of instanceof: a Date created in another realm (e.g. the console REPL) would
     // fail instanceof, skip this conversion, and serialize as an empty SQL value downstream.
     if (isDate(value)) {
-      return strftime("%F %T.%L", value)
+      return formatDateForDatabase(value, {databaseType: this.getType()})
     }
 
     // JSON-encode plain objects/arrays so they land in JSON/text columns as valid

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -30,6 +30,10 @@ export default class VelociousDatabaseDriversMssql extends Base{
     try {
       if (this.connection) await this.close()
 
+      if (sqlConfig) {
+        sqlConfig.options = Object.assign({}, sqlConfig.options, {useUTC: true})
+      }
+
       if (sqlConfig?.server && !sqlConfig.options?.serverName && net.isIP(sqlConfig.server)) {
         sqlConfig.options = Object.assign({}, sqlConfig.options, {serverName: ""})
       }

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -86,7 +86,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
     /**
      * Connect args.
      * @type {Record<string, ?>} */
-    const connectArgs = {charset: "utf8mb4"}
+    const connectArgs = {charset: "utf8mb4", timezone: "Z"}
 
     for (const forwardValue of forward) {
       if (forwardValue in args) connectArgs[forwardValue] = digg(args, forwardValue)

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -37,6 +37,8 @@ export default class VelociousDatabaseDriversMysql extends Base{
   async connect() {
     this.pool = mysql.createPool(Object.assign({connectionLimit: 1}, this.connectArgs()))
     this.pool.on("error", this.onPoolError)
+
+    await this.setSessionTimezoneToUtc()
   }
 
   /**
@@ -73,6 +75,14 @@ export default class VelociousDatabaseDriversMysql extends Base{
   async clearConnectionCheckoutName() {
     await this.query("SET @velocious_connection_checkout_name = NULL", {logName: "Clear Connection Checkout Name", processListComment: false})
     await super.clearConnectionCheckoutName()
+  }
+
+  /**
+   * Sets the database session timezone to UTC so bare timestamp literals store UTC instants.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async setSessionTimezoneToUtc() {
+    await this.query("SET time_zone = '+00:00'", {logName: "Set Session Time Zone", processListComment: false})
   }
 
   /**

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -29,6 +29,8 @@ export default class VelociousDatabaseDriversPgsql extends Base{
 
     try {
       await client.connect()
+      this.connection = client
+      await this.setSessionTimezoneToUtc()
     } catch (error) {
       // Re-throw to recover real stack trace
       if (error instanceof Error) {
@@ -37,8 +39,6 @@ export default class VelociousDatabaseDriversPgsql extends Base{
         throw new Error(`Connect to Postgres server failed: ${error}`, {cause: error})
       }
     }
-
-    this.connection = client
   }
 
   connectArgs() {
@@ -87,6 +87,14 @@ export default class VelociousDatabaseDriversPgsql extends Base{
   async clearConnectionCheckoutName() {
     await this.query("RESET application_name", {logName: "Clear Connection Checkout Name", processListComment: false})
     await super.clearConnectionCheckoutName()
+  }
+
+  /**
+   * Sets the database session timezone to UTC so bare timestamp literals store UTC instants.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async setSessionTimezoneToUtc() {
+    await this.query("SET TIME ZONE 'UTC'", {logName: "Set Session Time Zone", processListComment: false})
   }
 
   /**

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -3,7 +3,7 @@
 import AlterTable from "./sql/alter-table.js"
 import wait from "awaitery/build/wait.js"
 import Base from "../base.js"
-import {Client} from "pg"
+import { Client, types as pgTypes } from "pg"
 import CreateDatabase from "./sql/create-database.js"
 import CreateIndex from "./sql/create-index.js"
 import CreateTable from "./sql/create-table.js"
@@ -18,6 +18,10 @@ import Table from "./table.js"
 import StructureSql from "./structure-sql.js"
 import Upsert from "./sql/upsert.js"
 import Update from "./sql/update.js"
+
+const PG_TIMESTAMP_WITHOUT_TIMEZONE_OID = 1114
+
+pgTypes.setTypeParser(PG_TIMESTAMP_WITHOUT_TIMEZONE_OID, (value) => new Date(`${value.replace(" ", "T")}Z`))
 
 export default class VelociousDatabaseDriversPgsql extends Base{
   async connect() {

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -26,7 +26,15 @@
  * CreateTableCallbackType type.
  * @typedef {(table: TableData) => void} CreateTableCallbackType
  */
+/**
+ * LegacyLocalDateTimesMigrationArgsType type.
+ * @typedef {object} LegacyLocalDateTimesMigrationArgsType
+ * @property {Record<string, string[]>} [columnsByTable] - Explicit datetime columns keyed by table name.
+ * @property {number} [legacyLocalOffsetMinutes] - UTC-minus-local offset in minutes for legacy rows.
+ * @property {string[]} [tables] - Tables to migrate. Defaults to all non-internal tables.
+ */
 
+import { convertLegacyDateValueToUtcStorage } from "../datetime-storage.js"
 import * as inflection from "inflection"
 import restArgsError from "../../utils/rest-args-error.js"
 import TableData from "../table-data/index.js"
@@ -273,6 +281,125 @@ export default class VelociousDatabaseMigration {
     if (!column) throw new Error(`Column ${columnName} does not exist in table ${tableName}`)
 
     await column.changeNullable(nullable)
+  }
+
+  /**
+   * Migrates legacy timezone-less local datetime rows into UTC datetime storage.
+   * New SQLite UTC rows include a timezone suffix and are skipped.
+   * @param {LegacyLocalDateTimesMigrationArgsType} [args] - Migration options.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async migrateLegacyLocalDateTimesToUtcStorage(args = {}) {
+    const {columnsByTable, legacyLocalOffsetMinutes, tables, ...restArgs} = args
+
+    restArgsError(restArgs)
+
+    const tableNames = await this._legacyLocalDateTimesTableNames(tables)
+
+    for (const tableName of tableNames) {
+      await this._migrateLegacyLocalDateTimesTable({
+        columnsByTable,
+        legacyLocalOffsetMinutes,
+        tableName
+      })
+    }
+  }
+
+  /**
+   * Resolves table names for a legacy local datetime migration.
+   * @param {string[] | undefined} tables - Explicit table names.
+   * @returns {Promise<string[]>} - Table names.
+   */
+  async _legacyLocalDateTimesTableNames(tables) {
+    if (tables) return tables
+
+    return (await this.getDriver().getTables())
+      .map((table) => table.getName())
+      .filter((tableName) => tableName != "schema_migrations" && !tableName.startsWith("sqlite_"))
+  }
+
+  /**
+   * Migrates one table's legacy local datetime values.
+   * @param {object} args - Options.
+   * @param {Record<string, string[]> | undefined} args.columnsByTable - Explicit columns keyed by table.
+   * @param {number | undefined} args.legacyLocalOffsetMinutes - UTC-minus-local offset in minutes.
+   * @param {string} args.tableName - Table name.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _migrateLegacyLocalDateTimesTable({columnsByTable, legacyLocalOffsetMinutes, tableName}) {
+    const driver = this.getDriver()
+    const table = await driver.getTableByNameOrFail(tableName)
+    const columns = await this._legacyLocalDateTimesColumns({columnsByTable, table})
+
+    if (columns.length === 0) return
+
+    const primaryKeyColumn = await this._legacyLocalDateTimesPrimaryKey(table)
+    const selectedColumns = [primaryKeyColumn, ...columns]
+    const selectSql = selectedColumns
+      .map((columnName) => driver.quoteColumn(columnName))
+      .join(", ")
+    const rows = await driver.query(`SELECT ${selectSql} FROM ${driver.quoteTable(tableName)}`)
+
+    for (const row of rows) {
+      for (const columnName of columns) {
+        const value = row[columnName]
+        const convertedValue = convertLegacyDateValueToUtcStorage(value, {
+          databaseType: driver.getType(),
+          legacyLocalOffsetMinutes
+        })
+
+        if (convertedValue === value) continue
+
+        await driver.query(`
+          UPDATE ${driver.quoteTable(tableName)}
+          SET ${driver.quoteColumn(columnName)} = ${driver.quote(convertedValue)}
+          WHERE ${driver.quoteColumn(primaryKeyColumn)} = ${driver.quote(row[primaryKeyColumn])}
+        `)
+      }
+    }
+  }
+
+  /**
+   * Resolves date-like columns for one table.
+   * @param {object} args - Options.
+   * @param {Record<string, string[]> | undefined} args.columnsByTable - Explicit columns keyed by table.
+   * @param {import("../drivers/base-table.js").default} args.table - Table metadata.
+   * @returns {Promise<string[]>} - Date-like column names.
+   */
+  async _legacyLocalDateTimesColumns({columnsByTable, table}) {
+    const explicitColumns = columnsByTable?.[table.getName()]
+
+    if (explicitColumns) return explicitColumns
+
+    return (await table.getColumns())
+      .filter((column) => this._legacyLocalDateTimesColumnIsDateLike(column))
+      .map((column) => column.getName())
+  }
+
+  /**
+   * Checks whether a column should be included by default.
+   * @param {import("../drivers/base-column.js").default} column - Column metadata.
+   * @returns {boolean} - Whether the column is date-like.
+   */
+  _legacyLocalDateTimesColumnIsDateLike(column) {
+    const columnType = column.getType().toLowerCase()
+
+    return columnType.includes("date") || columnType.includes("timestamp")
+  }
+
+  /**
+   * Resolves the single primary key column for row updates.
+   * @param {import("../drivers/base-table.js").default} table - Table metadata.
+   * @returns {Promise<string>} - Primary key column name.
+   */
+  async _legacyLocalDateTimesPrimaryKey(table) {
+    const primaryKeyColumns = (await table.getColumns()).filter((column) => column.getPrimaryKey())
+
+    if (primaryKeyColumns.length != 1) {
+      throw new Error(`Expected exactly one primary key on ${table.getName()} but found ${primaryKeyColumns.length}`)
+    }
+
+    return primaryKeyColumns[0].getName()
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -31,13 +31,13 @@ import HasOneRelationship from "./relationships/has-one.js"
 import RecordAttachmentHandle from "./attachments/handle.js"
 import * as inflection from "inflection"
 import deburrColumnName from "../../utils/deburr-column-name.js"
-import isDate from "../../utils/is-date.js"
 import ModelClassQuery from "../query/model-class-query.js"
 import Preloader from "../query/preloader.js"
 import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQueryData, setPayloadAssociationCount, setPayloadComputedAbility, setPayloadQueryData} from "../../record-payload-values.js"
 import restArgsError from "../../utils/rest-args-error.js"
 import singularizeModelName from "../../utils/singularize-model-name.js"
 import {defineModelScope} from "../../utils/model-scope.js"
+import { normalizeDateStringForWrite, normalizeDateValueForRead, normalizeDateValueForWrite } from "../datetime-storage.js"
 import {formatValue} from "../../utils/format-value.js"
 import ValidatorsFormat from "./validators/format.js"
 import ValidatorsPresence from "./validators/presence.js"
@@ -1866,17 +1866,7 @@ class VelociousDatabaseRecord {
    * @returns {?} - The date value.
    */
   _normalizeDateValue(value) {
-    if (typeof value != "string") return value
-
-    const isoDateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/
-
-    if (!isoDateTimeRegex.test(value)) return value
-
-    const timestamp = Date.parse(value)
-
-    if (Number.isNaN(timestamp)) return value
-
-    return new Date(timestamp)
+    return normalizeDateValueForWrite(value)
   }
 
   /**
@@ -2240,21 +2230,7 @@ class VelociousDatabaseRecord {
    * @returns {?} - Normalized value.
    */
   static _normalizeDateValueForInsert(value) {
-    let normalizedValue = value
-
-    if (typeof normalizedValue == "string") {
-      normalizedValue = this._normalizeDateStringForInsert(normalizedValue)
-    }
-
-    if (isDate(normalizedValue)) {
-      const configuration = this._getConfiguration()
-      const offsetMinutes = configuration.getEnvironmentHandler().getTimezoneOffsetMinutes(configuration)
-      const offsetMs = offsetMinutes * 60 * 1000
-
-      normalizedValue = new Date(normalizedValue.getTime() - offsetMs)
-    }
-
-    return normalizedValue
+    return normalizeDateValueForWrite(value)
   }
 
   /**
@@ -2263,15 +2239,7 @@ class VelociousDatabaseRecord {
    * @returns {string | Date} - Parsed date or original string.
    */
   static _normalizeDateStringForInsert(value) {
-    const isoDateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/
-
-    if (!isoDateTimeRegex.test(value)) return value
-
-    const timestamp = Date.parse(value)
-
-    if (Number.isNaN(timestamp)) return value
-
-    return new Date(timestamp)
+    return normalizeDateStringForWrite(value)
   }
 
   /**
@@ -3925,26 +3893,7 @@ class VelociousDatabaseRecord {
    * @returns {?} - Normalized value.
    */
   _normalizeDateValueForRead(value) {
-    if (value === null || value === undefined) return value
-
-    const configuration = this.getModelClass()._getConfiguration()
-    const offsetMinutes = configuration.getEnvironmentHandler().getTimezoneOffsetMinutes(configuration)
-    const offsetMs = offsetMinutes * 60 * 1000
-
-    if (isDate(value)) {
-      return new Date(value.getTime() + offsetMs)
-    }
-
-    if (typeof value != "string") return value
-
-    const hasTimezone = /[zZ]|[+-]\d{2}:\d{2}$/.test(value)
-    const normalized = value.includes("T") ? value : value.replace(" ", "T")
-    const parseValue = hasTimezone ? normalized : `${normalized}Z`
-    const parsed = Date.parse(parseValue)
-
-    if (Number.isNaN(parsed)) return value
-
-    return new Date(parsed + offsetMs)
+    return normalizeDateValueForRead(value, {databaseType: this.getModelClass().getDatabaseType()})
   }
 
   _belongsToChanges() {
@@ -4079,10 +4028,6 @@ class VelociousDatabaseRecord {
    * @returns {void} - No return value.
    */
   _normalizeDateValuesForWrite(data) {
-    const configuration = this.getModelClass()._getConfiguration()
-    const offsetMinutes = configuration.getEnvironmentHandler().getTimezoneOffsetMinutes(configuration)
-    const offsetMs = offsetMinutes * 60 * 1000
-
     for (const columnName in data) {
       const columnType = this.getModelClass().getColumnTypeByName(columnName)
 
@@ -4090,9 +4035,7 @@ class VelociousDatabaseRecord {
 
       const value = data[columnName]
 
-      if (!isDate(value)) continue
-
-      data[columnName] = new Date(value.getTime() - offsetMs)
+      data[columnName] = normalizeDateValueForWrite(value)
     }
   }
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -10,7 +10,9 @@ import {normalizeGroup as normalizeQueryGroup, normalizeJoins as normalizeQueryJ
 import {assignSafeProperty, deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
 import RoutesResolver from "./routes/resolver.js"
 import {ValidationError} from "./database/record/index.js"
+import { normalizeDateStringForWrite } from "./database/datetime-storage.js"
 import VelociousError from "./velocious-error.js"
+import isDate from "./utils/is-date.js"
 import isPlainObject from "./utils/plain-object.js"
 
 /**
@@ -2212,9 +2214,9 @@ export default class FrontendModelController extends Controller {
       const isDateTimeColumn = typeof columnType === "string" && ["date", "datetime", "timestamp"].some((type) => columnType.includes(type))
 
       if (isDateTimeColumn) {
-        const parsedDate = new Date(value)
+        const parsedDate = normalizeDateStringForWrite(value)
 
-        if (!Number.isNaN(parsedDate.getTime())) {
+        if (isDate(parsedDate)) {
           return parsedDate
         }
       }

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -5,6 +5,7 @@ import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
 import FrontendModelQuery, {frontendModelEventOptionsPayload} from "./query.js"
 import FrontendModelPreloader from "./preloader.js"
+import { normalizeDateStringForWrite } from "../database/datetime-storage.js"
 import {registerFrontendModel, resolveFrontendModelClass} from "./model-registry.js"
 import {validateFrontendModelResourceCommandName, validateFrontendModelResourcePath} from "./resource-config-validation.js"
 import {deserializeFrontendModelTransportValue, serializeFrontendModelTransportValue} from "./transport-serialization.js"
@@ -3775,6 +3776,12 @@ export default class FrontendModelBase {
    */
   static findByPrimitiveValuesMatch(actualValue, expectedValue) {
     if (actualValue instanceof Date && typeof expectedValue === "string") {
+      const normalizedExpectedValue = normalizeDateStringForWrite(expectedValue)
+
+      if (normalizedExpectedValue instanceof Date) {
+        return actualValue.toISOString() === normalizedExpectedValue.toISOString()
+      }
+
       return actualValue.toISOString() === expectedValue
     }
 


### PR DESCRIPTION
## Summary
- Persist Date values as UTC instants instead of runtime-local wall-clock strings
- Treat timezone-less datetime input as UTC, while preserving legacy local SQLite row compatibility
- Add a migration helper for rewriting legacy local SQLite datetime rows to UTC storage
- Configure SQL drivers to read/write timestamp values using UTC semantics

## Validation
- NODE_ENV=test VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/record/datetime-persistence-spec.js
- NODE_ENV=test npm run test:browser -- spec/database/record/create.browser-spec.js
- NODE_ENV=test npm run test:browser -- spec/database/migration/datetime-storage.browser-spec.js
- cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow
- Restored spec/dummy/src/config/configuration.js after validation