### PR TITLE
Make VelociousJob generic over its perform args tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -1981,12 +1981,25 @@ Beacon is opt-in for the rest of the framework, but the dispatcher uses event-dr
 ```js
 import VelociousJob from "velocious/build/src/background-jobs/job.js"
 
+/** @augments {VelociousJob<[string, string]>} */
 export default class MyJob extends VelociousJob {
+  /**
+   * @param {string} arg1
+   * @param {string} arg2
+   * @returns {Promise<void>}
+   */
   async perform(arg1, arg2) {
     await doWork(arg1, arg2)
   }
 }
 ```
+
+`VelociousJob` is generic over the tuple of arguments `perform` takes. Declaring it
+with `@augments {VelociousJob<[...]>}` (or `extends VelociousJob<[...]>` in TypeScript)
+lets a type-checked codebase declare `perform`'s parameters as required and typed.
+Argument-less jobs use a bare `extends VelociousJob` with `async perform()` — the
+default empty-tuple type argument keeps that working unchanged. Plain (unchecked)
+JavaScript can ignore the annotation entirely.
 
 Queue a job:
 

--- a/src/background-jobs/job.js
+++ b/src/background-jobs/job.js
@@ -2,6 +2,16 @@
 
 import BackgroundJobsClient from "./client.js"
 
+/**
+ * Base class for background jobs.
+ *
+ * `TArgs` is the tuple of arguments the subclass's `perform` accepts, so a job that
+ * needs arguments declares them as required and typed — for example
+ * `class RunBuildJob extends VelociousJob<[string]>` with `async perform(buildId)`.
+ * The default empty tuple keeps argument-less jobs (`extends VelociousJob`,
+ * `async perform()`) working unchanged.
+ * @template {Array<?>} [TArgs=[]]
+ */
 export default class VelociousJob {
   /**
    * Runs job name.
@@ -69,9 +79,10 @@ export default class VelociousJob {
 
   /**
    * Override in subclasses.
+   * @param {TArgs} _args - Job args (the tuple this job class was parameterized with).
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async perform() {
+  async perform(..._args) {
     throw new Error("perform not implemented")
   }
 }

--- a/src/jobs/mail-delivery.js
+++ b/src/jobs/mail-delivery.js
@@ -5,18 +5,15 @@ import {deliverPayload} from "../mailer.js"
 
 /**
  * Background job for delivering mailer payloads.
+ * @augments {VelociousJob<[import("../mailer.js").MailerDeliveryPayload]>}
  */
 export default class MailDeliveryJob extends VelociousJob {
   /**
    * Runs perform.
-   * @param {import("../mailer.js").MailerDeliveryPayload} [payload] - Mail delivery payload.
+   * @param {import("../mailer.js").MailerDeliveryPayload} payload - Mail delivery payload.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async perform(payload) {
-    if (!payload) {
-      throw new Error(`Missing mail delivery payload. Got: ${String(payload)}`)
-    }
-
     await deliverPayload(payload)
   }
 }


### PR DESCRIPTION
## Problem

`VelociousJob.perform()` is declared zero-arity. Under a consumer's `strict` checkJs (e.g. TensorBuzz), any subclass overriding `perform` with **required** parameters is an arity error — "Property 'perform' … is not assignable to the same property in base type" — because a value typed as the base `perform()` can be called with no args, but the override requires them.

The only way to satisfy the checker was to declare every argument **optional** and re-assert it at runtime:

```js
/** @param {string} [buildId] @param {SomeEvent} [event] */
async perform(buildId, event) {
  if (buildId === undefined) throw new Error("… requires a buildId.")
  if (event === undefined) throw new Error("… requires an event.")
}
```

That's a runtime workaround standing in for a type contract.

## Fix

Make `VelociousJob` generic over a tuple of its `perform` arguments and type the override site through it:

```js
/** @template {Array<?>} [TArgs=[]] */
export default class VelociousJob {
  /** @param {TArgs} _args */
  async perform(..._args) { throw new Error("perform not implemented") }
}
```

Emitted `.d.ts`: `class VelociousJob<TArgs extends Array<unknown> = []>` / `perform(..._args: TArgs): Promise<void>`.

A job that needs arguments now declares them once, required and typed:

```js
/** @augments {VelociousJob<[string, SomeEvent]>} */
class BuildStatusSideEffectsJob extends VelociousJob {
  /** @param {string} buildId @param {SomeEvent} event */
  async perform(buildId, event) { /* required, no throws */ }
}
```

- **Backward compatible:** the empty-tuple default makes `extends VelociousJob` + `async perform()` resolve to a zero-arity `perform()`, so every argument-less job and existing consumer compiles unchanged.
- **Runtime untouched:** the worker/runner already call `perform.apply(jobInstance, payload.args || [])`; the change is type-level only.
- **Static enqueue stays `unknown[]`** (`performLater`/`performLaterWithOptions`) — static members can't reference the instance type parameter. Known, acceptable limitation; this PR targets the `perform` override contract.

Also migrates the in-repo `MailDeliveryJob` to `@augments {VelociousJob<[MailerDeliveryPayload]>}` with a required `payload` (dropping its `if (!payload) throw`) as the canonical, type-checked example.

## Validation

- `npm run typecheck` (tsc --noEmit) — 0 errors, incl. the migrated `MailDeliveryJob` (proves a required typed `perform` param compiles against the generic base).
- `npm run lint` — green.
- `spec/background-jobs/*` — 70/70 pass (dispatch + throw-on-unimplemented intact).

Downstream: lets TensorBuzz replace ~12 jobs' optional-param + manual-throw hack with required typed `perform` params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)