### PR TITLE
feat(sync): add local mutation log

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * Migrations for schema changes and UTC datetime storage (see [docs/database-migrations.md](docs/database-migrations.md))
 * Controllers and views for HTTP endpoints
 * Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
+* Client-side offline sync mutation logs and frontend-model optimistic queueing primitives (see [docs/offline-sync.md](docs/offline-sync.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))
 * Gap-less positional lists with automatic reordering via `actsAsList` (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))

--- a/changelog.d/20260624065822-offline-sync-mutation-log.md
+++ b/changelog.d/20260624065822-offline-sync-mutation-log.md
@@ -1,0 +1,1 @@
+Add local offline sync mutation log primitives and frontend-model optimistic queueing for sync-enabled save/destroy operations.

--- a/changelog.d/20260624065822-offline-sync-mutation-log.md
+++ b/changelog.d/20260624065822-offline-sync-mutation-log.md
@@ -1,1 +1,1 @@
-Add local offline sync mutation log primitives and frontend-model optimistic queueing for sync-enabled save/destroy operations.
+Add row-oriented local offline sync mutation log primitives and frontend-model optimistic queueing for sync-enabled save/destroy operations.

--- a/docs/offline-sync.md
+++ b/docs/offline-sync.md
@@ -20,7 +20,7 @@ The storage adapter must expose:
 - `getItem(key)`
 - `setItem(key, value)`
 
-Both methods may be synchronous or async. Browser `localStorage`, AsyncStorage-style wrappers, and SQLite-backed wrappers can all be adapted.
+Both methods may be synchronous or async. Browser `localStorage`, AsyncStorage-style wrappers, and SQLite-backed wrappers can all be adapted. Writes are serialized per `storageKey` before the log reads, appends, and persists a new record so concurrent `append()` calls do not drop mutations or reuse the same sequence number.
 
 Each appended record contains:
 
@@ -61,6 +61,10 @@ Supported first-slice operations:
 - `destroy()` queues `destroy`.
 
 When a new record has no primary key yet, Velocious assigns the client mutation id as the temporary primary key and includes it in the mutation attributes. This gives later replay logic a stable id for create dependencies and temporary-id mapping.
+
+For persisted records, offline `update` mutations include the primary key alongside changed attributes so replay and conflict handling can identify the target row even though normal online updates carry the id outside `attributes`.
+
+Nested attributes and attachment payloads are not replayable in this first slice. If an offline `save()` includes either, Velocious rejects the offline save before queueing a mutation and leaves the nested/attachment pending state intact so the caller can retry online or with a later sync implementation.
 
 If the local sync policy does not list the operation, the write is rejected locally and no mutation is queued.
 

