### PR TITLE
Fix relationship lint for translation models

### DIFF
--- a/changelog.d/20260618143000-relationship-lint-translations.md
+++ b/changelog.d/20260618143000-relationship-lint-translations.md
@@ -1,0 +1,1 @@
+Fix relationship lint so implicit translation relationships created by `translates(...)` satisfy concrete translation model `belongsTo` inverses.

--- a/spec/cli/commands/lint/relationships-spec.js
+++ b/spec/cli/commands/lint/relationships-spec.js
@@ -20,6 +20,14 @@ class LintOrphanSetting extends DatabaseRecord {}
 
 LintOrphanSetting.belongsTo("lintEvent", {className: "LintEvent"})
 
+class LintArticle extends DatabaseRecord {}
+class LintArticleTranslation extends DatabaseRecord {}
+
+LintArticle.setTableName("lint_articles")
+LintArticle.translates("title")
+LintArticleTranslation.setTableName("lint_article_translations")
+LintArticleTranslation.belongsTo("lintArticle", {className: "LintArticle"})
+
 /**
  * @param {Array<typeof DatabaseRecord>} modelClasses - Model classes to register.
  * @returns {Configuration} - Configuration instance.
@@ -86,5 +94,9 @@ describe("Cli - lint - relationships", () => {
     } finally {
       await fs.rm(configPath, {force: true})
     }
+  })
+
+  it("accepts the implicit inverse created by translates for concrete translation models", async () => {
+    await runLint(buildConfiguration([LintArticle, LintArticleTranslation]))
   })
 })

--- a/spec/cli/commands/lint/relationships-spec.js
+++ b/spec/cli/commands/lint/relationships-spec.js
@@ -8,6 +8,7 @@ import dummyDirectory from "../../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
 import fs from "fs/promises"
 import path from "node:path"
+import {pathToFileURL} from "node:url"
 
 class LintProject extends DatabaseRecord {}
 class LintTask extends DatabaseRecord {}
@@ -52,15 +53,18 @@ function buildConfiguration(modelClasses) {
 /**
  * @param {Configuration} configuration - Configuration instance.
  * @param {string[]} processArgs - CLI arguments.
+ * @param {object} [options] - Run options.
+ * @param {string} [options.directory] - CLI project directory.
+ * @param {boolean} [options.testing] - Whether to run the CLI in test mode.
  * @returns {Promise<?>} - Resolves with the CLI result.
  */
