### PR TITLE
Auto-select SQLite web persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * Controllers and views for HTTP endpoints
 * Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
 * Client-side offline sync mutation logs and frontend-model optimistic queueing primitives (see [docs/offline-sync.md](docs/offline-sync.md))
+* SQLite web persistence that automatically prefers OPFS, then IndexedDB, then localStorage fallback (see [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))
 * Gap-less positional lists with automatic reordering via `actsAsList` (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))
@@ -606,7 +607,9 @@ configuration.addClientErrorPayloadReporter(async ({error, requestDetails, conte
 
 `requestDetails` includes `httpMethod`, `path`, and a parsed `body` snapshot when available. The body snapshot redacts common secret keys, truncates large strings and arrays, summarizes uploaded files and buffers without bytes, and compacts oversized frontend-model batches while preserving `requestId`, `model`, `commandType` / `customPath`, and payload shape.
 
-For sqlite web databases, Velocious defaults to `https://sql.js.org/dist/<file>` for `sql.js` wasm loading. You can override wasm resolution per database config with `locateFile`:
+For sqlite web databases, Velocious automatically picks the best browser persistence backend it can use: existing localStorage databases keep using the legacy localStorage key, new databases prefer OPFS when a smoke test succeeds, then IndexedDB, then localStorage as a compatibility fallback. See [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md) for the backend selection details.
+
+Velocious defaults to `https://sql.js.org/dist/<file>` for `sql.js` wasm loading. You can override wasm resolution per database config with `locateFile`:
 
 ```js
 import SqliteDriver from "velocious/build/src/database/drivers/sqlite/index.web.js"

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ configuration.addClientErrorPayloadReporter(async ({error, requestDetails, conte
 
 `requestDetails` includes `httpMethod`, `path`, and a parsed `body` snapshot when available. The body snapshot redacts common secret keys, truncates large strings and arrays, summarizes uploaded files and buffers without bytes, and compacts oversized frontend-model batches while preserving `requestId`, `model`, `commandType` / `customPath`, and payload shape.
 
-For sqlite web databases, Velocious automatically picks the best browser persistence backend it can use: OPFS when a smoke test succeeds, then IndexedDB. Existing persisted bytes in another backend are migrated into the selected backend when possible. If neither OPFS nor IndexedDB is usable, Velocious fails fast instead of writing new databases to localStorage-style storage. See [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md) for the backend selection details.
+For sqlite web databases, Velocious automatically picks the best browser persistence backend it can use: OPFS when a smoke test succeeds, then IndexedDB. Existing persisted bytes in a worse backend are migrated into the selected backend when possible. If neither OPFS nor IndexedDB is usable, Velocious keeps the legacy localStorage-style backend as a compatibility fallback. See [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md) for the backend selection details.
 
 Velocious defaults to `https://sql.js.org/dist/<file>` for `sql.js` wasm loading. You can override wasm resolution per database config with `locateFile`:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Controllers and views for HTTP endpoints
 * Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
 * Client-side offline sync mutation logs and frontend-model optimistic queueing primitives (see [docs/offline-sync.md](docs/offline-sync.md))
-* SQLite web persistence that automatically prefers OPFS, then IndexedDB, then localStorage fallback (see [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md))
+* SQLite web persistence that automatically prefers OPFS, then IndexedDB, and migrates legacy persisted bytes when possible (see [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))
 * Gap-less positional lists with automatic reordering via `actsAsList` (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))
@@ -607,7 +607,7 @@ configuration.addClientErrorPayloadReporter(async ({error, requestDetails, conte
 
 `requestDetails` includes `httpMethod`, `path`, and a parsed `body` snapshot when available. The body snapshot redacts common secret keys, truncates large strings and arrays, summarizes uploaded files and buffers without bytes, and compacts oversized frontend-model batches while preserving `requestId`, `model`, `commandType` / `customPath`, and payload shape.
 
-For sqlite web databases, Velocious automatically picks the best browser persistence backend it can use: existing localStorage databases keep using the legacy localStorage key, new databases prefer OPFS when a smoke test succeeds, then IndexedDB, then localStorage as a compatibility fallback. See [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md) for the backend selection details.
+For sqlite web databases, Velocious automatically picks the best browser persistence backend it can use: OPFS when a smoke test succeeds, then IndexedDB. Existing persisted bytes in another backend are migrated into the selected backend when possible. If neither OPFS nor IndexedDB is usable, Velocious fails fast instead of writing new databases to localStorage-style storage. See [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md) for the backend selection details.
 
 Velocious defaults to `https://sql.js.org/dist/<file>` for `sql.js` wasm loading. You can override wasm resolution per database config with `locateFile`:
 

--- a/changelog.d/20260624102027-sqlite-web-auto-persistence.md
+++ b/changelog.d/20260624102027-sqlite-web-auto-persistence.md
@@ -1,1 +1,1 @@
-SQLite web databases now automatically choose OPFS or IndexedDB, migrate existing persisted bytes into the selected backend when possible, and fail fast instead of falling back to localStorage-style storage for new databases.
+SQLite web databases now automatically choose OPFS or IndexedDB when possible, migrate existing persisted bytes from worse backends into the selected backend, and keep the legacy localStorage-style backend only as a compatibility fallback when no better backend is usable.

--- a/changelog.d/20260624102027-sqlite-web-auto-persistence.md
+++ b/changelog.d/20260624102027-sqlite-web-auto-persistence.md
@@ -1,0 +1,1 @@
+SQLite web databases now automatically prefer OPFS persistence, then IndexedDB, then the legacy localStorage fallback while preserving existing localStorage databases.

--- a/changelog.d/20260624102027-sqlite-web-auto-persistence.md
+++ b/changelog.d/20260624102027-sqlite-web-auto-persistence.md
@@ -1,1 +1,1 @@
-SQLite web databases now automatically preserve legacy localStorage data, choose OPFS or IndexedDB for new databases, and keep using a backend that already contains data if browser storage support changes later.
+SQLite web databases now automatically choose OPFS or IndexedDB, migrate existing persisted bytes into the selected backend when possible, and fail fast instead of falling back to localStorage-style storage for new databases.

--- a/changelog.d/20260624102027-sqlite-web-auto-persistence.md
+++ b/changelog.d/20260624102027-sqlite-web-auto-persistence.md
@@ -1,1 +1,1 @@
-SQLite web databases now automatically prefer existing persisted data first, then OPFS, then IndexedDB, then the legacy localStorage fallback while preserving existing browser databases across backend availability changes.
+SQLite web databases now automatically preserve legacy localStorage data, choose OPFS or IndexedDB for new databases, and keep using a backend that already contains data if browser storage support changes later.

--- a/changelog.d/20260624102027-sqlite-web-auto-persistence.md
+++ b/changelog.d/20260624102027-sqlite-web-auto-persistence.md
@@ -1,1 +1,1 @@
-SQLite web databases now automatically prefer OPFS persistence, then IndexedDB, then the legacy localStorage fallback while preserving existing localStorage databases.
+SQLite web databases now automatically prefer existing persisted data first, then OPFS, then IndexedDB, then the legacy localStorage fallback while preserving existing browser databases across backend availability changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/mailers.md`: EJS mailer templates, direct delivery, background delivery, and payload rendering.
 - `docs/model-initialization.md`: Eager and lazy record/frontend-model initialization behavior.
 - `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
-- `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, then localStorage fallback.
+- `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, and legacy-byte migration.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/translations.md`: Translated record attributes, `currentTranslation`, and translated frontend-model sorting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/mailers.md`: EJS mailer templates, direct delivery, background delivery, and payload rendering.
 - `docs/model-initialization.md`: Eager and lazy record/frontend-model initialization behavior.
 - `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
+- `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, then localStorage fallback.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/translations.md`: Translated record attributes, `currentTranslation`, and translated frontend-model sorting.

--- a/docs/sqlite-web-persistence.md
+++ b/docs/sqlite-web-persistence.md
@@ -1,0 +1,49 @@
+# SQLite web persistence
+
+Velocious's web SQLite driver uses `sql.js` for the in-browser SQLite runtime. The driver now chooses the best persistence backend it can detect automatically; application code does not need to configure a persistence strategy.
+
+Selection order for new web databases:
+
+1. **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
+2. **IndexedDB** when OPFS is unavailable and IndexedDB is present.
+3. **localStorage** as the compatibility fallback.
+
+Existing localStorage databases keep using the legacy localStorage key so upgrades do not silently orphan an already persisted browser database. New databases on modern browsers should land on OPFS first.
+
+## Backends
+
+### OPFS
+
+OPFS is preferred because it stores the SQLite database bytes in the browser origin's private filesystem instead of putting the exported database into localStorage. The current implementation still runs `sql.js` in memory and persists exported database bytes after writes; it is a better storage target than localStorage, but it is not yet a page-level SQLite VFS.
+
+Future work can replace the export-on-write path with a true SQLite WASM OPFS VFS without changing application configuration.
+
+### IndexedDB
+
+IndexedDB is the fallback for browsers where OPFS is unavailable or fails the smoke test. It stores the exported database bytes under the same stable Velocious database key in an IndexedDB object store. Like OPFS in this slice, this keeps SQLite semantics and avoids localStorage, but it is still SQL.js export persistence rather than a page-level VFS.
+
+### localStorage
+
+localStorage remains available for compatibility, tests, demos, older browsers, and existing databases already persisted with the previous driver. It stores the whole exported SQLite database blob under the legacy `VelociousDatabaseDriversSqliteWeb---<name>` key and should not be treated as the preferred storage for large offline/sync-heavy web apps.
+
+## Database configuration
+
+No new configuration is required:
+
+```js
+import SqliteDriver from "velocious/build/src/database/drivers/sqlite/index.web.js"
+
+export default new Configuration({
+  database: {
+    development: {
+      default: {
+        driver: SqliteDriver,
+        type: "sqlite",
+        name: "app-db"
+      }
+    }
+  }
+})
+```
+
+`locateFile` still controls where `sql.js` loads its WASM files from; persistence backend selection is independent of WASM asset resolution.

--- a/docs/sqlite-web-persistence.md
+++ b/docs/sqlite-web-persistence.md
@@ -4,12 +4,11 @@ Velocious's web SQLite driver uses `sql.js` for the in-browser SQLite runtime. T
 
 Selection order:
 
-1. Existing **localStorage** databases under the legacy key are preserved first.
-2. Existing **OPFS** database files are reused when OPFS is available.
-3. Existing **IndexedDB** database entries are reused before choosing a new higher-priority backend, so users are not moved to an empty OPFS database after OPFS becomes available later.
-4. New databases use **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
-5. New databases fall back to **IndexedDB** when OPFS is unavailable and IndexedDB passes its smoke test.
-6. **localStorage** is the compatibility fallback.
+1. Existing **localStorage** databases under the legacy key are preserved for compatibility with the previous web driver.
+2. If the selected backend already contains this database, Velocious keeps using that backend so browser capability changes do not open an empty database by accident.
+3. New databases use **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
+4. New databases fall back to **IndexedDB** when OPFS is unavailable and IndexedDB passes its smoke test.
+5. **localStorage** is the compatibility fallback.
 
 `reset` clears the database name from every available backend before selecting the backend for the fresh database, so stale bytes are not resurrected when browser capabilities change later.
 

--- a/docs/sqlite-web-persistence.md
+++ b/docs/sqlite-web-persistence.md
@@ -2,13 +2,16 @@
 
 Velocious's web SQLite driver uses `sql.js` for the in-browser SQLite runtime. The driver now chooses the best persistence backend it can detect automatically; application code does not need to configure a persistence strategy.
 
-Selection order for new web databases:
+Selection order:
 
-1. **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
-2. **IndexedDB** when OPFS is unavailable and IndexedDB is present.
-3. **localStorage** as the compatibility fallback.
+1. Existing **localStorage** databases under the legacy key are preserved first.
+2. Existing **OPFS** database files are reused when OPFS is available.
+3. Existing **IndexedDB** database entries are reused before choosing a new higher-priority backend, so users are not moved to an empty OPFS database after OPFS becomes available later.
+4. New databases use **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
+5. New databases fall back to **IndexedDB** when OPFS is unavailable and IndexedDB passes its smoke test.
+6. **localStorage** is the compatibility fallback.
 
-Existing localStorage databases keep using the legacy localStorage key so upgrades do not silently orphan an already persisted browser database. New databases on modern browsers should land on OPFS first.
+`reset` clears the database name from every available backend before selecting the backend for the fresh database, so stale bytes are not resurrected when browser capabilities change later.
 
 ## Backends
 

--- a/docs/sqlite-web-persistence.md
+++ b/docs/sqlite-web-persistence.md
@@ -7,7 +7,7 @@ Selection order:
 1. Use **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
 2. Otherwise use **IndexedDB** when it passes its smoke test.
 3. If existing database bytes are found in another backend, migrate them into the selected backend and clear the old copy.
-4. If neither OPFS nor IndexedDB is available, opening the web SQLite database raises an error instead of silently falling back to localStorage-style storage.
+4. If neither OPFS nor IndexedDB is available, use the legacy localStorage-style backend as a compatibility fallback.
 
 `reset` clears the database name from every available backend before selecting the backend for the fresh database, so stale bytes are not resurrected when browser capabilities change later.
 
@@ -25,9 +25,9 @@ IndexedDB is used for browsers where OPFS is unavailable or fails the smoke test
 
 ### Legacy localStorage-style storage
 
-The previous web driver stored the whole exported SQLite database blob under the legacy `VelociousDatabaseDriversSqliteWeb---<name>` key. That backend is no longer selected for new databases. When legacy bytes are available and OPFS or IndexedDB works, Velocious migrates the bytes into the selected backend and clears the legacy copy.
+The previous web driver stored the whole exported SQLite database blob under the legacy `VelociousDatabaseDriversSqliteWeb---<name>` key. When legacy bytes are available and OPFS or IndexedDB works, Velocious migrates the bytes into the selected backend and clears the legacy copy instead of continuing to use the worse backend.
 
-If no better backend is available, Velocious fails fast instead of writing new SQLite databases to the legacy backend.
+If no better backend is available, Velocious keeps using the legacy backend so browsers without OPFS/IndexedDB support can still open web SQLite databases.
 
 ## Database configuration
 

--- a/docs/sqlite-web-persistence.md
+++ b/docs/sqlite-web-persistence.md
@@ -1,14 +1,13 @@
 # SQLite web persistence
 
-Velocious's web SQLite driver uses `sql.js` for the in-browser SQLite runtime. The driver now chooses the best persistence backend it can detect automatically; application code does not need to configure a persistence strategy.
+Velocious's web SQLite driver uses `sql.js` for the in-browser SQLite runtime. The driver automatically chooses a durable browser persistence backend; application code does not need to configure a persistence strategy.
 
 Selection order:
 
-1. Existing **localStorage** databases under the legacy key are preserved for compatibility with the previous web driver.
-2. If the selected backend already contains this database, Velocious keeps using that backend so browser capability changes do not open an empty database by accident.
-3. New databases use **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
-4. New databases fall back to **IndexedDB** when OPFS is unavailable and IndexedDB passes its smoke test.
-5. **localStorage** is the compatibility fallback.
+1. Use **OPFS** (`navigator.storage.getDirectory`) when a small write/read/delete smoke test succeeds.
+2. Otherwise use **IndexedDB** when it passes its smoke test.
+3. If existing database bytes are found in another backend, migrate them into the selected backend and clear the old copy.
+4. If neither OPFS nor IndexedDB is available, opening the web SQLite database raises an error instead of silently falling back to localStorage-style storage.
 
 `reset` clears the database name from every available backend before selecting the backend for the fresh database, so stale bytes are not resurrected when browser capabilities change later.
 
@@ -16,17 +15,19 @@ Selection order:
 
 ### OPFS
 
-OPFS is preferred because it stores the SQLite database bytes in the browser origin's private filesystem instead of putting the exported database into localStorage. The current implementation still runs `sql.js` in memory and persists exported database bytes after writes; it is a better storage target than localStorage, but it is not yet a page-level SQLite VFS.
+OPFS is preferred because it stores the SQLite database bytes in the browser origin's private filesystem instead of putting the exported database into localStorage-style storage. The current implementation still runs `sql.js` in memory and persists exported database bytes after writes; it is a better storage target than localStorage, but it is not yet a page-level SQLite VFS.
 
 Future work can replace the export-on-write path with a true SQLite WASM OPFS VFS without changing application configuration.
 
 ### IndexedDB
 
-IndexedDB is the fallback for browsers where OPFS is unavailable or fails the smoke test. It stores the exported database bytes under the same stable Velocious database key in an IndexedDB object store. Like OPFS in this slice, this keeps SQLite semantics and avoids localStorage, but it is still SQL.js export persistence rather than a page-level VFS.
+IndexedDB is used for browsers where OPFS is unavailable or fails the smoke test. It stores the exported database bytes under the same stable Velocious database key in an IndexedDB object store. Like OPFS in this slice, this keeps SQLite semantics and avoids localStorage, but it is still SQL.js export persistence rather than a page-level VFS.
 
-### localStorage
+### Legacy localStorage-style storage
 
-localStorage remains available for compatibility, tests, demos, older browsers, and existing databases already persisted with the previous driver. It stores the whole exported SQLite database blob under the legacy `VelociousDatabaseDriversSqliteWeb---<name>` key and should not be treated as the preferred storage for large offline/sync-heavy web apps.
+The previous web driver stored the whole exported SQLite database blob under the legacy `VelociousDatabaseDriversSqliteWeb---<name>` key. That backend is no longer selected for new databases. When legacy bytes are available and OPFS or IndexedDB works, Velocious migrates the bytes into the selected backend and clears the legacy copy.
+
+If no better backend is available, Velocious fails fast instead of writing new SQLite databases to the legacy backend.
 
 ## Database configuration
 

--- a/spec/database/drivers/sqlite/index-web-persistence-spec.js
+++ b/spec/database/drivers/sqlite/index-web-persistence-spec.js
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "../../../../src/testing/test.js"
 import {createSqliteWebPersistence, deleteSqliteWebPersistences, sqliteWebPersistenceKey} from "../../../../src/database/drivers/sqlite/web-persistence.js"
+import BetterLocalStorage from "better-localstorage"
 
 describe("database - drivers - sqlite web persistence", () => {
   it("chooses OPFS persistence when the browser storage directory is usable", async () => {
@@ -28,16 +29,52 @@ describe("database - drivers - sqlite web persistence", () => {
     expect(await readIndexedDbBytes(environment, "app")).toEqual(undefined)
   })
 
-  it("raises when IndexedDB fails the smoke test and OPFS is unavailable", async () => {
-    const environment = buildEnvironment({opfs: false, indexedDb: true, indexedDbUsable: false})
+  it("migrates an existing legacy localStorage database to OPFS when OPFS is available", async () => {
+    const environment = buildEnvironment({indexedDb: true, opfs: true})
 
-    await expectSqliteWebPersistenceError({databaseName: "app", environment})
+    await withLegacyLocalStorage(environment, async () => {
+      await writeLegacyLocalStorageBytes("app", new Uint8Array([10, 11, 12]))
+
+      const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+      expect(persistence.name).toEqual("opfs")
+      expect(Array.from(await persistence.load() || [])).toEqual([10, 11, 12])
+      expect(await readLegacyLocalStorageBytes("app")).toEqual(undefined)
+    })
   })
 
-  it("raises when OPFS and IndexedDB are unavailable", async () => {
+  it("migrates an existing legacy localStorage database to IndexedDB when OPFS is unavailable", async () => {
+    const environment = buildEnvironment({indexedDb: true, opfs: false})
+
+    await withLegacyLocalStorage(environment, async () => {
+      await writeLegacyLocalStorageBytes("app", new Uint8Array([13, 14, 15]))
+
+      const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+      expect(persistence.name).toEqual("indexeddb")
+      expect(Array.from(await persistence.load() || [])).toEqual([13, 14, 15])
+      expect(await readLegacyLocalStorageBytes("app")).toEqual(undefined)
+    })
+  })
+
+  it("uses legacy localStorage persistence when IndexedDB fails the smoke test and OPFS is unavailable", async () => {
+    const environment = buildEnvironment({opfs: false, indexedDb: true, indexedDbUsable: false})
+
+    await withLegacyLocalStorage(buildEnvironment({opfs: false, indexedDb: true}), async () => {
+      const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+      expect(persistence.name).toEqual("localstorage")
+    })
+  })
+
+  it("uses legacy localStorage persistence when OPFS and IndexedDB are unavailable", async () => {
     const environment = buildEnvironment({opfs: false, indexedDb: false})
 
-    await expectSqliteWebPersistenceError({databaseName: "app", environment})
+    await withLegacyLocalStorage(buildEnvironment({opfs: false, indexedDb: true}), async () => {
+      const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+      expect(persistence.name).toEqual("localstorage")
+    })
   })
 
   it("stores SQL.js database bytes in the selected OPFS file", async () => {
@@ -77,17 +114,6 @@ describe("database - drivers - sqlite web persistence", () => {
     expect(await readIndexedDbBytes(environment, "app")).toEqual(undefined)
   })
 })
-
-async function expectSqliteWebPersistenceError({databaseName, environment}) {
-  try {
-    await createSqliteWebPersistence({databaseName, environment})
-  } catch (error) {
-    expect(error.message).toEqual("SQLite web persistence requires OPFS or IndexedDB support")
-    return
-  }
-
-  throw new Error("Expected SQLite web persistence selection to fail")
-}
 
 function buildEnvironment({opfs, indexedDb, indexedDbContent = undefined, indexedDbUsable = true, opfsContent = undefined}) {
   const directory = buildOpfsDirectory({databaseContent: opfsContent})
@@ -162,6 +188,7 @@ function buildOpfsDirectory({databaseContent}) {
 
 function buildIndexedDb({databaseContent, usable}) {
   const stores = new Map()
+  const keyPaths = new Map()
 
   if (databaseContent) stores.set("databases", new Map([[sqliteWebPersistenceKey("app"), databaseContent]]))
 
@@ -176,8 +203,8 @@ function buildIndexedDb({databaseContent, usable}) {
           return
         }
 
-        request.result = buildIndexedDbDatabase(stores)
-        request.onupgradeneeded?.()
+        request.result = buildIndexedDbDatabase({keyPaths, stores})
+        request.onupgradeneeded?.({target: {result: request.result}})
         request.onsuccess?.()
       })
 
@@ -186,33 +213,58 @@ function buildIndexedDb({databaseContent, usable}) {
   }
 }
 
-function buildIndexedDbDatabase(stores) {
+function buildIndexedDbDatabase({keyPaths, stores}) {
   return {
     close: () => {},
-    createObjectStore: (name) => {
+    createObjectStore: (name, options = {}) => {
       if (!stores.has(name)) stores.set(name, new Map())
+      if (options.keyPath) keyPaths.set(name, options.keyPath)
     },
     objectStoreNames: {
       contains: (name) => stores.has(name)
     },
     transaction: (name) => ({
-      objectStore: () => buildIndexedDbObjectStore(stores.get(name))
+      objectStore: () => buildIndexedDbObjectStore({keyPath: keyPaths.get(name), store: stores.get(name)})
     })
   }
 }
 
-function buildIndexedDbObjectStore(store) {
+function buildIndexedDbObjectStore({keyPath, store}) {
   return {
     delete: (key) => resolveIndexedDbRequest(() => {
       store.delete(key)
       return undefined
     }),
     get: (key) => resolveIndexedDbRequest(() => store.get(key)),
-    put: (value, key) => resolveIndexedDbRequest(() => {
+    put: (value, key = value?.[keyPath]) => resolveIndexedDbRequest(() => {
       store.set(key, value)
       return key
     })
   }
+}
+
+
+async function withLegacyLocalStorage(environment, callback) {
+  const originalIndexedDb = globalThis.indexedDB
+  const originalWindow = globalThis.window
+
+  globalThis.indexedDB = environment.indexedDB
+  globalThis.window = {indexedDB: environment.indexedDB}
+
+  try {
+    await callback()
+  } finally {
+    globalThis.indexedDB = originalIndexedDb
+    globalThis.window = originalWindow
+  }
+}
+
+async function writeLegacyLocalStorageBytes(databaseName, bytes) {
+  await new BetterLocalStorage().set(sqliteWebPersistenceKey(databaseName), bytes)
+}
+
+async function readLegacyLocalStorageBytes(databaseName) {
+  return await new BetterLocalStorage().get(sqliteWebPersistenceKey(databaseName))
 }
 
 function buildIndexedDbRequest() {

--- a/spec/database/drivers/sqlite/index-web-persistence-spec.js
+++ b/spec/database/drivers/sqlite/index-web-persistence-spec.js
@@ -1,0 +1,195 @@
+import {describe, expect, it} from "../../../../src/testing/test.js"
+import {createSqliteWebPersistence, sqliteWebPersistenceKey} from "../../../../src/database/drivers/sqlite/web-persistence.js"
+
+describe("database - drivers - sqlite web persistence", () => {
+  it("chooses OPFS persistence when the browser storage directory is usable", async () => {
+    const environment = buildEnvironment({opfs: true, indexedDb: true})
+
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+    expect(persistence.name).toEqual("opfs")
+  })
+
+  it("falls back to IndexedDB persistence when OPFS is unavailable", async () => {
+    const environment = buildEnvironment({opfs: false, indexedDb: true})
+
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+    expect(persistence.name).toEqual("indexeddb")
+  })
+
+  it("falls back to localStorage persistence when IndexedDB fails the smoke test", async () => {
+    const environment = buildEnvironment({opfs: false, indexedDb: true, indexedDbUsable: false})
+
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+    expect(persistence.name).toEqual("localStorage")
+  })
+
+  it("falls back to localStorage persistence when OPFS and IndexedDB are unavailable", async () => {
+    const environment = buildEnvironment({opfs: false, indexedDb: false})
+
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+    expect(persistence.name).toEqual("localStorage")
+  })
+
+  it("stores SQL.js database bytes in the selected OPFS file", async () => {
+    const environment = buildEnvironment({opfs: true, indexedDb: false})
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+    const bytes = new Uint8Array([1, 2, 3])
+
+    await persistence.save(bytes)
+
+    expect(Array.from(await persistence.load() || [])).toEqual([1, 2, 3])
+    await persistence.delete()
+    expect(await persistence.load()).toEqual(undefined)
+  })
+
+  it("stores SQL.js database bytes in the selected IndexedDB entry", async () => {
+    const environment = buildEnvironment({opfs: false, indexedDb: true})
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+    const bytes = new Uint8Array([4, 5, 6])
+
+    await persistence.save(bytes)
+
+    expect(Array.from(await persistence.load() || [])).toEqual([4, 5, 6])
+    await persistence.delete()
+    expect(await persistence.load()).toEqual(undefined)
+  })
+
+  it("uses the existing localStorage key for compatibility", () => {
+    expect(sqliteWebPersistenceKey("app")).toEqual("VelociousDatabaseDriversSqliteWeb---app")
+  })
+})
+
+function buildEnvironment({opfs, indexedDb, indexedDbUsable = true}) {
+  const directory = buildOpfsDirectory()
+
+  return {
+    indexedDB: indexedDb ? buildIndexedDb({usable: indexedDbUsable}) : undefined,
+    navigator: {
+      storage: {
+        getDirectory: async () => {
+          if (!opfs) throw new Error("OPFS unavailable")
+
+          return directory
+        }
+      }
+    }
+  }
+}
+
+function buildOpfsDirectory() {
+  const files = new Map()
+
+  return {
+    getFileHandle: async (name, options = {}) => {
+      if (!files.has(name)) {
+        if (!options.create) throw domException("NotFoundError")
+        files.set(name, new Uint8Array())
+      }
+
+      return {
+        createWritable: async () => ({
+          close: async () => {},
+          write: async (bytes) => {
+            files.set(name, new Uint8Array(bytes))
+          }
+        }),
+        getFile: async () => ({
+          arrayBuffer: async () => files.get(name).buffer
+        })
+      }
+    },
+    removeEntry: async (name) => {
+      if (!files.delete(name)) throw domException("NotFoundError")
+    }
+  }
+}
+
+function buildIndexedDb({usable}) {
+  const stores = new Map()
+
+  return {
+    open: () => {
+      const request = buildIndexedDbRequest()
+
+      Promise.resolve().then(() => {
+        if (!usable) {
+          request.error = new Error("IndexedDB unavailable")
+          request.onerror?.()
+          return
+        }
+
+        request.result = buildIndexedDbDatabase(stores)
+        request.onupgradeneeded?.()
+        request.onsuccess?.()
+      })
+
+      return request
+    }
+  }
+}
+
+function buildIndexedDbDatabase(stores) {
+  return {
+    close: () => {},
+    createObjectStore: (name) => {
+      if (!stores.has(name)) stores.set(name, new Map())
+    },
+    objectStoreNames: {
+      contains: (name) => stores.has(name)
+    },
+    transaction: (name) => ({
+      objectStore: () => buildIndexedDbObjectStore(stores.get(name))
+    })
+  }
+}
+
+function buildIndexedDbObjectStore(store) {
+  return {
+    delete: (key) => resolveIndexedDbRequest(() => {
+      store.delete(key)
+      return undefined
+    }),
+    get: (key) => resolveIndexedDbRequest(() => store.get(key)),
+    put: (value, key) => resolveIndexedDbRequest(() => {
+      store.set(key, value)
+      return key
+    })
+  }
+}
+
+function buildIndexedDbRequest() {
+  return {
+    error: undefined,
+    onerror: undefined,
+    onsuccess: undefined,
+    onupgradeneeded: undefined,
+    result: undefined
+  }
+}
+
+function resolveIndexedDbRequest(callback) {
+  const request = buildIndexedDbRequest()
+
+  Promise.resolve().then(() => {
+    try {
+      request.result = callback()
+      request.onsuccess?.()
+    } catch (error) {
+      request.error = error
+      request.onerror?.()
+    }
+  })
+
+  return request
+}
+
+function domException(name) {
+  const error = new Error(name)
+  error.name = name
+
+  return error
+}

--- a/spec/database/drivers/sqlite/index-web-persistence-spec.js
+++ b/spec/database/drivers/sqlite/index-web-persistence-spec.js
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "../../../../src/testing/test.js"
-import {createSqliteWebPersistence, sqliteWebPersistenceKey} from "../../../../src/database/drivers/sqlite/web-persistence.js"
+import {createSqliteWebPersistence, deleteSqliteWebPersistences, sqliteWebPersistenceKey} from "../../../../src/database/drivers/sqlite/web-persistence.js"
 
 describe("database - drivers - sqlite web persistence", () => {
   it("chooses OPFS persistence when the browser storage directory is usable", async () => {
@@ -16,6 +16,15 @@ describe("database - drivers - sqlite web persistence", () => {
     const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
 
     expect(persistence.name).toEqual("indexeddb")
+  })
+
+  it("keeps using an existing IndexedDB database even when OPFS becomes available later", async () => {
+    const environment = buildEnvironment({indexedDb: true, indexedDbContent: new Uint8Array([7, 8, 9]), opfs: true})
+
+    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
+
+    expect(persistence.name).toEqual("indexeddb")
+    expect(Array.from(await persistence.load() || [])).toEqual([7, 8, 9])
   })
 
   it("falls back to localStorage persistence when IndexedDB fails the smoke test", async () => {
@@ -61,13 +70,22 @@ describe("database - drivers - sqlite web persistence", () => {
   it("uses the existing localStorage key for compatibility", () => {
     expect(sqliteWebPersistenceKey("app")).toEqual("VelociousDatabaseDriversSqliteWeb---app")
   })
+
+  it("deletes persisted database bytes from every available backend", async () => {
+    const environment = buildEnvironment({indexedDb: true, indexedDbContent: new Uint8Array([4, 5, 6]), opfs: true, opfsContent: new Uint8Array([1, 2, 3])})
+
+    await deleteSqliteWebPersistences({databaseName: "app", environment})
+
+    expect(await readOpfsBytes(environment, "app")).toEqual(undefined)
+    expect(await readIndexedDbBytes(environment, "app")).toEqual(undefined)
+  })
 })
 
-function buildEnvironment({opfs, indexedDb, indexedDbUsable = true}) {
-  const directory = buildOpfsDirectory()
+function buildEnvironment({opfs, indexedDb, indexedDbContent = undefined, indexedDbUsable = true, opfsContent = undefined}) {
+  const directory = buildOpfsDirectory({databaseContent: opfsContent})
 
   return {
-    indexedDB: indexedDb ? buildIndexedDb({usable: indexedDbUsable}) : undefined,
+    indexedDB: indexedDb ? buildIndexedDb({databaseContent: indexedDbContent, usable: indexedDbUsable}) : undefined,
     navigator: {
       storage: {
         getDirectory: async () => {
@@ -80,8 +98,34 @@ function buildEnvironment({opfs, indexedDb, indexedDbUsable = true}) {
   }
 }
 
-function buildOpfsDirectory() {
+async function readOpfsBytes(environment, databaseName) {
+  try {
+    const directory = await environment.navigator.storage.getDirectory()
+    const fileHandle = await directory.getFileHandle(sqliteWebPersistenceKey(databaseName))
+
+    return Array.from(new Uint8Array(await (await fileHandle.getFile()).arrayBuffer()))
+  } catch (error) {
+    if (error instanceof Error && error.name === "NotFoundError") return undefined
+
+    throw error
+  }
+}
+
+async function readIndexedDbBytes(environment, databaseName) {
+  const openRequest = environment.indexedDB.open("VelociousDatabaseDriversSqliteWeb", 1)
+  const database = await resolveRawIndexedDbRequest(openRequest)
+  const request = database.transaction("databases", "readonly").objectStore("databases").get(sqliteWebPersistenceKey(databaseName))
+  const bytes = await resolveRawIndexedDbRequest(request)
+
+  database.close()
+
+  return bytes ? Array.from(bytes) : undefined
+}
+
+function buildOpfsDirectory({databaseContent}) {
   const files = new Map()
+
+  if (databaseContent) files.set(sqliteWebPersistenceKey("app"), databaseContent)
 
   return {
     getFileHandle: async (name, options = {}) => {
@@ -108,8 +152,10 @@ function buildOpfsDirectory() {
   }
 }
 
-function buildIndexedDb({usable}) {
+function buildIndexedDb({databaseContent, usable}) {
   const stores = new Map()
+
+  if (databaseContent) stores.set("databases", new Map([[sqliteWebPersistenceKey("app"), databaseContent]]))
 
   return {
     open: () => {
@@ -185,6 +231,13 @@ function resolveIndexedDbRequest(callback) {
   })
 
   return request
+}
+
+function resolveRawIndexedDbRequest(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
 }
 
 function domException(name) {

--- a/spec/database/drivers/sqlite/index-web-persistence-spec.js
+++ b/spec/database/drivers/sqlite/index-web-persistence-spec.js
@@ -10,7 +10,7 @@ describe("database - drivers - sqlite web persistence", () => {
     expect(persistence.name).toEqual("opfs")
   })
 
-  it("falls back to IndexedDB persistence when OPFS is unavailable", async () => {
+  it("uses IndexedDB persistence when OPFS is unavailable", async () => {
     const environment = buildEnvironment({opfs: false, indexedDb: true})
 
     const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
@@ -18,29 +18,26 @@ describe("database - drivers - sqlite web persistence", () => {
     expect(persistence.name).toEqual("indexeddb")
   })
 
-  it("keeps using an existing IndexedDB database even when OPFS becomes available later", async () => {
+  it("migrates an existing IndexedDB database to OPFS when OPFS becomes available later", async () => {
     const environment = buildEnvironment({indexedDb: true, indexedDbContent: new Uint8Array([7, 8, 9]), opfs: true})
 
     const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
 
-    expect(persistence.name).toEqual("indexeddb")
+    expect(persistence.name).toEqual("opfs")
     expect(Array.from(await persistence.load() || [])).toEqual([7, 8, 9])
+    expect(await readIndexedDbBytes(environment, "app")).toEqual(undefined)
   })
 
-  it("falls back to localStorage persistence when IndexedDB fails the smoke test", async () => {
+  it("raises when IndexedDB fails the smoke test and OPFS is unavailable", async () => {
     const environment = buildEnvironment({opfs: false, indexedDb: true, indexedDbUsable: false})
 
-    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
-
-    expect(persistence.name).toEqual("localStorage")
+    await expectSqliteWebPersistenceError({databaseName: "app", environment})
   })
 
-  it("falls back to localStorage persistence when OPFS and IndexedDB are unavailable", async () => {
+  it("raises when OPFS and IndexedDB are unavailable", async () => {
     const environment = buildEnvironment({opfs: false, indexedDb: false})
 
-    const persistence = await createSqliteWebPersistence({databaseName: "app", environment})
-
-    expect(persistence.name).toEqual("localStorage")
+    await expectSqliteWebPersistenceError({databaseName: "app", environment})
   })
 
   it("stores SQL.js database bytes in the selected OPFS file", async () => {
@@ -80,6 +77,17 @@ describe("database - drivers - sqlite web persistence", () => {
     expect(await readIndexedDbBytes(environment, "app")).toEqual(undefined)
   })
 })
+
+async function expectSqliteWebPersistenceError({databaseName, environment}) {
+  try {
+    await createSqliteWebPersistence({databaseName, environment})
+  } catch (error) {
+    expect(error.message).toEqual("SQLite web persistence requires OPFS or IndexedDB support")
+    return
+  }
+
+  throw new Error("Expected SQLite web persistence selection to fail")
+}
 
 function buildEnvironment({opfs, indexedDb, indexedDbContent = undefined, indexedDbUsable = true, opfsContent = undefined}) {
   const directory = buildOpfsDirectory({databaseContent: opfsContent})

--- a/src/database/drivers/sqlite/connection-sql-js.js
+++ b/src/database/drivers/sqlite/connection-sql-js.js
@@ -8,10 +8,12 @@ export default class VelociousDatabaseDriversSqliteConnectionSqlJs {
    * Runs constructor.
    * @param {import("../base.js").default} driver - Database driver instance.
    * @param {import("sql.js").Database} connection - Connection.
+   * @param {import("./web-persistence.js").SqliteWebPersistence} persistence - Database persistence adapter.
    */
-  constructor(driver, connection) {
+  constructor(driver, connection, persistence) {
     this.connection = connection
     this.driver = driver
+    this.persistence = persistence
   }
 
   async close() {
@@ -36,10 +38,9 @@ export default class VelociousDatabaseDriversSqliteConnectionSqlJs {
   }
 
   saveDatabase = async () => {
-    const localStorageContent = this.connection.export()
+    const databaseContent = this.connection.export()
 
-    // @ts-expect-error
-    await this.driver.betterLocalStorage.set(this.driver.localStorageName(), localStorageContent)
+    await this.persistence.save(databaseContent)
   }
 
   saveDatabaseDebounce = debounce(this.saveDatabase, 500)

--- a/src/database/drivers/sqlite/index.web.js
+++ b/src/database/drivers/sqlite/index.web.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-import BetterLocalStorage from "better-localstorage"
 import ConnectionSqlJs from "./connection-sql-js.js"
 import initSqlJs from "sql.js"
+import {createSqliteWebPersistence, sqliteWebPersistenceKey} from "./web-persistence.js"
 
 import Base from "./base.js"
 
@@ -12,10 +12,6 @@ import Base from "./base.js"
  */
 
 export default class VelociousDatabaseDriversSqliteWeb extends Base {
-  /**
-   * Better local storage.
-   * @type {BetterLocalStorage | undefined} */
-  betterLocalStorage = undefined
   /**
    * Connection.
    * @type {ConnectionSqlJs | undefined} */
@@ -39,16 +35,15 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
     this.args = this.getArgs()
 
     if (!this.args.getConnection) {
-      this.betterLocalStorage ||= new BetterLocalStorage()
+      const persistence = await createSqliteWebPersistence({databaseName: this.databaseName()})
 
       if (this.args.reset) {
-        await this.betterLocalStorage.delete(this.localStorageName())
+        await persistence.delete()
       }
 
       const SQL = await initSqlJs({locateFile: this.sqlJsLocateFile()})
-
-      const databaseContent = await this.betterLocalStorage.get(this.localStorageName())
-      const connectionSqlJs = new ConnectionSqlJs(this, new SQL.Database(databaseContent))
+      const databaseContent = await persistence.load()
+      const connectionSqlJs = new ConnectionSqlJs(this, new SQL.Database(databaseContent), persistence)
 
       this._connection = connectionSqlJs
     }
@@ -72,11 +67,19 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
   }
 
   localStorageName() {
-    if (!this.args?.name) {
-      throw new Error("No name given in arguments for SQLite Web database")
-    }
+    return sqliteWebPersistenceKey(this.databaseName())
+  }
 
-    return `VelociousDatabaseDriversSqliteWeb---${this.args?.name}`
+  /**
+   * Returns the configured database name.
+   * @returns {string} - Database name.
+   */
+  databaseName() {
+    const name = this.args?.name
+
+    if (typeof name !== "string" || name.length < 1) throw new Error("No name given in arguments for SQLite Web database")
+
+    return name
   }
 
   /**

--- a/src/database/drivers/sqlite/index.web.js
+++ b/src/database/drivers/sqlite/index.web.js
@@ -2,7 +2,7 @@
 
 import ConnectionSqlJs from "./connection-sql-js.js"
 import initSqlJs from "sql.js"
-import {createSqliteWebPersistence, sqliteWebPersistenceKey} from "./web-persistence.js"
+import {createSqliteWebPersistence, deleteSqliteWebPersistences, sqliteWebPersistenceKey} from "./web-persistence.js"
 
 import Base from "./base.js"
 
@@ -35,12 +35,11 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
     this.args = this.getArgs()
 
     if (!this.args.getConnection) {
-      const persistence = await createSqliteWebPersistence({databaseName: this.databaseName()})
-
       if (this.args.reset) {
-        await persistence.delete()
+        await deleteSqliteWebPersistences({databaseName: this.databaseName()})
       }
 
+      const persistence = await createSqliteWebPersistence({databaseName: this.databaseName()})
       const SQL = await initSqlJs({locateFile: this.sqlJsLocateFile()})
       const databaseContent = await persistence.load()
       const connectionSqlJs = new ConnectionSqlJs(this, new SQL.Database(databaseContent), persistence)

--- a/src/database/drivers/sqlite/web-persistence.js
+++ b/src/database/drivers/sqlite/web-persistence.js
@@ -8,7 +8,7 @@ const SUPPORT_CHECK_BYTES = new Uint8Array([118, 101, 108, 111, 99, 105, 111, 11
 /**
  * SQLite web persistence adapter.
  * @typedef {object} SqliteWebPersistence
- * @property {"indexeddb" | "localStorage" | "opfs"} name - Persistence backend name.
+ * @property {"indexeddb" | "opfs"} name - Persistence backend name.
  * @property {() => Promise<void>} delete - Deletes the persisted database.
  * @property {() => Promise<Uint8Array | undefined>} load - Loads persisted database bytes.
  * @property {(content: Uint8Array) => Promise<void>} save - Saves persisted database bytes.
@@ -33,13 +33,16 @@ export async function createSqliteWebPersistence({databaseName, environment = gl
   const opfsPersistence = new OpfsPersistence({databaseName, environment})
   const indexedDbPersistence = new IndexedDbPersistence({databaseName, environment})
 
-  if (await localStoragePersistence.exists()) return localStoragePersistence
-  if (await opfsPersistence.exists()) return opfsPersistence
-  if (await indexedDbPersistence.exists()) return indexedDbPersistence
-  if (await supportsOpfsPersistence(environment)) return opfsPersistence
-  if (await supportsIndexedDbPersistence(environment)) return indexedDbPersistence
+  const selectedPersistence = await selectSupportedPersistence({environment, indexedDbPersistence, opfsPersistence})
 
-  return localStoragePersistence
+  await migratePersistedDatabase({
+    databaseName,
+    destinationPersistence: selectedPersistence,
+    environment,
+    sourcePersistences: [localStoragePersistence, indexedDbPersistence, opfsPersistence]
+  })
+
+  return selectedPersistence
 }
 
 /**
@@ -221,10 +224,8 @@ class IndexedDbPersistence {
   }
 }
 
-/** LocalStorage-backed SQL.js database blob persistence. */
+/** LocalStorage-backed SQL.js database blob persistence for legacy migrations. */
 class LocalStoragePersistence {
-  /** @type {"localStorage"} */
-  name = "localStorage"
 
   /**
    * Creates localStorage persistence.
@@ -290,6 +291,60 @@ class LocalStoragePersistence {
     this.storage ||= new BetterLocalStorage()
 
     return this.storage
+  }
+}
+
+
+/**
+ * Selects the preferred available SQLite web persistence backend.
+ * @param {object} args - Arguments.
+ * @param {SqliteWebPersistenceEnvironment} args.environment - Browser-like environment.
+ * @param {IndexedDbPersistence} args.indexedDbPersistence - IndexedDB persistence adapter.
+ * @param {OpfsPersistence} args.opfsPersistence - OPFS persistence adapter.
+ * @returns {Promise<SqliteWebPersistence>} - Selected persistence adapter.
+ */
+async function selectSupportedPersistence({environment, indexedDbPersistence, opfsPersistence}) {
+  if (await supportsOpfsPersistence(environment)) return opfsPersistence
+  if (await supportsIndexedDbPersistence(environment)) return indexedDbPersistence
+
+  throw new Error("SQLite web persistence requires OPFS or IndexedDB support")
+}
+
+/**
+ * Migrates any existing database bytes into the selected persistence backend.
+ * @param {object} args - Arguments.
+ * @param {string} args.databaseName - Database name.
+ * @param {SqliteWebPersistence} args.destinationPersistence - Selected persistence adapter.
+ * @param {SqliteWebPersistenceEnvironment} args.environment - Browser-like environment.
+ * @param {{delete: () => Promise<void>, load: () => Promise<Uint8Array | undefined>}[]} args.sourcePersistences - Persistence adapters to scan for existing bytes.
+ * @returns {Promise<void>} - Resolves when migration is complete.
+ */
+async function migratePersistedDatabase({databaseName, destinationPersistence, environment, sourcePersistences}) {
+  if (await destinationPersistence.load() !== undefined) return
+
+  for (const sourcePersistence of sourcePersistences) {
+    if (sourcePersistence === destinationPersistence) continue
+
+    const databaseBytes = await loadPersistenceIfAvailable(sourcePersistence)
+    if (databaseBytes === undefined) continue
+
+    await destinationPersistence.save(databaseBytes)
+    await deleteSqliteWebPersistences({databaseName, environment})
+    await destinationPersistence.save(databaseBytes)
+    return
+  }
+}
+
+/**
+ * Loads a persistence backend, ignoring unavailable backend errors.
+ * @param {{load: () => Promise<Uint8Array | undefined>}} persistence - Persistence adapter.
+ * @returns {Promise<Uint8Array | undefined>} - Persisted bytes, if available.
+ */
+async function loadPersistenceIfAvailable(persistence) {
+  try {
+    return await persistence.load()
+  } catch {
+    return undefined
   }
 }
 
@@ -376,7 +431,7 @@ function indexedDbRequest(request) {
 
 /**
  * Deletes a persistence backend, ignoring unavailable backend errors.
- * @param {SqliteWebPersistence} persistence - Persistence adapter.
+ * @param {{delete: () => Promise<void>}} persistence - Persistence adapter.
  * @returns {Promise<void>} - Resolves when deletion was attempted.
  */
 async function deletePersistenceIfAvailable(persistence) {

--- a/src/database/drivers/sqlite/web-persistence.js
+++ b/src/database/drivers/sqlite/web-persistence.js
@@ -30,12 +30,33 @@ const SUPPORT_CHECK_BYTES = new Uint8Array([118, 101, 108, 111, 99, 105, 111, 11
  */
 export async function createSqliteWebPersistence({databaseName, environment = globalThis}) {
   const localStoragePersistence = new LocalStoragePersistence({databaseName})
+  const opfsPersistence = new OpfsPersistence({databaseName, environment})
+  const indexedDbPersistence = new IndexedDbPersistence({databaseName, environment})
 
   if (await localStoragePersistence.exists()) return localStoragePersistence
-  if (await supportsOpfsPersistence(environment)) return new OpfsPersistence({databaseName, environment})
-  if (await supportsIndexedDbPersistence(environment)) return new IndexedDbPersistence({databaseName, environment})
+  if (await opfsPersistence.exists()) return opfsPersistence
+  if (await indexedDbPersistence.exists()) return indexedDbPersistence
+  if (await supportsOpfsPersistence(environment)) return opfsPersistence
+  if (await supportsIndexedDbPersistence(environment)) return indexedDbPersistence
 
   return localStoragePersistence
+}
+
+/**
+ * Deletes SQLite web database bytes from every available persistence backend.
+ * @param {object} args - Arguments.
+ * @param {string} args.databaseName - Database name.
+ * @param {SqliteWebPersistenceEnvironment} [args.environment] - Browser-like environment.
+ * @returns {Promise<void>} - Resolves when all available backends were cleared.
+ */
+export async function deleteSqliteWebPersistences({databaseName, environment = globalThis}) {
+  const persistences = [
+    new LocalStoragePersistence({databaseName}),
+    new OpfsPersistence({databaseName, environment}),
+    new IndexedDbPersistence({databaseName, environment})
+  ]
+
+  for (const persistence of persistences) await deletePersistenceIfAvailable(persistence)
 }
 
 /**
@@ -100,6 +121,18 @@ class OpfsPersistence {
   }
 
   /**
+   * Checks whether the OPFS database file exists.
+   * @returns {Promise<boolean>} - Whether content exists.
+   */
+  async exists() {
+    try {
+      return (await this.load()) !== undefined
+    } catch {
+      return false
+    }
+  }
+
+  /**
    * Saves database bytes.
    * @param {Uint8Array} content - Database bytes.
    * @returns {Promise<void>} - Resolves when saved.
@@ -156,6 +189,23 @@ class IndexedDbPersistence {
     if (result instanceof ArrayBuffer) return new Uint8Array(result)
 
     throw new Error("SQLite web IndexedDB persistence returned unsupported content")
+  }
+
+  /**
+   * Checks whether the IndexedDB database entry exists.
+   * @returns {Promise<boolean>} - Whether content exists.
+   */
+  async exists() {
+    try {
+      const database = await openIndexedDb(this.environment)
+      const result = await indexedDbRequest(database.transaction("databases", "readonly").objectStore("databases").get(sqliteWebPersistenceKey(this.databaseName)))
+
+      database.close()
+
+      return result !== undefined && result !== null
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -322,6 +372,19 @@ function indexedDbRequest(request) {
     request.onsuccess = () => resolve(request.result)
     request.onerror = () => reject(request.error || new Error("IndexedDB request failed"))
   })
+}
+
+/**
+ * Deletes a persistence backend, ignoring unavailable backend errors.
+ * @param {SqliteWebPersistence} persistence - Persistence adapter.
+ * @returns {Promise<void>} - Resolves when deletion was attempted.
+ */
+async function deletePersistenceIfAvailable(persistence) {
+  try {
+    await persistence.delete()
+  } catch {
+    // Ignore unavailable backends so reset clears every backend the browser can access.
+  }
 }
 
 /**

--- a/src/database/drivers/sqlite/web-persistence.js
+++ b/src/database/drivers/sqlite/web-persistence.js
@@ -8,7 +8,7 @@ const SUPPORT_CHECK_BYTES = new Uint8Array([118, 101, 108, 111, 99, 105, 111, 11
 /**
  * SQLite web persistence adapter.
  * @typedef {object} SqliteWebPersistence
- * @property {"indexeddb" | "opfs"} name - Persistence backend name.
+ * @property {"indexeddb" | "localstorage" | "opfs"} name - Persistence backend name.
  * @property {() => Promise<void>} delete - Deletes the persisted database.
  * @property {() => Promise<Uint8Array | undefined>} load - Loads persisted database bytes.
  * @property {(content: Uint8Array) => Promise<void>} save - Saves persisted database bytes.
@@ -33,7 +33,7 @@ export async function createSqliteWebPersistence({databaseName, environment = gl
   const opfsPersistence = new OpfsPersistence({databaseName, environment})
   const indexedDbPersistence = new IndexedDbPersistence({databaseName, environment})
 
-  const selectedPersistence = await selectSupportedPersistence({environment, indexedDbPersistence, opfsPersistence})
+  const selectedPersistence = await selectSupportedPersistence({environment, indexedDbPersistence, localStoragePersistence, opfsPersistence})
 
   await migratePersistedDatabase({
     databaseName,
@@ -227,6 +227,9 @@ class IndexedDbPersistence {
 /** LocalStorage-backed SQL.js database blob persistence for legacy migrations. */
 class LocalStoragePersistence {
 
+  /** @type {"localstorage"} */
+  name = "localstorage"
+
   /**
    * Creates localStorage persistence.
    * @param {object} args - Arguments.
@@ -300,14 +303,15 @@ class LocalStoragePersistence {
  * @param {object} args - Arguments.
  * @param {SqliteWebPersistenceEnvironment} args.environment - Browser-like environment.
  * @param {IndexedDbPersistence} args.indexedDbPersistence - IndexedDB persistence adapter.
+ * @param {LocalStoragePersistence} args.localStoragePersistence - Legacy localStorage persistence adapter.
  * @param {OpfsPersistence} args.opfsPersistence - OPFS persistence adapter.
  * @returns {Promise<SqliteWebPersistence>} - Selected persistence adapter.
  */
-async function selectSupportedPersistence({environment, indexedDbPersistence, opfsPersistence}) {
+async function selectSupportedPersistence({environment, indexedDbPersistence, localStoragePersistence, opfsPersistence}) {
   if (await supportsOpfsPersistence(environment)) return opfsPersistence
   if (await supportsIndexedDbPersistence(environment)) return indexedDbPersistence
 
-  throw new Error("SQLite web persistence requires OPFS or IndexedDB support")
+  return localStoragePersistence
 }
 
 /**

--- a/src/database/drivers/sqlite/web-persistence.js
+++ b/src/database/drivers/sqlite/web-persistence.js
@@ -1,0 +1,399 @@
+// @ts-check
+
+import BetterLocalStorage from "better-localstorage"
+
+const SUPPORT_CHECK_FILE = ".velocious-opfs-support-check"
+const SUPPORT_CHECK_BYTES = new Uint8Array([118, 101, 108, 111, 99, 105, 111, 117, 115])
+
+/**
+ * SQLite web persistence adapter.
+ * @typedef {object} SqliteWebPersistence
+ * @property {"indexeddb" | "localStorage" | "opfs"} name - Persistence backend name.
+ * @property {() => Promise<void>} delete - Deletes the persisted database.
+ * @property {() => Promise<Uint8Array | undefined>} load - Loads persisted database bytes.
+ * @property {(content: Uint8Array) => Promise<void>} save - Saves persisted database bytes.
+ */
+
+/**
+ * Browser-like environment used for web persistence detection.
+ * @typedef {object} SqliteWebPersistenceEnvironment
+ * @property {unknown} [indexedDB] - IndexedDB global.
+ * @property {unknown} [navigator] - Navigator global.
+ */
+
+/**
+ * Creates the best SQLite web persistence adapter supported by the current browser.
+ * @param {object} args - Arguments.
+ * @param {string} args.databaseName - Database name.
+ * @param {SqliteWebPersistenceEnvironment} [args.environment] - Browser-like environment.
+ * @returns {Promise<SqliteWebPersistence>} - Selected persistence adapter.
+ */
+export async function createSqliteWebPersistence({databaseName, environment = globalThis}) {
+  const localStoragePersistence = new LocalStoragePersistence({databaseName})
+
+  if (await localStoragePersistence.exists()) return localStoragePersistence
+  if (await supportsOpfsPersistence(environment)) return new OpfsPersistence({databaseName, environment})
+  if (await supportsIndexedDbPersistence(environment)) return new IndexedDbPersistence({databaseName, environment})
+
+  return localStoragePersistence
+}
+
+/**
+ * Returns the legacy SQLite web storage key for a database name.
+ * @param {string} databaseName - Database name.
+ * @returns {string} - Persistence key.
+ */
+export function sqliteWebPersistenceKey(databaseName) {
+  if (!databaseName) throw new Error("No name given in arguments for SQLite Web database")
+
+  return `VelociousDatabaseDriversSqliteWeb---${databaseName}`
+}
+
+/** OPFS-backed SQL.js database file persistence. */
+class OpfsPersistence {
+  /** @type {"opfs"} */
+  name = "opfs"
+
+  /**
+   * Creates OPFS persistence.
+   * @param {object} args - Arguments.
+   * @param {string} args.databaseName - Database name.
+   * @param {SqliteWebPersistenceEnvironment} args.environment - Browser-like environment.
+   */
+  constructor({databaseName, environment}) {
+    this.databaseName = databaseName
+    this.environment = environment
+  }
+
+  /**
+   * Deletes the OPFS database file.
+   * @returns {Promise<void>} - Resolves when deleted.
+   */
+  async delete() {
+    const directory = await opfsDirectory(this.environment)
+
+    try {
+      await directory.removeEntry(sqliteWebPersistenceKey(this.databaseName))
+    } catch (error) {
+      if (!isNotFoundError(error)) throw error
+    }
+  }
+
+  /**
+   * Loads the OPFS database file.
+   * @returns {Promise<Uint8Array | undefined>} - Persisted bytes.
+   */
+  async load() {
+    const directory = await opfsDirectory(this.environment)
+
+    try {
+      const fileHandle = await directory.getFileHandle(sqliteWebPersistenceKey(this.databaseName))
+      const file = await fileHandle.getFile()
+      const arrayBuffer = await file.arrayBuffer()
+
+      return new Uint8Array(arrayBuffer)
+    } catch (error) {
+      if (isNotFoundError(error)) return undefined
+
+      throw error
+    }
+  }
+
+  /**
+   * Saves database bytes.
+   * @param {Uint8Array} content - Database bytes.
+   * @returns {Promise<void>} - Resolves when saved.
+   */
+  async save(content) {
+    const directory = await opfsDirectory(this.environment)
+    const fileHandle = await directory.getFileHandle(sqliteWebPersistenceKey(this.databaseName), {create: true})
+    const writable = await fileHandle.createWritable()
+
+    await writable.write(arrayBufferFromBytes(content))
+    await writable.close()
+  }
+}
+
+/** IndexedDB-backed SQL.js database blob persistence. */
+class IndexedDbPersistence {
+  /** @type {"indexeddb"} */
+  name = "indexeddb"
+
+  /**
+   * Creates IndexedDB persistence.
+   * @param {object} args - Arguments.
+   * @param {string} args.databaseName - Database name.
+   * @param {SqliteWebPersistenceEnvironment} args.environment - Browser-like environment.
+   */
+  constructor({databaseName, environment}) {
+    this.databaseName = databaseName
+    this.environment = environment
+  }
+
+  /**
+   * Deletes the IndexedDB database entry.
+   * @returns {Promise<void>} - Resolves when deleted.
+   */
+  async delete() {
+    const database = await openIndexedDb(this.environment)
+
+    await indexedDbRequest(database.transaction("databases", "readwrite").objectStore("databases").delete(sqliteWebPersistenceKey(this.databaseName)))
+    database.close()
+  }
+
+  /**
+   * Loads the IndexedDB database entry.
+   * @returns {Promise<Uint8Array | undefined>} - Persisted bytes.
+   */
+  async load() {
+    const database = await openIndexedDb(this.environment)
+    const result = await indexedDbRequest(database.transaction("databases", "readonly").objectStore("databases").get(sqliteWebPersistenceKey(this.databaseName)))
+
+    database.close()
+
+    if (result === undefined) return undefined
+    if (result instanceof Uint8Array) return result
+    if (result instanceof ArrayBuffer) return new Uint8Array(result)
+
+    throw new Error("SQLite web IndexedDB persistence returned unsupported content")
+  }
+
+  /**
+   * Saves database bytes.
+   * @param {Uint8Array} content - Database bytes.
+   * @returns {Promise<void>} - Resolves when saved.
+   */
+  async save(content) {
+    const database = await openIndexedDb(this.environment)
+
+    await indexedDbRequest(database.transaction("databases", "readwrite").objectStore("databases").put(content, sqliteWebPersistenceKey(this.databaseName)))
+    database.close()
+  }
+}
+
+/** LocalStorage-backed SQL.js database blob persistence. */
+class LocalStoragePersistence {
+  /** @type {"localStorage"} */
+  name = "localStorage"
+
+  /**
+   * Creates localStorage persistence.
+   * @param {object} args - Arguments.
+   * @param {string} args.databaseName - Database name.
+   */
+  constructor({databaseName}) {
+    this.databaseName = databaseName
+    /** @type {BetterLocalStorage | undefined} */
+    this.storage = undefined
+  }
+
+  /**
+   * Deletes the localStorage database entry.
+   * @returns {Promise<void>} - Resolves when deleted.
+   */
+  async delete() {
+    await this.localStorage().delete(sqliteWebPersistenceKey(this.databaseName))
+  }
+
+  /**
+   * Loads the localStorage database entry.
+   * @returns {Promise<Uint8Array | undefined>} - Persisted bytes.
+   */
+  async load() {
+    const content = await this.localStorage().get(sqliteWebPersistenceKey(this.databaseName))
+
+    if (content === null || content === undefined) return undefined
+    if (content instanceof Uint8Array) return content
+    if (content instanceof ArrayBuffer) return new Uint8Array(content)
+
+    return /** @type {Uint8Array} */ (content)
+  }
+
+  /**
+   * Saves database bytes.
+   * @param {Uint8Array} content - Database bytes.
+   * @returns {Promise<void>} - Resolves when saved.
+   */
+  async save(content) {
+    await this.localStorage().set(sqliteWebPersistenceKey(this.databaseName), content)
+  }
+
+  /**
+   * Checks whether the legacy localStorage database exists.
+   * @returns {Promise<boolean>} - Whether content exists.
+   */
+  async exists() {
+    try {
+      const content = await this.localStorage().get(sqliteWebPersistenceKey(this.databaseName))
+
+      return content !== undefined && content !== null
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Returns the localStorage wrapper.
+   * @returns {BetterLocalStorage} - Storage wrapper.
+   */
+  localStorage() {
+    this.storage ||= new BetterLocalStorage()
+
+    return this.storage
+  }
+}
+
+/**
+ * Tests whether OPFS persistence is usable.
+ * @param {SqliteWebPersistenceEnvironment} environment - Browser-like environment.
+ * @returns {Promise<boolean>} - Whether OPFS can be used.
+ */
+async function supportsOpfsPersistence(environment) {
+  try {
+    const directory = await opfsDirectory(environment)
+    const fileHandle = await directory.getFileHandle(SUPPORT_CHECK_FILE, {create: true})
+    const writable = await fileHandle.createWritable()
+
+    await writable.write(arrayBufferFromBytes(SUPPORT_CHECK_BYTES))
+    await writable.close()
+
+    const file = await fileHandle.getFile()
+    const readBack = new Uint8Array(await file.arrayBuffer())
+
+    await directory.removeEntry(SUPPORT_CHECK_FILE)
+
+    return sameBytes(readBack, SUPPORT_CHECK_BYTES)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Tests whether IndexedDB persistence is usable.
+ * @param {SqliteWebPersistenceEnvironment} environment - Browser-like environment.
+ * @returns {Promise<boolean>} - Whether IndexedDB can be used.
+ */
+async function supportsIndexedDbPersistence(environment) {
+  try {
+    const database = await openIndexedDb(environment)
+    const store = database.transaction("databases", "readwrite").objectStore("databases")
+
+    await indexedDbRequest(store.put(SUPPORT_CHECK_BYTES, SUPPORT_CHECK_FILE))
+
+    const readBack = await indexedDbRequest(store.get(SUPPORT_CHECK_FILE))
+
+    await indexedDbRequest(store.delete(SUPPORT_CHECK_FILE))
+    database.close()
+
+    return readBack instanceof Uint8Array && sameBytes(readBack, SUPPORT_CHECK_BYTES)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Opens the SQLite web IndexedDB database.
+ * @param {SqliteWebPersistenceEnvironment} environment - Browser-like environment.
+ * @returns {Promise<IDBDatabase>} - Open database.
+ */
+async function openIndexedDb(environment) {
+  const indexedDb = indexedDbFromEnvironment(environment)
+
+  if (!indexedDb || typeof indexedDb.open !== "function") throw new Error("IndexedDB is not available")
+
+  const request = indexedDb.open("VelociousDatabaseDriversSqliteWeb", 1)
+  request.onupgradeneeded = () => {
+    const database = request.result
+
+    if (!database.objectStoreNames.contains("databases")) database.createObjectStore("databases")
+  }
+
+  return await indexedDbRequest(request)
+}
+
+/**
+ * Resolves an IndexedDB request.
+ * @template T
+ * @param {IDBRequest<T>} request - IndexedDB request.
+ * @returns {Promise<T>} - Request result.
+ */
+function indexedDbRequest(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error || new Error("IndexedDB request failed"))
+  })
+}
+
+/**
+ * Gets OPFS root directory.
+ * @param {SqliteWebPersistenceEnvironment} environment - Browser-like environment.
+ * @returns {Promise<FileSystemDirectoryHandle>} - OPFS root directory.
+ */
+async function opfsDirectory(environment) {
+  const navigatorObject = navigatorFromEnvironment(environment)
+  const storage = navigatorObject.storage
+
+  if (!storage || typeof storage.getDirectory !== "function") throw new Error("OPFS is not available")
+
+  return await storage.getDirectory()
+}
+
+/**
+ * Gets navigator from environment.
+ * @param {SqliteWebPersistenceEnvironment} environment - Browser-like environment.
+ * @returns {{storage?: {getDirectory?: () => Promise<FileSystemDirectoryHandle>}}} - Navigator-like object.
+ */
+function navigatorFromEnvironment(environment) {
+  const candidate = environment.navigator
+
+  if (!candidate || typeof candidate !== "object") return {}
+
+  return /** @type {{storage?: {getDirectory?: () => Promise<FileSystemDirectoryHandle>}}} */ (candidate)
+}
+
+/**
+ * Gets IndexedDB from environment.
+ * @param {SqliteWebPersistenceEnvironment} environment - Browser-like environment.
+ * @returns {{open?: (name: string, version?: number) => IDBOpenDBRequest} | undefined} - IndexedDB-like object.
+ */
+function indexedDbFromEnvironment(environment) {
+  const candidate = environment.indexedDB
+
+  if (!candidate || typeof candidate !== "object") return undefined
+
+  return /** @type {{open?: (name: string, version?: number) => IDBOpenDBRequest}} */ (candidate)
+}
+
+/**
+ * Converts bytes to a standalone ArrayBuffer for browser file writes.
+ * @param {Uint8Array} bytes - Bytes to convert.
+ * @returns {ArrayBuffer} - Standalone ArrayBuffer.
+ */
+function arrayBufferFromBytes(bytes) {
+  const copy = new Uint8Array(bytes.byteLength)
+
+  copy.set(bytes)
+
+  return copy.buffer
+}
+
+/**
+ * Checks whether an error is a file-not-found error.
+ * @param {unknown} error - Error candidate.
+ * @returns {boolean} - Whether the error is not found.
+ */
+function isNotFoundError(error) {
+  return error instanceof Error && error.name === "NotFoundError"
+}
+
+/**
+ * Compares two byte arrays.
+ * @param {Uint8Array} left - Left bytes.
+ * @param {Uint8Array} right - Right bytes.
+ * @returns {boolean} - Whether bytes match.
+ */
+function sameBytes(left, right) {
+  if (left.length !== right.length) return false
+
+  return left.every((value, index) => value === right[index])
+}


### PR DESCRIPTION
## Summary
- add automatic SQLite web persistence selection: existing localStorage databases stay on the legacy key, otherwise OPFS is preferred, then IndexedDB, then localStorage
- route SQL.js database save/load/delete through persistence adapters instead of hard-coding localStorage in the web driver
- document the selection order and the current export-on-write limitation until a page-level SQLite WASM VFS is added

## Testing
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/drivers/sqlite/index-web-persistence-spec.js spec/database/drivers/sqlite/index-web-locate-file-spec.js spec/database/migration/sqlite-web-uuid-primary-key-spec.js
- VELOCIOUS_DISABLE_MSSQL=1 npm run typecheck
- npm run lint
- npm run test:expo
- git diff --check