--- a/docs/offline-sync.md
+++ b/docs/offline-sync.md
@@ -10,17 +10,23 @@ Velocious has a client-side local mutation log for the first local-first/offline
 import LocalMutationLog from "velocious/build/src/sync/local-mutation-log.js"
 
 const mutationLog = new LocalMutationLog({
-  storage: window.localStorage,
+  storage: sqliteMutationLogStorage,
   storageKey: "my-app.sync.mutations"
 })
 ```
 
+The storage adapter is intentionally **row-oriented**. Do not store the entire log as one JSON blob: native devices have SQLite available and small devices should not have to parse/stringify a growing mutation history for every append.
+
 The storage adapter must expose:
 
-- `getItem(key)`
-- `setItem(key, value)`
+- `appendRecord(storageKey, record)`
+- `deleteRecords(storageKey, ids)`
+- `nextSequence(storageKey)`
+- `record(storageKey, id)`
+- `records(storageKey, options)`
+- `updateRecord(storageKey, record)`
 
-Both methods may be synchronous or async. Browser `localStorage`, AsyncStorage-style wrappers, and SQLite-backed wrappers can all be adapted. Writes are serialized per `storageKey` before the log reads, appends, and persists a new record so concurrent `append()` calls do not drop mutations or reuse the same sequence number.
+Methods may be synchronous or async. On native/Expo, back this with SQLite using one row per mutation and indexes on `storageKey`, `status`, and `sequence`. On web, use IndexedDB or another row/key-per-record store rather than `localStorage` as one growing blob. Writes are serialized per `storageKey` so concurrent `append()` calls do not drop mutations or reuse the same sequence number.
 
 Each appended record contains:
 
@@ -32,7 +38,7 @@ Each appended record contains:
 - `createdAt` / `updatedAt`.
 - optional `syncResult` for backend replay metadata.
 
-Use `pendingRecords()` to get records that still need reconciliation. Use `updateStatus(...)` after a replay, conflict, rejection, or successful sync.
+Use `pendingRecords()` to get records that still need reconciliation; storage adapters can service this through a status index rather than loading terminal history. Use `updateStatus(...)` after a replay, conflict, rejection, or successful sync. Use `compact(...)` after successful replay/sync to delete old terminal records while preserving pending/conflict records and records referenced by pending dependencies.
 
 ## Offline frontend-model writes
 

--- a/docs/offline-sync.md
+++ b/docs/offline-sync.md
@@ -1,0 +1,69 @@
+# Offline sync mutation log
+
+Velocious has a client-side local mutation log for the first local-first/offline write path. It is intentionally small and append-only: frontend code records what the user tried to do, applies the allowed change optimistically to the in-memory model instance, and leaves server replay/conflict resolution to later sync pipeline steps.
+
+## LocalMutationLog
+
+`LocalMutationLog` lives in `velocious/build/src/sync/local-mutation-log.js`.
+
+```js
+import LocalMutationLog from "velocious/build/src/sync/local-mutation-log.js"
+
+const mutationLog = new LocalMutationLog({
+  storage: window.localStorage,
+  storageKey: "my-app.sync.mutations"
+})
+```
+
+The storage adapter must expose:
+
+- `getItem(key)`
+- `setItem(key, value)`
+
+Both methods may be synchronous or async. Browser `localStorage`, AsyncStorage-style wrappers, and SQLite-backed wrappers can all be adapted.
+
+Each appended record contains:
+
+- `id`: local log record id.
+- `sequence`: monotonically increasing local replay order.
+- `status`: `pending`, `applied-locally`, `peer-applied`, `conflict`, `rejected`, or `synced`.
+- `mutation`: the device mutation payload with actor user/device, grant id, policy hash, base version, model, operation, attributes/payload, and occurred timestamp.
+- `dependencies`: optional create/temp-id dependencies that must replay first.
+- `createdAt` / `updatedAt`.
+- optional `syncResult` for backend replay metadata.
+
+Use `pendingRecords()` to get records that still need reconciliation. Use `updateStatus(...)` after a replay, conflict, rejection, or successful sync.
+
+## Offline frontend-model writes
+
+Frontend models can queue offline mutations by configuring transport-level offline sync:
+
+```js
+FrontendModelBase.configureTransport({
+  offlineSync: {
+    enabled: true,
+    mutationLog,
+    actorUserId: currentUser.id,
+    actorDeviceId: currentDevice.id,
+    offlineGrant: signedGrant.grant,
+    clientMutationId: () => crypto.randomUUID(),
+    now: () => new Date()
+  }
+})
+```
+
+A frontend model only queues locally when its generated `resourceConfig().sync` is enabled and the operation is listed in `sync.operations`.
+
+Supported first-slice operations:
+
+- `save()` on a new record queues `create`.
+- `save()` on a persisted record queues `update`.
+- `destroy()` queues `destroy`.
+
+When a new record has no primary key yet, Velocious assigns the client mutation id as the temporary primary key and includes it in the mutation attributes. This gives later replay logic a stable id for create dependencies and temporary-id mapping.
+
+If the local sync policy does not list the operation, the write is rejected locally and no mutation is queued.
+
+## Current boundaries
+
+This slice does not replay mutations to the backend, resolve conflicts, import peer logs, or persist frontend-model rows into app SQLite tables by itself. Those belong to the later server replay, change feed, conflict, P2P, and app integration tasks. The current contract is the durable local mutation log plus the optimistic frontend-model `save()`/`destroy()` queue path.

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -96,6 +96,70 @@ function buildOfflineSyncTestModelClass({operations}) {
 }
 
 /**
+ * @returns {typeof FrontendModelBase} - Offline sync attachment test model class.
+ */
+function buildOfflineAttachmentSyncTestModelClass() {
+  /** Offline sync frontend model with attachment definitions. */
+  class Task extends FrontendModelBase {
+    /** @returns {import("../../src/frontend-models/base.js").FrontendModelResourceConfig} - Resource configuration. */
+    static resourceConfig() {
+      return {
+        attachments: {descriptionFile: {type: "hasOne"}},
+        attributes: ["id", "name"],
+        commands: ["update"],
+        primaryKey: "id",
+        sync: {
+          enabled: true,
+          operations: ["update"],
+          policyHash: "sha256-task",
+          policyVersion: null
+        }
+      }
+    }
+  }
+
+  return Task
+}
+
+/**
+ * @returns {{Project: typeof FrontendModelBase}} - Offline sync nested test classes.
+ */
+function buildOfflineNestedSyncTestClasses() {
+  /** Offline nested sync child model. */
+  class Task extends FrontendModelBase {
+    /** @returns {import("../../src/frontend-models/base.js").FrontendModelResourceConfig} - Resource configuration. */
+    static resourceConfig() {
+      return {attributes: ["id", "projectId", "name"], primaryKey: "id"}
+    }
+  }
+
+  /** Offline nested sync parent model. */
+  class Project extends FrontendModelBase {
+    /** @returns {import("../../src/frontend-models/base.js").FrontendModelResourceConfig} - Resource configuration. */
+    static resourceConfig() {
+      return {
+        attributes: ["id", "name"],
+        commands: ["create"],
+        nestedAttributes: {tasks: {allowDestroy: true}},
+        primaryKey: "id",
+        sync: {
+          enabled: true,
+          operations: ["create"],
+          policyHash: "sha256-project",
+          policyVersion: null
+        }
+      }
+    }
+    /** @returns {Record<string, typeof FrontendModelBase>} */
+    static relationshipModelClasses() { return {tasks: Task} }
+    /** @returns {Record<string, {type: "hasMany"}>} */
+    static relationshipDefinitions() { return {tasks: {type: "hasMany"}} }
+  }
+
+  return {Project}
+}
+
+/**
  * @returns {typeof FrontendModelBase} - Test model with createdAt attribute.
  */
 function buildCreatedAtTestModelClass() {
@@ -2423,6 +2487,123 @@ describe("Frontend models - base", {databaseCleaning: {transaction: true}}, () =
     }
   })
 
+  it("offline update queues changed attributes with the primary key", async () => {
+    const User = buildOfflineSyncTestModelClass({operations: ["update"]})
+    const fetchStub = stubFetch({model: {email: "john@example.com", id: 5, name: "Network"}})
+    const mutationLog = new LocalMutationLog({
+      idGenerator: () => "log-1",
+      now: () => new Date("2026-06-24T10:00:00.000Z"),
+      storage: buildMemoryStorage()
+    })
+    const user = User.instantiateFromResponse({email: "john@example.com", id: 5, name: "John"})
+
+    try {
+      FrontendModelBase.configureTransport({
+        offlineSync: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          clientMutationId: () => "mutation-1",
+          enabled: true,
+          mutationLog,
+          now: () => new Date("2026-06-24T09:59:59.000Z"),
+          offlineGrant: {id: "grant-1"}
+        }
+      })
+      user.setAttribute("name", "Offline Renamed")
+
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([])
+      expect(user.isChanged()).toEqual(false)
+      expect((await mutationLog.records())[0].mutation).toEqual({
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        attributes: {id: 5, name: "Offline Renamed"},
+        baseVersion: null,
+        clientMutationId: "mutation-1",
+        model: "User",
+        occurredAt: "2026-06-24T09:59:59.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        policyHash: "sha256-user"
+      })
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("offline save rejects nested attributes without clearing queued nested state", async () => {
+    const {Project} = buildOfflineNestedSyncTestClasses()
+    const fetchStub = stubFetch({model: {id: 7, name: "Launch"}})
+    const mutationLog = new LocalMutationLog({storage: buildMemoryStorage()})
+    const project = new Project({name: "Launch"})
+    project.getRelationshipByName("tasks").build({name: "Design"})
+
+    try {
+      FrontendModelBase.configureTransport({
+        offlineSync: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          enabled: true,
+          mutationLog,
+          offlineGrant: {id: "grant-1"}
+        }
+      })
+
+      await expect(async () => {
+        await project.save()
+      }).toThrow("Offline sync for Project does not support nested attributes or attachments yet")
+      expect(await mutationLog.records()).toEqual([])
+
+      FrontendModelBase.configureTransport({offlineSync: undefined})
+      await project.save()
+
+      expect(fetchStub.calls[0].body.nestedAttributes).toEqual({tasks: [{attributes: {name: "Design"}}]})
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("offline save rejects attachments without clearing queued attachment state", async () => {
+    const Task = buildOfflineAttachmentSyncTestModelClass()
+    const fetchStub = stubFetch({model: {id: 5, name: "Task"}})
+    const mutationLog = new LocalMutationLog({storage: buildMemoryStorage()})
+    const task = Task.instantiateFromResponse({id: 5, name: "Task"})
+
+    try {
+      FrontendModelBase.configureTransport({
+        offlineSync: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          enabled: true,
+          mutationLog,
+          offlineGrant: {id: "grant-1"}
+        }
+      })
+
+      await expect(async () => {
+        await task.update({descriptionFile: {contentBase64: "YQ==", filename: "a.txt"}})
+      }).toThrow("Offline sync for Task does not support nested attributes or attachments yet")
+      expect(await mutationLog.records()).toEqual([])
+
+      FrontendModelBase.configureTransport({offlineSync: undefined})
+      await task.save()
+
+      expect(fetchStub.calls[0].body.attachments).toEqual({
+        descriptionFile: {
+          contentBase64: "YQ==",
+          contentType: null,
+          filename: "a.txt"
+        }
+      })
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
   it("offline save rejects writes not allowed by the local sync policy", async () => {
     const User = buildOfflineSyncTestModelClass({operations: ["find", "index"]})
     const mutationLog = new LocalMutationLog({storage: buildMemoryStorage()})
@@ -2439,14 +2620,9 @@ describe("Frontend models - base", {databaseCleaning: {transaction: true}}, () =
         }
       })
 
-      let error
-      try {
+      await expect(async () => {
         await user.save()
-      } catch (caughtError) {
-        error = caughtError
-      }
-
-      expect(error.message).toEqual("Offline sync for User does not allow create")
+      }).toThrow("Offline sync for User does not allow create")
       expect(await mutationLog.records()).toEqual([])
     } finally {
       resetFrontendModelTransport()

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -2,6 +2,7 @@
 
 import {describe, expect, it} from "../../src/testing/test.js"
 import FrontendModelBase, {AttributeNotSelectedError} from "../../src/frontend-models/base.js"
+import LocalMutationLog from "../../src/sync/local-mutation-log.js"
 import {buildPreloadTestModelClasses, resetFrontendModelTransport, stubFrontendModelFetch} from "../helpers/frontend-model-test-helpers.js"
 
 /** @typedef {{body: Record<string, any>, url: string}} FetchCall */
@@ -60,6 +61,35 @@ function buildTestModelClass() {
      * @returns {any}
      */
     setUserId(newValue) { return this.setAttribute("userId", newValue) }
+  }
+
+  return User
+}
+
+/**
+ * @param {{operations: string[]}} args - Sync configuration args.
+ * @returns {typeof FrontendModelBase} - Offline sync test frontend model class.
+ */
+function buildOfflineSyncTestModelClass({operations}) {
+  /** Test model implementation for offline sync specs. */
+  class User extends FrontendModelBase {
+    /** @returns {{attributes: string[], commands: string[], primaryKey: string, sync: {enabled: boolean, operations: string[], policyHash: string, policyVersion: string | null}}} - Resource configuration. */
+    static resourceConfig() {
+      return {
+        attributes: ["id", "name", "email", "userId"],
+        commands: ["create", "destroy", "find", "index", "update"],
+        primaryKey: "id",
+        sync: {
+          enabled: true,
+          operations,
+          policyHash: "sha256-user",
+          policyVersion: null
+        }
+      }
+    }
+
+    /** @returns {any} */
+    id() { return this.readAttribute("id") }
   }
 
   return User
@@ -190,6 +220,23 @@ function buildCustomPrimaryKeyTestModelClass() {
 function restoreFrontendModelFetch(fetchStub) {
   resetFrontendModelTransport()
   fetchStub.restore()
+}
+
+function buildMemoryStorage() {
+  const values = new Map()
+
+  return {
+    getItem: async (key) => values.get(key) || null,
+    setItem: async (key, value) => {
+      values.set(key, value)
+    }
+  }
+}
+
+function nextNow(values) {
+  let index = 0
+
+  return () => new Date(values[index++] || values[values.length - 1])
 }
 
 /**
@@ -2315,6 +2362,143 @@ describe("Frontend models - base", {databaseCleaning: {transaction: true}}, () =
       expect(user.isPersisted()).toEqual(true)
       expect(user.id()).toEqual(7)
       expect(user.isChanged()).toEqual(false)
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("offline save queues a local create mutation and applies optimistic persisted state without network", async () => {
+    const User = buildOfflineSyncTestModelClass({operations: ["create", "update", "destroy"]})
+    const fetchStub = stubFetch({model: {email: "network@example.com", id: 99, name: "Network"}})
+    const mutationLog = new LocalMutationLog({
+      idGenerator: () => "log-1",
+      now: nextNow(["2026-06-24T10:00:00.000Z"]),
+      storage: buildMemoryStorage()
+    })
+    const user = new User({email: "offline@example.com", name: "Offline"})
+
+    try {
+      FrontendModelBase.configureTransport({
+        offlineSync: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          clientMutationId: () => "mutation-1",
+          enabled: true,
+          mutationLog,
+          now: () => new Date("2026-06-24T09:59:59.000Z"),
+          offlineGrant: {id: "grant-1"}
+        }
+      })
+
+      await user.save()
+
+      expect(fetchStub.calls).toEqual([])
+      expect(user.isNewRecord()).toEqual(false)
+      expect(user.id()).toEqual("mutation-1")
+      expect(user.isChanged()).toEqual(false)
+      expect(await mutationLog.records()).toEqual([{
+        createdAt: "2026-06-24T10:00:00.000Z",
+        dependencies: [],
+        id: "log-1",
+        mutation: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          attributes: {email: "offline@example.com", id: "mutation-1", name: "Offline"},
+          baseVersion: null,
+          clientMutationId: "mutation-1",
+          model: "User",
+          occurredAt: "2026-06-24T09:59:59.000Z",
+          offlineGrantId: "grant-1",
+          operation: "create",
+          policyHash: "sha256-user"
+        },
+        sequence: 1,
+        status: "pending",
+        updatedAt: "2026-06-24T10:00:00.000Z"
+      }])
+    } finally {
+      resetFrontendModelTransport()
+      fetchStub.restore()
+    }
+  })
+
+  it("offline save rejects writes not allowed by the local sync policy", async () => {
+    const User = buildOfflineSyncTestModelClass({operations: ["find", "index"]})
+    const mutationLog = new LocalMutationLog({storage: buildMemoryStorage()})
+    const user = new User({email: "offline@example.com", name: "Offline"})
+
+    try {
+      FrontendModelBase.configureTransport({
+        offlineSync: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          enabled: true,
+          mutationLog,
+          offlineGrant: {id: "grant-1"}
+        }
+      })
+
+      let error
+      try {
+        await user.save()
+      } catch (caughtError) {
+        error = caughtError
+      }
+
+      expect(error.message).toEqual("Offline sync for User does not allow create")
+      expect(await mutationLog.records()).toEqual([])
+    } finally {
+      resetFrontendModelTransport()
+    }
+  })
+
+  it("offline destroy queues a local destroy mutation without network", async () => {
+    const User = buildOfflineSyncTestModelClass({operations: ["destroy"]})
+    const fetchStub = stubFetch({status: "success"})
+    const mutationLog = new LocalMutationLog({
+      idGenerator: () => "log-1",
+      now: () => new Date("2026-06-24T10:00:00.000Z"),
+      storage: buildMemoryStorage()
+    })
+    const user = User.instantiateFromResponse({email: "john@example.com", id: 5, name: "John"})
+
+    try {
+      FrontendModelBase.configureTransport({
+        offlineSync: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          clientMutationId: () => "mutation-1",
+          enabled: true,
+          mutationLog,
+          now: () => new Date("2026-06-24T09:59:59.000Z"),
+          offlineGrant: {id: "grant-1"}
+        }
+      })
+
+      await user.destroy()
+
+      expect(fetchStub.calls).toEqual([])
+      expect(await mutationLog.records()).toEqual([{
+        createdAt: "2026-06-24T10:00:00.000Z",
+        dependencies: [],
+        id: "log-1",
+        mutation: {
+          actorDeviceId: "device-1",
+          actorUserId: "user-1",
+          attributes: {id: 5},
+          baseVersion: null,
+          clientMutationId: "mutation-1",
+          model: "User",
+          occurredAt: "2026-06-24T09:59:59.000Z",
+          offlineGrantId: "grant-1",
+          operation: "destroy",
+          policyHash: "sha256-user"
+        },
+        sequence: 1,
+        status: "pending",
+        updatedAt: "2026-06-24T10:00:00.000Z"
+      }])
     } finally {
       resetFrontendModelTransport()
       fetchStub.restore()

--- a/spec/frontend-models/base-spec.js
+++ b/spec/frontend-models/base-spec.js
@@ -287,12 +287,45 @@ function restoreFrontendModelFetch(fetchStub) {
 }
 
 function buildMemoryStorage() {
-  const values = new Map()
+  const recordsByKey = new Map()
+
+  function recordsFor(storageKey) {
+    if (!recordsByKey.has(storageKey)) recordsByKey.set(storageKey, [])
+
+    return recordsByKey.get(storageKey)
+  }
 
   return {
-    getItem: async (key) => values.get(key) || null,
-    setItem: async (key, value) => {
-      values.set(key, value)
+    appendRecord: async (storageKey, record) => {
+      recordsFor(storageKey).push(JSON.parse(JSON.stringify(record)))
+    },
+    deleteRecords: async (storageKey, ids) => {
+      const idSet = new Set(ids)
+      recordsByKey.set(storageKey, recordsFor(storageKey).filter((record) => !idSet.has(record.id)))
+    },
+    nextSequence: async (storageKey) => recordsFor(storageKey).reduce((max, record) => Math.max(max, record.sequence + 1), 1),
+    record: async (storageKey, id) => {
+      const record = recordsFor(storageKey).find((candidate) => candidate.id === id)
+
+      return record ? JSON.parse(JSON.stringify(record)) : null
+    },
+    records: async (storageKey, options = {}) => {
+      let records = recordsFor(storageKey)
+
+      if (options.statuses) {
+        const statuses = new Set(options.statuses)
+        records = records.filter((record) => statuses.has(record.status))
+      }
+
+      return records.map((record) => JSON.parse(JSON.stringify(record)))
+    },
+    updateRecord: async (storageKey, record) => {
+      const rows = recordsFor(storageKey)
+      const index = rows.findIndex((candidate) => candidate.id === record.id)
+
+      if (index === -1) throw new Error(`No record ${record.id}`)
+
+      rows[index] = JSON.parse(JSON.stringify(record))
     }
   }
 }

--- a/spec/helpers/frontend-model-test-helpers.js
+++ b/spec/helpers/frontend-model-test-helpers.js
@@ -148,7 +148,7 @@ export function stubFrontendModelFetchWith(responders) {
 
 /** @returns {void} */
 export function resetFrontendModelTransport() {
-  FrontendModelBase.configureTransport({shared: undefined, url: undefined, websocketClient: undefined})
+  FrontendModelBase.configureTransport({offlineSync: undefined, shared: undefined, url: undefined, websocketClient: undefined})
 }
 
 /**

--- a/spec/sync/local-mutation-log-spec.js
+++ b/spec/sync/local-mutation-log-spec.js
@@ -83,6 +83,29 @@ describe("local sync mutation log", () => {
     })
     expect(await mutationLog.pendingRecords()).toEqual([])
   })
+
+  it("serializes concurrent appends so no mutation is lost", async () => {
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({
+      idGenerator: nextValue(["log-1", "log-2"]),
+      now: nextNow(["2026-06-24T10:00:00.000Z", "2026-06-24T10:00:01.000Z"]),
+      storage
+    })
+
+    await Promise.all([
+      mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-1"})}),
+      mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-2"})})
+    ])
+
+    expect((await mutationLog.records()).map((record) => ({
+      clientMutationId: record.mutation.clientMutationId,
+      id: record.id,
+      sequence: record.sequence
+    }))).toEqual([
+      {clientMutationId: "mutation-1", id: "log-1", sequence: 1},
+      {clientMutationId: "mutation-2", id: "log-2", sequence: 2}
+    ])
+  })
 })
 
 function buildMutation(overrides = {}) {
@@ -114,4 +137,10 @@ function nextNow(values) {
   let index = 0
 
   return () => new Date(values[index++] || values[values.length - 1])
+}
+
+function nextValue(values) {
+  let index = 0
+
+  return () => values[index++] || values[values.length - 1]
 }

--- a/spec/sync/local-mutation-log-spec.js
+++ b/spec/sync/local-mutation-log-spec.js
@@ -1,0 +1,117 @@
+import {describe, expect, it} from "../../src/testing/test.js"
+import LocalMutationLog from "../../src/sync/local-mutation-log.js"
+
+describe("local sync mutation log", () => {
+  it("appends pending mutations with actor device grant policy and dependency metadata", async () => {
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({
+      idGenerator: () => "log-1",
+      now: () => new Date("2026-06-24T10:00:00.000Z"),
+      storage
+    })
+
+    const record = await mutationLog.append({
+      dependencies: [{clientMutationId: "parent-1", model: "Project"}],
+      mutation: {
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        attributes: {name: "Offline task"},
+        baseVersion: "v1",
+        clientMutationId: "mutation-1",
+        model: "Task",
+        occurredAt: "2026-06-24T09:59:59.000Z",
+        offlineGrantId: "grant-1",
+        operation: "create",
+        policyHash: "sha256-task"
+      }
+    })
+
+    expect(record).toEqual({
+      createdAt: "2026-06-24T10:00:00.000Z",
+      dependencies: [{clientMutationId: "parent-1", model: "Project"}],
+      id: "log-1",
+      mutation: {
+        actorDeviceId: "device-1",
+        actorUserId: "user-1",
+        attributes: {name: "Offline task"},
+        baseVersion: "v1",
+        clientMutationId: "mutation-1",
+        model: "Task",
+        occurredAt: "2026-06-24T09:59:59.000Z",
+        offlineGrantId: "grant-1",
+        operation: "create",
+        policyHash: "sha256-task"
+      },
+      sequence: 1,
+      status: "pending",
+      updatedAt: "2026-06-24T10:00:00.000Z"
+    })
+    expect(await mutationLog.records()).toEqual([record])
+  })
+
+  it("persists pending mutations across new log instances", async () => {
+    const storage = buildMemoryStorage()
+    const firstLog = new LocalMutationLog({idGenerator: () => "log-1", storage})
+
+    await firstLog.append({mutation: buildMutation({clientMutationId: "mutation-1"})})
+
+    const reloadedLog = new LocalMutationLog({storage})
+
+    expect((await reloadedLog.pendingRecords()).map((record) => record.mutation.clientMutationId)).toEqual(["mutation-1"])
+  })
+
+  it("updates mutation status without rewriting the original actor payload", async () => {
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({
+      idGenerator: () => "log-1",
+      now: nextNow(["2026-06-24T10:00:00.000Z", "2026-06-24T10:01:00.000Z"]),
+      storage
+    })
+    const original = await mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-1"})})
+
+    const updated = await mutationLog.updateStatus({
+      id: original.id,
+      status: "synced",
+      syncResult: {serverSequence: 42}
+    })
+
+    expect(updated).toEqual({
+      ...original,
+      status: "synced",
+      syncResult: {serverSequence: 42},
+      updatedAt: "2026-06-24T10:01:00.000Z"
+    })
+    expect(await mutationLog.pendingRecords()).toEqual([])
+  })
+})
+
+function buildMutation(overrides = {}) {
+  return {
+    actorDeviceId: "device-1",
+    actorUserId: "user-1",
+    attributes: {name: "Offline task"},
+    baseVersion: null,
+    clientMutationId: "mutation-1",
+    model: "Task",
+    occurredAt: "2026-06-24T09:59:59.000Z",
+    offlineGrantId: "grant-1",
+    operation: "create",
+    policyHash: "sha256-task",
+    ...overrides
+  }
+}
+
+function buildMemoryStorage() {
+  const values = new Map()
+
+  return {
+    getItem: async (key) => values.get(key) || null,
+    setItem: async (key, value) => values.set(key, value)
+  }
+}
+
+function nextNow(values) {
+  let index = 0
+
+  return () => new Date(values[index++] || values[values.length - 1])
+}

--- a/spec/sync/local-mutation-log-spec.js
+++ b/spec/sync/local-mutation-log-spec.js
@@ -47,9 +47,10 @@ describe("local sync mutation log", () => {
       updatedAt: "2026-06-24T10:00:00.000Z"
     })
     expect(await mutationLog.records()).toEqual([record])
+    expect(storage.calls.map((call) => call.method)).toEqual(["nextSequence", "appendRecord", "records"])
   })
 
-  it("persists pending mutations across new log instances", async () => {
+  it("persists pending mutations across new log instances without one JSON blob", async () => {
     const storage = buildMemoryStorage()
     const firstLog = new LocalMutationLog({idGenerator: () => "log-1", storage})
 
@@ -58,6 +59,7 @@ describe("local sync mutation log", () => {
     const reloadedLog = new LocalMutationLog({storage})
 
     expect((await reloadedLog.pendingRecords()).map((record) => record.mutation.clientMutationId)).toEqual(["mutation-1"])
+    expect(storage.calls.some((call) => call.method === "getItem" || call.method === "setItem")).toEqual(false)
   })
 
   it("updates mutation status without rewriting the original actor payload", async () => {
@@ -84,6 +86,22 @@ describe("local sync mutation log", () => {
     expect(await mutationLog.pendingRecords()).toEqual([])
   })
 
+  it("asks storage for pending statuses instead of loading all terminal records", async () => {
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({idGenerator: nextValue(["log-1", "log-2"]), storage})
+
+    const pending = await mutationLog.append({mutation: buildMutation({clientMutationId: "pending-1"})})
+    const synced = await mutationLog.append({mutation: buildMutation({clientMutationId: "synced-1"})})
+    await mutationLog.updateStatus({id: synced.id, status: "synced"})
+
+    expect(await mutationLog.pendingRecords()).toEqual([pending])
+    expect(storage.calls[storage.calls.length - 1]).toEqual({
+      method: "records",
+      options: {statuses: ["pending", "applied-locally", "peer-applied"]},
+      storageKey: "velocious.sync.localMutationLog"
+    })
+  })
+
   it("serializes concurrent appends so no mutation is lost", async () => {
     const storage = buildMemoryStorage()
     const mutationLog = new LocalMutationLog({
@@ -106,6 +124,39 @@ describe("local sync mutation log", () => {
       {clientMutationId: "mutation-2", id: "log-2", sequence: 2}
     ])
   })
+
+  it("compacts old terminal records while preserving pending dependencies", async () => {
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({
+      idGenerator: nextValue(["log-1", "log-2", "log-3", "log-4"]),
+      now: nextNow([
+        "2026-06-24T10:00:00.000Z",
+        "2026-06-24T10:00:01.000Z",
+        "2026-06-24T10:00:02.000Z",
+        "2026-06-24T10:00:03.000Z",
+        "2026-06-24T10:00:04.000Z",
+        "2026-06-24T10:00:05.000Z",
+        "2026-06-24T10:00:06.000Z"
+      ]),
+      storage
+    })
+    const dependency = await mutationLog.append({mutation: buildMutation({clientMutationId: "dependency-1"})})
+    const prunable = await mutationLog.append({mutation: buildMutation({clientMutationId: "prunable-1"})})
+    const newestTerminal = await mutationLog.append({mutation: buildMutation({clientMutationId: "newest-1"})})
+    const pending = await mutationLog.append({
+      dependencies: [{clientMutationId: "dependency-1", model: "Task"}],
+      mutation: buildMutation({clientMutationId: "pending-1"})
+    })
+
+    await mutationLog.updateStatus({id: dependency.id, status: "synced"})
+    await mutationLog.updateStatus({id: prunable.id, status: "synced"})
+    await mutationLog.updateStatus({id: newestTerminal.id, status: "synced"})
+
+    const result = await mutationLog.compact({maxTerminalRecords: 1})
+
+    expect(result.deletedRecordIds).toEqual([prunable.id])
+    expect((await mutationLog.records()).map((record) => record.id)).toEqual([dependency.id, newestTerminal.id, pending.id])
+  })
 })
 
 function buildMutation(overrides = {}) {
@@ -125,11 +176,57 @@ function buildMutation(overrides = {}) {
 }
 
 function buildMemoryStorage() {
-  const values = new Map()
+  const recordsByKey = new Map()
+  const calls = []
+
+  function recordsFor(storageKey) {
+    if (!recordsByKey.has(storageKey)) recordsByKey.set(storageKey, [])
+
+    return recordsByKey.get(storageKey)
+  }
 
   return {
-    getItem: async (key) => values.get(key) || null,
-    setItem: async (key, value) => values.set(key, value)
+    calls,
+    appendRecord: async (storageKey, record) => {
+      calls.push({method: "appendRecord", record, storageKey})
+      recordsFor(storageKey).push(JSON.parse(JSON.stringify(record)))
+    },
+    deleteRecords: async (storageKey, ids) => {
+      calls.push({ids, method: "deleteRecords", storageKey})
+      const idSet = new Set(ids)
+      recordsByKey.set(storageKey, recordsFor(storageKey).filter((record) => !idSet.has(record.id)))
+    },
+    nextSequence: async (storageKey) => {
+      calls.push({method: "nextSequence", storageKey})
+
+      return recordsFor(storageKey).reduce((max, record) => Math.max(max, record.sequence + 1), 1)
+    },
+    record: async (storageKey, id) => {
+      calls.push({id, method: "record", storageKey})
+      const record = recordsFor(storageKey).find((candidate) => candidate.id === id)
+
+      return record ? JSON.parse(JSON.stringify(record)) : null
+    },
+    records: async (storageKey, options = {}) => {
+      calls.push({method: "records", options, storageKey})
+      let records = recordsFor(storageKey)
+
+      if (options.statuses) {
+        const statuses = new Set(options.statuses)
+        records = records.filter((record) => statuses.has(record.status))
+      }
+
+      return records.map((record) => JSON.parse(JSON.stringify(record)))
+    },
+    updateRecord: async (storageKey, record) => {
+      calls.push({method: "updateRecord", record, storageKey})
+      const rows = recordsFor(storageKey)
+      const index = rows.findIndex((candidate) => candidate.id === record.id)
+
+      if (index === -1) throw new Error(`No record ${record.id}`)
+
+      rows[index] = JSON.parse(JSON.stringify(record))
+    }
   }
 }
 

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -4003,6 +4003,12 @@ export default class FrontendModelBase {
           this.setAttribute(primaryKey, clientMutationId)
           offlineAttributes[primaryKey] = clientMutationId
         }
+      } else {
+        offlineAttributes[ModelClass.primaryKey()] = payload.id
+      }
+
+      if (payload.nestedAttributes !== undefined || payload.attachments !== undefined) {
+        throw new Error(`Offline sync for ${ModelClass.name} does not support nested attributes or attachments yet`)
       }
 
       await queueFrontendModelMutationOffline({

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -112,6 +112,7 @@ import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQuer
  * @property {Record<string, string> | (() => Record<string, string>)} [requestHeaders] - Extra HTTP/WS headers to attach to every frontend-model API request. Pass a function to compute them at request time (for example to include the current locale).
  * @property {{get: () => string | null | undefined | Promise<string | null | undefined>, set: (sessionId: string) => void | Promise<void>, clear: () => void | Promise<void>}} [sessionStore] - Optional sessionId persistence hook forwarded to the internal `VelociousWebsocketClient` so WS sessions can be resumed across page reloads / app restarts.
  * @property {string | (() => string | null | undefined)} [timeZone] - IANA timezone sent with every frontend-model API request for timezone-less datetime parsing.
+ * @property {{actorDeviceId: string, actorUserId: string, clientMutationId?: () => string, enabled?: boolean, mutationLog: import("../sync/local-mutation-log.js").default, now?: () => Date, offlineGrant: {id: string}}} [offlineSync] - Offline mutation queue configuration.
  */
 /**
  * FrontendModelIdleWaitArgs type.
@@ -783,6 +784,89 @@ function frontendModelClassFor(model) {
   const constructorValue = model.constructor
 
   return /** @type {FrontendModelClass} */ (constructorValue)
+}
+
+/**
+ * Whether the configured offline queue should handle a model operation.
+ * @param {FrontendModelClass} ModelClass - Model class.
+ * @param {"create" | "update" | "destroy"} operation - Sync operation.
+ * @returns {boolean} - Whether to queue locally.
+ */
+function shouldQueueFrontendModelOperationOffline(ModelClass, operation) {
+  const offlineSync = frontendModelTransportConfig.offlineSync
+
+  if (!offlineSync?.enabled) return false
+
+  const syncConfig = ModelClass.resourceConfig().sync
+
+  if (!syncConfig?.enabled) return false
+  if (!syncConfig.operations.includes(operation)) throw new Error(`Offline sync for ${ModelClass.getModelName()} does not allow ${operation}`)
+
+  return true
+}
+
+/**
+ * Queues an offline sync mutation.
+ * @param {object} args - Arguments.
+ * @param {Record<string, FrontendModelAttributeValue>} args.attributes - Mutation attributes.
+ * @param {string} [args.clientMutationId] - Pre-generated mutation id.
+ * @param {FrontendModelClass} args.ModelClass - Model class.
+ * @param {"create" | "update" | "destroy"} args.operation - Sync operation.
+ * @returns {Promise<string>} - Client mutation id.
+ */
+async function queueFrontendModelMutationOffline({attributes, clientMutationId: providedClientMutationId, ModelClass, operation}) {
+  const offlineSync = frontendModelTransportConfig.offlineSync
+
+  if (!offlineSync) throw new Error("Offline sync is not configured")
+
+  const syncConfig = ModelClass.resourceConfig().sync
+  if (!syncConfig?.enabled) throw new Error(`Offline sync is not enabled for ${ModelClass.getModelName()}`)
+
+  const now = offlineSync.now ? offlineSync.now() : new Date()
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error("offlineSync.now must return a valid Date")
+
+  const clientMutationId = providedClientMutationId || (offlineSync.clientMutationId ? offlineSync.clientMutationId() : frontendModelOfflineMutationId())
+  if (typeof clientMutationId !== "string" || clientMutationId.length < 1) throw new Error("offlineSync.clientMutationId must return a non-empty string")
+
+  await offlineSync.mutationLog.append({
+    mutation: {
+      actorDeviceId: offlineSync.actorDeviceId,
+      actorUserId: offlineSync.actorUserId,
+      attributes: frontendModelSyncJsonObject(attributes),
+      baseVersion: null,
+      clientMutationId,
+      model: ModelClass.getModelName(),
+      occurredAt: now.toISOString(),
+      offlineGrantId: offlineSync.offlineGrant.id,
+      operation,
+      policyHash: syncConfig.policyHash
+    }
+  })
+
+  return clientMutationId
+}
+
+/**
+ * Generates a frontend-model offline mutation id.
+ * @returns {string} - Local mutation id.
+ */
+function frontendModelOfflineMutationId() {
+  if (globalThis.crypto && typeof globalThis.crypto.randomUUID === "function") return globalThis.crypto.randomUUID()
+
+  return `frontend-mutation-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+/**
+ * Converts model attributes to sync-safe JSON payload values.
+ * @param {Record<string, FrontendModelAttributeValue>} attributes - Frontend model attributes.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} - Sync-safe attributes.
+ */
+function frontendModelSyncJsonObject(attributes) {
+  const serialized = JSON.parse(JSON.stringify(attributes))
+
+  if (!serialized || typeof serialized !== "object" || Array.isArray(serialized)) throw new Error("Expected sync mutation attributes object")
+
+  return /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (serialized)
 }
 
 /**
@@ -2787,6 +2871,10 @@ export default class FrontendModelBase {
       // Reset cached internal client so the new sessionStore is picked up.
       internalWebsocketClient = null
     }
+
+    if (Object.prototype.hasOwnProperty.call(config, "offlineSync")) {
+      frontendModelTransportConfig.offlineSync = config.offlineSync
+    }
   }
 
   /**
@@ -3900,6 +3988,37 @@ export default class FrontendModelBase {
       payload.attachments = attachments
     }
 
+    if (shouldQueueFrontendModelOperationOffline(ModelClass, commandType)) {
+      const offlineAttributes = {...payload.attributes}
+      let clientMutationId
+
+      if (isNew) {
+        const primaryKey = ModelClass.primaryKey()
+        const currentPrimaryKey = this.readAttribute(primaryKey)
+
+        if (currentPrimaryKey === undefined || currentPrimaryKey === null) {
+          clientMutationId = frontendModelTransportConfig.offlineSync?.clientMutationId
+            ? frontendModelTransportConfig.offlineSync.clientMutationId()
+            : frontendModelOfflineMutationId()
+          this.setAttribute(primaryKey, clientMutationId)
+          offlineAttributes[primaryKey] = clientMutationId
+        }
+      }
+
+      await queueFrontendModelMutationOffline({
+        attributes: offlineAttributes,
+        clientMutationId,
+        ModelClass,
+        operation: commandType
+      })
+      this.setIsNewRecord(false)
+      this._persistedAttributes = cloneFrontendModelAttributes(this.attributes())
+      this._pendingNestedAttributes = {}
+      this._clearPendingAttachments()
+
+      return this
+    }
+
     const response = await ModelClass.executeCommand(commandType, payload)
 
     this.assignAttributes(ModelClass.attributesFromResponse(response))
@@ -3952,9 +4071,20 @@ export default class FrontendModelBase {
    */
   async destroy() {
     const ModelClass = frontendModelClassFor(this)
+    const id = this.primaryKeyValue()
+
+    if (shouldQueueFrontendModelOperationOffline(ModelClass, "destroy")) {
+      await queueFrontendModelMutationOffline({
+        attributes: {[ModelClass.primaryKey()]: id},
+        ModelClass,
+        operation: "destroy"
+      })
+
+      return
+    }
 
     await ModelClass.executeCommand("destroy", {
-      id: this.primaryKeyValue()
+      id
     })
   }
 

