### PR TITLE
Bump snapreq to ^0.0.8

### DIFF
--- a/changelog.d/20260618090000-bump-snapreq-0.0.8.md
+++ b/changelog.d/20260618090000-bump-snapreq-0.0.8.md
@@ -1,0 +1,6 @@
+Bump the `snapreq` dependency to `^0.0.8`. snapreq 0.0.8 resolves a subscription's
+`ready` promise when the client itself closes the channel before the server's
+subscribe acknowledgement (a benign race when a UI component unmounts right after
+subscribing), instead of rejecting with `Subscription closed before
+acknowledgement: client_unsubscribe`. That spurious error surfaced as a browser
+error in consumers' realtime/system tests during navigation-during-subscribe.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "proxy-addr": "^2.0.7",
         "pure-uuid": "^2.0.0",
         "set-state-compare": "^1.0.61",
-        "snapreq": "^0.0.5",
+        "snapreq": "^0.0.8",
         "sql-escape-string": "^1.1.0",
         "sql.js": "^1.12.0",
         "strftime": "^0.10.2"
@@ -15322,9 +15322,10 @@
       }
     },
     "node_modules/snapreq": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.5.tgz",
-      "integrity": "sha512-XDePqrCqE3+ZT4hmrtd62tgnEEzRtwv8hxjU4vyLDJ5XOgGjBwb3f+WcxWpzNbUOBr5EP4j2ukTrUoH95EdHrQ=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.8.tgz",
+      "integrity": "sha512-S7ecgyOBPI4bkiJ8TrMPsbfA0aN8brWvBZo+Hsoy1bVSJUp3kNi4EzZtoZPUXdHe+Ej1IvbydhKP7lNFnP+yfg==",
+      "license": "ISC"
     },
     "node_modules/socks": {
       "version": "2.8.7",
@@ -27652,9 +27653,9 @@
       }
     },
     "snapreq": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.5.tgz",
-      "integrity": "sha512-XDePqrCqE3+ZT4hmrtd62tgnEEzRtwv8hxjU4vyLDJ5XOgGjBwb3f+WcxWpzNbUOBr5EP4j2ukTrUoH95EdHrQ=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.8.tgz",
+      "integrity": "sha512-S7ecgyOBPI4bkiJ8TrMPsbfA0aN8brWvBZo+Hsoy1bVSJUp3kNi4EzZtoZPUXdHe+Ej1IvbydhKP7lNFnP+yfg=="
     },
     "socks": {
       "version": "2.8.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "proxy-addr": "^2.0.7",
     "pure-uuid": "^2.0.0",
     "set-state-compare": "^1.0.61",
-    "snapreq": "^0.0.5",
+    "snapreq": "^0.0.8",
     "sql-escape-string": "^1.1.0",
     "sql.js": "^1.12.0",
     "strftime": "^0.10.2"


### PR DESCRIPTION
## What

Bumps the `snapreq` dependency from `^0.0.5` to `^0.0.8`.

## Why

snapreq 0.0.8 ([kaspernj/snapreq#9](https://github.com/kaspernj/snapreq/pull/9)) resolves a subscription channel's `ready` promise when the **client itself** closes the channel before the server's subscribe acknowledgement — a benign race when a UI component unmounts/navigates right after subscribing — instead of rejecting with `Subscription closed before acknowledgement: client_unsubscribe`.

That spurious rejection surfaced as a **browser error** in downstream consumers' realtime/system tests during navigation-during-subscribe (e.g. a TensorBuzz move-requests system spec). velocious pinned `^0.0.5`, which for a `0.0.x` version resolves to exactly `0.0.5`, so this range bump is what lets the released fix reach consumers transitively.

## Validation

`npm run typecheck` clean; the websocket/transport specs pass against snapreq 0.0.8.

Supersedes #778, which was accidentally opened off the #770 branch and bundled unrelated commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
