### PR TITLE
Flush SQL.js truncation persistence

### DIFF
--- a/changelog.d/20260623193459-flush-sqljs-truncate-writes.md
+++ b/changelog.d/20260623193459-flush-sqljs-truncate-writes.md
@@ -1,0 +1,1 @@
+Flush pending SQL.js local persistence before `truncateAllTables()` resolves so immediate browser reloads see reset rows.

--- a/spec/database/drivers/sqlite/persistence-spec.js
+++ b/spec/database/drivers/sqlite/persistence-spec.js
@@ -1,0 +1,119 @@
+// @ts-check
+
+import Configuration from "../../../../src/configuration.js"
+import ConnectionSqlJs from "../../../../src/database/drivers/sqlite/connection-sql-js.js"
+import SqliteWebDriver from "../../../../src/database/drivers/sqlite/index.web.js"
+import initSqlJs from "sql.js"
+import path from "path"
+import {describe, expect, it} from "../../../../src/testing/test.js"
+import {fileURLToPath} from "url"
+
+const projectRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "../../../../")
+
+/**
+ * Test storage implementing the async persistence calls the SQL.js connection uses.
+ */
+class InMemorySqlJsStorage {
+  /** @type {Map<string, Uint8Array>} */
+  values = new Map()
+
+  /**
+   * @param {string} key - Storage key.
+   * @param {Uint8Array} value - Database bytes.
+   * @returns {Promise<void>} - Resolves when stored.
+   */
+  async set(key, value) {
+    this.values.set(key, new Uint8Array(value))
+  }
+
+  /**
+   * @param {string} key - Storage key.
+   * @returns {Promise<Uint8Array | undefined>} - Stored database bytes, if present.
+   */
+  async get(key) {
+    const value = this.values.get(key)
+
+    return value ? new Uint8Array(value) : undefined
+  }
+}
+
+/**
+ * @param {string} databaseName - SQL.js local storage database name.
+ * @returns {string} - SQL.js local storage key.
+ */
+function localStorageName(databaseName) {
+  return `VelociousDatabaseDriversSqliteWeb---${databaseName}`
+}
+
+/**
+ * @returns {Promise<import("sql.js").SqlJsStatic>} - SQL.js module.
+ */
+async function loadSqlJs() {
+  return await initSqlJs({
+    locateFile: (file) => path.join(projectRoot, "node_modules/sql.js/dist", file)
+  })
+}
+
+/**
+ * @param {object} args - Driver setup args.
+ * @param {import("sql.js").SqlJsStatic} args.SQL - SQL.js module.
+ * @param {string} args.databaseName - SQL.js local storage database name.
+ * @param {InMemorySqlJsStorage} args.storage - Persistence storage.
+ * @returns {Promise<SqliteWebDriver>} - Connected SQLite web driver.
+ */
+async function buildSqliteWebDriver({SQL, databaseName, storage}) {
+  const databaseContent = await storage.get(localStorageName(databaseName))
+  const driver = new SqliteWebDriver({name: databaseName}, Configuration.current())
+
+  driver.args = driver.getArgs()
+  driver.betterLocalStorage = /** @type {import("better-localstorage")} */ (storage)
+  driver._connection = new ConnectionSqlJs(driver, new SQL.Database(databaseContent))
+
+  return driver
+}
+
+/**
+ * @param {SqliteWebDriver} driver - SQLite web driver.
+ * @returns {Promise<number>} - Persisted test row count.
+ */
+async function persistedItemsCount(driver) {
+  const rows = await driver.query("SELECT COUNT(*) AS count FROM persisted_items")
+  const count = rows[0]?.count
+
+  if (typeof count !== "number") {
+    throw new Error(`Expected numeric persisted item count, got: ${typeof count}`)
+  }
+
+  return count
+}
+
+describe("database - sqlite web driver - persistence", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("persists truncateAllTables before it resolves so immediate reloads see reset rows", async () => {
+    const SQL = await loadSqlJs()
+    const databaseName = `sqlite-web-truncate-flush-${Date.now()}`
+    const storage = new InMemorySqlJsStorage()
+    let setupDriver, truncateDriver, reloadDriver
+
+    try {
+      setupDriver = await buildSqliteWebDriver({SQL, databaseName, storage})
+      await setupDriver.query("CREATE TABLE persisted_items(id INTEGER PRIMARY KEY, name TEXT)")
+      await setupDriver.query("INSERT INTO persisted_items(name) VALUES ('before truncate')")
+      await setupDriver.close()
+      setupDriver = undefined
+
+      truncateDriver = await buildSqliteWebDriver({SQL, databaseName, storage})
+
+      expect(await persistedItemsCount(truncateDriver)).toEqual(1)
+
+      await truncateDriver.truncateAllTables()
+
+      reloadDriver = await buildSqliteWebDriver({SQL, databaseName, storage})
+
+      expect(await persistedItemsCount(reloadDriver)).toEqual(0)
+    } finally {
+      if (reloadDriver) await reloadDriver.close()
+      if (truncateDriver) await truncateDriver.close()
+      if (setupDriver) await setupDriver.close()
+    }
+  })
+})

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -238,6 +238,14 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Flushes pending writes that the driver delayed for persistence.
+   * @returns {Promise<void>} - Resolves when pending writes are durable.
+   */
+  async flushPendingWrites() {
+    // No-op by default
+  }
+
+  /**
    * Runs set connection checkout name.
    * @param {string | undefined} name - Human-readable name for this active checkout.
    * @returns {Promise<void>} - Resolves when complete.
@@ -1504,6 +1512,7 @@ export default class VelociousDatabaseDriversBase {
         }
       }
     })
+    await this.flushPendingWrites()
   }
 
   /**

--- a/src/database/drivers/sqlite/connection-sql-js.js
+++ b/src/database/drivers/sqlite/connection-sql-js.js
@@ -18,6 +18,16 @@ export default class VelociousDatabaseDriversSqliteConnectionSqlJs {
     await this.saveDatabase()
     await this.connection.close()
   }
+
+  /**
+   * Flushes any debounced database save and waits until persistence is complete.
+   * @returns {Promise<void>} - Resolves when the current database bytes are stored.
+   */
+  async flushDatabaseSave() {
+    this.saveDatabaseDebounce.clear()
+    await this.saveDatabase()
+  }
+
   /**
    * Runs query.
    * @param {string} sql - SQL string.

--- a/src/database/drivers/sqlite/index.web.js
+++ b/src/database/drivers/sqlite/index.web.js
@@ -59,6 +59,18 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
   }
 
   /**
+   * Flushes pending SQL.js local persistence writes.
+   * @returns {Promise<void>} - Resolves when pending writes are durable.
+   */
+  async flushPendingWrites() {
+    if (!this.args?.getConnection) {
+      if (!this._connection) throw new Error("SQLite web connection has not been initialized")
+
+      await this._connection.flushDatabaseSave()
+    }
+  }
+
+  /**
    * Runs get connection.
    * @returns {ConnectionSqlJs | SqliteWebConnection} - The connection.
    */


### PR DESCRIPTION
## Summary
- flush pending SQL.js local persistence after successful `truncateAllTables()`
- persist SQL.js immediately by clearing the debounce and awaiting `saveDatabase()`
- add regression coverage for immediate reload after truncation

## Verification
- `npm run test -- spec/database/drivers/sqlite/persistence-spec.js` (failed before fix with stale row, passes after fix)
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `npm run build`
