### PR TITLE
feat: add shared resource fallback

### DIFF
--- a/changelog.d/20260623131500-shared-resource-fallback.md
+++ b/changelog.d/20260623131500-shared-resource-fallback.md
@@ -1,0 +1,1 @@
+Add shared frontend-model resource fallback support so environment-specific resources can inherit static configuration and default instance behavior from bundled shared resources.

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -26,6 +26,9 @@ Without a resource definition, frontend models should not silently work.
 - Default instance methods such as `permittedParams`, normalization hooks, mutation hooks, `runMutationTransaction`, `beforeAction`, and `abilities` fall back to the shared resource only when the environment resource does not override the method.
 - Custom resource methods such as collection/member commands, computed `${name}Attribute` hooks, and virtual setters can live on the shared resource when their config is inherited from it.
 - Shared `abilities()` runs with the environment resource's model class, so helpers such as `this.can("read")` authorize the concrete backend model.
+- Shared resources should resolve portable model classes through `this.model("Task")` instead of importing backend-only files directly. The resource context can provide `modelRegistry`, `model(name)`, or a backend `configuration` model map.
+- Portable context helpers available to shared resources include `currentUser()`, `currentDevice()`, `offlineGrant()`, `now()`, `resourceRuntime()`, `isBackend()`, `isFrontend()`, and `isOffline()`.
+- Shared resources should treat `this.model(...)`, query APIs, and context helpers as the portability boundary. Avoid raw SQL, Node-only imports, secrets, direct database driver access, or environment-specific globals in shared resource files.
 - Treat shared resources as reusable defaults, not a security boundary. Environment resources should still override attributes, permissions, commands, or hooks whenever a frontend/backend deployment needs narrower behavior.
 
 ## Custom index records

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -3,13 +3,16 @@
 ## Resource recipe requirement
 Frontend model usage should require explicit backend resource recipes.
 
-A backend project should declare resources with:
-- `path`
-- `attributes`
-- `abilities`
+A backend project should declare resources with static resource properties:
+- `static attributes`
+- optional `abilities` for additional per-record `record.can(action)` checks
 - optional `commands`
 - optional `attachments`
 - optional server behavior (`records`, `serialize`, `beforeAction`)
+
+Backend resource classes must not override `static resourceConfig()`; Velocious throws during resource normalization. Use declarative static fields instead so resource config stays easy to scan and shared-resource fallback has one config path.
+
+Base CRUD ability actions (`read`, `create`, `update`, `destroy`) are always included by the framework; do not list them in `abilities` or Velocious throws during resource normalization.
 
 Without a resource definition, frontend models should not silently work.
 
@@ -19,7 +22,7 @@ Without a resource definition, frontend models should not silently work.
 
 ## Shared resource fallback
 - Environment-specific resources may declare `static SharedResource = SharedModelResource` to reuse a bundled shared resource recipe.
-- Static frontend-model config resolves in this order: environment resource value, inherited environment resource value, shared resource value or shared `resourceConfig()` value, framework default.
+- Static frontend-model config resolves in this order: environment resource value, inherited environment resource value, shared resource value, framework default.
 - Default instance methods such as `permittedParams`, normalization hooks, mutation hooks, `runMutationTransaction`, `beforeAction`, and `abilities` fall back to the shared resource only when the environment resource does not override the method.
 - Custom resource methods such as collection/member commands, computed `${name}Attribute` hooks, and virtual setters can live on the shared resource when their config is inherited from it.
 - Shared `abilities()` runs with the environment resource's model class, so helpers such as `this.can("read")` authorize the concrete backend model.
@@ -40,16 +43,12 @@ Without a resource definition, frontend models should not silently work.
 - Both forms can be mixed in the same array; string entries are unchanged and stay variadic (`async refresh(...commandArguments)`).
 
 ```js
-static resourceConfig() {
-  return {
-    abilities: ["read"],
-    attributes: ["id"],
-    memberCommands: [
-      "suspend",
-      {name: "refresh", args: [{name: "age", type: "number"}], returnType: "string"}
-    ]
-  }
-}
+static attributes = ["id"]
+
+static memberCommands = [
+  "suspend",
+  {name: "refresh", args: [{name: "age", type: "number"}], returnType: "string"}
+]
 ```
 
 generates, on the frontend model:

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -19,8 +19,9 @@ Without a resource definition, frontend models should not silently work.
 
 ## Shared resource fallback
 - Environment-specific resources may declare `static SharedResource = SharedModelResource` to reuse a bundled shared resource recipe.
-- Static frontend-model config resolves in this order: environment resource value, inherited environment resource value, shared resource value, framework default.
+- Static frontend-model config resolves in this order: environment resource value, inherited environment resource value, shared resource value or shared `resourceConfig()` value, framework default.
 - Default instance methods such as `permittedParams`, normalization hooks, mutation hooks, `runMutationTransaction`, `beforeAction`, and `abilities` fall back to the shared resource only when the environment resource does not override the method.
+- Custom resource methods such as collection/member commands, computed `${name}Attribute` hooks, and virtual setters can live on the shared resource when their config is inherited from it.
 - Shared `abilities()` runs with the environment resource's model class, so helpers such as `this.can("read")` authorize the concrete backend model.
 - Treat shared resources as reusable defaults, not a security boundary. Environment resources should still override attributes, permissions, commands, or hooks whenever a frontend/backend deployment needs narrower behavior.
 

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -17,6 +17,13 @@ Without a resource definition, frontend models should not silently work.
 - Resource `commands` can map `attach`, `download`, and `url` in addition to CRUD/index commands.
 - Resource `attachments` defines attachment helpers generated on frontend models.
 
+## Shared resource fallback
+- Environment-specific resources may declare `static SharedResource = SharedModelResource` to reuse a bundled shared resource recipe.
+- Static frontend-model config resolves in this order: environment resource value, inherited environment resource value, shared resource value, framework default.
+- Default instance methods such as `permittedParams`, normalization hooks, mutation hooks, `runMutationTransaction`, `beforeAction`, and `abilities` fall back to the shared resource only when the environment resource does not override the method.
+- Shared `abilities()` runs with the environment resource's model class, so helpers such as `this.can("read")` authorize the concrete backend model.
+- Treat shared resources as reusable defaults, not a security boundary. Environment resources should still override attributes, permissions, commands, or hooks whenever a frontend/backend deployment needs narrower behavior.
+
 ## Custom index records
 - Override `indexQuery(options)` when the default index behavior is correct but the resource needs an additional scope. Call `super.indexQuery(options)` and add the resource-specific filters, joins, or select data. The `options` object can include `includePagination` and `includeSort`.
 - Override `countIndexQueryOptions()` when a resource-specific `count()` needs different index-query options, for example `{includePagination: false, includeSort: false}` to count the full filtered scope while keeping paginated records.

--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -23,10 +23,7 @@ class Call extends DatabaseRecord {
 class CallFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Call
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: {
+    static attributes = {
         id: {type: "uuid"},
         startedAt: {type: "datetime", null: true},
         durationSeconds: {dataType: "integer"},
@@ -34,8 +31,6 @@ class CallFrontendResource extends FrontendModelBaseResource {
         active: {type: "boolean"},
         endedAt: {type: "timestamp without time zone", null: true}
       }
-    }
-  }
 
   /** @returns {Array<string>} - Permit spec for Call writes. */
   permittedParams() {
@@ -46,10 +41,7 @@ class CallFrontendResource extends FrontendModelBaseResource {
 class InferredCallFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Call
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: [
+    static attributes = [
         "id",
         {name: "startedAt", selectedByDefault: false},
         {name: "durationSeconds", selectedByDefault: false},
@@ -57,8 +49,6 @@ class InferredCallFrontendResource extends FrontendModelBaseResource {
         {name: "active", selectedByDefault: false},
         {name: "eA", selectedByDefault: false}
       ]
-    }
-  }
 }
 
 class TranslatedCall extends DatabaseRecord {}
@@ -69,34 +59,19 @@ class TranslatedCallFrontendResource extends FrontendModelBaseResource {
   static ModelClass = TranslatedCall
   static translatedAttributes = ["title"]
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: ["id", {name: "title", selectedByDefault: false}]
-    }
-  }
+    static attributes = ["id", {name: "title", selectedByDefault: false}]
 }
 
 class UninferableCallFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Call
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: ["unknownComputed"]
-    }
-  }
+    static attributes = ["unknownComputed"]
 }
 
 class MissingAbilitiesTaskFrontendResource extends FrontendModelBaseResource {
   static ModelClass = backendProjects[0].frontendModels.Task.ModelClass
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: ["id", "name"]
-    }
-  }
+    static attributes = ["id", "name"]
 }
 
 class MissingRelationshipTargetTask extends DatabaseRecord {}
@@ -105,51 +80,35 @@ MissingRelationshipTargetTask.belongsTo("project")
 class MissingRelationshipTargetTaskFrontendResource extends FrontendModelBaseResource {
   static ModelClass = MissingRelationshipTargetTask
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: {
+    static attributes = {
         id: {type: "integer"},
         name: {type: "varchar", null: true}
-      },
-      relationships: ["project"]
-    }
-  }
+      }
+
+  static relationships = ["project"]
 }
 
 class NullableIdCallFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Call
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: {id: {type: "uuid", null: true}}
-    }
-  }
+    static attributes = {id: {type: "uuid", null: true}}
 }
 
 class CommandReturnTypeFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Call
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: {id: {type: "uuid"}},
-      memberCommands: [
+    static attributes = {id: {type: "uuid"}}
+
+  static memberCommands = [
         "ping",
         {name: "refresh", args: [{name: "age", type: "number"}], returnType: "{refreshedAt: string}"}
       ]
-    }
-  }
 }
 
 // An abstract base resource other resources extend — deliberately has no static
 // ModelClass, like an app's shared `BaseResource`.
 class AbstractBaseFrontendResource extends FrontendModelBaseResource {
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {attributes: []}
-  }
+    static attributes = []
 }
 
 class User extends DatabaseRecord {}
