### PR TITLE
Add frontend-model sync policy metadata

### DIFF
--- a/changelog.d/20260623184904-sync-policy-manifest.md
+++ b/changelog.d/20260623184904-sync-policy-manifest.md
@@ -1,0 +1,1 @@
+Add frontend-model sync policy metadata with deterministic policy hashes and frontend-safe generated resource config.

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -31,6 +31,23 @@ Without a resource definition, frontend models should not silently work.
 - Shared resources should treat `this.model(...)`, query APIs, and context helpers as the portability boundary. Avoid raw SQL, Node-only imports, secrets, direct database driver access, or environment-specific globals in shared resource files.
 - Treat shared resources as reusable defaults, not a security boundary. Environment resources should still override attributes, permissions, commands, or hooks whenever a frontend/backend deployment needs narrower behavior.
 
+## Sync policy metadata
+- Resources that participate in local/offline sync may declare `static sync` with safe metadata:
+
+  ```js
+  static sync = {
+    operations: ["index", "find", "update", "scanTicket"],
+    policyVersion: "scanner-v1",
+    metadata: {scope: "event"},
+    policy: {grantScopeAttributes: ["eventId"], writableAttributes: ["scanState"]}
+  }
+  ```
+
+- `metadata` is copied into generated frontend-model `resourceConfig().sync` and the sync manifest. Keep it frontend-safe: no secrets, tokens, private keys, raw SQL, backend file paths, driver config, or environment-specific values.
+- `policy` is not copied into generated frontend config. It is deterministic JSON included in `policyHash` so clients and peers can detect that their bundled resource policy no longer matches the backend policy.
+- `policyHash` is a `sha256-...` hash over deterministic sync inputs (`operations`, `policyVersion`, safe `metadata`, and `policy`). Bump `policyVersion` whenever shared resource policy changes in a way that should invalidate offline grants or peer-applied mutations.
+- Sync config accepts deterministic JSON only. Functions, classes, Dates, Maps, Sets, and secret-looking keys such as `privateKey`, `token`, `password`, or `secret` are rejected during resource normalization.
+
 ## Custom index records
 - Override `indexQuery(options)` when the default index behavior is correct but the resource needs an additional scope. Call `super.indexQuery(options)` and add the resource-specific filters, joins, or select data. The `options` object can include `includePagination` and `includeSort`.
 - Override `countIndexQueryOptions()` when a resource-specific `count()` needs different index-query options, for example `{includePagination: false, includeSort: false}` to count the full filtered scope while keeping paginated records.

--- a/spec/cli/commands/generate/frontend-models-spec.js
+++ b/spec/cli/commands/generate/frontend-models-spec.js
@@ -105,6 +105,19 @@ class CommandReturnTypeFrontendResource extends FrontendModelBaseResource {
       ]
 }
 
