### PR TITLE
Collapse multiline command JSDoc types to a single line for inline casts

### DIFF
--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -1159,6 +1159,10 @@ export default class ReportResource extends FrontendModelBaseResource {
     // An explicit resourceConfig returnType wins over the method's own JSDoc.
     expect(userContents).toContain("@returns {Promise<{fromConfig: boolean}>} - Command response.")
     expect(userContents).not.toContain("fromJsDoc")
+    // A multiline backend `@returns` is collapsed to a single line so the inline cast is valid.
+    expect(userContents).toContain("@returns {Promise<{ first: string, second: number }>} - Command response.")
+    expect(userContents).toContain("/** @type {{ first: string, second: number }} */ (await this.executeCustomCommand({")
+    expect(userContents).not.toContain("*   first: string")
 
     await fs.rm(`${dummyDirectory()}/src/frontend-models`, {force: true, recursive: true})
   })

--- a/spec/dummy/src/config/backend-projects.js
+++ b/spec/dummy/src/config/backend-projects.js
@@ -142,6 +142,7 @@ class UserFrontendResource extends FrontendModelBaseResource {
         "delayedLookupByEmail",
         "echoMessage",
         "echoObjectStyle",
+        "multiLineReturn",
         {name: "echoOverride", returnType: "{fromConfig: boolean}"}
       ],
       memberCommands: ["refreshProfile", "echoMemberPayload"]
@@ -182,6 +183,18 @@ class UserFrontendResource extends FrontendModelBaseResource {
   /** @returns {Promise<{fromJsDoc: boolean}>} - JSDoc response the explicit resourceConfig returnType overrides. */
   async echoOverride() {
     return {fromJsDoc: true}
+  }
+
+  /**
+   * Has a multiline `@returns` so the generator must collapse it into a single line
+   * before emitting the inline cast (a multiline cast makes TypeScript read `undefined`).
+   * @returns {Promise<{
+   *   first: string,
+   *   second: number
+   * }>} - Multiline response.
+   */
+  async multiLineReturn() {
+    return {first: "x", second: 1}
   }
 
   /** @returns {Promise<{success: true}>} */

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -1852,13 +1852,25 @@ export default class DbGenerateFrontendModels extends BaseCommand {
       throw new Error(`Could not parse JSDoc return type from: ${jsDocText}`)
     }
 
-    const returnType = jsDocText.slice(typeOpenIndex + 1, typeCloseIndex).trim()
+    const returnType = this.normalizeJsDocType(jsDocText.slice(typeOpenIndex + 1, typeCloseIndex))
 
     if (returnType.length < 1) {
       throw new Error(`Expected non-empty JSDoc return type in: ${jsDocText}`)
     }
 
     return returnType
+  }
+
+  /**
+   * Collapses a JSDoc type spanning multiple comment lines into a single line so it can
+   * be emitted into an inline type-assertion cast. A multiline backend return type keeps
+   * its leading continuation asterisks in the captured substring, which are invalid inside
+   * an inline cast and make TypeScript read the asserted type as `undefined`.
+   * @param {string} jsDocType - Raw captured JSDoc type, possibly multiline.
+   * @returns {string} - Single-line JSDoc type.
+   */
+  normalizeJsDocType(jsDocType) {
+    return jsDocType.replace(/\s*\n\s*\*?[ \t]*/g, " ").trim()
   }
 
   /**
@@ -1879,7 +1891,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
         throw new Error(`Could not parse JSDoc parameter type from: ${jsDocText}`)
       }
 
-      const type = jsDocText.slice(typeOpenIndex + 1, typeCloseIndex).trim()
+      const type = this.normalizeJsDocType(jsDocText.slice(typeOpenIndex + 1, typeCloseIndex))
 
       if (type.length < 1) {
         throw new Error(`Expected non-empty JSDoc parameter type in: ${jsDocText}`)


### PR DESCRIPTION
## Why

Follow-up to #785. A custom-command method whose backend `@returns` (or `@param`) type spans multiple comment lines — e.g.

```js
/**
 * @returns {Promise<{
 *   artifactLinks: Array<Record<string, unknown>>,
 *   buildId: string,
 *   status: "ok"
 * }>}
 */
async aiLogContext() { ... }
```

kept its leading ` * ` continuation markers in the captured type string. Emitted into the generated inline `/** @type {...} */` cast, those markers are invalid and TypeScript reads the asserted type as `undefined`, breaking the generated method and every consumer of that command.

## What

`normalizeJsDocType` collapses a captured JSDoc type to a single line (newline + optional continuation `*` → single space) in both `jsDocReturnType` and `jsDocParameters`, so the type is valid in both the emitted `@returns` tag and the inline cast.

## Tests

Adds a dummy command with a multiline `@returns` and asserts the generated `@returns` and inline cast are single-line (`{ first: string, second: number }`) with no continuation markers.

## Validation

`tsc --noEmit` clean, `eslint` clean, `fallow` clean, generator spec green (24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
