### PR TITLE
checkJs type fixes: tenant Record typing, AddColumnArgsType maxLength/limit, databaseCleaning.truncateBefore

### DIFF
--- a/changelog.d/20260617130000-tenant-record-typing.md
+++ b/changelog.d/20260617130000-tenant-record-typing.md
@@ -1,0 +1,1 @@
+Type the tenant value as `Record<string, unknown>` instead of `unknown` on `Current.tenant()`, `Current.setTenant()`, `Current.withTenant()`, and the `switchesTenantDatabase(...)` resolver callback. Application code stores app-defined tenant objects, so consumers can now read and narrow tenant fields (for example `databaseIdentifiers`) without casting `unknown`.

--- a/changelog.d/20260617140000-add-column-maxlength-type.md
+++ b/changelog.d/20260617140000-add-column-maxlength-type.md
@@ -1,0 +1,1 @@
+Add `limit` and `maxLength` to `AddColumnArgsType` so `addColumn(table, name, "string", {maxLength})` type-checks. The value was already honored at runtime via `TableColumn`/the column drivers; only the migration arg type omitted it.

--- a/changelog.d/20260617150000-database-cleaning-truncate-before.md
+++ b/changelog.d/20260617150000-database-cleaning-truncate-before.md
@@ -1,0 +1,1 @@
+Add `databaseCleaning.truncateBefore` to the test describe-options type. The option already flows through to test setup; only the type omitted it.

--- a/src/current.js
+++ b/src/current.js
@@ -47,7 +47,7 @@ export default class Current {
 
   /**
    * Runs tenant.
-   * @returns {?} - Current tenant.
+   * @returns {Record<string, unknown> | undefined} - Current tenant.
    */
   static tenant() {
     try {
@@ -61,7 +61,7 @@ export default class Current {
 
   /**
    * Runs set tenant.
-   * @param {?} tenant - Tenant.
+   * @param {Record<string, unknown>} tenant - Tenant.
    * @returns {void} - No return value.
    */
   static setTenant(tenant) {
@@ -70,7 +70,7 @@ export default class Current {
 
   /**
    * Runs with tenant.
-   * @param {?} tenant - Tenant.
+   * @param {Record<string, unknown>} tenant - Tenant.
    * @param {() => Promise<?>} callback - Callback.
    * @returns {Promise<?>} - Callback result.
    */

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -6,6 +6,8 @@
  * @property {?} [default] - Default value for the column.
  * @property {object} [foreignKey] - Foreign key definition for the column.
  * @property {boolean | {unique: boolean}} [index] - Whether to add an index (optionally unique).
+ * @property {number} [limit] - Alias for maxLength (varchar length limit) on string-like columns.
+ * @property {number} [maxLength] - Maximum length for string-like columns (e.g. varchar length).
  * @property {boolean} [null] - Whether the column allows null values.
  * @property {boolean} [primaryKey] - Whether the column is a primary key.
  * @property {boolean} [unique] - Whether the column enforces uniqueness.

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -1678,7 +1678,7 @@ class VelociousDatabaseRecord {
 
   /**
    * Declares a tenant-aware database identifier resolver for this model class.
-   * @param {string | ((args: {modelClass: typeof VelociousDatabaseRecord, tenant: ?}) => string | undefined)} databaseIdentifierOrResolver - Static identifier or resolver.
+   * @param {string | ((args: {modelClass: typeof VelociousDatabaseRecord, tenant: Record<string, unknown>}) => string | undefined)} databaseIdentifierOrResolver - Static identifier or resolver.
    * @returns {void} - No return value.
    */
   static switchesTenantDatabase(databaseIdentifierOrResolver) {

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -74,6 +74,7 @@ function toFileSlug(value) {
  * @property {object} [databaseCleaning] - Database cleanup options for tests.
  * @property {boolean} [databaseCleaning.transaction] - Use transactions to rollback between tests.
  * @property {boolean} [databaseCleaning.truncate] - Truncate tables between tests.
+ * @property {boolean} [databaseCleaning.truncateBefore] - Truncate tables before each test, in addition to the default cleanup.
  * @property {boolean} [focus] - Whether this test is focused.
  * @property {() => (void|Promise<void>)} [function] - Test callback function.
  * @property {number} [retry] - Number of retries when a test fails.


### PR DESCRIPTION
Type-only fixes surfaced while enabling `checkJs` in a downstream consumer (TensorBuzz). Each value is already honored/passed at runtime — only the declared types omitted it. Velocious self-typecheck stays clean (`npm run build` → 0 errors).

## Changes
1. **Tenant typing** — `Current.tenant()/setTenant()/withTenant()` and the `switchesTenantDatabase(...)` resolver callback typed `tenant` as `unknown`; consumers couldn't read a tenant field without casting. Typed as `Record<string, unknown>` (the tenant is an app-defined object — consumers narrow their own fields).
2. **`AddColumnArgsType.maxLength` / `.limit`** — `addColumn(t, c, "string", {maxLength})` failed typecheck though `TableColumn`/the column drivers already honor it. Added the missing properties.
3. **`databaseCleaning.truncateBefore`** — the test describe-option already flows through to test setup; added it to the options type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)