--- a/src/sync/local-mutation-log.js
+++ b/src/sync/local-mutation-log.js
@@ -3,6 +3,8 @@
 const DEFAULT_STORAGE_KEY = "velocious.sync.localMutationLog"
 const PENDING_STATUSES = new Set(["pending", "applied-locally", "peer-applied"])
 const MUTATION_STATUSES = new Set([...PENDING_STATUSES, "conflict", "rejected", "synced"])
+/** @type {Map<string, Promise<unknown>>} */
+const STORAGE_KEY_LOCKS = new Map()
 
 /**
  * Local mutation log storage adapter.
@@ -65,23 +67,25 @@ export default class LocalMutationLog {
    * @returns {Promise<LocalMutationLogRecord>} - Created log record.
    */
   async append({dependencies = [], mutation}) {
-    const state = await this.loadState()
-    const timestamp = this.currentTimestamp()
-    const record = {
-      createdAt: timestamp,
-      dependencies: normalizeDependencies(dependencies),
-      id: this.idGenerator(),
-      mutation: normalizeMutation(mutation),
-      sequence: state.nextSequence,
-      status: /** @type {LocalMutationStatus} */ ("pending"),
-      updatedAt: timestamp
-    }
+    return await withStorageKeyLock(this.storageKey, async () => {
+      const state = await this.loadState()
+      const timestamp = this.currentTimestamp()
+      const record = {
+        createdAt: timestamp,
+        dependencies: normalizeDependencies(dependencies),
+        id: this.idGenerator(),
+        mutation: normalizeMutation(mutation),
+        sequence: state.nextSequence,
+        status: /** @type {LocalMutationStatus} */ ("pending"),
+        updatedAt: timestamp
+      }
 
-    state.nextSequence += 1
-    state.records.push(record)
-    await this.saveState(state)
+      state.nextSequence += 1
+      state.records.push(record)
+      await this.saveState(state)
 
-    return cloneRecord(record)
+      return cloneRecord(record)
+    })
   }
 
   /**
@@ -118,17 +122,19 @@ export default class LocalMutationLog {
   async updateStatus({id, status, syncResult}) {
     if (!MUTATION_STATUSES.has(status)) throw new Error(`Unknown local mutation status '${status}'`)
 
-    const state = await this.loadState()
-    const record = state.records.find((candidate) => candidate.id === id)
+    return await withStorageKeyLock(this.storageKey, async () => {
+      const state = await this.loadState()
+      const record = state.records.find((candidate) => candidate.id === id)
 
-    if (!record) throw new Error(`No local mutation log record '${id}'`)
+      if (!record) throw new Error(`No local mutation log record '${id}'`)
 
-    record.status = status
-    if (syncResult !== undefined) record.syncResult = cloneJsonObject(syncResult, "syncResult")
-    record.updatedAt = this.currentTimestamp()
-    await this.saveState(state)
+      record.status = status
+      if (syncResult !== undefined) record.syncResult = cloneJsonObject(syncResult, "syncResult")
+      record.updatedAt = this.currentTimestamp()
+      await this.saveState(state)
 
-    return cloneRecord(record)
+      return cloneRecord(record)
+    })
   }
 
   /**
@@ -176,6 +182,31 @@ export default class LocalMutationLog {
     if (!(date instanceof Date) || Number.isNaN(date.getTime())) throw new Error("LocalMutationLog now() must return a valid Date")
 
     return date.toISOString()
+  }
+}
+
+/**
+ * Runs a callback after earlier writes for the same storage key have completed.
+ * @template T
+ * @param {string} storageKey - Storage key to serialize.
+ * @param {() => Promise<T>} callback - Callback to run under the storage-key lock.
+ * @returns {Promise<T>} - Callback result.
+ */
+async function withStorageKeyLock(storageKey, callback) {
+  const previous = STORAGE_KEY_LOCKS.get(storageKey) || Promise.resolve()
+  let release = () => {}
+  const current = new Promise((resolve) => { release = () => resolve(undefined) })
+  const chained = previous.catch((_error) => {}).then(() => current)
+
+  STORAGE_KEY_LOCKS.set(storageKey, chained)
+
+  try {
+    await previous.catch((_error) => {})
+
+    return await callback()
+  } finally {
+    release()
+    if (STORAGE_KEY_LOCKS.get(storageKey) === chained) STORAGE_KEY_LOCKS.delete(storageKey)
   }
 }
 

