### PR TITLE
Avoid extra DB checkout for websocket broadcasts

### DIFF
--- a/changelog.d/20260623083151-frontend-model-broadcast-checkouts.md
+++ b/changelog.d/20260623083151-frontend-model-broadcast-checkouts.md
@@ -1,0 +1,1 @@
+Avoid holding an extra database checkout while delivering frontend-model websocket broadcasts.

--- a/spec/controller/frontend-model-tenant-context-spec.js
+++ b/spec/controller/frontend-model-tenant-context-spec.js
@@ -25,9 +25,10 @@ class TenantAwareFrontendModelController extends FrontendModelController {
 
 /**
  * @param {Record<string, any>} params
+ * @param {{configure?: (configuration: Configuration) => void}} [options]
  * @returns {Promise<Record<string, any>>}
  */
-async function runFrontendApi(params) {
+async function runFrontendApi(params, options = {}) {
   const configuration = new Configuration({
     database: {test: {}},
     directory: process.cwd(),
@@ -47,6 +48,9 @@ async function runFrontendApi(params) {
       return {slug: projectSlug}
     }
   })
+
+  if (options.configure) options.configure(configuration)
+
   const client = {remoteAddress: "127.0.0.1"}
   const request = new Request({client, configuration})
   const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
@@ -77,6 +81,45 @@ async function runFrontendApi(params) {
 }
 
 describe("Controller frontend model tenant context", {databaseCleaning: {transaction: true}}, () => {
+  it("resolves tenant context inside ensureConnections", async () => {
+    let inEnsureConnections = false
+    const response = await runFrontendApi(serializeFrontendModelTransportValue({
+      requests: [{
+        commandType: "index",
+        model: "Task",
+        payload: {
+          project_slug: "alpha"
+        },
+        requestId: "request-1"
+      }]
+    }), {
+      configure: (configuration) => {
+        const originalEnsureConnections = configuration.ensureConnections.bind(configuration)
+
+        configuration.setTenantResolver(() => {
+          if (!inEnsureConnections) {
+            throw new Error("Frontend-model tenant resolver called outside ensureConnections")
+          }
+
+          return {slug: "alpha"}
+        })
+
+        configuration.ensureConnections = async (...args) => {
+          inEnsureConnections = true
+
+          try {
+            return await originalEnsureConnections(...args)
+          } finally {
+            inEnsureConnections = false
+          }
+        }
+      }
+    })
+
+    expect(response.responses[0].response.status).toEqual("success")
+    expect(response.responses[0].response.tenantSlug).toEqual("alpha")
+  })
+
   it("resolves tenant context from each batched shared frontend-model request entry", async () => {
     const response = await runFrontendApi(serializeFrontendModelTransportValue({
       requests: [{

--- a/spec/frontend-models/websocket-channel-spec.js
+++ b/spec/frontend-models/websocket-channel-spec.js
@@ -158,6 +158,70 @@ describe("FrontendModelWebsocketChannel", {databaseCleaning: {transaction: true}
     ])
   })
 
+  it("does not hold a generic broadcast checkout while resolving tenant-scoped event access", async () => {
+    /** @type {string[]} */
+    const checkoutNames = []
+    /** @type {Array<{body?: object, type?: string}>} */
+    const sentFrames = []
+    /** @type {string | null} */
+    let activeCheckoutName = null
+    const configuration = {
+      ensureConnections: async (/** @type {{name: string}} */ options, /** @type {() => Promise<boolean | void>} */ callback) => {
+        if (activeCheckoutName) {
+          throw new Error(`Nested checkout ${options.name} while ${activeCheckoutName} is active`)
+        }
+
+        activeCheckoutName = options.name
+        checkoutNames.push(options.name)
+
+        try {
+          return await callback()
+        } finally {
+          activeCheckoutName = null
+        }
+      },
+      resolveTenant: async () => ({slug: "alpha"}),
+      runWithTenant: async (/** @type {{slug: string}} */ _tenant, /** @type {() => Promise<boolean | void>} */ callback) => await callback()
+    }
+    const channel = new FrontendModelWebsocketChannel({
+      params: {model: "Task", project_slug: "alpha"},
+      // @ts-expect-error Minimal session stub for direct channel delivery.
+      session: {
+        configuration,
+        getMetadata: () => ({}),
+        sendJson: (/** @type {{body?: object, type?: string}} */ frame) => sentFrames.push(frame),
+        upgradeRequest: {
+          headers: () => ({}),
+          remoteAddress: () => "127.0.0.1"
+        }
+      },
+      subscriptionId: "tenant-access-checkout"
+    })
+
+    channel._frontendModelControllerClass = async () => /** @type {typeof import("../../src/frontend-model-controller.js").default} */ (class FrontendModelController {})
+    channel._eventIsAccessible = async (id) => {
+      return await channel._withEventTenant(id, async () => true)
+    }
+
+    await channel.deliverBroadcast({
+      action: "update",
+      id: "task-1",
+      record: {id: "task-1", name: "Task 1"}
+    })
+
+    expect(checkoutNames).toEqual(["Frontend model websocket event tenant"])
+    expect(sentFrames.map((frame) => frame.body)).toEqual([
+      {
+        action: "update",
+        id: "task-1",
+        record: {
+          id: "task-1",
+          name: "Task 1"
+        }
+      }
+    ])
+  })
+
   it("forwards the subscriber's auth params to resolveAbility", async () => {
     /** @type {Array<Record<string, unknown>>} */
     const resolveAbilityParams = []

--- a/spec/frontend-models/websocket-channel-spec.js
+++ b/spec/frontend-models/websocket-channel-spec.js
@@ -180,7 +180,13 @@ describe("FrontendModelWebsocketChannel", {databaseCleaning: {transaction: true}
           activeCheckoutName = null
         }
       },
-      resolveTenant: async () => ({slug: "alpha"}),
+      resolveTenant: async () => {
+        if (!activeCheckoutName) {
+          throw new Error("Tenant resolution did not run inside a checkout")
+        }
+
+        return {slug: "alpha"}
+      },
       runWithTenant: async (/** @type {{slug: string}} */ _tenant, /** @type {() => Promise<boolean | void>} */ callback) => await callback()
     }
     const channel = new FrontendModelWebsocketChannel({
@@ -209,7 +215,10 @@ describe("FrontendModelWebsocketChannel", {databaseCleaning: {transaction: true}
       record: {id: "task-1", name: "Task 1"}
     })
 
-    expect(checkoutNames).toEqual(["Frontend model websocket event tenant"])
+    expect(checkoutNames).toEqual([
+      "Frontend model websocket event tenant resolution",
+      "Frontend model websocket event tenant"
+    ])
     expect(sentFrames.map((frame) => frame.body)).toEqual([
       {
         action: "update",

--- a/spec/routes/resolver-params-reset-spec.js
+++ b/spec/routes/resolver-params-reset-spec.js
@@ -10,6 +10,74 @@ import RoutesResolver from "../../src/routes/resolver.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 
 describe("routes - resolver params reset", {databaseCleaning: {transaction: true}}, async () => {
+  it("resolves tenants inside ensureConnections", async () => {
+    let inEnsureConnections = false
+
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: dummyDirectory(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      logging: {console: true, file: false, levels: ["info", "warn", "error"]},
+      tenantResolver: () => {
+        if (!inEnsureConnections) {
+          throw new Error("Tenant resolver called outside ensureConnections")
+        }
+
+        return {slug: "alpha"}
+      }
+    })
+    const originalEnsureConnections = configuration.ensureConnections.bind(configuration)
+
+    configuration.ensureConnections = async (...args) => {
+      inEnsureConnections = true
+
+      try {
+        return await originalEnsureConnections(...args)
+      } finally {
+        inEnsureConnections = false
+      }
+    }
+
+    let previousConfiguration
+    try {
+      previousConfiguration = Configuration.current()
+    } catch {
+      // Ignore missing configuration
+    }
+
+    configuration.setCurrent()
+    configuration.setRoutes(dummyRoutes.routes)
+
+    const client = {remoteAddress: "127.0.0.1"}
+    const request = new Request({client, configuration})
+    const response = new Response({configuration})
+    const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+    const requestLines = [
+      "GET /ping HTTP/1.1",
+      "Host: example.com",
+      "",
+      ""
+    ].join("\r\n")
+
+    try {
+      request.feed(Buffer.from(requestLines, "utf8"))
+      await donePromise
+
+      const resolver = new RoutesResolver({configuration, request, response})
+
+      await resolver.resolve()
+    } finally {
+      if (previousConfiguration) previousConfiguration.setCurrent()
+    }
+
+    expect(JSON.parse(response.getBody())).toEqual({message: "Pong"})
+  })
+
   it("resolves abilities inside ensureConnections", async () => {
     let inEnsureConnections = false
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -638,11 +638,15 @@ export default class FrontendModelController extends Controller {
    */
   async withFrontendModelRequestContext(params, response, callback) {
     const configuration = this.getConfiguration()
-    const tenant = await configuration.resolveTenant({
-      params,
-      request: this.request(),
-      response
-    })
+    const tenant = configuration.getTenantResolver()
+      ? await configuration.ensureConnections({name: "Frontend model request tenant resolution"}, async () => {
+          return await configuration.resolveTenant({
+            params,
+            request: this.request(),
+            response
+          })
+        })
+      : undefined
 
     return await configuration.runWithTenant(tenant, async () => {
       return await configuration.ensureConnections({name: "Frontend model request"}, async () => {

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -106,15 +106,6 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
    * @returns {Promise<void>} Resolves after delivery.
    */
   async deliverBroadcast(body, meta) {
-    const configuration = this.session.configuration
-
-    if (configuration) {
-      await configuration.ensureConnections({name: "Frontend model websocket broadcast"}, async () => {
-        await this._deliverBroadcast(body, meta)
-      })
-      return
-    }
-
     await this._deliverBroadcast(body, meta)
   }
 

--- a/src/frontend-models/websocket-channel.js
+++ b/src/frontend-models/websocket-channel.js
@@ -359,6 +359,29 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
   }
 
   /**
+   * Resolves tenant for event.
+   * @param {string | number} id - Event record id.
+   * @returns {Promise<?>} - Resolved tenant.
+   */
+  async _resolveEventTenant(id) {
+    const configuration = this.session.configuration
+
+    return await configuration.ensureConnections({name: "Frontend model websocket event tenant resolution"}, async () => {
+      // Mirror the subscribe-time tenant resolution (`WebsocketSession._resolveTenant`):
+      // pass `subscription: {channel, params}` so resolvers that derive scope from the
+      // subscription behave the same for broadcasts as they did at `channel-subscribe`.
+      // The synthetic request forwards the subscriber's params (e.g. authenticationToken),
+      // matching this channel's ability resolution above.
+      return await configuration.resolveTenant({
+        params: {...this.params, id, model: this._modelName()},
+        request: /** @type {import("../http-server/client/request.js").default} */ (this._syntheticRequest()),
+        response: new Response({configuration}),
+        subscription: {channel: FRONTEND_MODELS_CHANNEL_NAME, params: this.params}
+      })
+    })
+  }
+
+  /**
    * Resolves the subscriber's tenant for the broadcast record and runs `callback` inside that tenant
    * context. Broadcast delivery runs in whatever ambient tenant context the publisher left behind. For
    * multi-tenant records that ambient tenant may have been resolved without the subscriber's request
@@ -379,17 +402,7 @@ export default class FrontendModelWebsocketChannel extends VelociousWebsocketCha
       return await callback()
     }
 
-    // Mirror the subscribe-time tenant resolution (`WebsocketSession._resolveTenant`):
-    // pass `subscription: {channel, params}` so resolvers that derive scope from the
-    // subscription behave the same for broadcasts as they did at `channel-subscribe`.
-    // The synthetic request forwards the subscriber's params (e.g. authenticationToken),
-    // matching this channel's ability resolution above.
-    const tenant = await configuration.resolveTenant({
-      params: {...this.params, id, model: this._modelName()},
-      request: /** @type {import("../http-server/client/request.js").default} */ (this._syntheticRequest()),
-      response: new Response({configuration}),
-      subscription: {channel: FRONTEND_MODELS_CHANNEL_NAME, params: this.params}
-    })
+    const tenant = await this._resolveEventTenant(id)
 
     // Always enter `runWithTenant`, even when no tenant resolved. Broadcast fan-out
     // runs in the publisher's ambient tenant context; falling back to `callback()`

--- a/src/routes/resolver.js
+++ b/src/routes/resolver.js
@@ -202,12 +202,14 @@ export default class VelociousRoutesResolver {
     await this._logActionStart({action, controllerClass, logMethod})
 
     try {
-      const tenant = skipTenantResolution
+      const tenant = skipTenantResolution || !this.configuration.getTenantResolver()
         ? undefined
-        : await this.configuration.resolveTenant({
-            params: {...this.queryParameters(), ...this.params},
-            request: this.request,
-            response: this.response
+        : await this.configuration.ensureConnections({name: `${controllerClass.name}.${action} tenant resolution`}, async () => {
+            return await this.configuration.resolveTenant({
+              params: {...this.queryParameters(), ...this.params},
+              request: this.request,
+              response: this.response
+            })
           })
 
       const runAction = async () => {

--- a/tensorbuzz.yml
+++ b/tensorbuzz.yml
@@ -1,9 +1,8 @@
 before_install:
-  - sudo mkdir -p /etc/apt/keyrings
-  - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --no-tty --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
-  - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-  - sudo apt-get update
-  - sudo apt-get install -y nodejs
+  - curl -fsSL https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.xz -o /tmp/node-v24.17.0-linux-x64.tar.xz
+  - sudo tar -xJf /tmp/node-v24.17.0-linux-x64.tar.xz -C /usr/local --strip-components=1
+  - node --version
+  - npm --version
 before_script:
   - git clean -fd spec src
   - git clean -fdx spec/dummy/db


### PR DESCRIPTION
## Summary
- remove the outer generic DB checkout around frontend-model websocket broadcast delivery
- keep tenant-scoped websocket event access on short tenant-resolution and event-access checkout paths
- resolve HTTP route and shared frontend-model request tenants inside short connection scopes when an app configures a tenant resolver
- add regressions for websocket broadcasts, HTTP route tenant resolution, and shared frontend-model tenant resolution
- avoid the TensorBuzz NodeSource apt install hang by using the official Node.js tarball in CI bootstrap

## Root cause
TensorBuzz production showed frontend-model websocket broadcast holders filling the DB pool while subscription delivery was also resolving tenant-scoped event access. Velocious was holding a generic `Frontend model websocket broadcast` checkout around the whole delivery, then `_withEventTenant` correctly attempted a tenant-specific checkout for event authorization. Under broad broadcast fan-out this doubled checkout pressure and could starve the pool.

A follow-up sweep found two more tenant-resolution gaps: normal HTTP routes and shared frontend-model requests resolved tenants before entering their request checkout scopes. DB-backed tenant resolvers could therefore run without a scoped connection before the controller/frontend-model request checkout began.

## Validation
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/frontend-models/websocket-channel-spec.js`
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/routes/resolver-params-reset-spec.js spec/routes/resolver-tenant-spec.js spec/controller/frontend-model-tenant-context-spec.js spec/controller/frontend-model-actions-spec.js spec/frontend-models/websocket-channel-spec.js`
- `npm run build`
- `npm run lint` after copying `spec/dummy/src/config/configuration.peakflow.sqlite.js` to `spec/dummy/src/config/configuration.js`
- `npm run typecheck`
- `npm run fallow`