@@ -158,15 +117,10 @@ User.setPrimaryKey("reference")
 class ReferenceUserFrontendResource extends FrontendModelBaseResource {
   static ModelClass = User
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: [
+    static attributes = [
         {name: "reference", type: "varchar"},
         {name: "email", type: "varchar"}
       ]
-    }
-  }
 }
 
 class LegacyPrimaryKeyUser extends DatabaseRecord {}
@@ -175,15 +129,10 @@ LegacyPrimaryKeyUser.setPrimaryKey("LegacyID")
 class LegacyPrimaryKeyUserFrontendResource extends FrontendModelBaseResource {
   static ModelClass = LegacyPrimaryKeyUser
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: [
+    static attributes = [
         {name: "legacyID", type: "integer"},
         {name: "email", type: "varchar"}
       ]
-    }
-  }
 }
 
 class ConfiguredPrimaryKeyUser extends DatabaseRecord {}
@@ -192,16 +141,12 @@ ConfiguredPrimaryKeyUser.setPrimaryKey("LegacyID")
 class ConfiguredPrimaryKeyUserFrontendResource extends FrontendModelBaseResource {
   static ModelClass = ConfiguredPrimaryKeyUser
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      attributes: [
+    static attributes = [
         {name: "legacyID", type: "integer"},
         {name: "email", type: "varchar"}
-      ],
-      primaryKey: "legacyID"
-    }
-  }
+      ]
+
+  static primaryKey = "legacyID"
 }
 
 /** @returns {void} */