-async function runLint(configuration, processArgs = ["lint:relationships"]) {
+async function runLint(configuration, processArgs = ["lint:relationships"], {directory = dummyDirectory(), testing = true} = {}) {
   const cli = new Cli({
     configuration,
-    directory: dummyDirectory(),
+    directory,
     environmentHandler: configuration.getEnvironmentHandler(),
     processArgs,
-    testing: true
+    testing
   })
 
   return await cli.execute()
@@ -98,5 +102,80 @@ describe("Cli - lint - relationships", () => {
 
   it("accepts the implicit inverse created by translates for concrete translation models", async () => {
     await runLint(buildConfiguration([LintArticle, LintArticleTranslation]))
+  })
+
+  it("registers conventional model files without running app initialization", async () => {
+    const projectDirectory = path.resolve(dummyDirectory(), "../..")
+    const tempDirectory = path.join(dummyDirectory(), "tmp-relationship-lint-static")
+    const modelsDirectory = path.join(tempDirectory, "src/models")
+    const databaseRecordImportPath = pathToFileURL(path.join(projectDirectory, "src/database/record/index.js")).href
+
+    await fs.rm(tempDirectory, {force: true, recursive: true})
+    await fs.mkdir(modelsDirectory, {recursive: true})
+
+    await fs.writeFile(path.join(modelsDirectory, "lint-static-project.js"), [
+      `import DatabaseRecord from ${JSON.stringify(databaseRecordImportPath)}`,
+      "class LintStaticProject extends DatabaseRecord {}",
+      "LintStaticProject.hasMany(\"lintStaticTasks\", {className: \"LintStaticTask\"})",
+      "export default LintStaticProject",
+      ""
+    ].join("\n"))
+
+    await fs.writeFile(path.join(modelsDirectory, "lint-static-task.js"), [
+      `import DatabaseRecord from ${JSON.stringify(databaseRecordImportPath)}`,
+      "class LintStaticTask extends DatabaseRecord {}",
+      "LintStaticTask.belongsTo(\"project\", {className: \"LintStaticProject\"})",
+      "export default LintStaticTask",
+      ""
+    ].join("\n"))
+
+    try {
+      const configuration = new Configuration({
+        database: {test: {}},
+        directory: tempDirectory,
+        environment: "test",
+        environmentHandler: new EnvironmentHandlerNode(),
+        initializeModels: async () => {
+          throw new Error("Relationship lint should not run app initialization when src/models exists")
+        },
+        locale: "en",
+        localeFallbacks: {en: ["en"]},
+        locales: ["en"]
+      })
+
+      await runLint(configuration, ["lint:relationships"], {directory: tempDirectory, testing: false})
+    } finally {
+      await fs.rm(tempDirectory, {force: true, recursive: true})
+    }
+  })
+
+  it("falls back to app initialization when the conventional model directory is empty", async () => {
+    const tempDirectory = path.join(dummyDirectory(), "tmp-relationship-lint-empty-static")
+    const modelsDirectory = path.join(tempDirectory, "src/models")
+    let initializeModelsCalled = false
+
+    await fs.rm(tempDirectory, {force: true, recursive: true})
+    await fs.mkdir(modelsDirectory, {recursive: true})
+
+    try {
+      const configuration = new Configuration({
+        database: {test: {}},
+        directory: tempDirectory,
+        environment: "test",
+        environmentHandler: new EnvironmentHandlerNode(),
+        initializeModels: async () => {
+          initializeModelsCalled = true
+        },
+        locale: "en",
+        localeFallbacks: {en: ["en"]},
+        locales: ["en"]
+      })
+
+      await runLint(configuration, ["lint:relationships"], {directory: tempDirectory, testing: false})
+
+      expect(initializeModelsCalled).toEqual(true)
+    } finally {
+      await fs.rm(tempDirectory, {force: true, recursive: true})
+    }
   })
 })

--- a/src/environment-handlers/node/cli/commands/lint/relationships.js
+++ b/src/environment-handlers/node/cli/commands/lint/relationships.js
@@ -3,6 +3,12 @@
 import BaseCommand from "../../../../../cli/base-command.js"
 import fs from "node:fs/promises"
 import path from "node:path"
+import requireContext from "require-context"
+
+/**
+ * @typedef {(id: string) => {default: typeof import("../../../../../database/record/index.js").default}} ModelFileRequireContextIdFunctionType
+ * @typedef {ModelFileRequireContextIdFunctionType & {keys: () => string[]}} ModelFileRequireContextType
+ */
 
 /**
  * Lints model relationships: every non-polymorphic belongs-to relationship should have an inverse
@@ -27,7 +33,9 @@ export default class VelociousCliCommandsLintRelationships extends BaseCommand {
     // current configuration, so make this command's configuration the current one.
     this.getConfiguration().setCurrent()
 
-    await this.getConfiguration().initializeModels()
+    if (!await this._registerStaticModelFiles()) {
+      await this.getConfiguration().initializeModels()
+    }
 
     const ignoredRelationships = await this._loadIgnoredRelationships()
     const offences = []
@@ -99,6 +107,71 @@ export default class VelociousCliCommandsLintRelationships extends BaseCommand {
     console.log(`Relationship lint passed for ${modelClasses.length} model(s).`)
 
     return {offences}
+  }
+
+  /**
+   * Registers model classes from the conventional src/models directory without
+   * running the application's full database/server initialization.
+   * @returns {Promise<boolean>} Whether static model files were registered.
+   */
+  async _registerStaticModelFiles() {
+    if (this.args.testing) return false
+
+    const modelsDirectory = path.join(this.directory(), "src/models")
+
+    try {
+      const stats = await fs.stat(modelsDirectory)
+
+      if (!stats.isDirectory()) return false
+    } catch (error) {
+      if (/** @type {NodeJS.ErrnoException} */ (error).code == "ENOENT") return false
+
+      throw error
+    }
+
+    if ((await this._javascriptFilesInDirectory(modelsDirectory)).length === 0) return false
+
+    /** @type {ModelFileRequireContextType} */
+    const requireContextModels = requireContext(modelsDirectory, true, /^(.+)\.js$/)
+
+    const modelFileNames = requireContextModels.keys()
+    for (const fileName of modelFileNames) {
+      const modelClassImport = requireContextModels(fileName)
+      const modelClass = modelClassImport.default
+
+      if (!modelClass) {
+        throw new Error(`Model wasn't exported from: ${fileName}`)
+      }
+
+      modelClass.registerRecordClass({configuration: this.getConfiguration()})
+    }
+
+    return true
+  }
+
+  /**
+   * Finds JavaScript files below a directory.
+   * @param {string} directory - Directory to scan.
+   * @returns {Promise<string[]>} JavaScript file paths.
+   */
+  async _javascriptFilesInDirectory(directory) {
+    const filePaths = []
+    const entries = await fs.readdir(directory, {withFileTypes: true})
+
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        filePaths.push(...await this._javascriptFilesInDirectory(entryPath))
+        continue
+      }
+
+      if (entry.isFile() && entry.name.endsWith(".js")) {
+        filePaths.push(entryPath)
+      }
+    }
+
+    return filePaths
   }
 
   /**

--- a/src/environment-handlers/node/cli/commands/lint/relationships.js
+++ b/src/environment-handlers/node/cli/commands/lint/relationships.js
@@ -66,7 +66,11 @@ export default class VelociousCliCommandsLintRelationships extends BaseCommand {
           if (candidate.through) return false
 
           try {
-            return candidate.getTargetModelClass() === modelClass
+            const candidateTargetModelClass = candidate.getTargetModelClass()
+
+            if (!candidateTargetModelClass) return false
+
+            return this._modelClassesMatch(candidateTargetModelClass, modelClass)
           } catch {
             // A has-many/has-one with an unresolvable target can't be the inverse of this belongs-to.
             // It is reported separately when its own model's belongs-to relationships are linted.
@@ -95,6 +99,22 @@ export default class VelociousCliCommandsLintRelationships extends BaseCommand {
     console.log(`Relationship lint passed for ${modelClasses.length} model(s).`)
 
     return {offences}
+  }
+
+  /**
+   * Checks whether two model class objects describe the same registered model.
+   * @param {typeof import("../../../../../database/record/index.js").default} leftModelClass - Candidate target model class.
+   * @param {typeof import("../../../../../database/record/index.js").default} rightModelClass - Belongs-to source model class.
+   * @returns {boolean} Whether both model classes represent the same model identity.
+   */
+  _modelClassesMatch(leftModelClass, rightModelClass) {
+    if (leftModelClass === rightModelClass) return true
+    // `translates()` creates an internal translation class; apps may also define
+    // a concrete class for the same model/table so generated code has a stable
+    // file and type name.
+    if (leftModelClass.getModelName() != rightModelClass.getModelName()) return false
+
+    return leftModelClass.tableName() == rightModelClass.tableName()
   }
 
   /**

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -55,3 +55,16 @@ declare module "is-plain-object" {
 declare module "escape-string-regexp" {
   export default function escapeStringRegexp(value: string): string
 }
+
+declare module "require-context" {
+  export interface RequireContext<TModule = {default?: unknown}> {
+    (id: string): TModule
+    keys(): string[]
+  }
+
+  export default function requireContext<TModule = {default?: unknown}>(
+    directory: string,
+    useSubdirectories?: boolean,
+    regExp?: RegExp
+  ): RequireContext<TModule>
+}


### PR DESCRIPTION
## Summary
- treat concrete translation model classes as matching the implicit `translates(...)` relationship model identity when relationship lint checks inverses
- add regression coverage for a concrete translation model `belongsTo` satisfied by the implicit translation inverse

## Validation
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/cli/commands/lint/relationships-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint`
- `npm run typecheck`
- `npm run fallow`