--- a/src/sync/local-mutation-log.js
+++ b/src/sync/local-mutation-log.js
@@ -1,16 +1,33 @@
 // @ts-check
 
 const DEFAULT_STORAGE_KEY = "velocious.sync.localMutationLog"
-const PENDING_STATUSES = new Set(["pending", "applied-locally", "peer-applied"])
+const PENDING_STATUS_VALUES = /** @type {LocalMutationStatus[]} */ (["pending", "applied-locally", "peer-applied"])
+const PENDING_STATUSES = new Set(PENDING_STATUS_VALUES)
 const MUTATION_STATUSES = new Set([...PENDING_STATUSES, "conflict", "rejected", "synced"])
+const TERMINAL_STATUSES = new Set(["rejected", "synced"])
 /** @type {Map<string, Promise<unknown>>} */
 const STORAGE_KEY_LOCKS = new Map()
 
 /**
- * Local mutation log storage adapter.
+ * Local mutation log record query options.
+ * @typedef {object} LocalMutationLogRecordsOptions
+ * @property {LocalMutationStatus[]} [statuses] - Optional status filter.
+ */
+
+/**
+ * Local mutation log row-oriented storage adapter.
+ *
+ * Implementations should store each mutation log record as its own row/entry.
+ * Native apps should back this with SQLite and indexes on storage key, status,
+ * and sequence. Avoid storing the whole log as one JSON blob.
+ *
  * @typedef {object} LocalMutationLogStorage
- * @property {(key: string) => Promise<string | null | undefined> | string | null | undefined} getItem - Reads a stored value.
- * @property {(key: string, value: string) => Promise<void> | void} setItem - Stores a value.
+ * @property {(storageKey: string, record: LocalMutationLogRecord) => Promise<void> | void} appendRecord - Appends one log record.
+ * @property {(storageKey: string, ids: string[]) => Promise<void> | void} deleteRecords - Deletes log records by id.
+ * @property {(storageKey: string) => Promise<number> | number} nextSequence - Returns the next local sequence number.
+ * @property {(storageKey: string, id: string) => Promise<LocalMutationLogRecord | null | undefined> | LocalMutationLogRecord | null | undefined} record - Reads one log record by id.
+ * @property {(storageKey: string, options?: LocalMutationLogRecordsOptions) => Promise<LocalMutationLogRecord[]> | LocalMutationLogRecord[]} records - Reads log records.
+ * @property {(storageKey: string, record: LocalMutationLogRecord) => Promise<void> | void} updateRecord - Replaces one log record.
  */
 
 /**
@@ -49,8 +66,8 @@ export default class LocalMutationLog {
    * @param {string} [args.storageKey] - Storage key.
    */
   constructor({idGenerator = randomRecordId, now = () => new Date(), storage, storageKey = DEFAULT_STORAGE_KEY}) {
-    if (!storage || typeof storage.getItem !== "function" || typeof storage.setItem !== "function") {
-      throw new Error("LocalMutationLog requires storage with getItem/setItem")
+    if (!validStorage(storage)) {
+      throw new Error("LocalMutationLog requires row storage with appendRecord/deleteRecords/nextSequence/record/records/updateRecord")
     }
 
     this.idGenerator = idGenerator
@@ -68,21 +85,18 @@ export default class LocalMutationLog {
    */
   async append({dependencies = [], mutation}) {
     return await withStorageKeyLock(this.storageKey, async () => {
-      const state = await this.loadState()
       const timestamp = this.currentTimestamp()
-      const record = {
+      const record = normalizeRecord({
         createdAt: timestamp,
-        dependencies: normalizeDependencies(dependencies),
+        dependencies,
         id: this.idGenerator(),
-        mutation: normalizeMutation(mutation),
-        sequence: state.nextSequence,
-        status: /** @type {LocalMutationStatus} */ ("pending"),
+        mutation,
+        sequence: await this.storage.nextSequence(this.storageKey),
+        status: "pending",
         updatedAt: timestamp
-      }
+      })
 
-      state.nextSequence += 1
-      state.records.push(record)
-      await this.saveState(state)
+      await this.storage.appendRecord(this.storageKey, cloneRecord(record))
 
       return cloneRecord(record)
     })
@@ -93,12 +107,7 @@ export default class LocalMutationLog {
    * @returns {Promise<LocalMutationLogRecord[]>} - Log records.
    */
   async records() {
-    const state = await this.loadState()
-
-    return state.records
-      .slice()
-      .sort((left, right) => left.sequence - right.sequence)
-      .map((record) => cloneRecord(record))
+    return normalizeRecordList(await this.storage.records(this.storageKey))
   }
 
   /**
@@ -106,9 +115,7 @@ export default class LocalMutationLog {
    * @returns {Promise<LocalMutationLogRecord[]>} - Pending records.
    */
   async pendingRecords() {
-    const records = await this.records()
-
-    return records.filter((record) => PENDING_STATUSES.has(record.status))
+    return normalizeRecordList(await this.storage.records(this.storageKey, {statuses: PENDING_STATUS_VALUES}))
   }
 
   /**
@@ -123,53 +130,60 @@ export default class LocalMutationLog {
     if (!MUTATION_STATUSES.has(status)) throw new Error(`Unknown local mutation status '${status}'`)
 
     return await withStorageKeyLock(this.storageKey, async () => {
-      const state = await this.loadState()
-      const record = state.records.find((candidate) => candidate.id === id)
+      const rawRecord = await this.storage.record(this.storageKey, id)
 
-      if (!record) throw new Error(`No local mutation log record '${id}'`)
+      if (!rawRecord) throw new Error(`No local mutation log record '${id}'`)
 
-      record.status = status
+      const record = normalizeRecord(rawRecord)
+
+      record.status = /** @type {LocalMutationStatus} */ (status)
       if (syncResult !== undefined) record.syncResult = cloneJsonObject(syncResult, "syncResult")
       record.updatedAt = this.currentTimestamp()
-      await this.saveState(state)
+      await this.storage.updateRecord(this.storageKey, cloneRecord(record))
 
       return cloneRecord(record)
     })
   }
 
   /**
-   * Loads the persisted log state.
-   * @returns {Promise<{nextSequence: number, records: LocalMutationLogRecord[]}>} - Log state.
+   * Prunes terminal records that are no longer needed for replay dependencies.
+   * @param {object} [args] - Compaction options.
+   * @param {number} [args.maxTerminalRecords] - Maximum terminal records to retain.
+   * @param {number} [args.terminalRetentionMs] - Minimum age before pruning terminal records.
+   * @returns {Promise<{deletedRecordIds: string[]}>} - Compaction result.
    */
-  async loadState() {
-    const raw = await this.storage.getItem(this.storageKey)
+  async compact({maxTerminalRecords, terminalRetentionMs} = {}) {
+    return await withStorageKeyLock(this.storageKey, async () => {
+      const records = await this.records()
+      const protectedClientMutationIds = new Set(
+        records
+          .filter((record) => PENDING_STATUSES.has(record.status) || record.status === "conflict")
+          .flatMap((record) => record.dependencies.map((dependency) => dependency.clientMutationId))
+      )
+      const terminalRecords = records
+        .filter((record) => TERMINAL_STATUSES.has(record.status))
+        .filter((record) => !protectedClientMutationIds.has(record.mutation.clientMutationId))
+        .sort(compareRecordsNewestFirst)
+      const deleteIds = new Set()
 
-    if (raw === undefined || raw === null || raw === "") return {nextSequence: 1, records: []}
-    if (typeof raw !== "string") throw new Error("Local mutation log storage returned a non-string value")
+      if (typeof maxTerminalRecords === "number" && maxTerminalRecords >= 0) {
+        for (const record of terminalRecords.slice(maxTerminalRecords)) deleteIds.add(record.id)
+      }
 
-    const parsed = JSON.parse(raw)
+      if (typeof terminalRetentionMs === "number" && terminalRetentionMs >= 0) {
+        const cutoff = this.now().getTime() - terminalRetentionMs
 
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("Local mutation log storage payload must be an object")
-    }
+        for (const record of terminalRecords) {
+          if (new Date(record.updatedAt).getTime() < cutoff) deleteIds.add(record.id)
+        }
+      }
 
-    const rawState = /** @type {{nextSequence?: unknown, records?: unknown}} */ (parsed)
-    const records = Array.isArray(rawState.records) ? rawState.records.map(normalizeRecord) : []
-    const rawNextSequence = rawState.nextSequence
-    const nextSequence = Number.isInteger(rawNextSequence) && typeof rawNextSequence === "number" && rawNextSequence > 0
-      ? rawNextSequence
-      : records.reduce((max, record) => Math.max(max, record.sequence + 1), 1)
+      const deletedRecordIds = Array.from(deleteIds)
 
-    return {nextSequence, records}
-  }
+      if (deletedRecordIds.length > 0) await this.storage.deleteRecords(this.storageKey, deletedRecordIds)
 
-  /**
-   * Persists the log state.
-   * @param {{nextSequence: number, records: LocalMutationLogRecord[]}} state - Log state.
-   * @returns {Promise<void>} - Resolves when stored.
-   */
-  async saveState(state) {
-    await this.storage.setItem(this.storageKey, JSON.stringify(state))
+      return {deletedRecordIds}
+    })
   }
 
   /**
@@ -183,6 +197,52 @@ export default class LocalMutationLog {
 
     return date.toISOString()
   }
+}
+
+/**
+ * Checks whether a storage adapter has all required row-store methods.
+ * @param {unknown} storage - Storage adapter candidate.
+ * @returns {storage is LocalMutationLogStorage} - Whether storage is valid.
+ */
+function validStorage(storage) {
+  if (!storage || typeof storage !== "object") return false
+
+  const storageObject = /** @type {Record<string, unknown>} */ (storage)
+
+  return typeof storageObject.appendRecord === "function"
+    && typeof storageObject.deleteRecords === "function"
+    && typeof storageObject.nextSequence === "function"
+    && typeof storageObject.record === "function"
+    && typeof storageObject.records === "function"
+    && typeof storageObject.updateRecord === "function"
+}
+
+/**
+ * Sorts records by newest update/sequence first.
+ * @param {LocalMutationLogRecord} left - Left record.
+ * @param {LocalMutationLogRecord} right - Right record.
+ * @returns {number} - Sort result.
+ */
+function compareRecordsNewestFirst(left, right) {
+  const updatedAtComparison = right.updatedAt.localeCompare(left.updatedAt)
+
+  if (updatedAtComparison !== 0) return updatedAtComparison
+
+  return right.sequence - left.sequence
+}
+
+/**
+ * Normalizes and sorts a list of records.
+ * @param {unknown} records - Raw records.
+ * @returns {LocalMutationLogRecord[]} - Normalized records.
+ */
+function normalizeRecordList(records) {
+  if (!Array.isArray(records)) throw new Error("Expected local mutation log storage records array")
+
+  return records
+    .map(normalizeRecord)
+    .sort((left, right) => left.sequence - right.sequence)
+    .map((record) => cloneRecord(record))
 }
 
 /**

--- a/src/sync/local-mutation-log.js
+++ b/src/sync/local-mutation-log.js
@@ -1,0 +1,357 @@
+// @ts-check
+
+const DEFAULT_STORAGE_KEY = "velocious.sync.localMutationLog"
+const PENDING_STATUSES = new Set(["pending", "applied-locally", "peer-applied"])
+const MUTATION_STATUSES = new Set([...PENDING_STATUSES, "conflict", "rejected", "synced"])
+
+/**
+ * Local mutation log storage adapter.
+ * @typedef {object} LocalMutationLogStorage
+ * @property {(key: string) => Promise<string | null | undefined> | string | null | undefined} getItem - Reads a stored value.
+ * @property {(key: string, value: string) => Promise<void> | void} setItem - Stores a value.
+ */
+
+/**
+ * Local sync mutation dependency metadata.
+ * @typedef {object} LocalMutationDependency
+ * @property {string} clientMutationId - Client mutation id this mutation depends on.
+ * @property {string} model - Dependent model/resource name.
+ */
+
+/**
+ * Local mutation log status.
+ * @typedef {"pending" | "applied-locally" | "peer-applied" | "conflict" | "rejected" | "synced"} LocalMutationStatus
+ * */
+
+/**
+ * Local mutation log record.
+ * @typedef {object} LocalMutationLogRecord
+ * @property {string} createdAt - ISO timestamp when the record was created locally.
+ * @property {LocalMutationDependency[]} dependencies - Other local mutations that must replay first.
+ * @property {string} id - Local log record id.
+ * @property {import("./device-identity.js").SyncMutation} mutation - Device mutation payload.
+ * @property {number} sequence - Monotonic local sequence.
+ * @property {LocalMutationStatus} status - Local replay/apply status.
+ * @property {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} [syncResult] - Backend replay/result metadata.
+ * @property {string} updatedAt - ISO timestamp when the record was last changed.
+ */
+
+/** Client-side append-only sync mutation log with pluggable persistent storage. */
+export default class LocalMutationLog {
+  /**
+   * Creates a local mutation log.
+   * @param {object} args - Arguments.
+   * @param {() => string} [args.idGenerator] - Record id generator.
+   * @param {() => Date} [args.now] - Clock callback.
+   * @param {LocalMutationLogStorage} args.storage - Persistent storage adapter.
+   * @param {string} [args.storageKey] - Storage key.
+   */
+  constructor({idGenerator = randomRecordId, now = () => new Date(), storage, storageKey = DEFAULT_STORAGE_KEY}) {
+    if (!storage || typeof storage.getItem !== "function" || typeof storage.setItem !== "function") {
+      throw new Error("LocalMutationLog requires storage with getItem/setItem")
+    }
+
+    this.idGenerator = idGenerator
+    this.now = now
+    this.storage = storage
+    this.storageKey = storageKey
+  }
+
+  /**
+   * Appends a pending mutation record.
+   * @param {object} args - Arguments.
+   * @param {LocalMutationDependency[]} [args.dependencies] - Mutation dependencies.
+   * @param {import("./device-identity.js").SyncMutation} args.mutation - Mutation payload.
+   * @returns {Promise<LocalMutationLogRecord>} - Created log record.
+   */
+  async append({dependencies = [], mutation}) {
+    const state = await this.loadState()
+    const timestamp = this.currentTimestamp()
+    const record = {
+      createdAt: timestamp,
+      dependencies: normalizeDependencies(dependencies),
+      id: this.idGenerator(),
+      mutation: normalizeMutation(mutation),
+      sequence: state.nextSequence,
+      status: /** @type {LocalMutationStatus} */ ("pending"),
+      updatedAt: timestamp
+    }
+
+    state.nextSequence += 1
+    state.records.push(record)
+    await this.saveState(state)
+
+    return cloneRecord(record)
+  }
+
+  /**
+   * Returns all records ordered by local sequence.
+   * @returns {Promise<LocalMutationLogRecord[]>} - Log records.
+   */
+  async records() {
+    const state = await this.loadState()
+
+    return state.records
+      .slice()
+      .sort((left, right) => left.sequence - right.sequence)
+      .map((record) => cloneRecord(record))
+  }
+
+  /**
+   * Returns records that still need local/server reconciliation.
+   * @returns {Promise<LocalMutationLogRecord[]>} - Pending records.
+   */
+  async pendingRecords() {
+    const records = await this.records()
+
+    return records.filter((record) => PENDING_STATUSES.has(record.status))
+  }
+
+  /**
+   * Updates a record status.
+   * @param {object} args - Arguments.
+   * @param {string} args.id - Record id.
+   * @param {LocalMutationStatus} args.status - New status.
+   * @param {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} [args.syncResult] - Result metadata.
+   * @returns {Promise<LocalMutationLogRecord>} - Updated record.
+   */
+  async updateStatus({id, status, syncResult}) {
+    if (!MUTATION_STATUSES.has(status)) throw new Error(`Unknown local mutation status '${status}'`)
+
+    const state = await this.loadState()
+    const record = state.records.find((candidate) => candidate.id === id)
+
+    if (!record) throw new Error(`No local mutation log record '${id}'`)
+
+    record.status = status
+    if (syncResult !== undefined) record.syncResult = cloneJsonObject(syncResult, "syncResult")
+    record.updatedAt = this.currentTimestamp()
+    await this.saveState(state)
+
+    return cloneRecord(record)
+  }
+
+  /**
+   * Loads the persisted log state.
+   * @returns {Promise<{nextSequence: number, records: LocalMutationLogRecord[]}>} - Log state.
+   */
+  async loadState() {
+    const raw = await this.storage.getItem(this.storageKey)
+
+    if (raw === undefined || raw === null || raw === "") return {nextSequence: 1, records: []}
+    if (typeof raw !== "string") throw new Error("Local mutation log storage returned a non-string value")
+
+    const parsed = JSON.parse(raw)
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Local mutation log storage payload must be an object")
+    }
+
+    const rawState = /** @type {{nextSequence?: unknown, records?: unknown}} */ (parsed)
+    const records = Array.isArray(rawState.records) ? rawState.records.map(normalizeRecord) : []
+    const rawNextSequence = rawState.nextSequence
+    const nextSequence = Number.isInteger(rawNextSequence) && typeof rawNextSequence === "number" && rawNextSequence > 0
+      ? rawNextSequence
+      : records.reduce((max, record) => Math.max(max, record.sequence + 1), 1)
+
+    return {nextSequence, records}
+  }
+
+  /**
+   * Persists the log state.
+   * @param {{nextSequence: number, records: LocalMutationLogRecord[]}} state - Log state.
+   * @returns {Promise<void>} - Resolves when stored.
+   */
+  async saveState(state) {
+    await this.storage.setItem(this.storageKey, JSON.stringify(state))
+  }
+
+  /**
+   * Returns the current log timestamp.
+   * @returns {string} - Current ISO timestamp.
+   */
+  currentTimestamp() {
+    const date = this.now()
+
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) throw new Error("LocalMutationLog now() must return a valid Date")
+
+    return date.toISOString()
+  }
+}
+
+/**
+ * Normalizes a persisted log record.
+ * @param {unknown} value - Raw record.
+ * @returns {LocalMutationLogRecord} - Normalized record.
+ */
+function normalizeRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected local mutation log record object")
+
+  const record = /** @type {Record<string, unknown>} */ (value)
+  const status = requiredString(record.status, "status")
+
+  if (!MUTATION_STATUSES.has(status)) throw new Error(`Unknown local mutation status '${status}'`)
+
+  const baseRecord = {
+    createdAt: requiredIsoTimestamp(record.createdAt, "createdAt"),
+    dependencies: normalizeDependencies(record.dependencies),
+    id: requiredString(record.id, "id"),
+    mutation: normalizeMutation(record.mutation),
+    sequence: requiredPositiveInteger(record.sequence, "sequence"),
+    status: /** @type {LocalMutationStatus} */ (status),
+    updatedAt: requiredIsoTimestamp(record.updatedAt, "updatedAt")
+  }
+
+  if (record.syncResult === undefined) return baseRecord
+
+  return {
+    ...baseRecord,
+    syncResult: cloneJsonObject(record.syncResult, "syncResult")
+  }
+}
+
+/**
+ * Normalizes dependency metadata entries.
+ * @param {unknown} value - Raw dependencies.
+ * @returns {LocalMutationDependency[]} - Normalized dependencies.
+ */
+function normalizeDependencies(value) {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new Error("Expected local mutation dependencies array")
+
+  return value.map((dependency) => {
+    if (!dependency || typeof dependency !== "object" || Array.isArray(dependency)) {
+      throw new Error("Expected local mutation dependency object")
+    }
+
+    const dependencyObject = /** @type {Record<string, unknown>} */ (dependency)
+
+    return {
+      clientMutationId: requiredString(dependencyObject.clientMutationId, "dependency clientMutationId"),
+      model: requiredString(dependencyObject.model, "dependency model")
+    }
+  })
+}
+
+/**
+ * Normalizes a sync mutation payload.
+ * @param {unknown} value - Raw mutation.
+ * @returns {import("./device-identity.js").SyncMutation} - Normalized mutation.
+ */
+function normalizeMutation(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected local sync mutation object")
+
+  const mutation = /** @type {Record<string, unknown>} */ (value)
+  const normalized = /** @type {import("./device-identity.js").SyncMutation} */ ({
+    actorDeviceId: requiredString(mutation.actorDeviceId, "actorDeviceId"),
+    actorUserId: requiredString(mutation.actorUserId, "actorUserId"),
+    clientMutationId: requiredString(mutation.clientMutationId, "clientMutationId"),
+    model: requiredString(mutation.model, "model"),
+    occurredAt: requiredIsoTimestamp(mutation.occurredAt, "occurredAt"),
+    offlineGrantId: requiredString(mutation.offlineGrantId, "offlineGrantId"),
+    operation: requiredString(mutation.operation, "operation"),
+    policyHash: requiredString(mutation.policyHash, "policyHash")
+  })
+
+  if (mutation.attributes !== undefined) normalized.attributes = cloneJsonObject(mutation.attributes, "attributes")
+  if (mutation.baseVersion !== undefined) normalized.baseVersion = cloneBaseVersion(mutation.baseVersion)
+  if (mutation.command !== undefined) normalized.command = requiredString(mutation.command, "command")
+  if (mutation.payload !== undefined) normalized.payload = cloneJsonObject(mutation.payload, "payload")
+
+  return normalized
+}
+
+/**
+ * Requires a non-empty string value.
+ * @param {unknown} value - Raw value.
+ * @param {string} label - Field label.
+ * @returns {string} - Required string.
+ */
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length < 1) throw new Error(`Expected local mutation ${label}`)
+
+  return value
+}
+
+/**
+ * Requires an ISO timestamp string.
+ * @param {unknown} value - Raw value.
+ * @param {string} label - Field label.
+ * @returns {string} - ISO timestamp.
+ */
+function requiredIsoTimestamp(value, label) {
+  const stringValue = requiredString(value, label)
+  const date = new Date(stringValue)
+
+  if (Number.isNaN(date.getTime()) || date.toISOString() !== stringValue) throw new Error(`Expected local mutation ${label} ISO timestamp`)
+
+  return stringValue
+}
+
+/**
+ * Requires a positive integer value.
+ * @param {unknown} value - Raw value.
+ * @param {string} label - Field label.
+ * @returns {number} - Positive integer.
+ */
+function requiredPositiveInteger(value, label) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) throw new Error(`Expected local mutation ${label} positive integer`)
+
+  return value
+}
+
+/**
+ * Clones a supported base-version value.
+ * @param {unknown} value - Raw base version.
+ * @returns {string | number | null} - Normalized base version.
+ */
+function cloneBaseVersion(value) {
+  if (value === null || typeof value === "string" || typeof value === "number") return value
+
+  throw new Error("Expected local mutation baseVersion string, number, or null")
+}
+
+/**
+ * Clones a JSON-compatible value.
+ * @param {unknown} value - Raw JSON value.
+ * @param {string} label - Field label.
+ * @returns {import("../configuration-types.js").FrontendModelSyncJsonValue} - Cloned JSON value.
+ */
+function cloneJsonValue(value, label) {
+  if (value === undefined || typeof value === "function") throw new Error(`Expected JSON-compatible local mutation ${label}`)
+
+  return /** @type {import("../configuration-types.js").FrontendModelSyncJsonValue} */ (JSON.parse(JSON.stringify(value)))
+}
+
+/**
+ * Clones a JSON-compatible object.
+ * @param {unknown} value - Raw JSON object.
+ * @param {string} label - Field label.
+ * @returns {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} - Cloned JSON object.
+ */
+function cloneJsonObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Expected local mutation ${label} object`)
+
+  return /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (cloneJsonValue(value, label))
+}
+
+/**
+ * Clones a local mutation log record.
+ * @param {LocalMutationLogRecord} record - Record to clone.
+ * @returns {LocalMutationLogRecord} - Cloned record.
+ */
+function cloneRecord(record) {
+  return /** @type {LocalMutationLogRecord} */ (JSON.parse(JSON.stringify(record)))
+}
+
+/**
+ * Generates a random local mutation record id.
+ * @returns {string} - Random record id.
+ */
+function randomRecordId() {
+  const cryptoProvider = globalThis.crypto
+
+  if (cryptoProvider && typeof cryptoProvider.randomUUID === "function") return cryptoProvider.randomUUID()
+
+  return `local-mutation-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}


### PR DESCRIPTION
## Summary
- Add a client-side LocalMutationLog primitive for append-only offline sync mutations
- Add frontend-model offline sync queueing for save/destroy when resource sync policy allows it
- Add docs, README link, changelog, and regression coverage for local mutation queue behavior

## Test Plan
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/sync/local-mutation-log-spec.js spec/frontend-models/base-spec.js
- VELOCIOUS_DISABLE_MSSQL=1 npm run typecheck
- npm run lint
- npm run test:expo
- git diff --check