@@ -681,13 +626,7 @@ Report._attributeNameToColumnName = {
 export default class ReportResource extends FrontendModelBaseResource {
   static ModelClass = Report
 
-  /** @returns {import("${repositoryDirectory}/src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id", "statusCode"]
-    }
-  }
+    static attributes = ["id", "statusCode"]
 
   /**
    * Formats the numeric status code for frontend display.
@@ -935,14 +874,9 @@ export default class ReportResource extends FrontendModelBaseResource {
         ]
       }
 
-      /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: {
-            id: {type: "integer"},
-            name: {type: "varchar", null: true}
-          }
-        }
+      static attributes = {
+        id: {type: "integer"},
+        name: {type: "varchar", null: true}
       }
     }
 

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -289,14 +289,9 @@ async function createTaskWithProject({projectName, taskName, creatingUserReferen
 class ScopedTaskFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Task
 
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} - Resource config. */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id", "name"],
-      builtInCollectionCommands: ["index"]
-    }
-  }
+    static attributes = ["id", "name"]
+
+  static builtInCollectionCommands = ["index"]
 
   /**
    * @param {{includePagination?: boolean, includeSort?: boolean}} [options] - Index-query options.
@@ -319,28 +314,18 @@ class ScopedTaskFrontendResource extends FrontendModelBaseResource {
 class DescriptionPluckTaskFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Task
 
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} - Resource config. */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id", {name: "description", selectedByDefault: false}],
-      builtInCollectionCommands: ["index"]
-    }
-  }
+    static attributes = ["id", {name: "description", selectedByDefault: false}]
+
+  static builtInCollectionCommands = ["index"]
 }
 
 /** Task resource using the legacy all-model-columns serialization default. */
 class AllColumnsPluckTaskFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Task
 
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} - Resource config. */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: [],
-      builtInCollectionCommands: ["index"]
-    }
-  }
+    static attributes = []
+
+  static builtInCollectionCommands = ["index"]
 }
 
 describe("Controller frontend model actions", {databaseCleaning: {transaction: false, truncate: true}}, () => {
@@ -533,27 +518,17 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     class RequestedLazyFrontendResource extends FrontendModelBaseResource {
       static ModelClass = RequestedLazyFrontendModel
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          abilities: ["read"],
-          attributes: ["id"],
-          builtInCollectionCommands: ["index"]
-        }
-      }
+      static attributes = ["id"]
+
+      static builtInCollectionCommands = ["index"]
     }
 
     class UnrequestedLazyFrontendResource extends FrontendModelBaseResource {
       static ModelClass = UnrequestedLazyFrontendModel
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          abilities: ["read"],
-          attributes: ["id"],
-          builtInCollectionCommands: ["index"]
-        }
-      }
+      static attributes = ["id"]
+
+      static builtInCollectionCommands = ["index"]
     }
 
     const configuration = new Configuration({

--- a/spec/dummy/src/config/backend-projects.js
+++ b/spec/dummy/src/config/backend-projects.js
@@ -12,21 +12,20 @@ import User from "../models/user.js"
 class TaskFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Task
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read", "create", "update", "destroy"],
-      attributes: ["id", "identifier", "isDone", "name", "nameUppercase", "asyncNameUppercase", "downloadToken", {name: "projectId", selectedByDefault: false}, {name: "createdAt", selectedByDefault: false}, "updatedAt"],
-      attachments: {
+    static attributes = ["id", "identifier", "isDone", "name", "nameUppercase", "asyncNameUppercase", "downloadToken", {name: "projectId", selectedByDefault: false}, {name: "createdAt", selectedByDefault: false}, "updatedAt"]
+
+  static attachments = {
         descriptionFile: {type: "hasOne"},
         files: {type: "hasMany"}
-      },
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find", "update", "destroy"],
-      relationships: ["project", "comments"],
-      primaryKey: "id"
-    }
-  }
+      }
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find", "update", "destroy"]
+
+  static relationships = ["project", "comments"]
+
+  static primaryKey = "id"
 
   /**
    * Virtual attribute: returns the task name in uppercase.
@@ -88,16 +87,13 @@ class ProjectFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Project
   static translatedAttributes = ["name"]
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read", "create", "update"],
-      attributes: ["id", {name: "name", selectedByDefault: false}],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find"],
-      relationships: ["creatingUser", "interactions", "tasks"]
-    }
-  }
+    static attributes = ["id", {name: "name", selectedByDefault: false}]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find"]
+
+  static relationships = ["creatingUser", "interactions", "tasks"]
 
   /** @returns {Array<string | Record<string, ?>>} - Permit spec for Project writes (name is translated). */
   permittedParams() {
@@ -112,15 +108,11 @@ class ProjectFrontendResource extends FrontendModelBaseResource {
 class InteractionFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Interaction
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read", "create", "update", "destroy"],
-      attributes: ["id", "kind", "subjectId", "subjectType"],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find", "update", "destroy"]
-    }
-  }
+    static attributes = ["id", "kind", "subjectId", "subjectType"]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find", "update", "destroy"]
 
   /** @returns {Array<string>} - Permit spec for Interaction writes. */
   permittedParams() {
@@ -131,14 +123,13 @@ class InteractionFrontendResource extends FrontendModelBaseResource {
 class UserFrontendResource extends FrontendModelBaseResource {
   static ModelClass = User
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id", "email", "name", {name: "reference", selectedByDefault: false}, "createdAt"],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find"],
-      collectionCommands: [
+    static attributes = ["id", "email", "name", {name: "reference", selectedByDefault: false}, "createdAt"]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find"]
+
+  static collectionCommands = [
         "currentSessionCookie",
         "setSessionCookie",
         "lookupByEmail",
@@ -149,10 +140,9 @@ class UserFrontendResource extends FrontendModelBaseResource {
         "multiLineReturn",
         "sharedEcho",
         {name: "echoOverride", returnType: "{fromConfig: boolean}"}
-      ],
-      memberCommands: ["refreshProfile", "echoMemberPayload"]
-    }
-  }
+      ]
+
+  static memberCommands = ["refreshProfile", "echoMemberPayload"]
 
   /**
    * Returns the client's own `id` argument to prove the member route id does not
@@ -278,15 +268,11 @@ class UserFrontendResource extends FrontendModelBaseResource {
 class SystemTestCommentFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Comment
 
-  /** @returns {import("../../../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read", "create", "update", "destroy"],
-      attributes: ["id", "body"],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find"]
-    }
-  }
+    static attributes = ["id", "body"]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find"]
 
   /** @returns {Array<string>} - Permit spec for Comment writes. */
   permittedParams() {

--- a/spec/frontend-model-resource/base-resource-spec.js
+++ b/spec/frontend-model-resource/base-resource-spec.js
@@ -10,7 +10,7 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
   it("falls back to shared resource static config when environment resource omits it", () => {
     class SharedProjectResource extends FrontendModelBaseResource {
       static attributes = ["id", "name"]
-      static abilities = ["read", "update"]
+      static abilities = ["approve", "archive"]
       static relationships = ["tasks"]
     }
 
@@ -19,7 +19,7 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
     }
 
     expect(ProjectResource.resourceConfig()).toEqual({
-      abilities: ["read", "update"],
+      abilities: ["approve", "archive"],
       attributes: ["id", "name"],
       relationships: ["tasks"]
     })
@@ -28,7 +28,7 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
   it("uses environment resource static config before shared resource static config", () => {
     class SharedProjectResource extends FrontendModelBaseResource {
       static attributes = ["id", "name"]
-      static abilities = ["read"]
+      static abilities = ["approve"]
     }
 
     class ProjectResource extends FrontendModelBaseResource {
@@ -37,7 +37,7 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
     }
 
     expect(ProjectResource.resourceConfig()).toEqual({
-      abilities: ["read"],
+      abilities: ["approve"],
       attributes: ["id", "title"]
     })
   })
@@ -54,15 +54,13 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
     expect(ProjectResource.translatedAttributesConfig()).toEqual(["name", "description"])
   })
 
-  it("falls back to shared resourceConfig overrides", () => {
+  it("falls back to shared static command config", () => {
     class SharedProjectResource extends FrontendModelBaseResource {
-      static resourceConfig() {
-        return {
-          attributes: ["id", "name"],
-          collectionCommands: ["refreshAll"],
-          memberCommands: ["archive"]
-        }
-      }
+      static attributes = ["id", "name"]
+
+      static collectionCommands = ["refreshAll"]
+
+      static memberCommands = ["archive"]
     }
 
     class ProjectResource extends FrontendModelBaseResource {

--- a/spec/frontend-model-resource/base-resource-spec.js
+++ b/spec/frontend-model-resource/base-resource-spec.js
@@ -54,6 +54,28 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
     expect(ProjectResource.translatedAttributesConfig()).toEqual(["name", "description"])
   })
 
+  it("falls back to shared resourceConfig overrides", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      static resourceConfig() {
+        return {
+          attributes: ["id", "name"],
+          collectionCommands: ["refreshAll"],
+          memberCommands: ["archive"]
+        }
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    expect(ProjectResource.resourceConfig()).toEqual({
+      attributes: ["id", "name"],
+      collectionCommands: ["refreshAll"],
+      memberCommands: ["archive"]
+    })
+  })
+
   it("preserves inherited environment static config before shared resource static config", () => {
     class ParentProjectResource extends FrontendModelBaseResource {
       static attributes = ["id", "parentName"]
@@ -164,6 +186,69 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
     })
 
     expect(resource.permittedParams({action: "create"})).toEqual(["environmentName"])
+  })
+
+  it("resolves shared custom command and attribute hook methods", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      /** @returns {{status: string}} */
+      refresh() {
+        return {status: "shared"}
+      }
+
+      /** @returns {string} */
+      statusAttribute() {
+        return "shared-status"
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    const resource = new ProjectResource({
+      modelClass: class extends DatabaseRecord {},
+      modelName: "Project",
+      params: {}
+    })
+
+    const command = resource.resourceMethod("refresh")
+    const attribute = resource.resourceMethod("statusAttribute")
+
+    expect(command?.method.call(command.resource)).toEqual({status: "shared"})
+    expect(attribute?.method.call(attribute.resource)).toEqual("shared-status")
+  })
+
+  it("applies shared virtual setters", async () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      /** @returns {string[]} */
+      permittedParams() {
+        return ["status"]
+      }
+
+      /**
+       * @param {Project} model - Project model.
+       * @param {unknown} value - Status value.
+       * @returns {void}
+       */
+      setStatusAttribute(model, value) {
+        model.setTasksCount(Number(value))
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    const resource = new ProjectResource({
+      modelClass: Project,
+      modelName: "Project",
+      params: {}
+    })
+    const model = await Project.create({})
+
+    await resource.update(model, {status: 42})
+
+    expect(model.tasksCount()).toEqual(42)
   })
 
   it("defaults to permitting nothing — subclasses must override to enable writes", () => {

--- a/spec/frontend-model-resource/base-resource-spec.js
+++ b/spec/frontend-model-resource/base-resource-spec.js
@@ -216,6 +216,59 @@ describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, (
     expect(attribute?.method.call(attribute.resource)).toEqual("shared-status")
   })
 
+  it("exposes portable context helpers and model registry to shared resources", () => {
+    const now = new Date("2026-01-02T03:04:05.000Z")
+    const currentUser = {id: 123}
+    const currentDevice = {id: "scanner-1"}
+    const offlineGrant = {id: "grant-1"}
+
+    class SharedProjectResource extends FrontendModelBaseResource {
+      /** @returns {Record<string, ?>} */
+      contextSnapshot() {
+        return {
+          currentDevice: this.currentDevice(),
+          currentUser: this.currentUser(),
+          isBackend: this.isBackend(),
+          isFrontend: this.isFrontend(),
+          isOffline: this.isOffline(),
+          now: this.now(),
+          offlineGrant: this.offlineGrant(),
+          taskModel: this.model("Task")
+        }
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    const resource = new ProjectResource({
+      context: {
+        currentDevice,
+        currentUser,
+        modelRegistry: {Task},
+        now: () => now,
+        offlineGrant,
+        resourceRuntime: "backend"
+      },
+      modelClass: Project,
+      modelName: "Project",
+      params: {}
+    })
+    const method = resource.resourceMethod("contextSnapshot")
+
+    expect(method?.method.call(method.resource)).toEqual({
+      currentDevice,
+      currentUser,
+      isBackend: true,
+      isFrontend: false,
+      isOffline: true,
+      now,
+      offlineGrant,
+      taskModel: Task
+    })
+  })
+
   it("applies shared virtual setters", async () => {
     class SharedProjectResource extends FrontendModelBaseResource {
       /** @returns {string[]} */

--- a/spec/frontend-model-resource/base-resource-spec.js
+++ b/spec/frontend-model-resource/base-resource-spec.js
@@ -7,6 +7,165 @@ import Project from "../dummy/src/models/project.js"
 import Task from "../dummy/src/models/task.js"
 
 describe("FrontendModelBaseResource", {databaseCleaning: {transaction: true}}, () => {
+  it("falls back to shared resource static config when environment resource omits it", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      static attributes = ["id", "name"]
+      static abilities = ["read", "update"]
+      static relationships = ["tasks"]
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    expect(ProjectResource.resourceConfig()).toEqual({
+      abilities: ["read", "update"],
+      attributes: ["id", "name"],
+      relationships: ["tasks"]
+    })
+  })
+
+  it("uses environment resource static config before shared resource static config", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      static attributes = ["id", "name"]
+      static abilities = ["read"]
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+      static attributes = ["id", "title"]
+    }
+
+    expect(ProjectResource.resourceConfig()).toEqual({
+      abilities: ["read"],
+      attributes: ["id", "title"]
+    })
+  })
+
+  it("falls back to shared resource translated attributes", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      static translatedAttributes = ["name", "description"]
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    expect(ProjectResource.translatedAttributesConfig()).toEqual(["name", "description"])
+  })
+
+  it("preserves inherited environment static config before shared resource static config", () => {
+    class ParentProjectResource extends FrontendModelBaseResource {
+      static attributes = ["id", "parentName"]
+      static abilities = ["parentRead"]
+    }
+
+    class SharedProjectResource extends FrontendModelBaseResource {
+      static attributes = ["id", "sharedName", "sharedSecret"]
+      static abilities = ["sharedRead", "sharedUpdate"]
+    }
+
+    class ProjectResource extends ParentProjectResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    expect(ProjectResource.resourceConfig()).toEqual({
+      abilities: ["parentRead"],
+      attributes: ["id", "parentName"]
+    })
+  })
+
+  it("runs shared abilities against the environment resource model class", () => {
+    const ModelClass = class ProjectForSharedAbilities extends DatabaseRecord {}
+    /** @type {{actions: string, conditions: unknown, modelClass: typeof DatabaseRecord}[]} */
+    const calls = []
+    const ability = /** @type {import("../../src/authorization/ability.js").default} */ ({
+      /**
+       * @param {string} actions - Ability action.
+       * @param {typeof DatabaseRecord} modelClass - Ability model class.
+       * @param {unknown} conditions - Ability conditions.
+       * @returns {void}
+       */
+      can(actions, modelClass, conditions) {
+        calls.push({actions, conditions, modelClass})
+      }
+    })
+
+    class SharedProjectResource extends FrontendModelBaseResource {
+      abilities() {
+        this.can("read")
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    const resource = new ProjectResource({
+      ability,
+      modelClass: ModelClass,
+      modelName: "Project",
+      params: {}
+    })
+
+    resource.abilities()
+
+    expect(calls).toEqual([{actions: "read", conditions: undefined, modelClass: ModelClass}])
+  })
+
+  it("falls back to shared resource instance methods when environment resource uses defaults", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      /** @returns {Array<string | Record<string, ?>>} */
+      permittedParams() {
+        return ["name", {tasksAttributes: ["name"]}]
+      }
+
+      /** @returns {{sharedNormalized: boolean}} */
+      normalizeCreateAttributes() {
+        return {sharedNormalized: true}
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+    }
+
+    const resource = new ProjectResource({
+      modelClass: class extends DatabaseRecord {},
+      modelName: "Project",
+      params: {}
+    })
+
+    expect(resource.permittedParams({action: "create"})).toEqual(["name", {tasksAttributes: ["name"]}])
+    expect(resource.normalizeCreateAttributes({}, {})).toEqual({sharedNormalized: true})
+  })
+
+  it("uses environment resource instance methods before shared resource methods", () => {
+    class SharedProjectResource extends FrontendModelBaseResource {
+      /** @returns {string[]} */
+      permittedParams() {
+        return ["sharedName"]
+      }
+    }
+
+    class ProjectResource extends FrontendModelBaseResource {
+      static SharedResource = SharedProjectResource
+
+      /** @returns {string[]} */
+      permittedParams() {
+        return ["environmentName"]
+      }
+    }
+
+    const resource = new ProjectResource({
+      modelClass: class extends DatabaseRecord {},
+      modelName: "Project",
+      params: {}
+    })
+
+    expect(resource.permittedParams({action: "create"})).toEqual(["environmentName"])
+  })
+
   it("defaults to permitting nothing — subclasses must override to enable writes", () => {
     class ProjectResource extends FrontendModelBaseResource {
       static attributes = ["id", "name", "description"]

--- a/spec/frontend-models/resource-definition-spec.js
+++ b/spec/frontend-models/resource-definition-spec.js
@@ -5,6 +5,19 @@ import FrontendModelBaseResource from "../../src/frontend-model-resource/base-re
 import {frontendModelResourceConfigurationFromDefinition} from "../../src/frontend-models/resource-definition.js"
 
 describe("frontendModelResourceConfigurationFromDefinition abilities normalization", {databaseCleaning: {transaction: true}}, () => {
+  it("rejects resourceConfig overrides on resource classes", () => {
+    class FooResource extends FrontendModelBaseResource {
+      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
+      static resourceConfig() {
+        return {attributes: ["id"]}
+      }
+    }
+
+    expect(() => {
+      frontendModelResourceConfigurationFromDefinition(FooResource)
+    }).toThrow("FooResource overrides static resourceConfig(), which is not supported. Use static resource properties instead.")
+  })
+
   it("defaults to full CRUD when abilities are not declared", () => {
     class FooResource extends FrontendModelBaseResource {
       static attributes = ["id"]
@@ -21,31 +34,33 @@ describe("frontendModelResourceConfigurationFromDefinition abilities normalizati
     })
   })
 
-  it("honors an explicit subset of CRUD abilities", () => {
+  it("rejects base CRUD abilities in explicit resource abilities", () => {
     class FooResource extends FrontendModelBaseResource {
       static attributes = ["id"]
       static abilities = ["read"]
     }
 
-    const config = frontendModelResourceConfigurationFromDefinition(FooResource)
-
-    expect(config?.abilities).toEqual({find: "read", index: "read"})
+    expect(() => {
+      frontendModelResourceConfigurationFromDefinition(FooResource)
+    }).toThrow("Resource abilities must not include base actions: read")
   })
 
-  it("collapses every CRUD action onto 'manage' when manage is listed", () => {
+  it("adds custom explicit abilities on top of default CRUD abilities", () => {
     class FooResource extends FrontendModelBaseResource {
       static attributes = ["id"]
-      static abilities = ["manage"]
+      static abilities = ["approve", "archive"]
     }
 
     const config = frontendModelResourceConfigurationFromDefinition(FooResource)
 
     expect(config?.abilities).toEqual({
-      create: "manage",
-      destroy: "manage",
-      find: "manage",
-      index: "manage",
-      update: "manage"
+      archive: "archive",
+      approve: "approve",
+      create: "create",
+      destroy: "destroy",
+      find: "read",
+      index: "read",
+      update: "update"
     })
   })
 })

--- a/spec/frontend-models/websocket-publishers-spec.js
+++ b/spec/frontend-models/websocket-publishers-spec.js
@@ -13,27 +13,21 @@ describe("Frontend models - websocket publishers", {databaseCleaning: {transacti
     class TestTaskResource extends FrontendModelBaseResource {
       static ModelClass = Task
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: ["id", "name"],
-          builtInCollectionCommands: ["index"],
-          builtInMemberCommands: ["find"]
-        }
-      }
+      static attributes = ["id", "name"]
+
+      static builtInCollectionCommands = ["index"]
+
+      static builtInMemberCommands = ["find"]
     }
 
     class TestUserResource extends FrontendModelBaseResource {
       static ModelClass = User
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: ["id", "email"],
-          builtInCollectionCommands: ["index"],
-          builtInMemberCommands: ["find"]
-        }
-      }
+      static attributes = ["id", "email"]
+
+      static builtInCollectionCommands = ["index"]
+
+      static builtInMemberCommands = ["find"]
     }
 
     /** @type {string[]} */
@@ -127,14 +121,11 @@ describe("Frontend models - websocket publishers", {databaseCleaning: {transacti
     class TestTaskResource extends FrontendModelBaseResource {
       static ModelClass = Task
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: ["id", "name"],
-          builtInCollectionCommands: ["index"],
-          builtInMemberCommands: ["find"]
-        }
-      }
+      static attributes = ["id", "name"]
+
+      static builtInCollectionCommands = ["index"]
+
+      static builtInMemberCommands = ["find"]
     }
 
     const mockConfiguration = {
@@ -163,14 +154,11 @@ describe("Frontend models - websocket publishers", {databaseCleaning: {transacti
     class TestTaskResource extends FrontendModelBaseResource {
       static ModelClass = Task
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: ["id", "name"],
-          builtInCollectionCommands: ["index"],
-          builtInMemberCommands: ["find"]
-        }
-      }
+      static attributes = ["id", "name"]
+
+      static builtInCollectionCommands = ["index"]
+
+      static builtInMemberCommands = ["find"]
     }
 
     const mockConfiguration = {
@@ -203,14 +191,11 @@ describe("Frontend models - websocket publishers", {databaseCleaning: {transacti
     class TestTaskResource extends FrontendModelBaseResource {
       static ModelClass = Task
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: ["id", "name"],
-          builtInCollectionCommands: ["index"],
-          builtInMemberCommands: ["find"]
-        }
-      }
+      static attributes = ["id", "name"]
+
+      static builtInCollectionCommands = ["index"]
+
+      static builtInMemberCommands = ["find"]
     }
 
     /** @type {{path: string, frontendModels?: Record<string, unknown>}} */

--- a/spec/routes/frontend-model-command-route-hook-spec.js
+++ b/spec/routes/frontend-model-command-route-hook-spec.js
@@ -6,29 +6,23 @@ import {frontendModelActionForCommand, frontendModelResourceConfigurationFromDef
 import {describe, expect, it} from "../../src/testing/test.js"
 
 class UserFrontendResource extends FrontendModelBaseResource {
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id"],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find", "update"],
-      collectionCommands: ["reindexAll"],
-      memberCommands: ["resetPassword"]
-    }
-  }
+    static attributes = ["id"]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find", "update"]
+
+  static collectionCommands = ["reindexAll"]
+
+  static memberCommands = ["resetPassword"]
 }
 
 class ProjectFrontendResource extends FrontendModelBaseResource {
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id"],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find"]
-    }
-  }
+    static attributes = ["id"]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find"]
 }
 
 
@@ -167,25 +161,23 @@ describe("routes - frontend model command route hook", {databaseCleaning: {trans
     })
   })
 
-  it("normalizes array ability subsets to a read-only abilities map", () => {
+  it("normalizes omitted abilities to the base CRUD abilities map", () => {
     const resourceConfiguration = frontendModelResourceConfigurationFromDefinition(UserFrontendResource)
 
     expect(resourceConfiguration?.abilities).toEqual({
+      create: "create",
+      destroy: "destroy",
       find: "read",
-      index: "read"
+      index: "read",
+      update: "update"
     })
   })
 
-  it("throws on unknown resourceConfig keys", () => {
+  it("throws on unknown static resource config keys", () => {
     class UnknownKeyUserFrontendResource extends FrontendModelBaseResource {
-      /** @returns {Record<string, any>} */
-      static resourceConfig() {
-        return {
-          attributes: ["id"],
-          capabilities: ["read"],
-          abilities: ["read"]
-        }
-      }
+      static attributes = ["id"]
+
+      static capabilities = ["read"]
     }
 
     expect(() => {
@@ -193,15 +185,11 @@ describe("routes - frontend model command route hook", {databaseCleaning: {trans
     }).toThrow("Unknown arguments: capabilities")
   })
 
-  it("throws when resourceConfig includes the removed path key", () => {
+  it("throws when static resource config includes the removed path key", () => {
     class PathUserFrontendResource extends FrontendModelBaseResource {
-      /** @returns {Record<string, any>} */
-      static resourceConfig() {
-        return {
-          attributes: ["id"],
-          path: "/users"
-        }
-      }
+      static attributes = ["id"]
+
+      static path = "/users"
     }
 
     expect(() => {

--- a/spec/routes/resolver-frontend-model-autoroute-spec.js
+++ b/spec/routes/resolver-frontend-model-autoroute-spec.js
@@ -13,28 +13,20 @@ import {describe, expect, it} from "../../src/testing/test.js"
 
 class ClassBasedFrontendModelResource extends FrontendModelBaseResource {
   static ModelClass = Task
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read"],
-      attributes: ["id"],
-      builtInCollectionCommands: ["index"],
-      builtInMemberCommands: ["find"]
-    }
-  }
+    static attributes = ["id"]
+
+  static builtInCollectionCommands = ["index"]
+
+  static builtInMemberCommands = ["find"]
 }
 
 class CreateFrontendModelResource extends FrontendModelBaseResource {
   static ModelClass = Task
-  /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-  static resourceConfig() {
-    return {
-      abilities: ["read", "create"],
-      attributes: ["id"],
-      builtInCollectionCommands: ["index", "create"],
-      builtInMemberCommands: ["find"]
-    }
-  }
+    static attributes = ["id"]
+
+  static builtInCollectionCommands = ["index", "create"]
+
+  static builtInMemberCommands = ["find"]
 }
 
 /**

--- a/spec/routes/resolver-route-hooks-spec.js
+++ b/spec/routes/resolver-route-hooks-spec.js
@@ -123,14 +123,11 @@ describe("routes - resolver hooks", {databaseCleaning: {transaction: true}}, asy
     class TaskFrontendResource extends FrontendModelBaseResource {
       static ModelClass = Task
 
-      /** @returns {import("../../src/configuration-types.js").FrontendModelResourceConfiguration} */
-      static resourceConfig() {
-        return {
-          attributes: ["id", "name"],
-          builtInCollectionCommands: ["index"],
-          builtInMemberCommands: ["find"]
-        }
-      }
+      static attributes = ["id", "name"]
+
+      static builtInCollectionCommands = ["index"]
+
+      static builtInMemberCommands = ["find"]
     }
 
     const routes = new Routes()

--- a/src/authorization/base-resource.js
+++ b/src/authorization/base-resource.js
@@ -116,6 +116,105 @@ export default class AuthorizationBaseResource {
   }
 
   /**
+   * Runs current device.
+   * @returns {unknown} - Current device from context.
+   */
+  currentDevice() {
+    return this.context.currentDevice
+  }
+
+  /**
+   * Runs offline grant.
+   * @returns {unknown} - Offline grant from context.
+   */
+  offlineGrant() {
+    return this.context.offlineGrant
+  }
+
+  /**
+   * Runs now.
+   * @returns {Date} - Current time from context or the system clock.
+   */
+  now() {
+    if (typeof this.context.now === "function") return this.context.now()
+    if (this.context.now instanceof Date) return this.context.now
+
+    return new Date()
+  }
+
+  /**
+   * Runs resource runtime.
+   * @returns {"backend" | "frontend" | "offline"} - Resource runtime context.
+   */
+  resourceRuntime() {
+    if (this.context.resourceRuntime === "frontend") return "frontend"
+    if (this.context.resourceRuntime === "offline") return "offline"
+
+    return "backend"
+  }
+
+  /**
+   * Runs is backend.
+   * @returns {boolean} - Whether the resource is running in the backend runtime.
+   */
+  isBackend() {
+    return this.resourceRuntime() === "backend"
+  }
+
+  /**
+   * Runs is frontend.
+   * @returns {boolean} - Whether the resource is running in the frontend runtime.
+   */
+  isFrontend() {
+    return this.resourceRuntime() === "frontend"
+  }
+
+  /**
+   * Runs is offline.
+   * @returns {boolean} - Whether the resource is running with offline context.
+   */
+  isOffline() {
+    return this.resourceRuntime() === "offline" || this.context.offlineGrant !== undefined
+  }
+
+  /**
+   * Resolves a model class from the portable resource context.
+   * @param {string} name - Model name.
+   * @returns {unknown} - Model class from registry.
+   */
+  model(name) {
+    const registry = this.context.modelRegistry
+
+    if (registry && typeof registry === "object") {
+      if ("model" in registry && typeof registry.model === "function") {
+        const modelClass = registry.model(name)
+
+        if (modelClass) return modelClass
+      }
+
+      if (name in registry) return /** @type {Record<string, unknown>} */ (registry)[name]
+    }
+
+    const contextModel = this.context.model
+
+    if (typeof contextModel === "function") {
+      const modelClass = contextModel(name)
+
+      if (modelClass) return modelClass
+    }
+
+    const configuration = this.context.configuration
+
+    if (configuration) {
+      const modelClasses = configuration.getModelClasses()
+
+      if (name in modelClasses) return modelClasses[name]
+    }
+
+    throw new Error(`${this.constructor.name} could not resolve model '${name}' from the resource context model registry.`)
+  }
+
+  /**
    * Runs request.
    * @returns {import("../http-server/client/request.js").default | import("../http-server/client/websocket-request.js").default | undefined} - Request from context.
    */

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -240,7 +240,7 @@
  */
 
 /**
- * @typedef {Record<string, unknown> & {configuration?: import("./configuration.js").default, currentUser?: unknown, params?: VelociousParams, request?: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default}} VelociousLooseObject
+ * @typedef {Record<string, unknown> & {configuration?: import("./configuration.js").default, currentDevice?: unknown, currentUser?: unknown, modelRegistry?: Record<string, unknown> | {model: (name: string) => unknown}, now?: Date | (() => Date), offlineGrant?: unknown, params?: VelociousParams, request?: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, resourceRuntime?: "backend" | "frontend" | "offline"}} VelociousLooseObject
  */
 
 /**

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -309,13 +309,14 @@
 /**
  * @typedef {object} FrontendModelResourceConfiguration
  * @property {Array<string | FrontendModelAttributeConfiguration> | Record<string, FrontendModelAttributeConfiguration | import("./database/drivers/base-column.js").default | boolean>} attributes - Attributes to expose on the frontend model.
- * @property {string[]} [abilities] - Ability action list (camelCase action names). Defaults to `["read"]` for `find` and `index` when omitted.
+ * @property {string[]} [abilities] - Additional camelCase ability action names to expose for per-record `record.can(action)` reads. Base CRUD actions (`read`, `create`, `update`, `destroy`) are always included and must not be listed here.
  * @property {Record<string, FrontendModelAttachmentConfiguration>} [attachments] - Attachment helpers keyed by attachment name.
  * @property {string[]} [commands] - Legacy built-in command names (`index`, `find`, `create`, `update`, `destroy`, `attach`, `download`, `url`).
  * @property {Array<FrontendModelResourceCustomCommand>} [collectionCommands] - Custom collection commands. Each entry is a camelCase method name, or a `{name, args?, returnType?}` object declaring typed arguments and/or a response type. The runtime derives the kebab-case command slug from the name.
  * @property {Array<FrontendModelResourceCustomCommand>} [memberCommands] - Custom member commands. Each entry is a camelCase method name, or a `{name, args?, returnType?}` object declaring typed arguments and/or a response type. The runtime derives the kebab-case command slug from the name.
  * @property {string[]} [builtInCollectionCommands] - Built-in collection command names (`index`, `create`).
  * @property {string[]} [builtInMemberCommands] - Built-in member command names (`find`, `update`, `destroy`, `attach`, `download`, `url`).
+ * @property {string} [modelName] - Frontend model name override.
  * @property {string[]} [relationships] - Relationship names to expose in frontend models. Type and target model are inferred from the backend model's registered relationships.
  * @property {string} [primaryKey] - Primary key attribute name.
  * @property {FrontendModelResourceServerConfiguration} [server] - Optional legacy backend behavior overrides for built-in frontend actions.

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -1439,7 +1439,7 @@ export default class DbGenerateFrontendModels extends BaseCommand {
    */
   frontendAttributeIsTranslated({attributeName, modelClass, resourceClass}) {
     if (resourceClass) {
-      const translatedAttributes = resourceClass.translatedAttributes
+      const translatedAttributes = resourceClass.translatedAttributesConfig()
 
       if (Array.isArray(translatedAttributes) && translatedAttributes.includes(attributeName)) return true
     }

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -2663,10 +2663,10 @@ export default class FrontendModelController extends Controller {
      * Resource has attribute.
      * @param {string} attributeName - Attribute name.
      */
-    const resourceHasAttribute = (attributeName) => {
+    const resourceAttributeMethod = (attributeName) => {
       const methodName = resourceAttributeMethodName(attributeName)
 
-      return resourceInstance && typeof /** @type {Record<string, ?>} */ (/** @type {?} */ (resourceInstance))[methodName] === "function"
+      return resourceInstance?.resourceMethod(methodName) || null
     }
 
     /**
@@ -2696,10 +2696,10 @@ export default class FrontendModelController extends Controller {
      */
     const serializedAttributeValue = async (attributeName) => {
       // Check resource instance first (virtual/computed attributes via ${name}Attribute convention)
-      if (resourceHasAttribute(attributeName)) {
-        const methodName = resourceAttributeMethodName(attributeName)
+      const resourceAttribute = resourceAttributeMethod(attributeName)
 
-        return await /** @type {Record<string, Function>} */ (/** @type {?} */ (resourceInstance))[methodName](model)
+      if (resourceAttribute) {
+        return await resourceAttribute.method.call(resourceAttribute.resource, model)
       }
 
       // Fall back to model method
@@ -2718,7 +2718,7 @@ export default class FrontendModelController extends Controller {
      * @param {string} attributeName - Attribute name.
      */
     const attributeExists = (attributeName) => {
-      return (attributeName in modelAttributes) || (attributeName in /** @type {Record<string, ?>} */ (model)) || resourceHasAttribute(attributeName)
+      return (attributeName in modelAttributes) || (attributeName in /** @type {Record<string, ?>} */ (model)) || Boolean(resourceAttributeMethod(attributeName))
     }
 
     if (!selectedAttributes) {
@@ -3766,10 +3766,10 @@ export default class FrontendModelController extends Controller {
       return this.frontendModelErrorPayload("Expected frontend-model custom command scope.")
     }
 
-    const resource = /** @type {Record<string, ?>} */ (this.frontendModelResourceInstance())
-    const commandMethod = resource[methodName]
+    const resource = this.frontendModelResourceInstance()
+    const command = resource.resourceMethod(methodName)
 
-    if (typeof commandMethod !== "function") {
+    if (!command) {
       return this.frontendModelErrorPayload(`Missing frontend-model custom command '${methodName}'.`)
     }
 
@@ -3779,7 +3779,7 @@ export default class FrontendModelController extends Controller {
     // unchanged, so existing parameterless methods keep working. The args are untrusted
     // client input typed only by the declared contract, so methods must still validate.
     const commandArguments = this.frontendModelCustomCommandArguments(params)
-    const responsePayload = await commandMethod.call(resource, commandArguments)
+    const responsePayload = await command.method.call(command.resource, commandArguments)
 
     if (!responsePayload || typeof responsePayload !== "object") {
       return {status: "success"}
@@ -3788,7 +3788,7 @@ export default class FrontendModelController extends Controller {
     return /** @type {Record<string, ?>} */ (
       await this.autoSerializeFrontendModelsInPayload(
         responsePayload,
-        /** @type {{serialize: (model: ?, action: string) => Promise<Record<string, ?>>}} */ (resource),
+        /** @type {{serialize: (model: ?, action: string) => Promise<Record<string, ?>>}} */ (command.resource),
         methodName
       )
     )

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -2426,7 +2426,7 @@ export default class FrontendModelController extends Controller {
 
     const resource = this.frontendModelResourceInstance()
     const resourceClass = /** @type {typeof import("./frontend-model-resource/base-resource.js").default} */ (resource.constructor)
-    const translatedSet = new Set(resourceClass.translatedAttributes || [])
+    const translatedSet = new Set(resourceClass.translatedAttributesConfig() || [])
     let needsTranslations = false
 
     for (const attributeName of selectedAttributes) {

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -148,6 +148,8 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   /** @type {Record<string, ?> | undefined} */
   static attachments = undefined
   /** @type {string[] | undefined} */
+  static commands = undefined
+  /** @type {string[] | undefined} */
   static collectionCommands = undefined
   /** @type {string[] | undefined} */
   static builtInCollectionCommands = undefined
@@ -157,6 +159,12 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   static builtInMemberCommands = undefined
   /** @type {string[] | undefined} */
   static relationships = undefined
+  /** @type {string | undefined} */
+  static modelName = undefined
+  /** @type {string | undefined} */
+  static primaryKey = undefined
+  /** @type {import("../configuration-types.js").FrontendModelResourceServerConfiguration | undefined} */
+  static server = undefined
   /** @type {string[] | undefined} */
   static translatedAttributes = undefined
   /** @type {?} */
@@ -196,7 +204,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   /**
    * Reads a static resource config value from the environment resource first,
    * then from the shared resource.
-   * @param {"abilities" | "attachments" | "attributes" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "memberCommands" | "relationships" | "translatedAttributes"} name - Static config property name.
+   * @param {"abilities" | "attachments" | "attributes" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "commands" | "memberCommands" | "modelName" | "primaryKey" | "relationships" | "server" | "translatedAttributes"} name - Static config property name.
    * @returns {?} - Resolved config value.
    */
   static sharedResourceStaticValue(name) {
@@ -206,14 +214,6 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
 
     if (!SharedResource) return undefined
     if (SharedResource[name] !== undefined) return SharedResource[name]
-
-    const resourceConfigOwner = staticMethodOwnerFor(SharedResource, "resourceConfig")
-
-    if (resourceConfigOwner && resourceConfigOwner !== FrontendModelBaseResource) {
-      const sharedConfig = /** @type {Record<string, ?>} */ (/** @type {unknown} */ (SharedResource.resourceConfig()))
-
-      return sharedConfig[name]
-    }
 
     return undefined
   }
@@ -350,11 +350,15 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     const attributes = this.sharedResourceStaticValue("attributes")
     const abilities = this.sharedResourceStaticValue("abilities")
     const attachments = this.sharedResourceStaticValue("attachments")
+    const commands = this.sharedResourceStaticValue("commands")
     const builtInCollectionCommands = this.sharedResourceStaticValue("builtInCollectionCommands")
     const builtInMemberCommands = this.sharedResourceStaticValue("builtInMemberCommands")
     const collectionCommands = this.sharedResourceStaticValue("collectionCommands")
     const memberCommands = this.sharedResourceStaticValue("memberCommands")
+    const modelName = this.sharedResourceStaticValue("modelName")
+    const primaryKey = this.sharedResourceStaticValue("primaryKey")
     const relationships = this.sharedResourceStaticValue("relationships")
+    const server = this.sharedResourceStaticValue("server")
     /** @type {import("../configuration-types.js").FrontendModelResourceConfiguration} */
     const config = {
       attributes: /** @type {Record<string, ?> | string[]} */ (attributes || [])
@@ -362,11 +366,15 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
 
     if (abilities) config.abilities = /** @type {string[]} */ (abilities)
     if (attachments) config.attachments = /** @type {Record<string, ?>} */ (attachments)
+    if (commands) config.commands = /** @type {string[]} */ (commands)
     if (builtInCollectionCommands) config.builtInCollectionCommands = /** @type {string[]} */ (builtInCollectionCommands)
     if (builtInMemberCommands) config.builtInMemberCommands = /** @type {string[]} */ (builtInMemberCommands)
     if (collectionCommands) config.collectionCommands = /** @type {string[]} */ (collectionCommands)
     if (memberCommands) config.memberCommands = /** @type {string[]} */ (memberCommands)
+    if (modelName) config.modelName = /** @type {string} */ (modelName)
+    if (primaryKey) config.primaryKey = /** @type {string} */ (primaryKey)
     if (relationships) config.relationships = /** @type {string[]} */ (relationships)
+    if (server) config.server = /** @type {import("../configuration-types.js").FrontendModelResourceServerConfiguration} */ (server)
 
     return config
   }
@@ -1730,24 +1738,6 @@ function prototypeOwnerForMethod(instance, methodName) {
     if (Object.prototype.hasOwnProperty.call(prototype, methodName)) return prototype
 
     prototype = Object.getPrototypeOf(prototype)
-  }
-
-  return null
-}
-
-/**
- * Locates which constructor owns a static method implementation.
- * @param {typeof FrontendModelBaseResource} ResourceClass - Resource class.
- * @param {string} methodName - Method name.
- * @returns {typeof FrontendModelBaseResource | null} - Class that owns the static method.
- */
-function staticMethodOwnerFor(ResourceClass, methodName) {
-  let currentClass = ResourceClass
-
-  while (currentClass && currentClass !== Function.prototype) {
-    if (Object.prototype.hasOwnProperty.call(currentClass, methodName)) return currentClass
-
-    currentClass = Object.getPrototypeOf(currentClass)
   }
 
   return null

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -202,11 +202,20 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   static sharedResourceStaticValue(name) {
     if (this[name] !== undefined) return this[name]
 
-    const SharedResource = this.sharedResourceClass()
+    const SharedResource = /** @type {typeof FrontendModelBaseResource | undefined} */ (this.sharedResourceClass())
 
     if (!SharedResource) return undefined
+    if (SharedResource[name] !== undefined) return SharedResource[name]
 
-    return SharedResource[name]
+    const resourceConfigOwner = staticMethodOwnerFor(SharedResource, "resourceConfig")
+
+    if (resourceConfigOwner && resourceConfigOwner !== FrontendModelBaseResource) {
+      const sharedConfig = /** @type {Record<string, ?>} */ (/** @type {unknown} */ (SharedResource.resourceConfig()))
+
+      return sharedConfig[name]
+    }
+
+    return undefined
   }
 
   /**
@@ -286,6 +295,35 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     if (sharedResult.called) return /** @type {Result} */ (sharedResult.result)
 
     return fallback()
+  }
+
+  /**
+   * Resolves a method on this resource or its shared fallback.
+   * @param {string} methodName - Method name.
+   * @returns {{method: (...methodArgs: unknown[]) => unknown, resource: FrontendModelBaseResource} | null} - Resolved method and receiver.
+   */
+  resourceMethod(methodName) {
+    const ownMethod = /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (this))[methodName]
+
+    if (typeof ownMethod === "function") {
+      return {
+        method: /** @type {(...methodArgs: unknown[]) => unknown} */ (ownMethod),
+        resource: this
+      }
+    }
+
+    const sharedResource = this.sharedResourceInstance()
+
+    if (!sharedResource) return null
+
+    const sharedMethod = /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (sharedResource))[methodName]
+
+    if (typeof sharedMethod !== "function") return null
+
+    return {
+      method: /** @type {(...methodArgs: unknown[]) => unknown} */ (sharedMethod),
+      resource: sharedResource
+    }
   }
 
   /**
@@ -820,10 +858,10 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
 
     for (const [name, value] of Object.entries(attributes)) {
       const resourceSetterName = `set${inflection.camelize(name)}Attribute`
-      const resourceSetter = virtualSetterLookup(this)[resourceSetterName]
+      const resourceSetter = this.resourceMethod(resourceSetterName)
 
-      if (typeof resourceSetter === "function") {
-        await resourceSetter.call(this, model, value)
+      if (resourceSetter) {
+        await resourceSetter.method.call(resourceSetter.resource, model, value)
       } else if (translatedSet.has(name)) {
         await this._setTranslatedAttributeOnModel(model, name, value)
       } else {
@@ -1680,15 +1718,6 @@ function parsePermittedParams(permitSpec) {
 }
 
 /**
- * Narrows a resource to its dynamic virtual setter lookup surface.
- * @param {FrontendModelBaseResource} resource - Resource instance.
- * @returns {Record<string, FrontendModelResourceVirtualSetter>} Dynamic virtual setter lookup.
- */
-function virtualSetterLookup(resource) {
-  return /** @type {Record<string, FrontendModelResourceVirtualSetter>} */ (/** @type {unknown} */ (resource))
-}
-
-/**
  * Locates which prototype owns a method implementation.
  * @param {object} instance - Instance receiving the method.
  * @param {string} methodName - Method name.
@@ -1701,6 +1730,24 @@ function prototypeOwnerForMethod(instance, methodName) {
     if (Object.prototype.hasOwnProperty.call(prototype, methodName)) return prototype
 
     prototype = Object.getPrototypeOf(prototype)
+  }
+
+  return null
+}
+
+/**
+ * Locates which constructor owns a static method implementation.
+ * @param {typeof FrontendModelBaseResource} ResourceClass - Resource class.
+ * @param {string} methodName - Method name.
+ * @returns {typeof FrontendModelBaseResource | null} - Class that owns the static method.
+ */
+function staticMethodOwnerFor(ResourceClass, methodName) {
+  let currentClass = ResourceClass
+
+  while (currentClass && currentClass !== Function.prototype) {
+    if (Object.prototype.hasOwnProperty.call(currentClass, methodName)) return currentClass
+
+    currentClass = Object.getPrototypeOf(currentClass)
   }
 
   return null
@@ -1753,11 +1800,11 @@ function filterWritableFrontendModelAttributes(
     const requestedSetterName = `set${inflection.camelize(resolvedAttributeName)}`
     const setterName = receiverClass.findMemberNameInsensitive(receiver, requestedSetterName) || requestedSetterName
     const resourceSetterName = `set${inflection.camelize(attributeName)}Attribute`
-    const resourceSetter = resource ? virtualSetterLookup(resource)[resourceSetterName] : undefined
+    const resourceSetter = resource?.resourceMethod(resourceSetterName)
 
     if (setterName in receiver) {
       writableAttributes[attributeName] = value
-    } else if (typeof resourceSetter === "function") {
+    } else if (resourceSetter) {
       writableAttributes[attributeName] = value
     } else if (translatedSet.has(attributeName)) {
       writableAttributes[attributeName] = value

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -159,6 +159,8 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   static relationships = undefined
   /** @type {string[] | undefined} */
   static translatedAttributes = undefined
+  /** @type {?} */
+  static SharedResource = undefined
 
   /**
    * Runs constructor.
@@ -179,6 +181,119 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     this.modelNameValue = "modelName" in args ? args.modelName : this.modelClass().getModelName()
     this.paramsValue = "params" in args ? args.params : undefined
     this.resourceConfigurationValue = "resourceConfiguration" in args ? args.resourceConfiguration : defaultResourceConfiguration
+    /** @type {FrontendModelBaseResource | null | undefined} */
+    this.sharedResourceInstanceValue = undefined
+  }
+
+  /**
+   * Returns the configured shared resource class.
+   * @returns {?} - Shared resource class.
+   */
+  static sharedResourceClass() {
+    return this.SharedResource
+  }
+
+  /**
+   * Reads a static resource config value from the environment resource first,
+   * then from the shared resource.
+   * @param {"abilities" | "attachments" | "attributes" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "memberCommands" | "relationships" | "translatedAttributes"} name - Static config property name.
+   * @returns {?} - Resolved config value.
+   */
+  static sharedResourceStaticValue(name) {
+    if (this[name] !== undefined) return this[name]
+
+    const SharedResource = this.sharedResourceClass()
+
+    if (!SharedResource) return undefined
+
+    return SharedResource[name]
+  }
+
+  /**
+   * Resolves translated attributes from environment and shared resources.
+   * @returns {string[] | undefined} - Translated attribute names.
+   */
+  static translatedAttributesConfig() {
+    return /** @type {string[] | undefined} */ (this.sharedResourceStaticValue("translatedAttributes"))
+  }
+
+  /**
+   * Builds a resource instance for shared-resource fallback calls.
+   * @returns {FrontendModelBaseResource | null} - Shared resource instance when configured.
+   */
+  sharedResourceInstance() {
+    if (this.sharedResourceInstanceValue !== undefined) return this.sharedResourceInstanceValue
+
+    const ResourceClass = /** @type {typeof FrontendModelBaseResource} */ (this.constructor)
+    const SharedResource = /** @type {typeof FrontendModelBaseResource | undefined} */ (ResourceClass.sharedResourceClass())
+
+    if (!SharedResource) {
+      this.sharedResourceInstanceValue = null
+      return this.sharedResourceInstanceValue
+    }
+
+    if (SharedResource === ResourceClass) {
+      throw new Error(`${ResourceClass.name}.SharedResource cannot point to itself.`)
+    }
+
+    this.sharedResourceInstanceValue = new SharedResource({
+      ability: this.ability,
+      controller: this.controller,
+      context: this.context,
+      locals: this.locals,
+      modelClass: this.modelClass(),
+      modelName: this.modelName(),
+      params: this.params(),
+      resourceConfiguration: this.resourceConfiguration()
+    })
+
+    return this.sharedResourceInstanceValue
+  }
+
+  /**
+   * Calls a shared-resource method only when the shared resource overrides the framework default.
+   * @param {string} methodName - Method name to resolve.
+   * @param {unknown[]} args - Method args.
+   * @returns {{called: boolean, result: unknown}} - Shared method call result.
+   */
+  callSharedResourceMethod(methodName, args) {
+    const sharedResource = this.sharedResourceInstance()
+
+    if (!sharedResource) return {called: false, result: undefined}
+
+    const methodOwner = prototypeOwnerForMethod(sharedResource, methodName)
+
+    if (!methodOwner || methodOwner === FrontendModelBaseResource.prototype || methodOwner === AuthorizationBaseResource.prototype) {
+      return {called: false, result: undefined}
+    }
+
+    const method = /** @type {Record<string, (...methodArgs: unknown[]) => unknown>} */ (/** @type {unknown} */ (sharedResource))[methodName]
+
+    return {called: true, result: method.apply(sharedResource, args)}
+  }
+
+  /**
+   * Runs shared method result or a fallback callback.
+   * @template Result
+   * @param {string} methodName - Shared method name.
+   * @param {unknown[]} args - Shared method args.
+   * @param {() => Result} fallback - Fallback callback.
+   * @returns {Result} - Shared or fallback result.
+   */
+  sharedResourceMethodOr(methodName, args, fallback) {
+    const sharedResult = this.callSharedResourceMethod(methodName, args)
+
+    if (sharedResult.called) return /** @type {Result} */ (sharedResult.result)
+
+    return fallback()
+  }
+
+  /**
+   * Runs abilities.
+   * @returns {void} - No return value.
+   */
+  abilities() {
+    this.sharedResourceMethodOr("abilities", [], () => undefined)
   }
 
   /**
@@ -194,18 +309,26 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {import("../configuration-types.js").FrontendModelResourceConfiguration} - Static resource config (raw user input shape; consumers normalize).
    */
   static resourceConfig() {
+    const attributes = this.sharedResourceStaticValue("attributes")
+    const abilities = this.sharedResourceStaticValue("abilities")
+    const attachments = this.sharedResourceStaticValue("attachments")
+    const builtInCollectionCommands = this.sharedResourceStaticValue("builtInCollectionCommands")
+    const builtInMemberCommands = this.sharedResourceStaticValue("builtInMemberCommands")
+    const collectionCommands = this.sharedResourceStaticValue("collectionCommands")
+    const memberCommands = this.sharedResourceStaticValue("memberCommands")
+    const relationships = this.sharedResourceStaticValue("relationships")
     /** @type {import("../configuration-types.js").FrontendModelResourceConfiguration} */
     const config = {
-      attributes: this.attributes || []
+      attributes: /** @type {Record<string, ?> | string[]} */ (attributes || [])
     }
 
-    if (this.abilities) config.abilities = this.abilities
-    if (this.attachments) config.attachments = this.attachments
-    if (this.builtInCollectionCommands) config.builtInCollectionCommands = this.builtInCollectionCommands
-    if (this.builtInMemberCommands) config.builtInMemberCommands = this.builtInMemberCommands
-    if (this.collectionCommands) config.collectionCommands = this.collectionCommands
-    if (this.memberCommands) config.memberCommands = this.memberCommands
-    if (this.relationships) config.relationships = this.relationships
+    if (abilities) config.abilities = /** @type {string[]} */ (abilities)
+    if (attachments) config.attachments = /** @type {Record<string, ?>} */ (attachments)
+    if (builtInCollectionCommands) config.builtInCollectionCommands = /** @type {string[]} */ (builtInCollectionCommands)
+    if (builtInMemberCommands) config.builtInMemberCommands = /** @type {string[]} */ (builtInMemberCommands)
+    if (collectionCommands) config.collectionCommands = /** @type {string[]} */ (collectionCommands)
+    if (memberCommands) config.memberCommands = /** @type {string[]} */ (memberCommands)
+    if (relationships) config.relationships = /** @type {string[]} */ (relationships)
 
     return config
   }
@@ -240,6 +363,14 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     }
 
     return /** @type {TModelClass} */ (this.modelClassValue)
+  }
+
+  /**
+   * Runs required model class for authorization helpers.
+   * @returns {TModelClass} - Backing model class.
+   */
+  requiredModelClass() {
+    return this.modelClass()
   }
 
   /**
@@ -307,9 +438,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {Array<string | Record<string, ?>>} - Permit spec.
    */
   permittedParams(arg) {
-    void arg
+    return this.sharedResourceMethodOr("permittedParams", [arg], () => {
+      void arg
 
-    return []
+      return []
+    })
   }
 
   /**
@@ -319,9 +452,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {FrontendModelResourceAttributePayload | Promise<FrontendModelResourceAttributePayload>} - Normalized attributes.
    */
   normalizeCreateAttributes(attributes, options) {
-    void options
+    return this.sharedResourceMethodOr("normalizeCreateAttributes", [attributes, options], () => {
+      void options
 
-    return attributes
+      return attributes
+    })
   }
 
   /**
@@ -332,10 +467,12 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {FrontendModelResourceAttributePayload | Promise<FrontendModelResourceAttributePayload>} - Normalized attributes.
    */
   normalizeUpdateAttributes(model, attributes, options) {
-    void model
-    void options
+    return this.sharedResourceMethodOr("normalizeUpdateAttributes", [model, attributes, options], () => {
+      void model
+      void options
 
-    return attributes
+      return attributes
+    })
   }
 
   /**
@@ -346,9 +483,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {void | Promise<void>} - Resolves when the hook finishes.
    */
   beforeCreate(model, attributes, options) {
-    void model
-    void attributes
-    void options
+    return this.sharedResourceMethodOr("beforeCreate", [model, attributes, options], () => {
+      void model
+      void attributes
+      void options
+    })
   }
 
   /**
@@ -359,9 +498,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {void | Promise<void>} - Resolves when the hook finishes.
    */
   afterCreate(model, attributes, options) {
-    void model
-    void attributes
-    void options
+    return this.sharedResourceMethodOr("afterCreate", [model, attributes, options], () => {
+      void model
+      void attributes
+      void options
+    })
   }
 
   /**
@@ -372,9 +513,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {void | Promise<void>} - Resolves when the hook finishes.
    */
   beforeUpdate(model, attributes, options) {
-    void model
-    void attributes
-    void options
+    return this.sharedResourceMethodOr("beforeUpdate", [model, attributes, options], () => {
+      void model
+      void attributes
+      void options
+    })
   }
 
   /**
@@ -385,9 +528,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {void | Promise<void>} - Resolves when the hook finishes.
    */
   afterUpdate(model, attributes, options) {
-    void model
-    void attributes
-    void options
+    return this.sharedResourceMethodOr("afterUpdate", [model, attributes, options], () => {
+      void model
+      void attributes
+      void options
+    })
   }
 
   /**
@@ -396,7 +541,9 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {void | Promise<void>} - Resolves when the hook finishes.
    */
   beforeDestroy(model) {
-    void model
+    return this.sharedResourceMethodOr("beforeDestroy", [model], () => {
+      void model
+    })
   }
 
   /**
@@ -405,7 +552,9 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {void | Promise<void>} - Resolves when the hook finishes.
    */
   afterDestroy(model) {
-    void model
+    return this.sharedResourceMethodOr("afterDestroy", [model], () => {
+      void model
+    })
   }
 
   /**
@@ -418,10 +567,12 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {Promise<Result>} - Callback result.
    */
   async runMutationTransaction({action, model, callback}) {
-    void action
-    void model
+    return await this.sharedResourceMethodOr("runMutationTransaction", [{action, model, callback}], async () => {
+      void action
+      void model
 
-    return await callback()
+      return await callback()
+    })
   }
 
   /**
@@ -517,9 +668,11 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
    * @returns {boolean | void | Promise<boolean | void>} - Continue processing unless false.
    */
   beforeAction(action) {
-    void action
+    return this.sharedResourceMethodOr("beforeAction", [action], () => {
+      void action
 
-    // No-op by default.
+      // No-op by default.
+    })
   }
 
   /**
@@ -663,7 +816,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     /** @type {Record<string, ?>} */
     const directAttributes = {}
     const ResourceClass = /** @type {typeof FrontendModelBaseResource} */ (this.constructor)
-    const translatedSet = new Set(ResourceClass.translatedAttributes || [])
+    const translatedSet = new Set(ResourceClass.translatedAttributesConfig() || [])
 
     for (const [name, value] of Object.entries(attributes)) {
       const resourceSetterName = `set${inflection.camelize(name)}Attribute`
@@ -1536,6 +1689,24 @@ function virtualSetterLookup(resource) {
 }
 
 /**
+ * Locates which prototype owns a method implementation.
+ * @param {object} instance - Instance receiving the method.
+ * @param {string} methodName - Method name.
+ * @returns {object | null} - Prototype that owns the method.
+ */
+function prototypeOwnerForMethod(instance, methodName) {
+  let prototype = Object.getPrototypeOf(instance)
+
+  while (prototype) {
+    if (Object.prototype.hasOwnProperty.call(prototype, methodName)) return prototype
+
+    prototype = Object.getPrototypeOf(prototype)
+  }
+
+  return null
+}
+
+/**
  * Runs filter writable frontend model attributes.
  * @param {Record<string, ?>} receiver - Model instance or prototype.
  * @param {WritableAttributeReceiverClass} receiverClass - Static helper owner for the receiver.
@@ -1567,7 +1738,7 @@ function filterWritableFrontendModelAttributes(
   if (resource) {
     const ResourceClass = /** @type {typeof FrontendModelBaseResource} */ (resource.constructor)
 
-    translatedAttributes = ResourceClass.translatedAttributes || []
+    translatedAttributes = ResourceClass.translatedAttributesConfig() || []
   }
 
   const translatedSet = new Set(translatedAttributes)

--- a/src/frontend-model-resource/velocious-attachment-resource.js
+++ b/src/frontend-model-resource/velocious-attachment-resource.js
@@ -27,9 +27,6 @@ export default class VelociousAttachmentResource extends FrontendModelBaseResour
   }
 
   /** @type {string[]} */
-  static abilities = ["read"]
-
-  /** @type {string[]} */
   static builtInCollectionCommands = ["index"]
 
   /** @type {string[]} */

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -5,6 +5,25 @@ import FrontendModelBaseResource from "../frontend-model-resource/base-resource.
 import restArgsError from "../utils/rest-args-error.js"
 import {validateFrontendModelResourceCommandName} from "./resource-config-validation.js"
 
+const BASE_FRONTEND_MODEL_ABILITY_ACTIONS = ["create", "destroy", "read", "update"]
+const RESOURCE_STATIC_CONFIG_KEYS = new Set([
+  "abilities",
+  "attachments",
+  "attributes",
+  "builtInCollectionCommands",
+  "builtInMemberCommands",
+  "collectionCommands",
+  "commands",
+  "memberCommands",
+  "modelName",
+  "ModelClass",
+  "primaryKey",
+  "relationships",
+  "server",
+  "SharedResource",
+  "translatedAttributes"
+])
+
 /**
  * Runs the frontendModelResourcesForBackendProject helper.
  * @param {import("../configuration-types.js").BackendProjectConfiguration} backendProject - Backend project config.
@@ -50,7 +69,72 @@ export function frontendModelResourceClassFromDefinition(resourceDefinition) {
 export function frontendModelResourceConfigurationFromDefinition(resourceDefinition) {
   if (!frontendModelResourceDefinitionIsClass(resourceDefinition)) return null
 
+  assertResourceConfigIsFrameworkDefined(resourceDefinition)
+
   return normalizeFrontendModelResourceConfiguration(resourceDefinition.resourceConfig())
+}
+
+/**
+ * Ensures resources use declarative static config properties instead of overriding resourceConfig().
+ * @param {import("../configuration-types.js").FrontendModelResourceClassType} ResourceClass - Resource class.
+ * @param {Set<import("../configuration-types.js").FrontendModelResourceClassType>} [visited] - Already inspected shared resources.
+ * @returns {void}
+ */
+function assertResourceConfigIsFrameworkDefined(ResourceClass, visited = new Set()) {
+  if (visited.has(ResourceClass)) return
+
+  visited.add(ResourceClass)
+  assertKnownResourceStaticConfigProperties(ResourceClass)
+
+  const owner = staticMethodOwnerFor(ResourceClass, "resourceConfig")
+
+  if (owner && owner !== FrontendModelBaseResource) {
+    throw new Error(`${ResourceClass.name} overrides static resourceConfig(), which is not supported. Use static resource properties instead.`)
+  }
+
+  const SharedResource = ResourceClass.sharedResourceClass()
+
+  if (SharedResource) assertResourceConfigIsFrameworkDefined(SharedResource, visited)
+}
+
+/**
+ * Ensures declarative static resource config does not silently ignore typos or removed keys.
+ * @param {import("../configuration-types.js").FrontendModelResourceClassType} ResourceClass - Resource class.
+ * @returns {void}
+ */
+function assertKnownResourceStaticConfigProperties(ResourceClass) {
+  let currentClass = ResourceClass
+
+  while (currentClass && currentClass !== FrontendModelBaseResource && currentClass !== Function.prototype) {
+    /** @type {Record<string, ?>} */
+    const unknownStaticConfig = {}
+
+    for (const key of Object.keys(currentClass)) {
+      if (!RESOURCE_STATIC_CONFIG_KEYS.has(key)) unknownStaticConfig[key] = /** @type {Record<string, ?>} */ (/** @type {unknown} */ (currentClass))[key]
+    }
+
+    restArgsError(unknownStaticConfig)
+
+    currentClass = Object.getPrototypeOf(currentClass)
+  }
+}
+
+/**
+ * Locates which constructor owns a static method implementation.
+ * @param {import("../configuration-types.js").FrontendModelResourceClassType} ResourceClass - Resource class.
+ * @param {string} methodName - Method name.
+ * @returns {import("../configuration-types.js").FrontendModelResourceClassType | typeof FrontendModelBaseResource | null} - Class that owns the static method.
+ */
+function staticMethodOwnerFor(ResourceClass, methodName) {
+  let currentClass = ResourceClass
+
+  while (currentClass && currentClass !== Function.prototype) {
+    if (Object.prototype.hasOwnProperty.call(currentClass, methodName)) return currentClass
+
+    currentClass = Object.getPrototypeOf(currentClass)
+  }
+
+  return null
 }
 
 /**
@@ -102,36 +186,27 @@ function normalizeFrontendModelResourceConfiguration(resourceConfiguration) {
  * @returns {Record<string, string>} - Normalized abilities config.
  */
 function normalizeFrontendModelResourceAbilities(abilities) {
-  if (abilities === undefined) {
-    return defaultCrudAbilities()
-  }
+  const normalized = defaultCrudAbilities()
+
+  if (abilities === undefined) return normalized
 
   if (!Array.isArray(abilities)) {
     throw new Error("Resource abilities must be an array of action names. Object form is no longer supported.")
   }
 
-  if (abilities.includes("manage")) {
-    return {
-      create: "manage",
-      destroy: "manage",
-      find: "manage",
-      index: "manage",
-      update: "manage"
+  const duplicatedBaseAbilities = abilities.filter((ability) => BASE_FRONTEND_MODEL_ABILITY_ACTIONS.includes(ability))
+
+  if (duplicatedBaseAbilities.length > 0) {
+    throw new Error(`Resource abilities must not include base actions: ${duplicatedBaseAbilities.join(", ")}`)
+  }
+
+  for (const ability of abilities) {
+    if (typeof ability !== "string" || ability.length < 1) {
+      throw new Error("Resource abilities entries must be non-empty strings.")
     }
-  }
 
-  /**
-   * Normalized.
-   * @type {Record<string, string>} */
-  const normalized = {}
-
-  if (abilities.includes("create")) normalized.create = "create"
-  if (abilities.includes("destroy")) normalized.destroy = "destroy"
-  if (abilities.includes("read")) {
-    normalized.find = "read"
-    normalized.index = "read"
+    normalized[ability] = ability
   }
-  if (abilities.includes("update")) normalized.update = "update"
 
   return normalized
 }

--- a/tensorbuzz.yml
+++ b/tensorbuzz.yml
@@ -1,13 +1,39 @@
 before_install:
+  - |
+    cat > /tmp/tensorbuzz-retry <<'SH'
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    attempts="${TENSORBUZZ_RETRY_ATTEMPTS:-5}"
+    delay="${TENSORBUZZ_RETRY_DELAY:-5}"
+
+    for attempt in $(seq 1 "$attempts"); do
+      if "$@"; then
+        exit 0
+      fi
+
+      if [ "$attempt" -eq "$attempts" ]; then
+        break
+      fi
+
+      echo "Command failed; retrying in ${delay}s (${attempt}/${attempts}): $*" >&2
+      sleep "$delay"
+      delay=$((delay * 2))
+    done
+
+    exec "$@"
+    SH
+    chmod +x /tmp/tensorbuzz-retry
   - sudo mkdir -p /etc/apt/keyrings
-  - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --no-tty --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  - /tmp/tensorbuzz-retry curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o /tmp/nodesource-repo.gpg.key
+  - sudo gpg --no-tty --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg /tmp/nodesource-repo.gpg.key
   - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-  - sudo apt-get update
-  - sudo apt-get install -y nodejs
+  - /tmp/tensorbuzz-retry sudo apt-get update -o Acquire::Retries=5
+  - DEBIAN_FRONTEND=noninteractive /tmp/tensorbuzz-retry sudo apt-get install -y -o Acquire::Retries=5 nodejs
 before_script:
   - git clean -fd spec src
   - git clean -fdx spec/dummy/db
-  - npm install
+  - /tmp/tensorbuzz-retry npm install
 environment:
   NODE_ENV: test
   VELOCIOUS_TEST_DIR: /home/build/project/spec


### PR DESCRIPTION
## Summary
- Add `static SharedResource` fallback support for frontend-model resources
- Resolve static resource config, translated attributes, and default instance methods from environment resource → inherited environment resource → shared resource → framework default
- Document shared-resource fallback semantics and add regression coverage for inherited config, abilities, translated attributes, method fallback, and environment override precedence

## Validation
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/frontend-model-resource/base-resource-spec.js` — 12 tests passed after sqlite dummy migration
- `npm run typecheck` — passed
- `npm run lint` — passed with existing repository warnings
- `git diff --check` — passed
- delegated pre-commit review — PASS