+class SyncPolicyCallFrontendResource extends FrontendModelBaseResource {
+  static ModelClass = Call
+
+    static attributes = {id: {type: "uuid"}, startedAt: {type: "datetime", null: true}}
+
+  static sync = {
+    metadata: {scope: "event"},
+    operations: ["index", "update"],
+    policy: {grantScopeAttributes: ["eventId"], writableAttributes: ["startedAt"]},
+    policyVersion: "scanner-v1"
+  }
+}
+
 // An abstract base resource other resources extend — deliberately has no static
 // ModelClass, like an app's shared `BaseResource`.
 class AbstractBaseFrontendResource extends FrontendModelBaseResource {
@@ -392,6 +405,41 @@ describe("Cli - generate - frontend-models", () => {
     expect(userContents).toContain("@typedef {Record<string, never>} UserUpdateAttributes")
     expect(userContents).not.toContain("@typedef {object} UserCreateAttributes")
     expect(userContents).not.toContain("@typedef {object} UserUpdateAttributes")
+  })
+
+  it("writes frontend-safe sync policy metadata into generated resource config", async () => {
+    const outputDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-sync-policy-models-"))
+    const backendProjectsList = [{
+      frontendModels: {Call: SyncPolicyCallFrontendResource},
+      frontendModelsOutputPath: outputDirectory,
+      path: "/tmp/backend"
+    }]
+    const cli = new Cli({
+      configuration: buildConfiguration({
+        backendProjectsList,
+        initializeModels: async () => configureCallColumns()
+      }),
+      directory: dummyDirectory(),
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["g:frontend-models"],
+      testing: true
+    })
+
+    await cli.execute()
+
+    const callContents = await fs.readFile(`${outputDirectory}/src/frontend-models/call.js`, "utf8")
+
+    expect(callContents).toContain("      sync: {\n")
+    expect(callContents).toContain("        enabled: true,\n")
+    expect(callContents).toContain("        operations: [\n")
+    expect(callContents).toContain("          \"index\",\n")
+    expect(callContents).toContain("          \"update\",\n")
+    expect(callContents).toContain("        policyHash: \"sha256-")
+    expect(callContents).toContain("        policyVersion: \"scanner-v1\",\n")
+    expect(callContents).toContain("        metadata: {\n")
+    expect(callContents).toContain("          scope: \"event\",\n")
+    expect(callContents).not.toContain("grantScopeAttributes")
+    expect(callContents).not.toContain("writableAttributes")
   })
 
   it("keeps generated frontend write attributes on inherited create and update", async () => {

--- a/spec/controller/frontend-model-sync-bootstrap-spec.js
+++ b/spec/controller/frontend-model-sync-bootstrap-spec.js
@@ -1,0 +1,121 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Ability from "../../src/authorization/ability.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
+import FrontendModelController from "../../src/frontend-model-controller.js"
+import Request from "../../src/http-server/client/request.js"
+import Response from "../../src/http-server/client/response.js"
+import frontendModelCommandRouteHook from "../../src/routes/hooks/frontend-model-command-route-hook.js"
+import {verifyOfflineGrant} from "../../src/sync/offline-grant.js"
+
+describe("frontend-model sync bootstrap", () => {
+  it("routes the sync bootstrap endpoint through the frontend-model controller", async () => {
+    const configuration = syncBootstrapConfiguration()
+    const routeMatch = await frontendModelCommandRouteHook({
+      configuration,
+      currentPath: "/frontend-models/sync/bootstrap"
+    })
+
+    expect(routeMatch?.action).toEqual("frontend-sync-bootstrap")
+    expect(routeMatch?.controller).toEqual("velocious/api")
+  })
+
+  it("returns a signed offline grant with the current sync manifest", async () => {
+    const configuration = syncBootstrapConfiguration()
+    const response = new Response({configuration})
+    const controller = new FrontendModelController({
+      action: "frontendSyncBootstrap",
+      configuration,
+      controller: "velocious/api",
+      params: {
+        deviceId: "scanner-1",
+        grantId: "grant-1",
+        now: "2026-01-02T03:04:05.000Z",
+        scopes: {eventId: "event-1"}
+      },
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+    controller._frontendModelAbilityOverride = new Ability({context: {currentUser: {id: "user-1"}}})
+
+    await controller.frontendSyncBootstrap()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.status).toEqual("success")
+    expect(payload.syncManifest.Ticket.policyHash).toMatch(/^sha256-[a-f0-9]{64}$/)
+    expect(payload.offlineGrant.grant).toMatchObject({
+      deviceId: "scanner-1",
+      expiresAt: "2026-01-02T03:05:05.000Z",
+      grantId: "grant-1",
+      issuedAt: "2026-01-02T03:04:05.000Z",
+      scopes: {eventId: "event-1"},
+      userId: "user-1"
+    })
+    expect(payload.offlineGrant.grant.resources).toEqual(payload.syncManifest)
+
+    const verifiedGrant = await verifyOfflineGrant({
+      now: new Date("2026-01-02T03:04:10.000Z"),
+      signedGrant: payload.offlineGrant,
+      signingKeys: configuration.getSyncConfiguration().offlineGrantSigningKeys
+    })
+
+    expect(verifiedGrant).toEqual(payload.offlineGrant.grant)
+  })
+})
+
+class TicketResource extends FrontendModelBaseResource {
+  static attributes = ["id"]
+  static sync = {
+    metadata: {scope: "event"},
+    operations: ["find", "scanAttempt"],
+    policy: {grantScopeAttributes: ["eventId"]},
+    policyVersion: "scanner-v1"
+  }
+}
+
+/**
+ * Builds test configuration for sync bootstrap specs.
+ * @returns {Configuration} - Test configuration.
+ */
+function syncBootstrapConfiguration() {
+  return new Configuration({
+    database: {test: {}},
+    directory: "/tmp",
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    backendProjects: [{frontendModels: {Ticket: TicketResource}, path: "/tmp/backend"}],
+    sync: {
+      offlineGrantSigningKeys: [{current: true, id: "key-1", secret: "test-signing-secret"}],
+      offlineGrantTtlMs: 60_000
+    }
+  })
+}
+
+/**
+ * Builds a minimal request object for sync bootstrap specs.
+ * @param {import("../../src/configuration.js").default} configuration - Test configuration.
+ * @returns {Request} - Request.
+ */
+function requestFor(configuration) {
+  const client = /** @type {any} */ ({remoteAddress: "127.0.0.1"})
+  const request = new Request({client, configuration})
+
+  request.feed(Buffer.from([
+    "POST /frontend-models/sync/bootstrap HTTP/1.1",
+    "Host: example.com",
+    "Content-Length: 0",
+    "",
+    ""
+  ].join("\r\n"), "utf8"))
+
+  return request
+}

--- a/spec/frontend-models/resource-definition-spec.js
+++ b/spec/frontend-models/resource-definition-spec.js
@@ -2,7 +2,7 @@
 
 import {describe, expect, it} from "../../src/testing/test.js"
 import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
-import {frontendModelResourceConfigurationFromDefinition} from "../../src/frontend-models/resource-definition.js"
+import {frontendModelResourceConfigurationFromDefinition, frontendModelSyncManifestForBackendProjects} from "../../src/frontend-models/resource-definition.js"
 
 describe("frontendModelResourceConfigurationFromDefinition abilities normalization", {databaseCleaning: {transaction: true}}, () => {
   it("rejects resourceConfig overrides on resource classes", () => {
@@ -62,5 +62,106 @@ describe("frontendModelResourceConfigurationFromDefinition abilities normalizati
       index: "read",
       update: "update"
     })
+  })
+})
+
+describe("frontendModelResourceConfigurationFromDefinition sync policy normalization", {databaseCleaning: {transaction: true}}, () => {
+  it("normalizes safe sync metadata and computes a deterministic policy hash", () => {
+    class FooResource extends FrontendModelBaseResource {
+      static attributes = ["id", "name"]
+      static sync = {
+        metadata: {scope: "event", strategy: "snapshot"},
+        operations: ["update", "index", "update"],
+        policy: {grantScopeAttributes: ["eventId"], writableAttributes: ["name"]},
+        policyVersion: "scanner-v1"
+      }
+    }
+
+    class SamePolicyResource extends FrontendModelBaseResource {
+      static attributes = ["id", "name"]
+      static sync = {
+        operations: ["index", "update"],
+        policyVersion: "scanner-v1",
+        policy: {writableAttributes: ["name"], grantScopeAttributes: ["eventId"]},
+        metadata: {strategy: "snapshot", scope: "event"}
+      }
+    }
+
+    class ChangedPolicyResource extends FrontendModelBaseResource {
+      static attributes = ["id", "name"]
+      static sync = {
+        operations: ["index", "update"],
+        policy: {grantScopeAttributes: ["eventId"], writableAttributes: ["name"]},
+        policyVersion: "scanner-v2"
+      }
+    }
+
+    const config = frontendModelResourceConfigurationFromDefinition(FooResource)
+    const sameConfig = frontendModelResourceConfigurationFromDefinition(SamePolicyResource)
+    const changedConfig = frontendModelResourceConfigurationFromDefinition(ChangedPolicyResource)
+
+    expect(config?.sync).toEqual({
+      enabled: true,
+      metadata: {scope: "event", strategy: "snapshot"},
+      operations: ["index", "update"],
+      policyHash: config?.sync?.policyHash,
+      policyVersion: "scanner-v1"
+    })
+    expect(config?.sync?.policyHash).toMatch(/^sha256-[a-f0-9]{64}$/)
+    expect(sameConfig?.sync?.policyHash).toEqual(config?.sync?.policyHash)
+    expect(changedConfig?.sync?.policyHash).not.toEqual(config?.sync?.policyHash)
+    expect("policy" in /** @type {Record<string, unknown>} */ (config?.sync || {})).toEqual(false)
+  })
+
+  it("rejects non-deterministic or secret-looking sync policy input", () => {
+    class FunctionPolicyResource extends FrontendModelBaseResource {
+      static attributes = ["id"]
+      static sync = {operations: ["index"], policy: {filter: () => true}}
+    }
+
+    class SecretPolicyResource extends FrontendModelBaseResource {
+      static attributes = ["id"]
+      static sync = {operations: ["index"], metadata: {privateKey: "do-not-leak"}}
+    }
+
+    expect(() => {
+      frontendModelResourceConfigurationFromDefinition(FunctionPolicyResource)
+    }).toThrow("Sync policy input must be deterministic JSON")
+
+    expect(() => {
+      frontendModelResourceConfigurationFromDefinition(SecretPolicyResource)
+    }).toThrow("Sync policy metadata/privateKey is not allowed in frontend-visible sync policy config")
+  })
+
+  it("builds a frontend-safe sync manifest for enabled resources only", () => {
+    class SyncResource extends FrontendModelBaseResource {
+      static attributes = ["id"]
+      static modelName = "Ticket"
+      static sync = {
+        metadata: {scope: "event"},
+        operations: ["index", "update"],
+        policyVersion: "scanner-v1"
+      }
+    }
+
+    class DisabledResource extends FrontendModelBaseResource {
+      static attributes = ["id"]
+      static sync = {enabled: false, operations: ["index"]}
+    }
+
+    const manifest = frontendModelSyncManifestForBackendProjects([{frontendModels: {
+      Disabled: DisabledResource,
+      Ticket: SyncResource
+    }, path: "/tmp/backend"}])
+
+    expect(Object.keys(manifest)).toEqual(["Ticket"])
+    expect(manifest.Ticket).toEqual({
+      enabled: true,
+      metadata: {scope: "event"},
+      operations: ["index", "update"],
+      policyHash: manifest.Ticket.policyHash,
+      policyVersion: "scanner-v1"
+    })
+    expect(manifest.Ticket.policyHash).toMatch(/^sha256-[a-f0-9]{64}$/)
   })
 })

--- a/spec/sync/device-identity-spec.js
+++ b/spec/sync/device-identity-spec.js
@@ -1,0 +1,103 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {
+  createDeviceCertificate,
+  createSignedMutation,
+  generateSyncSigningKeyPair,
+  mutationIdempotencyKey,
+  verifyDeviceCertificate,
+  verifySignedMutation
+} from "../../src/sync/device-identity.js"
+
+describe("sync device identity and mutation signing", () => {
+  it("creates a backend-signed device certificate that peers can verify offline", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const deviceKeys = await generateSyncSigningKeyPair()
+    const certificate = await createDeviceCertificate({
+      backendPrivateKey: backendKeys.privateKey,
+      certificate: {
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        certificateId: "cert-1",
+        devicePublicKey: deviceKeys.publicKey,
+        expiresAt: "2026-01-03T03:04:05.000Z",
+        issuedAt: "2026-01-02T03:04:05.000Z"
+      }
+    })
+
+    expect(certificate.algorithm).toEqual("ECDSA-P256-SHA256")
+    expect(certificate.signature).toMatch(/^ecdsa-p256-sha256-[A-Za-z0-9_-]+$/)
+
+    const verifiedCertificate = await verifyDeviceCertificate({
+      backendPublicKey: backendKeys.publicKey,
+      certificate,
+      now: new Date("2026-01-02T04:04:05.000Z")
+    })
+
+    expect(verifiedCertificate).toEqual(certificate.certificate)
+  })
+
+  it("rejects tampered mutations and expired device certificates", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const deviceKeys = await generateSyncSigningKeyPair()
+    const deviceCertificate = await createDeviceCertificate({
+      backendPrivateKey: backendKeys.privateKey,
+      certificate: {
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        certificateId: "cert-1",
+        devicePublicKey: deviceKeys.publicKey,
+        expiresAt: "2026-01-03T03:04:05.000Z",
+        issuedAt: "2026-01-02T03:04:05.000Z"
+      }
+    })
+    const signedMutation = await createSignedMutation({
+      deviceCertificate,
+      devicePrivateKey: deviceKeys.privateKey,
+      mutation: {
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        attributes: {scanState: "accepted"},
+        baseVersion: "server-100",
+        clientMutationId: "mutation-1",
+        model: "Ticket",
+        occurredAt: "2026-01-02T04:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        policyHash: "sha256-policy"
+      }
+    })
+
+    await expect(async () => {
+      await verifySignedMutation({
+        backendPublicKey: backendKeys.publicKey,
+        now: new Date("2026-01-02T04:05:00.000Z"),
+        signedMutation: {
+          ...signedMutation,
+          mutation: {...signedMutation.mutation, attributes: {scanState: "rejected"}}
+        }
+      })
+    }).toThrow("Sync mutation signature did not match")
+
+    await expect(async () => {
+      await verifySignedMutation({
+        backendPublicKey: backendKeys.publicKey,
+        now: new Date("2026-01-03T03:04:06.000Z"),
+        signedMutation
+      })
+    }).toThrow("Device certificate expired")
+  })
+
+  it("derives idempotency from actor user, actor device, and client mutation id", async () => {
+    const signedMutation = {
+      mutation: {
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        clientMutationId: "mutation-1"
+      }
+    }
+
+    expect(mutationIdempotencyKey(signedMutation)).toEqual("user-1:device-1:mutation-1")
+  })
+})

--- a/spec/sync/offline-grant-spec.js
+++ b/spec/sync/offline-grant-spec.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {
+  createOfflineGrant,
+  verifyOfflineGrant
+} from "../../src/sync/offline-grant.js"
+
+describe("offline grant signing", () => {
+  it("creates a signed grant and verifies it with the active signing key", async () => {
+    const signedGrant = await createOfflineGrant({
+      grant: {
+        deviceId: "scanner-1",
+        expiresAt: "2026-01-02T04:04:05.000Z",
+        grantId: "grant-1",
+        issuedAt: "2026-01-02T03:04:05.000Z",
+        resources: {
+          Ticket: {
+            operations: ["find", "scanAttempt"],
+            policyHash: "sha256-abc123",
+            policyVersion: "scanner-v1"
+          }
+        },
+        scopes: {eventId: "event-1"},
+        userId: "user-1"
+      },
+      signingKey: {id: "key-1", secret: "test-signing-secret"}
+    })
+
+    expect(signedGrant.algorithm).toEqual("HS256")
+    expect(signedGrant.keyId).toEqual("key-1")
+    expect(signedGrant.signature).toMatch(/^hmac-sha256-[a-f0-9]{64}$/)
+
+    const verifiedGrant = await verifyOfflineGrant({
+      now: new Date("2026-01-02T03:05:00.000Z"),
+      signedGrant,
+      signingKeys: [{id: "key-1", secret: "test-signing-secret"}]
+    })
+
+    expect(verifiedGrant).toEqual(signedGrant.grant)
+  })
+
+  it("rejects tampered and expired grants", async () => {
+    const signedGrant = await createOfflineGrant({
+      grant: {
+        deviceId: "scanner-1",
+        expiresAt: "2026-01-02T04:04:05.000Z",
+        grantId: "grant-1",
+        issuedAt: "2026-01-02T03:04:05.000Z",
+        resources: {},
+        scopes: {eventId: "event-1"},
+        userId: "user-1"
+      },
+      signingKey: {id: "key-1", secret: "test-signing-secret"}
+    })
+
+    await expect(async () => {
+      await verifyOfflineGrant({
+        now: new Date("2026-01-02T03:05:00.000Z"),
+        signedGrant: {
+          ...signedGrant,
+          grant: {...signedGrant.grant, deviceId: "scanner-2"}
+        },
+        signingKeys: [{id: "key-1", secret: "test-signing-secret"}]
+      })
+    }).toThrow("Offline grant signature did not match")
+
+    await expect(async () => {
+      await verifyOfflineGrant({
+        now: new Date("2026-01-02T04:04:06.000Z"),
+        signedGrant,
+        signingKeys: [{id: "key-1", secret: "test-signing-secret"}]
+      })
+    }).toThrow("Offline grant expired")
+  })
+})

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -356,6 +356,13 @@
  */
 
 /**
+ * Velocious sync configuration.
+ * @typedef {object} VelociousSyncConfiguration
+ * @property {Array<import("./sync/offline-grant.js").OfflineGrantSigningKey>} offlineGrantSigningKeys - Signing keys used to issue and verify offline grants. Secrets must never be exposed to clients.
+ * @property {number} [offlineGrantTtlMs] - Default offline grant TTL in milliseconds. Defaults to 24 hours.
+ */
+
+/**
  * Frontend-safe normalized sync metadata.
  * @typedef {object} NormalizedFrontendModelResourceSyncConfiguration
  * @property {boolean} enabled - Whether the resource is sync-enabled.
@@ -500,6 +507,7 @@
  * @property {string[]} locales - Supported locales.
  * @property {LocaleFallbacksType} localeFallbacks - Locale fallback map.
  * @property {StructureSqlConfiguration} [structureSql] - Structure SQL generation configuration.
+ * @property {VelociousSyncConfiguration} [sync] - Local/offline sync framework configuration.
  * @property {TenantResolverType} [tenantResolver] - Resolver for creating request-scoped tenant context objects.
  * @property {TenantDatabaseResolverType} [tenantDatabaseResolver] - Resolver for deriving tenant-specific database config overrides.
  * @property {Record<string, TenantDatabaseProviderType>} [tenantDatabaseProviders] - Tenant database lifecycle providers keyed by database identifier.

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -320,6 +320,7 @@
  * @property {string[]} [relationships] - Relationship names to expose in frontend models. Type and target model are inferred from the backend model's registered relationships.
  * @property {string} [primaryKey] - Primary key attribute name.
  * @property {FrontendModelResourceServerConfiguration} [server] - Optional legacy backend behavior overrides for built-in frontend actions.
+ * @property {FrontendModelResourceSyncConfiguration | boolean} [sync] - Optional safe local/offline sync policy metadata. `policy` participates in the hash but is not exposed to generated frontend config/manifest.
  */
 
 /**
@@ -338,13 +339,41 @@
  */
 
 /**
- * @typedef {Omit<FrontendModelResourceConfiguration, "abilities" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "commands" | "memberCommands"> & {
+ * JSON value accepted by sync policy metadata/hash inputs.
+ * @typedef {null | string | number | boolean | unknown[] | Record<string, unknown>} FrontendModelSyncJsonValue
+ */
+
+/**
+ * Frontend-model local/offline sync policy config. `metadata` is exposed to
+ * frontends and peers; `policy` is hashed but intentionally omitted from
+ * frontend-safe manifests.
+ * @typedef {object} FrontendModelResourceSyncConfiguration
+ * @property {boolean} [enabled] - Whether the resource is sync-enabled. Defaults to true when `sync` is configured.
+ * @property {string[]} [operations] - Sync operation names such as `index`, `find`, `create`, `update`, custom domain commands, etc.
+ * @property {string | number} [policyVersion] - App-controlled policy version used as a stable change signal.
+ * @property {Record<string, FrontendModelSyncJsonValue>} [metadata] - Safe frontend-visible metadata.
+ * @property {Record<string, FrontendModelSyncJsonValue>} [policy] - Deterministic non-secret policy inputs included in the policy hash only.
+ */
+
+/**
+ * Frontend-safe normalized sync metadata.
+ * @typedef {object} NormalizedFrontendModelResourceSyncConfiguration
+ * @property {boolean} enabled - Whether the resource is sync-enabled.
+ * @property {string[]} operations - Sorted, duplicate-free sync operation names.
+ * @property {string | null} policyVersion - App-controlled policy version, or null.
+ * @property {string} policyHash - Deterministic sha256 hash of safe policy inputs.
+ * @property {Record<string, FrontendModelSyncJsonValue>} [metadata] - Safe frontend-visible metadata.
+ */
+
+/**
+ * @typedef {Omit<FrontendModelResourceConfiguration, "abilities" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "commands" | "memberCommands" | "sync"> & {
  *   abilities: FrontendModelResourceAbilitiesConfiguration
  *   builtInCollectionCommands: Record<string, string>
  *   builtInMemberCommands: Record<string, string>
  *   collectionCommands: Record<string, string>
  *   commandMetadata: Record<string, {args: Array<{name: string, type: string}>, returnType: string | null}>
  *   memberCommands: Record<string, string>
+ *   sync?: NormalizedFrontendModelResourceSyncConfiguration
  * }} NormalizedFrontendModelResourceConfiguration
  */
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -20,6 +20,7 @@ import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channe
 import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
 import {requestDetails} from "./error-reporting/request-details.js"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
+import {currentOfflineGrantSigningKey, normalizeOfflineGrantSigningKey} from "./sync/offline-grant.js"
 import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
 import {validateTimeZone} from "./time-zone.js"
@@ -126,7 +127,7 @@ export default class VelociousConfiguration {
    * Runs constructor.
    * @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments.
    */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -189,6 +190,7 @@ export default class VelociousConfiguration {
     this._trustedProxies = trustedProxies
     this._requestTimeoutMs = requestTimeoutMs
     this._structureSql = structureSql
+    this._sync = this._normalizeSyncConfiguration(sync)
     this._tenantDatabaseProviders = tenantDatabaseProviders || {}
     this._tenantDatabaseResolver = tenantDatabaseResolver
     this._tenantResolver = tenantResolver
@@ -378,6 +380,44 @@ export default class VelociousConfiguration {
    */
   getCookieSecret() {
     return this._cookieSecret
+  }
+
+  /**
+   * Runs get sync configuration.
+   * @returns {import("./configuration-types.js").VelociousSyncConfiguration} - Sync configuration.
+   */
+  getSyncConfiguration() {
+    return this._sync
+  }
+
+  /**
+   * Runs current offline grant signing key.
+   * @returns {import("./sync/offline-grant.js").OfflineGrantSigningKey} - Current signing key.
+   */
+  currentOfflineGrantSigningKey() {
+    const signingKeys = this.getSyncConfiguration().offlineGrantSigningKeys
+
+    return currentOfflineGrantSigningKey(signingKeys)
+  }
+
+  /**
+   * Normalizes sync configuration.
+   * @param {import("./configuration-types.js").VelociousSyncConfiguration | undefined} sync - Sync configuration.
+   * @returns {import("./configuration-types.js").VelociousSyncConfiguration} - Normalized sync configuration.
+   */
+  _normalizeSyncConfiguration(sync) {
+    const offlineGrantSigningKeys = sync?.offlineGrantSigningKeys || []
+    const offlineGrantTtlMs = sync?.offlineGrantTtlMs
+
+    if (!Array.isArray(offlineGrantSigningKeys)) throw new Error("sync.offlineGrantSigningKeys must be an array")
+    if (offlineGrantTtlMs !== undefined && (!Number.isInteger(offlineGrantTtlMs) || offlineGrantTtlMs <= 0)) {
+      throw new Error("sync.offlineGrantTtlMs must be a positive integer number of milliseconds")
+    }
+
+    return {
+      offlineGrantSigningKeys: offlineGrantSigningKeys.map((key) => normalizeOfflineGrantSigningKey(key)),
+      offlineGrantTtlMs: offlineGrantTtlMs || 24 * 60 * 60 * 1000
+    }
   }
 
   /**

--- a/src/environment-handlers/node/cli/commands/generate/frontend-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/frontend-models.js
@@ -442,6 +442,13 @@ export default class DbGenerateFrontendModels extends BaseCommand {
       }
       fileContent += "      },\n"
     }
+    if (modelConfig.sync?.enabled) {
+      fileContent += this.formattedJsonProperty({
+        indent: "      ",
+        propertyName: "sync",
+        value: modelConfig.sync
+      })
+    }
     fileContent += "    }\n"
     fileContent += "  }\n"
 
@@ -997,6 +1004,62 @@ export default class DbGenerateFrontendModels extends BaseCommand {
     output += `${indent}},\n`
 
     return output
+  }
+
+  /**
+   * Runs formatted JSON property.
+   * @param {object} args - Formatting args.
+   * @param {string} args.indent - Base indentation.
+   * @param {string} args.propertyName - Object property name.
+   * @param {unknown} args.value - JSON-compatible value.
+   * @returns {string} - Formatted property.
+   */
+  formattedJsonProperty({indent, propertyName, value}) {
+    return `${indent}${propertyName}: ${this.formattedJsonValue({indent, value})},\n`
+  }
+
+  /**
+   * Runs formatted JSON value.
+   * @param {object} args - Formatting args.
+   * @param {string} args.indent - Indentation before this value.
+   * @param {unknown} args.value - JSON-compatible value.
+   * @returns {string} - Formatted value.
+   */
+  formattedJsonValue({indent, value}) {
+    if (Array.isArray(value)) {
+      let output = "[\n"
+
+      for (const entry of value) {
+        output += `${indent}  ${this.formattedJsonValue({indent: `${indent}  `, value: entry})},\n`
+      }
+
+      output += `${indent}]`
+
+      return output
+    }
+
+    if (value && typeof value === "object") {
+      let output = "{\n"
+
+      for (const key of Object.keys(value)) {
+        output += `${indent}  ${this.formattedObjectKey(key)}: ${this.formattedJsonValue({indent: `${indent}  `, value: /** @type {Record<string, unknown>} */ (value)[key]})},\n`
+      }
+
+      output += `${indent}}`
+
+      return output
+    }
+
+    return JSON.stringify(value)
+  }
+
+  /**
+   * Runs formatted object key.
+   * @param {string} key - Object key.
+   * @returns {string} - JavaScript object key.
+   */
+  formattedObjectKey(key) {
+    return /^[A-Za-z_$][\w$]*$/.test(key) ? key : JSON.stringify(key)
   }
 
   /**

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -5,7 +5,8 @@ import Controller from "./controller.js"
 import FrontendModelBaseResource from "./frontend-model-resource/base-resource.js"
 import Response from "./http-server/client/response.js"
 import {frontendModelResourcesWithBuiltInsForBackendProject} from "./frontend-models/built-in-resources.js"
-import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
+import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject, frontendModelSyncManifestForBackendProjects} from "./frontend-models/resource-definition.js"
+import {createOfflineGrantFromBootstrap} from "./sync/offline-grant.js"
 import {FrontendModelQueryError, normalizeGroup as normalizeQueryGroup, normalizeJoins as normalizeQueryJoins, normalizePluck as normalizeQueryPluck, normalizePreload as normalizeQueryPreload, normalizeSearchOperator as normalizeQuerySearchOperator, normalizeSort as normalizeQuerySort} from "./frontend-models/query.js"
 import {assignSafeProperty, deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
 import {requestDetails} from "./error-reporting/request-details.js"
@@ -3436,6 +3437,106 @@ export default class FrontendModelController extends Controller {
     await resource.destroy(model)
 
     return {status: "success"}
+  }
+
+  /**
+   * Runs frontend sync bootstrap.
+   * @returns {Promise<void>} - Sync bootstrap response with manifest and signed offline grant.
+   */
+  async frontendSyncBootstrap() {
+    if (this.request().httpMethod() === "OPTIONS") {
+      await this.render({status: 204, json: {}})
+      return
+    }
+
+    const params = /** @type {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue | undefined>} */ (deserializeFrontendModelTransportValue(this.params()))
+    const configuration = this.getConfiguration()
+    const syncManifest = frontendModelSyncManifestForBackendProjects(configuration.getBackendProjects())
+    const offlineGrant = await createOfflineGrantFromBootstrap({
+      deviceId: this.frontendSyncBootstrapDeviceId(params),
+      grantId: this.frontendSyncBootstrapGrantId(params),
+      grantTtlMs: configuration.getSyncConfiguration().offlineGrantTtlMs,
+      now: this.frontendSyncBootstrapNow(params),
+      resources: syncManifest,
+      scopes: this.frontendSyncBootstrapScopes(params),
+      signingKey: configuration.currentOfflineGrantSigningKey(),
+      userId: this.frontendSyncBootstrapUserId()
+    })
+
+    await this.render({
+      json: /** @type {Record<string, ?>} */ (serializeFrontendModelTransportValue({
+        offlineGrant,
+        status: "success",
+        syncManifest
+      }, this.transportSerializationOptions()))
+    })
+  }
+
+  /**
+   * Resolves device id for sync bootstrap.
+   * @param {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue | undefined>} params - Request params.
+   * @returns {string} - Device id.
+   */
+  frontendSyncBootstrapDeviceId(params) {
+    if (typeof params.deviceId === "string" && params.deviceId.length > 0) return params.deviceId
+
+    throw new Error("Expected sync bootstrap deviceId")
+  }
+
+  /**
+   * Resolves grant id for sync bootstrap.
+   * @param {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue | undefined>} params - Request params.
+   * @returns {string | undefined} - Deterministic grant id for tests, generated id otherwise.
+   */
+  frontendSyncBootstrapGrantId(params) {
+    if (this.getConfiguration().getEnvironment() === "test" && typeof params.grantId === "string") return params.grantId
+
+    return undefined
+  }
+
+  /**
+   * Resolves bootstrap issue time.
+   * @param {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue | undefined>} params - Request params.
+   * @returns {Date} - Issue time.
+   */
+  frontendSyncBootstrapNow(params) {
+    if (this.getConfiguration().getEnvironment() === "test" && typeof params.now === "string") return new Date(params.now)
+
+    return new Date()
+  }
+
+  /**
+   * Resolves sync bootstrap scopes.
+   * @param {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue | undefined>} params - Request params.
+   * @returns {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue>} - Grant scopes.
+   */
+  frontendSyncBootstrapScopes(params) {
+    const scopes = params.scopes
+
+    if (scopes && typeof scopes === "object" && !Array.isArray(scopes)) {
+      return /** @type {Record<string, import("./configuration-types.js").FrontendModelSyncJsonValue>} */ (scopes)
+    }
+
+    return {}
+  }
+
+  /**
+   * Resolves current user id for sync bootstrap.
+   * @returns {string} - User id.
+   */
+  frontendSyncBootstrapUserId() {
+    const ability = this.currentAbility()
+    const currentUser = ability?.currentUser()
+
+    if (typeof currentUser === "string" || typeof currentUser === "number") return String(currentUser)
+    if (currentUser && typeof currentUser === "object") {
+      const userRecord = /** @type {{id?: string | number | (() => string | number)}} */ (currentUser)
+      const idValue = typeof userRecord.id === "function" ? userRecord.id() : userRecord.id
+
+      if (typeof idValue === "string" || typeof idValue === "number") return String(idValue)
+    }
+
+    throw new Error("Expected sync bootstrap current user")
   }
 
   /**

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -165,6 +165,8 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   static primaryKey = undefined
   /** @type {import("../configuration-types.js").FrontendModelResourceServerConfiguration | undefined} */
   static server = undefined
+  /** @type {import("../configuration-types.js").FrontendModelResourceSyncConfiguration | boolean | undefined} */
+  static sync = undefined
   /** @type {string[] | undefined} */
   static translatedAttributes = undefined
   /** @type {?} */
@@ -204,7 +206,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
   /**
    * Reads a static resource config value from the environment resource first,
    * then from the shared resource.
-   * @param {"abilities" | "attachments" | "attributes" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "commands" | "memberCommands" | "modelName" | "primaryKey" | "relationships" | "server" | "translatedAttributes"} name - Static config property name.
+   * @param {"abilities" | "attachments" | "attributes" | "builtInCollectionCommands" | "builtInMemberCommands" | "collectionCommands" | "commands" | "memberCommands" | "modelName" | "primaryKey" | "relationships" | "server" | "sync" | "translatedAttributes"} name - Static config property name.
    * @returns {?} - Resolved config value.
    */
   static sharedResourceStaticValue(name) {
@@ -359,6 +361,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     const primaryKey = this.sharedResourceStaticValue("primaryKey")
     const relationships = this.sharedResourceStaticValue("relationships")
     const server = this.sharedResourceStaticValue("server")
+    const sync = this.sharedResourceStaticValue("sync")
     /** @type {import("../configuration-types.js").FrontendModelResourceConfiguration} */
     const config = {
       attributes: /** @type {Record<string, ?> | string[]} */ (attributes || [])
@@ -375,6 +378,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     if (primaryKey) config.primaryKey = /** @type {string} */ (primaryKey)
     if (relationships) config.relationships = /** @type {string[]} */ (relationships)
     if (server) config.server = /** @type {import("../configuration-types.js").FrontendModelResourceServerConfiguration} */ (server)
+    if (sync !== undefined) config.sync = /** @type {import("../configuration-types.js").FrontendModelResourceSyncConfiguration | boolean} */ (sync)
 
     return config
   }

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -58,7 +58,15 @@ import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQuer
  */
 /**
  * Defines this typedef.
- * @typedef {{attributes?: Array<string | FrontendModelAttributeDefinition> | Record<string, FrontendModelAttributeDefinition>, builtInCollectionCommands?: string[], builtInMemberCommands?: string[], collectionCommands?: string[], commands?: string[], memberCommands?: string[], attachments?: Record<string, FrontendModelAttachmentDefinition>, modelName?: string, nestedAttributes?: Record<string, {allowDestroy?: boolean, limit?: number}>, primaryKey?: string, relationships?: string[]}} FrontendModelResourceConfig
+ * @typedef {Record<string, FrontendModelTransportValue>} FrontendModelSyncMetadata
+ */
+/**
+ * Defines this typedef.
+ * @typedef {{enabled: boolean, operations: string[], policyHash: string, policyVersion: string | null, metadata?: FrontendModelSyncMetadata}} FrontendModelSyncConfig
+ */
+/**
+ * Defines this typedef.
+ * @typedef {{attributes?: Array<string | FrontendModelAttributeDefinition> | Record<string, FrontendModelAttributeDefinition>, builtInCollectionCommands?: string[], builtInMemberCommands?: string[], collectionCommands?: string[], commands?: string[], memberCommands?: string[], attachments?: Record<string, FrontendModelAttachmentDefinition>, modelName?: string, nestedAttributes?: Record<string, {allowDestroy?: boolean, limit?: number}>, primaryKey?: string, relationships?: string[], sync?: FrontendModelSyncConfig}} FrontendModelResourceConfig
  */
 /**
  * Frontend model constructor type.

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -1,12 +1,33 @@
 // @ts-check
 
 import * as inflection from "inflection"
-import crypto from "node:crypto"
 import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
 import restArgsError from "../utils/rest-args-error.js"
 import {validateFrontendModelResourceCommandName} from "./resource-config-validation.js"
 
 const BASE_FRONTEND_MODEL_ABILITY_ACTIONS = ["create", "destroy", "read", "update"]
+const SHA256_INITIAL_HASH = [
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+]
+const SHA256_K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+  0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+  0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+  0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+  0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+  0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+]
 const RESOURCE_STATIC_CONFIG_KEYS = new Set([
   "abilities",
   "attachments",
@@ -334,7 +355,123 @@ function normalizeSyncOperations(operations) {
  * @returns {string} - sha256-prefixed hash.
  */
 function syncPolicyHash(value) {
-  return `sha256-${crypto.createHash("sha256").update(stableJsonStringify(value)).digest("hex")}`
+  return `sha256-${sha256Hex(stableJsonStringify(value))}`
+}
+
+/**
+ * Computes SHA-256 without importing Node-only crypto modules, keeping this
+ * resource-definition module safe for Expo/browser bundles.
+ * @param {string} message - UTF-8 message.
+ * @returns {string} - Hex digest.
+ */
+function sha256Hex(message) {
+  const bytes = utf8Bytes(message)
+  const padded = [...bytes]
+  const bitLength = bytes.length * 8
+  const hash = [...SHA256_INITIAL_HASH]
+  /** @type {number[]} */
+  const words = new Array(64)
+
+  padded.push(0x80)
+  while (padded.length % 64 !== 56) padded.push(0)
+
+  const highLength = Math.floor(bitLength / 0x100000000)
+  const lowLength = bitLength >>> 0
+
+  for (const value of [highLength, lowLength]) {
+    padded.push((value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff)
+  }
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      const index = offset + (i * 4)
+
+      words[i] = (((padded[index] || 0) << 24) | ((padded[index + 1] || 0) << 16) | ((padded[index + 2] || 0) << 8) | (padded[index + 3] || 0)) >>> 0
+    }
+
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotateRight(words[i - 15], 7) ^ rotateRight(words[i - 15], 18) ^ (words[i - 15] >>> 3)
+      const s1 = rotateRight(words[i - 2], 17) ^ rotateRight(words[i - 2], 19) ^ (words[i - 2] >>> 10)
+
+      words[i] = add32(words[i - 16], s0, words[i - 7], s1)
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash
+
+    for (let i = 0; i < 64; i++) {
+      const s1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)
+      const ch = (e & f) ^ ((~e) & g)
+      const temp1 = add32(h, s1, ch, SHA256_K[i], words[i])
+      const s0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22)
+      const maj = (a & b) ^ (a & c) ^ (b & c)
+      const temp2 = add32(s0, maj)
+
+      h = g
+      g = f
+      f = e
+      e = add32(d, temp1)
+      d = c
+      c = b
+      b = a
+      a = add32(temp1, temp2)
+    }
+
+    hash[0] = add32(hash[0], a)
+    hash[1] = add32(hash[1], b)
+    hash[2] = add32(hash[2], c)
+    hash[3] = add32(hash[3], d)
+    hash[4] = add32(hash[4], e)
+    hash[5] = add32(hash[5], f)
+    hash[6] = add32(hash[6], g)
+    hash[7] = add32(hash[7], h)
+  }
+
+  return hash.map((value) => value.toString(16).padStart(8, "0")).join("")
+}
+
+/**
+ * Converts a string to UTF-8 bytes.
+ * @param {string} value - String value.
+ * @returns {number[]} - UTF-8 bytes.
+ */
+function utf8Bytes(value) {
+  /** @type {number[]} */
+  const bytes = []
+
+  for (const character of value) {
+    const codePoint = /** @type {number} */ (character.codePointAt(0))
+
+    if (codePoint <= 0x7f) {
+      bytes.push(codePoint)
+    } else if (codePoint <= 0x7ff) {
+      bytes.push(0xc0 | (codePoint >>> 6), 0x80 | (codePoint & 0x3f))
+    } else if (codePoint <= 0xffff) {
+      bytes.push(0xe0 | (codePoint >>> 12), 0x80 | ((codePoint >>> 6) & 0x3f), 0x80 | (codePoint & 0x3f))
+    } else {
+      bytes.push(0xf0 | (codePoint >>> 18), 0x80 | ((codePoint >>> 12) & 0x3f), 0x80 | ((codePoint >>> 6) & 0x3f), 0x80 | (codePoint & 0x3f))
+    }
+  }
+
+  return bytes
+}
+
+/**
+ * Adds unsigned 32-bit integers.
+ * @param {...number} values - Values to add.
+ * @returns {number} - Unsigned 32-bit result.
+ */
+function add32(...values) {
+  return values.reduce((sum, value) => (sum + value) >>> 0, 0)
+}
+
+/**
+ * Rotates a 32-bit integer right.
+ * @param {number} value - Value to rotate.
+ * @param {number} bits - Bit count.
+ * @returns {number} - Rotated value.
+ */
+function rotateRight(value, bits) {
+  return (value >>> bits) | (value << (32 - bits))
 }
 
 /**

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import * as inflection from "inflection"
+import crypto from "node:crypto"
 import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
 import restArgsError from "../utils/rest-args-error.js"
 import {validateFrontendModelResourceCommandName} from "./resource-config-validation.js"
@@ -21,6 +22,7 @@ const RESOURCE_STATIC_CONFIG_KEYS = new Set([
   "relationships",
   "server",
   "SharedResource",
+  "sync",
   "translatedAttributes"
 ])
 
@@ -157,7 +159,8 @@ function normalizeFrontendModelResourceConfiguration(resourceConfiguration) {
     "modelName",
     "primaryKey",
     "relationships",
-    "server"
+    "server",
+    "sync"
   ]) {
     delete restArgs[key]
   }
@@ -165,6 +168,7 @@ function normalizeFrontendModelResourceConfiguration(resourceConfiguration) {
   restArgsError(restArgs)
 
   const normalizedCommands = normalizeFrontendModelResourceCommands(resourceConfiguration)
+  const sync = normalizeFrontendModelResourceSync(resourceConfiguration)
 
   return {
     ...resourceConfiguration,
@@ -176,7 +180,8 @@ function normalizeFrontendModelResourceConfiguration(resourceConfiguration) {
     // name, derived from `{name, args?, returnType?}` command entries. The
     // generator uses it to type each custom command method.
     commandMetadata: normalizedCommands.commandMetadata,
-    memberCommands: normalizedCommands.memberCommands
+    memberCommands: normalizedCommands.memberCommands,
+    sync
   }
 }
 
@@ -223,6 +228,166 @@ function defaultCrudAbilities() {
     index: "read",
     update: "update"
   }
+}
+
+/**
+ * Builds a frontend-safe sync manifest for all sync-enabled frontend-model resources.
+ * @param {import("../configuration-types.js").BackendProjectConfiguration[]} backendProjects - Backend projects to scan.
+ * @returns {Record<string, import("../configuration-types.js").NormalizedFrontendModelResourceSyncConfiguration>} - Sync metadata keyed by model name.
+ */
+export function frontendModelSyncManifestForBackendProjects(backendProjects) {
+  /** @type {Record<string, import("../configuration-types.js").NormalizedFrontendModelResourceSyncConfiguration>} */
+  const manifest = {}
+
+  for (const backendProject of backendProjects) {
+    const resources = frontendModelResourcesForBackendProject(backendProject)
+
+    for (const configuredModelName of Object.keys(resources).sort()) {
+      const resourceDefinition = resources[configuredModelName]
+      const resourceConfiguration = frontendModelResourceConfigurationFromDefinition(resourceDefinition)
+
+      if (!resourceConfiguration) continue
+      if (!resourceConfiguration.sync?.enabled) continue
+
+      const modelName = resourceConfiguration.modelName || configuredModelName
+
+      manifest[modelName] = resourceConfiguration.sync
+    }
+  }
+
+  return manifest
+}
+
+/**
+ * Normalizes sync policy metadata and computes a deterministic hash from safe policy inputs.
+ * @param {import("../configuration-types.js").FrontendModelResourceConfiguration} resourceConfiguration - Raw resource configuration.
+ * @returns {import("../configuration-types.js").NormalizedFrontendModelResourceSyncConfiguration | undefined} - Frontend-safe sync metadata.
+ */
+function normalizeFrontendModelResourceSync(resourceConfiguration) {
+  const sync = resourceConfiguration.sync
+
+  if (sync === undefined || sync === null) return undefined
+  if (sync === false) return {enabled: false, operations: [], policyHash: syncPolicyHash({enabled: false}), policyVersion: null}
+  if (sync === true) {
+    return normalizeFrontendModelResourceSync({
+      ...resourceConfiguration,
+      sync: {operations: ["index", "find"]}
+    })
+  }
+  if (!sync || typeof sync !== "object" || Array.isArray(sync)) {
+    throw new Error("Resource sync configuration must be true, false, or an object.")
+  }
+
+  const {enabled = true, metadata, operations, policy, policyVersion, ...rest} = /** @type {import("../configuration-types.js").FrontendModelResourceSyncConfiguration} */ (sync)
+
+  if (Object.keys(rest).length > 0) {
+    throw new Error(`Unexpected sync keys: ${Object.keys(rest).join(", ")}. Allowed: enabled, metadata, operations, policy, policyVersion`)
+  }
+  if (enabled !== true && enabled !== false) throw new Error("Resource sync enabled must be true or false when provided.")
+
+  const normalizedOperations = normalizeSyncOperations(operations)
+  const normalizedMetadata = metadata === undefined ? undefined : deterministicSyncJson({label: "metadata", value: metadata})
+  const normalizedPolicy = policy === undefined ? undefined : deterministicSyncJson({label: "policy", value: policy})
+  const normalizedPolicyVersion = policyVersion === undefined || policyVersion === null ? null : String(policyVersion)
+  const hashInput = {
+    enabled,
+    metadata: normalizedMetadata,
+    modelName: resourceConfiguration.modelName || null,
+    operations: normalizedOperations,
+    policy: normalizedPolicy,
+    policyVersion: normalizedPolicyVersion
+  }
+  /** @type {import("../configuration-types.js").NormalizedFrontendModelResourceSyncConfiguration} */
+  const normalized = {
+    enabled,
+    operations: normalizedOperations,
+    policyHash: syncPolicyHash(hashInput),
+    policyVersion: normalizedPolicyVersion
+  }
+
+  if (normalizedMetadata !== undefined) normalized.metadata = /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (normalizedMetadata)
+
+  return normalized
+}
+
+/**
+ * Normalizes sync operations into a stable, duplicate-free list.
+ * @param {unknown} operations - Raw operations value.
+ * @returns {string[]} - Normalized operations.
+ */
+function normalizeSyncOperations(operations) {
+  if (operations === undefined) return []
+  if (!Array.isArray(operations)) throw new Error("Resource sync operations must be an array of operation names.")
+
+  const normalized = operations.map((operation) => {
+    if (typeof operation !== "string" || operation.length < 1) throw new Error("Resource sync operations entries must be non-empty strings.")
+
+    return operation
+  })
+
+  return [...new Set(normalized)].sort()
+}
+
+/**
+ * Builds a deterministic policy hash.
+ * @param {unknown} value - Hash input.
+ * @returns {string} - sha256-prefixed hash.
+ */
+function syncPolicyHash(value) {
+  return `sha256-${crypto.createHash("sha256").update(stableJsonStringify(value)).digest("hex")}`
+}
+
+/**
+ * Validates that a sync config subtree is deterministic JSON and does not contain obvious secrets.
+ * @param {object} args - Arguments.
+ * @param {string} args.label - Diagnostic path label.
+ * @param {unknown} args.value - Value to validate.
+ * @returns {import("../configuration-types.js").FrontendModelSyncJsonValue} - Stable JSON value.
+ */
+function deterministicSyncJson({label, value}) {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value
+
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => deterministicSyncJson({label: `${label}/${index}`, value: entry}))
+  }
+
+  if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+    /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */
+    const normalized = {}
+
+    for (const key of Object.keys(value).sort()) {
+      const childValue = /** @type {Record<string, unknown>} */ (value)[key]
+
+      if (childValue === undefined) continue
+      if (syncConfigKeyLooksSecret(key)) {
+        throw new Error(`Sync policy ${label}/${key} is not allowed in frontend-visible sync policy config`)
+      }
+
+      normalized[key] = deterministicSyncJson({label: `${label}/${key}`, value: childValue})
+    }
+
+    return normalized
+  }
+
+  throw new Error("Sync policy input must be deterministic JSON")
+}
+
+/**
+ * Stable JSON stringifier with sorted object keys.
+ * @param {unknown} value - Value to stringify.
+ * @returns {string} - Stable JSON.
+ */
+function stableJsonStringify(value) {
+  return JSON.stringify(deterministicSyncJson({label: "hash", value}))
+}
+
+/**
+ * Returns whether a sync config key looks like a credential/secret.
+ * @param {string} key - Object key.
+ * @returns {boolean} - Whether key is disallowed.
+ */
+function syncConfigKeyLooksSecret(key) {
+  return /secret|token|password|private.?key|signing.?key/i.test(key)
 }
 
 /**

--- a/src/routes/hooks/frontend-model-command-route-hook.js
+++ b/src/routes/hooks/frontend-model-command-route-hook.js
@@ -17,6 +17,14 @@ const FRONTEND_MODEL_CONTROLLER_PATH = new URL("../../frontend-model-controller.
 export default async function frontendModelCommandRouteHook({configuration, currentPath, hasMatchingCustomRoute}) {
   const normalizedCurrentPath = normalizePath(currentPath)
 
+  if (normalizedCurrentPath === "/frontend-models/sync/bootstrap") {
+    return {
+      action: "frontend-sync-bootstrap",
+      controller: "velocious/api",
+      controllerPath: FRONTEND_MODEL_CONTROLLER_PATH
+    }
+  }
+
   if (normalizedCurrentPath === SHARED_FRONTEND_MODEL_API_PATH) {
     return {
       action: "frontend-api",

--- a/src/sync/device-identity.js
+++ b/src/sync/device-identity.js
@@ -1,0 +1,503 @@
+// @ts-check
+
+const ECDSA_P256_SHA256_ALGORITHM = "ECDSA-P256-SHA256"
+const ECDSA_P256_SHA256_SIGNATURE_PREFIX = "ecdsa-p256-sha256-"
+
+/**
+ * JSON Web Key used by the sync signing helpers.
+ * @typedef {JsonWebKey} SyncJsonWebKey
+ */
+
+/**
+ * Backend-signed device certificate payload.
+ * @typedef {object} DeviceCertificatePayload
+ * @property {string} actorDeviceId - Device id allowed to sign mutations.
+ * @property {string} actorUserId - User id represented by the device.
+ * @property {string} certificateId - Certificate id.
+ * @property {SyncJsonWebKey} devicePublicKey - Device public key peers/backends use to verify mutations.
+ * @property {string} expiresAt - ISO timestamp after which the certificate is invalid.
+ * @property {string} issuedAt - ISO timestamp when the backend issued the certificate.
+ */
+
+/**
+ * Backend-signed device certificate envelope.
+ * @typedef {object} DeviceCertificate
+ * @property {"ECDSA-P256-SHA256"} algorithm - Signature algorithm.
+ * @property {DeviceCertificatePayload} certificate - Certificate payload.
+ * @property {string} signature - Backend signature over the certificate payload.
+ */
+
+/**
+ * Sync mutation payload signed by a device.
+ * @typedef {object} SyncMutation
+ * @property {string} actorDeviceId - Device that signed the mutation.
+ * @property {string} actorUserId - User represented by the signing device.
+ * @property {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} [attributes] - Model attributes for CRUD mutations.
+ * @property {string | number | null} [baseVersion] - Base server/client version.
+ * @property {string} clientMutationId - Device-local idempotency id.
+ * @property {string} [command] - Domain command name for command mutations.
+ * @property {string} model - Sync model/resource name.
+ * @property {string} occurredAt - ISO timestamp when the mutation occurred.
+ * @property {string} offlineGrantId - Offline grant id authorizing the mutation.
+ * @property {string} operation - CRUD operation or command operation.
+ * @property {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} [payload] - Domain command payload.
+ * @property {string} policyHash - Sync policy hash the mutation was checked against.
+ */
+
+/**
+ * Device-signed mutation envelope.
+ * @typedef {object} SignedSyncMutation
+ * @property {"ECDSA-P256-SHA256"} algorithm - Signature algorithm.
+ * @property {DeviceCertificate} deviceCertificate - Backend-signed device certificate.
+ * @property {SyncMutation} mutation - Mutation payload.
+ * @property {string} signature - Device signature over the mutation envelope.
+ */
+
+/**
+ * Generates an ECDSA P-256 keypair exported as JWKs.
+ * @returns {Promise<{privateKey: SyncJsonWebKey, publicKey: SyncJsonWebKey}>} - Exported keypair.
+ */
+export async function generateSyncSigningKeyPair() {
+  const keyPair = await cryptoSubtle().generateKey(
+    {name: "ECDSA", namedCurve: "P-256"},
+    true,
+    ["sign", "verify"]
+  )
+
+  return {
+    privateKey: await cryptoSubtle().exportKey("jwk", keyPair.privateKey),
+    publicKey: await cryptoSubtle().exportKey("jwk", keyPair.publicKey)
+  }
+}
+
+/**
+ * Creates a backend-signed device certificate.
+ * @param {object} args - Arguments.
+ * @param {SyncJsonWebKey} args.backendPrivateKey - Backend private signing key.
+ * @param {DeviceCertificatePayload} args.certificate - Certificate payload.
+ * @returns {Promise<DeviceCertificate>} - Signed certificate.
+ */
+export async function createDeviceCertificate({backendPrivateKey, certificate}) {
+  const normalizedCertificate = normalizeDeviceCertificatePayload(certificate)
+
+  return {
+    algorithm: ECDSA_P256_SHA256_ALGORITHM,
+    certificate: normalizedCertificate,
+    signature: await signStableJson({
+      privateKey: backendPrivateKey,
+      value: deviceCertificateSignatureValue(normalizedCertificate)
+    })
+  }
+}
+
+/**
+ * Verifies a backend-signed device certificate.
+ * @param {object} args - Arguments.
+ * @param {SyncJsonWebKey} args.backendPublicKey - Backend public key.
+ * @param {DeviceCertificate} args.certificate - Signed certificate.
+ * @param {Date} [args.now] - Verification time. Defaults to current time.
+ * @returns {Promise<DeviceCertificatePayload>} - Verified certificate payload.
+ */
+export async function verifyDeviceCertificate({backendPublicKey, certificate, now = new Date()}) {
+  const normalizedCertificate = normalizeDeviceCertificate(certificate)
+  const verified = await verifyStableJsonSignature({
+    publicKey: backendPublicKey,
+    signature: normalizedCertificate.signature,
+    value: deviceCertificateSignatureValue(normalizedCertificate.certificate)
+  })
+
+  if (!verified) throw new Error("Device certificate signature did not match")
+  assertNotExpired({expiresAt: normalizedCertificate.certificate.expiresAt, label: "Device certificate", now})
+
+  return normalizedCertificate.certificate
+}
+
+/**
+ * Creates a device-signed mutation envelope.
+ * @param {object} args - Arguments.
+ * @param {DeviceCertificate} args.deviceCertificate - Backend-signed device certificate.
+ * @param {SyncJsonWebKey} args.devicePrivateKey - Device private signing key.
+ * @param {SyncMutation} args.mutation - Mutation payload.
+ * @returns {Promise<SignedSyncMutation>} - Signed mutation.
+ */
+export async function createSignedMutation({deviceCertificate, devicePrivateKey, mutation}) {
+  const normalizedDeviceCertificate = normalizeDeviceCertificate(deviceCertificate)
+  const normalizedMutation = normalizeSyncMutation(mutation)
+
+  assertMutationMatchesCertificate({certificate: normalizedDeviceCertificate.certificate, mutation: normalizedMutation})
+
+  return {
+    algorithm: ECDSA_P256_SHA256_ALGORITHM,
+    deviceCertificate: normalizedDeviceCertificate,
+    mutation: normalizedMutation,
+    signature: await signStableJson({
+      privateKey: devicePrivateKey,
+      value: signedMutationSignatureValue({
+        deviceCertificate: normalizedDeviceCertificate,
+        mutation: normalizedMutation
+      })
+    })
+  }
+}
+
+/**
+ * Verifies a signed sync mutation and its device certificate.
+ * @param {object} args - Arguments.
+ * @param {SyncJsonWebKey} args.backendPublicKey - Backend public key used to verify the device certificate.
+ * @param {Date} [args.now] - Verification time. Defaults to current time.
+ * @param {SignedSyncMutation} args.signedMutation - Signed mutation envelope.
+ * @returns {Promise<SyncMutation>} - Verified mutation payload.
+ */
+export async function verifySignedMutation({backendPublicKey, now = new Date(), signedMutation}) {
+  const normalizedSignedMutation = normalizeSignedSyncMutation(signedMutation)
+  const certificatePayload = await verifyDeviceCertificate({
+    backendPublicKey,
+    certificate: normalizedSignedMutation.deviceCertificate,
+    now
+  })
+
+  assertMutationMatchesCertificate({certificate: certificatePayload, mutation: normalizedSignedMutation.mutation})
+
+  const verified = await verifyStableJsonSignature({
+    publicKey: certificatePayload.devicePublicKey,
+    signature: normalizedSignedMutation.signature,
+    value: signedMutationSignatureValue({
+      deviceCertificate: normalizedSignedMutation.deviceCertificate,
+      mutation: normalizedSignedMutation.mutation
+    })
+  })
+
+  if (!verified) throw new Error("Sync mutation signature did not match")
+
+  return normalizedSignedMutation.mutation
+}
+
+/**
+ * Returns the replay/idempotency key for a signed mutation.
+ * @param {{mutation: {actorDeviceId?: unknown, actorUserId?: unknown, clientMutationId?: unknown}}} signedMutation - Signed mutation-like object.
+ * @returns {string} - Idempotency key.
+ */
+export function mutationIdempotencyKey(signedMutation) {
+  const mutation = signedMutation.mutation
+
+  return [
+    requiredString(mutation.actorUserId, "actorUserId"),
+    requiredString(mutation.actorDeviceId, "actorDeviceId"),
+    requiredString(mutation.clientMutationId, "clientMutationId")
+  ].join(":")
+}
+
+/**
+ * Builds the stable value signed by backend device certificates.
+ * @param {DeviceCertificatePayload} certificate - Certificate payload.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} - Stable signature value.
+ */
+function deviceCertificateSignatureValue(certificate) {
+  return {
+    algorithm: ECDSA_P256_SHA256_ALGORITHM,
+    certificate: /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (deterministicJsonObject({label: "certificate", value: certificate}))
+  }
+}
+
+/**
+ * Builds the stable value signed by sync mutations.
+ * @param {object} args - Arguments.
+ * @param {DeviceCertificate} args.deviceCertificate - Device certificate.
+ * @param {SyncMutation} args.mutation - Mutation payload.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} - Stable signature value.
+ */
+function signedMutationSignatureValue({deviceCertificate, mutation}) {
+  return {
+    algorithm: ECDSA_P256_SHA256_ALGORITHM,
+    deviceCertificate: /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (deterministicJsonObject({label: "deviceCertificate", value: deviceCertificate})),
+    mutation: /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (deterministicJsonObject({label: "mutation", value: mutation}))
+  }
+}
+
+/**
+ * Signs a deterministic JSON value with ECDSA P-256/SHA-256.
+ * @param {object} args - Arguments.
+ * @param {SyncJsonWebKey} args.privateKey - Private JWK.
+ * @param {unknown} args.value - Value to sign.
+ * @returns {Promise<string>} - Prefixed base64url signature.
+ */
+async function signStableJson({privateKey, value}) {
+  const key = await cryptoSubtle().importKey("jwk", privateKey, {name: "ECDSA", namedCurve: "P-256"}, false, ["sign"])
+  const signature = await cryptoSubtle().sign({hash: "SHA-256", name: "ECDSA"}, key, /** @type {BufferSource} */ (utf8(stableJsonStringify(value))))
+
+  return `${ECDSA_P256_SHA256_SIGNATURE_PREFIX}${base64UrlEncode(new Uint8Array(signature))}`
+}
+
+/**
+ * Verifies a deterministic JSON value with ECDSA P-256/SHA-256.
+ * @param {object} args - Arguments.
+ * @param {SyncJsonWebKey} args.publicKey - Public JWK.
+ * @param {string} args.signature - Prefixed base64url signature.
+ * @param {unknown} args.value - Value to verify.
+ * @returns {Promise<boolean>} - Whether the signature matches.
+ */
+async function verifyStableJsonSignature({publicKey, signature, value}) {
+  const key = await cryptoSubtle().importKey("jwk", publicKey, {name: "ECDSA", namedCurve: "P-256"}, false, ["verify"])
+  const signatureBytes = base64UrlDecode(signatureWithoutPrefix(signature))
+
+  return await cryptoSubtle().verify({hash: "SHA-256", name: "ECDSA"}, key, /** @type {BufferSource} */ (signatureBytes), /** @type {BufferSource} */ (utf8(stableJsonStringify(value))))
+}
+
+/**
+ * Normalizes a signed device certificate envelope.
+ * @param {DeviceCertificate} certificate - Signed certificate.
+ * @returns {DeviceCertificate} - Normalized certificate.
+ */
+function normalizeDeviceCertificate(certificate) {
+  if (!certificate || typeof certificate !== "object" || Array.isArray(certificate)) throw new Error("Expected device certificate object")
+  if (certificate.algorithm !== ECDSA_P256_SHA256_ALGORITHM) throw new Error(`Unsupported device certificate algorithm '${String(certificate.algorithm)}'`)
+
+  return {
+    algorithm: certificate.algorithm,
+    certificate: normalizeDeviceCertificatePayload(certificate.certificate),
+    signature: normalizeSignature(certificate.signature, "device certificate signature")
+  }
+}
+
+/**
+ * Normalizes a device certificate payload.
+ * @param {DeviceCertificatePayload} certificate - Certificate payload.
+ * @returns {DeviceCertificatePayload} - Normalized certificate payload.
+ */
+function normalizeDeviceCertificatePayload(certificate) {
+  if (!certificate || typeof certificate !== "object" || Array.isArray(certificate)) throw new Error("Expected device certificate payload object")
+
+  return {
+    actorDeviceId: requiredString(certificate.actorDeviceId, "actorDeviceId"),
+    actorUserId: requiredString(certificate.actorUserId, "actorUserId"),
+    certificateId: requiredString(certificate.certificateId, "certificateId"),
+    devicePublicKey: normalizeJwk(certificate.devicePublicKey, "devicePublicKey"),
+    expiresAt: isoDateString(new Date(requiredString(certificate.expiresAt, "expiresAt")), "expiresAt"),
+    issuedAt: isoDateString(new Date(requiredString(certificate.issuedAt, "issuedAt")), "issuedAt")
+  }
+}
+
+/**
+ * Normalizes a signed sync mutation envelope.
+ * @param {SignedSyncMutation} signedMutation - Signed mutation.
+ * @returns {SignedSyncMutation} - Normalized signed mutation.
+ */
+function normalizeSignedSyncMutation(signedMutation) {
+  if (!signedMutation || typeof signedMutation !== "object" || Array.isArray(signedMutation)) throw new Error("Expected signed sync mutation object")
+  if (signedMutation.algorithm !== ECDSA_P256_SHA256_ALGORITHM) throw new Error(`Unsupported sync mutation algorithm '${String(signedMutation.algorithm)}'`)
+
+  return {
+    algorithm: signedMutation.algorithm,
+    deviceCertificate: normalizeDeviceCertificate(signedMutation.deviceCertificate),
+    mutation: normalizeSyncMutation(signedMutation.mutation),
+    signature: normalizeSignature(signedMutation.signature, "sync mutation signature")
+  }
+}
+
+/**
+ * Normalizes a sync mutation payload.
+ * @param {SyncMutation} mutation - Mutation payload.
+ * @returns {SyncMutation} - Normalized mutation payload.
+ */
+function normalizeSyncMutation(mutation) {
+  if (!mutation || typeof mutation !== "object" || Array.isArray(mutation)) throw new Error("Expected sync mutation object")
+
+  /** @type {SyncMutation} */
+  const normalized = {
+    actorDeviceId: requiredString(mutation.actorDeviceId, "actorDeviceId"),
+    actorUserId: requiredString(mutation.actorUserId, "actorUserId"),
+    clientMutationId: requiredString(mutation.clientMutationId, "clientMutationId"),
+    model: requiredString(mutation.model, "model"),
+    occurredAt: isoDateString(new Date(requiredString(mutation.occurredAt, "occurredAt")), "occurredAt"),
+    offlineGrantId: requiredString(mutation.offlineGrantId, "offlineGrantId"),
+    operation: requiredString(mutation.operation, "operation"),
+    policyHash: requiredString(mutation.policyHash, "policyHash")
+  }
+
+  if (mutation.attributes !== undefined) normalized.attributes = deterministicJsonObject({label: "attributes", value: mutation.attributes})
+  if (mutation.baseVersion !== undefined) normalized.baseVersion = /** @type {string | number | null} */ (deterministicJson({label: "baseVersion", value: mutation.baseVersion}))
+  if (mutation.command !== undefined) normalized.command = requiredString(mutation.command, "command")
+  if (mutation.payload !== undefined) normalized.payload = deterministicJsonObject({label: "payload", value: mutation.payload})
+
+  return normalized
+}
+
+/**
+ * Asserts that mutation actor fields match the certificate actor.
+ * @param {object} args - Arguments.
+ * @param {DeviceCertificatePayload} args.certificate - Device certificate payload.
+ * @param {SyncMutation} args.mutation - Mutation payload.
+ * @returns {void} - No return value.
+ */
+function assertMutationMatchesCertificate({certificate, mutation}) {
+  if (mutation.actorDeviceId !== certificate.actorDeviceId || mutation.actorUserId !== certificate.actorUserId) {
+    throw new Error("Sync mutation actor does not match device certificate")
+  }
+}
+
+/**
+ * Asserts a timestamp is not expired.
+ * @param {object} args - Arguments.
+ * @param {string} args.expiresAt - Expiry timestamp.
+ * @param {string} args.label - Error label.
+ * @param {Date} args.now - Verification time.
+ * @returns {void} - No return value.
+ */
+function assertNotExpired({expiresAt, label, now}) {
+  if (Number.isNaN(now.getTime())) throw new Error("Invalid sync verification time")
+  if (new Date(expiresAt).getTime() <= now.getTime()) throw new Error(`${label} expired`)
+}
+
+/**
+ * Normalizes a JSON Web Key object.
+ * @param {SyncJsonWebKey} key - JWK.
+ * @param {string} label - Key label.
+ * @returns {SyncJsonWebKey} - Normalized JWK.
+ */
+function normalizeJwk(key, label) {
+  const normalized = deterministicJsonObject({label, value: key})
+
+  return /** @type {SyncJsonWebKey} */ (normalized)
+}
+
+/**
+ * Normalizes a prefixed signature string.
+ * @param {unknown} signature - Signature value.
+ * @param {string} label - Error label.
+ * @returns {string} - Signature string.
+ */
+function normalizeSignature(signature, label) {
+  if (typeof signature !== "string" || !signature.startsWith(ECDSA_P256_SHA256_SIGNATURE_PREFIX)) throw new Error(`Expected ${label}`)
+
+  return signature
+}
+
+/**
+ * Removes the signature prefix.
+ * @param {string} signature - Prefixed signature.
+ * @returns {string} - Base64url signature body.
+ */
+function signatureWithoutPrefix(signature) {
+  return signature.slice(ECDSA_P256_SHA256_SIGNATURE_PREFIX.length)
+}
+
+/**
+ * Requires a non-empty string field.
+ * @param {unknown} value - Value.
+ * @param {string} name - Field name.
+ * @returns {string} - String value.
+ */
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.length < 1) throw new Error(`Expected sync ${name}`)
+
+  return value
+}
+
+/**
+ * Normalizes a Date to an ISO timestamp.
+ * @param {Date} date - Date value.
+ * @param {string} label - Field label.
+ * @returns {string} - ISO timestamp.
+ */
+function isoDateString(date, label) {
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid sync ${label}`)
+
+  return date.toISOString()
+}
+
+/**
+ * Returns encoded UTF-8 bytes for a string.
+ * @param {string} value - String value.
+ * @returns {Uint8Array} - UTF-8 bytes.
+ */
+function utf8(value) {
+  return new TextEncoder().encode(value)
+}
+
+/**
+ * Returns WebCrypto subtle API.
+ * @returns {SubtleCrypto} - SubtleCrypto implementation.
+ */
+function cryptoSubtle() {
+  if (!globalThis.crypto?.subtle) throw new Error("WebCrypto subtle API is required for sync signing")
+
+  return globalThis.crypto.subtle
+}
+
+/**
+ * Base64url-encodes bytes.
+ * @param {Uint8Array} bytes - Bytes.
+ * @returns {string} - Base64url string.
+ */
+function base64UrlEncode(bytes) {
+  let binary = ""
+
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "")
+}
+
+/**
+ * Base64url-decodes bytes.
+ * @param {string} value - Base64url string.
+ * @returns {Uint8Array} - Bytes.
+ */
+function base64UrlDecode(value) {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=")
+  const binary = atob(base64)
+
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0))
+}
+
+/**
+ * Stable JSON stringifier with sorted object keys.
+ * @param {unknown} value - Value.
+ * @returns {string} - JSON string.
+ */
+function stableJsonStringify(value) {
+  return JSON.stringify(deterministicJson({label: "root", value}))
+}
+
+/**
+ * Normalizes a value as a JSON object.
+ * @param {object} args - Arguments.
+ * @param {string} args.label - Diagnostic label.
+ * @param {unknown} args.value - Value.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} - JSON object.
+ */
+function deterministicJsonObject({label, value}) {
+  const normalized = deterministicJson({label, value})
+
+  if (!normalized || typeof normalized !== "object" || Array.isArray(normalized)) throw new Error(`Expected sync ${label} object`)
+
+  return /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (normalized)
+}
+
+/**
+ * Normalizes deterministic JSON with sorted object keys.
+ * @param {object} args - Arguments.
+ * @param {string} args.label - Diagnostic label.
+ * @param {unknown} args.value - Value.
+ * @returns {import("../configuration-types.js").FrontendModelSyncJsonValue} - Normalized JSON value.
+ */
+function deterministicJson({label, value}) {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value
+
+  if (Array.isArray(value)) return value.map((entry, index) => deterministicJson({label: `${label}/${index}`, value: entry}))
+
+  if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+    /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */
+    const normalized = {}
+
+    for (const key of Object.keys(value).sort()) {
+      const childValue = /** @type {Record<string, unknown>} */ (value)[key]
+
+      if (childValue === undefined) continue
+      normalized[key] = deterministicJson({label: `${label}/${key}`, value: childValue})
+    }
+
+    return normalized
+  }
+
+  throw new Error(`Sync ${label} must be deterministic JSON`)
+}

--- a/src/sync/offline-grant.js
+++ b/src/sync/offline-grant.js
@@ -1,0 +1,327 @@
+// @ts-check
+
+const OFFLINE_GRANT_SIGNATURE_ALGORITHM = "HS256"
+const OFFLINE_GRANT_SIGNATURE_PREFIX = "hmac-sha256-"
+
+/**
+ * Signed offline grant envelope.
+ * @typedef {object} SignedOfflineGrant
+ * @property {"HS256"} algorithm - Signature algorithm.
+ * @property {OfflineGrant} grant - Signed grant payload.
+ * @property {string} keyId - Signing key id.
+ * @property {string} signature - Hex HMAC signature with a hmac-sha256 prefix.
+ */
+
+/**
+ * Backend-issued offline grant payload.
+ * @typedef {object} OfflineGrant
+ * @property {string} deviceId - Device id allowed to use the grant.
+ * @property {string} expiresAt - ISO timestamp after which replay must reject the grant.
+ * @property {string} grantId - Stable grant id.
+ * @property {string} issuedAt - ISO timestamp when the backend issued the grant.
+ * @property {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} resources - Sync manifest/materialized resource metadata.
+ * @property {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} scopes - Materialized grant scopes.
+ * @property {string} userId - Actor user id allowed to use the grant.
+ */
+
+/**
+ * Offline grant signing key.
+ * @typedef {object} OfflineGrantSigningKey
+ * @property {boolean} [current] - Whether this is the active key for new grants.
+ * @property {string} id - Public key id included in signed grant envelopes.
+ * @property {string} secret - Private HMAC secret. Never expose this to clients.
+ */
+
+/**
+ * Creates a signed offline grant envelope.
+ * @param {object} args - Arguments.
+ * @param {OfflineGrant} args.grant - Grant payload.
+ * @param {OfflineGrantSigningKey} args.signingKey - Current signing key.
+ * @returns {Promise<SignedOfflineGrant>} - Signed grant envelope.
+ */
+export async function createOfflineGrant({grant, signingKey}) {
+  const normalizedGrant = normalizeOfflineGrant(grant)
+  const normalizedSigningKey = normalizeOfflineGrantSigningKey(signingKey)
+  const signatureInput = offlineGrantSignatureInput({
+    algorithm: OFFLINE_GRANT_SIGNATURE_ALGORITHM,
+    grant: normalizedGrant,
+    keyId: normalizedSigningKey.id
+  })
+
+  return {
+    algorithm: OFFLINE_GRANT_SIGNATURE_ALGORITHM,
+    grant: normalizedGrant,
+    keyId: normalizedSigningKey.id,
+    signature: await hmacSha256Hex({message: signatureInput, secret: normalizedSigningKey.secret})
+  }
+}
+
+/**
+ * Verifies a signed offline grant and returns the trusted grant payload.
+ * @param {object} args - Arguments.
+ * @param {Date} [args.now] - Verification time. Defaults to current time.
+ * @param {SignedOfflineGrant} args.signedGrant - Signed grant envelope.
+ * @param {OfflineGrantSigningKey[]} args.signingKeys - Candidate verification keys.
+ * @returns {Promise<OfflineGrant>} - Verified grant payload.
+ */
+export async function verifyOfflineGrant({now = new Date(), signedGrant, signingKeys}) {
+  const normalizedSignedGrant = normalizeSignedOfflineGrant(signedGrant)
+
+  if (normalizedSignedGrant.algorithm !== OFFLINE_GRANT_SIGNATURE_ALGORITHM) {
+    throw new Error(`Unsupported offline grant signature algorithm '${normalizedSignedGrant.algorithm}'`)
+  }
+
+  const signingKey = signingKeys
+    .map((key) => normalizeOfflineGrantSigningKey(key))
+    .find((key) => key.id === normalizedSignedGrant.keyId)
+
+  if (!signingKey) throw new Error(`No offline grant signing key for key id '${normalizedSignedGrant.keyId}'`)
+
+  const expectedSignature = await hmacSha256Hex({
+    message: offlineGrantSignatureInput(normalizedSignedGrant),
+    secret: signingKey.secret
+  })
+
+  if (expectedSignature !== normalizedSignedGrant.signature) {
+    throw new Error("Offline grant signature did not match")
+  }
+
+  if (Number.isNaN(now.getTime())) throw new Error("Invalid offline grant verification time")
+  if (new Date(normalizedSignedGrant.grant.expiresAt).getTime() <= now.getTime()) throw new Error("Offline grant expired")
+
+  return normalizedSignedGrant.grant
+}
+
+/**
+ * Builds a signed grant from bootstrap request inputs.
+ * @param {object} args - Arguments.
+ * @param {string} args.deviceId - Device id.
+ * @param {string | undefined} [args.grantId] - Optional deterministic grant id for tests/custom callers.
+ * @param {number | undefined} [args.grantTtlMs] - Grant TTL in milliseconds.
+ * @param {Date} args.now - Issue time.
+ * @param {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} args.resources - Resource sync manifest.
+ * @param {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} args.scopes - Grant scopes.
+ * @param {OfflineGrantSigningKey} args.signingKey - Current signing key.
+ * @param {string} args.userId - Actor user id.
+ * @returns {Promise<SignedOfflineGrant>} - Signed grant.
+ */
+export async function createOfflineGrantFromBootstrap({deviceId, grantId, grantTtlMs, now, resources, scopes, signingKey, userId}) {
+  const issuedAt = isoDateString(now, "issuedAt")
+  const ttlMs = grantTtlMs === undefined ? 24 * 60 * 60 * 1000 : grantTtlMs
+
+  if (!Number.isInteger(ttlMs) || ttlMs <= 0) throw new Error("Offline grant TTL must be a positive integer number of milliseconds")
+
+  return await createOfflineGrant({
+    grant: {
+      deviceId,
+      expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+      grantId: grantId || randomGrantId(),
+      issuedAt,
+      resources,
+      scopes,
+      userId
+    },
+    signingKey
+  })
+}
+
+/**
+ * Normalizes signed grant signature input.
+ * @param {{algorithm: "HS256", grant: OfflineGrant, keyId: string}} signedGrant - Grant signature fields.
+ * @returns {string} - Stable signature input.
+ */
+function offlineGrantSignatureInput(signedGrant) {
+  return stableJsonStringify({
+    algorithm: signedGrant.algorithm,
+    grant: signedGrant.grant,
+    keyId: signedGrant.keyId
+  })
+}
+
+/**
+ * Normalizes a signed offline grant envelope.
+ * @param {SignedOfflineGrant} signedGrant - Signed grant.
+ * @returns {SignedOfflineGrant} - Normalized signed grant.
+ */
+function normalizeSignedOfflineGrant(signedGrant) {
+  if (!signedGrant || typeof signedGrant !== "object" || Array.isArray(signedGrant)) throw new Error("Expected signed offline grant object")
+  if (signedGrant.algorithm !== OFFLINE_GRANT_SIGNATURE_ALGORITHM) throw new Error(`Unsupported offline grant signature algorithm '${String(signedGrant.algorithm)}'`)
+  if (typeof signedGrant.keyId !== "string" || signedGrant.keyId.length < 1) throw new Error("Expected offline grant key id")
+  if (typeof signedGrant.signature !== "string" || !signedGrant.signature.match(/^hmac-sha256-[a-f0-9]{64}$/)) throw new Error("Expected offline grant signature")
+
+  return {
+    algorithm: signedGrant.algorithm,
+    grant: normalizeOfflineGrant(signedGrant.grant),
+    keyId: signedGrant.keyId,
+    signature: signedGrant.signature
+  }
+}
+
+/**
+ * Normalizes an offline grant payload.
+ * @param {OfflineGrant} grant - Grant payload.
+ * @returns {OfflineGrant} - Normalized grant payload.
+ */
+function normalizeOfflineGrant(grant) {
+  if (!grant || typeof grant !== "object" || Array.isArray(grant)) throw new Error("Expected offline grant object")
+
+  return {
+    deviceId: requiredString(grant.deviceId, "deviceId"),
+    expiresAt: isoDateString(new Date(requiredString(grant.expiresAt, "expiresAt")), "expiresAt"),
+    grantId: requiredString(grant.grantId, "grantId"),
+    issuedAt: isoDateString(new Date(requiredString(grant.issuedAt, "issuedAt")), "issuedAt"),
+    resources: deterministicJsonObject({label: "resources", value: grant.resources}),
+    scopes: deterministicJsonObject({label: "scopes", value: grant.scopes}),
+    userId: requiredString(grant.userId, "userId")
+  }
+}
+
+/**
+ * Normalizes an offline grant signing key.
+ * @param {OfflineGrantSigningKey} signingKey - Signing key.
+ * @returns {OfflineGrantSigningKey} - Normalized signing key.
+ */
+export function normalizeOfflineGrantSigningKey(signingKey) {
+  if (!signingKey || typeof signingKey !== "object" || Array.isArray(signingKey)) throw new Error("Expected offline grant signing key object")
+
+  return {
+    current: signingKey.current === true,
+    id: requiredString(signingKey.id, "signingKey.id"),
+    secret: requiredString(signingKey.secret, "signingKey.secret")
+  }
+}
+
+/**
+ * Returns the current key used to sign new grants.
+ * @param {OfflineGrantSigningKey[]} signingKeys - Configured signing keys.
+ * @returns {OfflineGrantSigningKey} - Current signing key.
+ */
+export function currentOfflineGrantSigningKey(signingKeys) {
+  const normalizedKeys = signingKeys.map((key) => normalizeOfflineGrantSigningKey(key))
+  const currentKeys = normalizedKeys.filter((key) => key.current === true)
+
+  if (normalizedKeys.length < 1) throw new Error("At least one offline grant signing key is required")
+  if (currentKeys.length > 1) throw new Error("Only one offline grant signing key can be current")
+
+  return currentKeys[0] || normalizedKeys[0]
+}
+
+/**
+ * Signs a message using HMAC-SHA256 and returns a prefixed hex signature.
+ * @param {object} args - Arguments.
+ * @param {string} args.message - Message to sign.
+ * @param {string} args.secret - HMAC secret.
+ * @returns {Promise<string>} - Prefixed hex signature.
+ */
+async function hmacSha256Hex({message, secret}) {
+  const cryptoProvider = globalThis.crypto
+
+  if (!cryptoProvider?.subtle) throw new Error("WebCrypto subtle API is required for offline grant signing")
+
+  const key = await cryptoProvider.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    {hash: "SHA-256", name: "HMAC"},
+    false,
+    ["sign"]
+  )
+  const signature = await cryptoProvider.subtle.sign("HMAC", key, new TextEncoder().encode(message))
+
+  return `${OFFLINE_GRANT_SIGNATURE_PREFIX}${hex(new Uint8Array(signature))}`
+}
+
+/**
+ * Converts bytes to lower-case hex.
+ * @param {Uint8Array} bytes - Bytes.
+ * @returns {string} - Hex string.
+ */
+function hex(bytes) {
+  return Array.from(bytes).map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}
+
+/**
+ * Requires a non-empty string field.
+ * @param {unknown} value - Value.
+ * @param {string} name - Field name.
+ * @returns {string} - String value.
+ */
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.length < 1) throw new Error(`Expected offline grant ${name}`)
+
+  return value
+}
+
+/**
+ * Normalizes a Date to an ISO timestamp.
+ * @param {Date} date - Date value.
+ * @param {string} label - Field label.
+ * @returns {string} - ISO timestamp.
+ */
+function isoDateString(date, label) {
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid offline grant ${label}`)
+
+  return date.toISOString()
+}
+
+/**
+ * Generates a fallback random grant id.
+ * @returns {string} - Grant id.
+ */
+function randomGrantId() {
+  return globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : `grant-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+/**
+ * Stable JSON stringifier with sorted object keys.
+ * @param {unknown} value - Value.
+ * @returns {string} - JSON string.
+ */
+function stableJsonStringify(value) {
+  return JSON.stringify(deterministicJson({label: "root", value}))
+}
+
+/**
+ * Normalizes a value as a JSON object.
+ * @param {object} args - Arguments.
+ * @param {string} args.label - Diagnostic label.
+ * @param {unknown} args.value - Value.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} - JSON object.
+ */
+function deterministicJsonObject({label, value}) {
+  const normalized = deterministicJson({label, value})
+
+  if (!normalized || typeof normalized !== "object" || Array.isArray(normalized)) throw new Error(`Expected offline grant ${label} object`)
+
+  return /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (normalized)
+}
+
+/**
+ * Normalizes deterministic JSON with sorted object keys.
+ * @param {object} args - Arguments.
+ * @param {string} args.label - Diagnostic label.
+ * @param {unknown} args.value - Value.
+ * @returns {import("../configuration-types.js").FrontendModelSyncJsonValue} - Normalized JSON value.
+ */
+function deterministicJson({label, value}) {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value
+
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => deterministicJson({label: `${label}/${index}`, value: entry}))
+  }
+
+  if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+    /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */
+    const normalized = {}
+
+    for (const key of Object.keys(value).sort()) {
+      const childValue = /** @type {Record<string, unknown>} */ (value)[key]
+
+      if (childValue === undefined) continue
+      normalized[key] = deterministicJson({label: `${label}/${key}`, value: childValue})
+    }
+
+    return normalized
+  }
+
+  throw new Error(`Offline grant ${label} must be deterministic JSON`)
+}


### PR DESCRIPTION
## Summary
- Add resource-level static sync policy metadata normalization
- Generate deterministic sha256 policy hashes while keeping policy internals hash-only
- Expose frontend-safe sync metadata in generated frontend model resourceConfig and a sync manifest helper
- Reject non-deterministic and secret-looking sync policy inputs
- Keep sync policy hashing Expo/browser bundle-safe without importing Node crypto
- Document sync policy metadata for shared/local/offline sync work

## Test Plan
- npm run typecheck
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/frontend-models/resource-definition-spec.js spec/cli/commands/generate/frontend-models-spec.js
- npm run eslint -- src/frontend-models/resource-definition.js src/frontend-model-resource/base-resource.js src/frontend-models/base.js src/environment-handlers/node/cli/commands/generate/frontend-models.js spec/frontend-models/resource-definition-spec.js spec/cli/commands/generate/frontend-models-spec.js
- npm run lint
- npm run test:expo
