### PR TITLE
fix(mysql): set session timezone before queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 * EJS-backed mailers with delivery, queueing, and payload rendering support (see [docs/mailers.md](docs/mailers.md))
 * Trusted reverse proxy handling for `request.remoteAddress()` (see [docs/trusted-proxies.md](docs/trusted-proxies.md))
 * In-process driver schema metadata caching (see [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md))
+* Planned local-first shared-resource sync architecture (see [docs/offline-sync.md](docs/offline-sync.md))
 * Named database connection checkouts, bounded pool waits, and debugging held connections (see [docs/database-connections.md](docs/database-connections.md))
 * Optional built-in debug endpoint for inspecting server and database connection state (see [docs/debug-endpoint.md](docs/debug-endpoint.md))
 

--- a/changelog.d/20260623123015-offline-sync-architecture.md
+++ b/changelog.d/20260623123015-offline-sync-architecture.md
@@ -1,0 +1,1 @@
+Document planned local-first shared-resource sync architecture, including offline grants, signed mutation logs, peer transfer, and server-sequenced backend replay.

--- a/changelog.d/20260623193459-flush-sqljs-truncate-writes.md
+++ b/changelog.d/20260623193459-flush-sqljs-truncate-writes.md
@@ -1,0 +1,1 @@
+Flush pending SQL.js local persistence before `truncateAllTables()` resolves so immediate browser reloads see reset rows.

--- a/changelog.d/20260624122845-mysql-lazy-session-timezone.md
+++ b/changelog.d/20260624122845-mysql-lazy-session-timezone.md
@@ -1,0 +1,1 @@
+MySQL/MariaDB drivers now set the session timezone to UTC immediately before each query instead of only during connect, so pooled/retried physical sessions keep timezone-less datetime storage consistent.

--- a/changelog.d/20260624122845-mysql-lazy-session-timezone.md
+++ b/changelog.d/20260624122845-mysql-lazy-session-timezone.md
@@ -1,1 +1,1 @@
-MySQL/MariaDB drivers now set the session timezone to UTC immediately before each query instead of only during connect, so pooled/retried physical sessions keep timezone-less datetime storage consistent.
+MySQL/MariaDB drivers now set the session timezone to UTC lazily when a connection is checked out or first used instead of only during connect, so pooled physical sessions keep timezone-less datetime storage consistent without issuing redundant setup SQL before every query.

--- a/changelog.d/20260624122845-mysql-lazy-session-timezone.md
+++ b/changelog.d/20260624122845-mysql-lazy-session-timezone.md
@@ -1,1 +1,1 @@
-MySQL/MariaDB drivers now set the session timezone to UTC lazily when a connection is checked out or first used instead of only during connect, so pooled physical sessions keep timezone-less datetime storage consistent without issuing redundant setup SQL before every query.
+MySQL/MariaDB drivers now set the session timezone to UTC lazily before the first real query on a physical connection and reuse the confirmed session timezone across checkouts, avoiding redundant setup SQL for checked-out connections that are never queried or already have the desired timezone.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/logging.md`: Rails-style request and database query logging behavior.
 - `docs/mailers.md`: EJS mailer templates, direct delivery, background delivery, and payload rendering.
 - `docs/model-initialization.md`: Eager and lazy record/frontend-model initialization behavior.
+- `docs/offline-sync.md`: Target architecture for local-first shared-resource sync, offline grants, peer transfer, and server-sequenced replay.
 - `docs/schema-metadata-cache.md`: Driver schema metadata caching, invalidation, and disabling.
 - `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, and legacy-byte migration.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.

--- a/docs/offline-sync.md
+++ b/docs/offline-sync.md
@@ -1,8 +1,274 @@
-# Offline sync mutation log
+# Offline Sync Architecture
+
+This document records the target architecture for Velocious local-first sync. It is an implementation plan and compatibility contract for building reusable offline sync in Velocious and then migrating downstream apps such as Printyourticket/ticket-app and AwesomeTasks onto the framework primitives.
+
+## Goals
+
+- Let frontend apps keep working for long periods with no backend connection.
+- Reuse Velocious resource authorization and `permittedParams` instead of creating a parallel sync write path.
+- Support shared resource files that run in both frontend and backend bundles.
+- Let devices exchange mutations directly while offline without trusting peer database rows.
+- Keep backend replay authoritative and auditable when connectivity returns.
+- Support both generic model mutations and app-defined domain commands.
+
+## Non-goals
+
+- Do not make frontend JavaScript a trusted security boundary.
+- Do not accept arbitrary `{resourceType, resourceId, data}` payloads as a privileged backend write API.
+- Do not require every resource authorization rule to be expressible as declarative JSON. Velocious resources may use real JavaScript, database queries, nested attributes, and CanCan-style abilities.
+- Do not force high-risk resources such as roles, billing settings, tokens, or security configuration to support offline writes.
+
+## Main concepts
+
+### Shared resources
+
+Projects that need long-lived offline or peer-to-peer sync should define shared resource files that are bundled into both the frontend and backend. The shared resource contains frontend-safe business policy and validation code:
+
+- model name and sync configuration
+- portable `abilities` helpers where they can run against either local SQLite or backend DB models
+- `permittedParams` / `offlinePermittedParams` logic, including nested attributes
+- offline validation
+- conflict strategy
+- domain sync command schemas and handlers where they are portable
+
+Backend and frontend resource wrappers should resolve behavior in this order:
+
+1. environment-specific resource method
+2. shared resource method
+3. framework default
+
+That fallback lets projects keep most resource behavior in one shared place while still adding backend-only hooks, frontend-only local runtime hooks, or compatibility behavior where needed.
+
+Shared resource modules must be bundle-safe. They should not import backend-only model files directly, use raw database drivers, read secrets, access the filesystem, or rely on Node-only APIs. Shared resource queries should use Velocious' portable model/query API through the resource context.
+
+### Resource context
+
+The framework should inject a consistent context into shared resources:
+
+- `currentUser()`
+- `currentDevice()`
+- `offlineGrant()`
+- `model(name)` to resolve the environment's model registry
+- `isFrontend()` / `isBackend()` / `isOffline()`
+- `now()`
+
+On the backend, `model(name)` resolves real database-backed model classes. On the frontend, it resolves local SQLite/frontend-local model classes. The same shared resource method can therefore query the local replica while offline and the authoritative database during backend replay.
+
+Frontend decisions are provisional because local SQLite may be stale or incomplete. Backend decisions are authoritative unless a resource explicitly chooses a grant-time offline policy.
+
+### Offline grants
+
+A long-offline app cannot ask the backend for live permission checks. During bootstrap or a later refresh, the backend issues a signed offline grant that materializes what a user/device may do offline.
+
+A grant should include at least:
+
+- grant id
+- user id
+- device id
+- issued/expiry timestamps
+- policy version and policy hash
+- resource operation metadata
+- materialized scopes or context needed by shared resource policy code
+- grant-time authorization policy
+
+The grant is signed by the backend. Clients and peers can verify the signature offline. The grant does not make frontend code trusted; it gives honest clients and peers a portable proof that a backend-authorized user/device received specific offline authority.
+
+Resources should be able to choose authorization policy per operation:
+
+- current permission wins during replay
+- grant-time permission wins during replay
+- custom resource policy
+- online-only / offline disabled
+
+True long-term offline operation implies delayed revocation. The framework should make that explicit through grant expiry, resource opt-outs, and audit trails.
+
+### Device certificates and mutation signatures
+
+Every offline-capable device should have a key pair. The backend registers the device public key and signs a device certificate containing:
+
+- device id
+- user id
+- public key
+- issued/expiry timestamps
+
+Offline mutations are signed by the originating device. Peer devices verify the device certificate, the offline grant, and the mutation signature before applying or forwarding a mutation.
+
+The HTTP uploader may differ from the mutation actor. If Device B receives Device A's mutations peer-to-peer, Device B may later upload those signed mutations to the backend. Backend replay must build the resource context from the signed actor/grant, not blindly from the uploader's HTTP session.
+
+### Mutation log
+
+Frontend apps should persist an append-only local mutation log instead of only storing dirty model rows. Each mutation should include:
+
+- client mutation id
+- actor user id and actor device id
+- model mutation or domain command name
+- operation
+- record id or client id
+- attributes or command payload
+- base version / base server sequence where applicable
+- offline grant id
+- policy hash
+- occurred-at timestamp
+- signature
+- dependency ids for offline-created records
+- local status
+
+Useful statuses include:
+
+- `pending`
+- `appliedLocally`
+- `peerReceivedUnapplied`
+- `peerAppliedPendingServerConfirmation`
+- `conflict`
+- `rejected`
+- `synced`
+
+Local writes update SQLite optimistically after shared resource policy checks pass. Server replay later returns per-mutation results so the client can mark mutations as synced, rejected, or conflicted.
+
+### Server replay
+
+The backend sync receiver should treat sync as batched delayed resource commands, not as a separate privileged write path.
+
+Replay pipeline:
+
+1. Verify mutation envelope, device certificate, grant signature, expiry, and idempotency key.
+2. Resolve the model/resource from the registered Velocious resource manifest.
+3. Build actor context from the signed mutation actor and offline grant.
+4. Resolve operation or domain command.
+5. Run sync-specific hooks when present; otherwise fall back to normal resource abilities and `permittedParams`.
+6. Reject unpermitted attributes and nested attributes as contract errors.
+7. Apply create/update/destroy through the normal resource/model pipeline.
+8. Persist the mutation result idempotently.
+9. Append server-sequenced changes to the change feed.
+10. Return a structured result for each mutation.
+
+Result statuses should distinguish at least:
+
+- `applied`
+- `duplicate`
+- `rejected`
+- `conflict`
+- `error`
+
+### Change feed and snapshots
+
+Accepted backend changes should be stored in an append-only server-sequenced feed. Clients pull with a stable cursor such as `serverSequence > lastSeenSequence`, not timestamp plus offset.
+
+A change should include:
+
+- server sequence
+- model or command result type
+- operation
+- record id
+- serialized payload
+- actor user/device
+- originating client mutation id when present
+- scope data needed for subscribers
+- server timestamp
+
+If a client is too far behind for retained changes, the server returns `snapshot_required`. The client then refreshes a scoped snapshot and resumes from the snapshot's sequence.
+
+### Peer-to-peer transfer
+
+Devices should exchange signed mutation logs and proof material, not trusted database rows.
+
+A peer export contains:
+
+- signed mutations
+- signed offline grants
+- signed device certificates
+- optional snapshot chunks and signed snapshot manifests when available
+
+On import, the receiving device verifies:
+
+1. backend signature on the offline grant
+2. backend signature on the device certificate
+3. device signature on the mutation
+4. policy hash compatibility
+5. grant scope and expiry
+6. shared resource `permittedParams` / offline policy against local data where possible
+7. duplicate mutation ids
+8. local conflict strategy
+
+If the receiver cannot verify because policy code or local related data is missing, it stores the mutation as `peerReceivedUnapplied` and may forward it later. If verification passes, it can apply the mutation locally as `peerAppliedPendingServerConfirmation`.
+
+### Generic model mutations vs domain commands
+
+Generic model sync is appropriate for normal CRUD-like resources such as tasks, comments, labels, and simple settings.
+
+Domain-sensitive workflows should use sync commands instead of raw model attribute writes. Examples:
+
+- ticket scanner `scanAttempt`
+- task board `moveCard`
+- ordering operations with conflict-prone row numbers
+- operations that create several model changes from one user action
+
+A sync command still uses offline grants, mutation signatures, idempotency, shared resource policy, and backend replay, but the resource owns the domain decision and the emitted model changes.
+
+## Sequence: bootstrap
+
+1. User signs in while online.
+2. Frontend asks for sync bootstrap for a project, event, board, or other scope.
+3. Backend evaluates resources, abilities, `permittedParams`, offline hooks, and materialized scopes for the actor/device.
+4. Backend returns initial snapshot data, server sequence, shared policy hashes, device certificate, and signed offline grant.
+5. Frontend stores snapshot data in local SQLite and persists the grant/device material.
+
+## Sequence: offline write
+
+1. User performs an action while offline.
+2. Frontend resolves the shared resource and checks the signed grant, local scope, `permittedParams`, and local validation.
+3. Frontend appends a signed mutation to the local log.
+4. Frontend updates local SQLite optimistically.
+5. UI shows the change as pending until backend confirmation.
+
+## Sequence: peer import
+
+1. Device A exports signed pending mutations and proof material.
+2. Device B imports the bundle.
+3. Device B verifies signatures, grants, policy hash, and local applicability.
+4. Device B applies verifiable mutations provisionally or stores unverifiable mutations for forwarding.
+5. Device B can later upload Device A's signed mutations to the backend.
+
+## Sequence: backend replay and catch-up
+
+1. A device uploads its own and/or peer-forwarded signed mutations.
+2. Backend verifies signatures, idempotency, actor context, grants, abilities, and `permittedParams`.
+3. Backend applies valid mutations or returns structured rejection/conflict results.
+4. Backend appends server-sequenced change records for accepted changes.
+5. Clients pull changes after their last sequence and converge on authoritative state.
+
+## Ticket-app migration outline
+
+1. Harden current ticket-app sync path while the framework is being built: remove unsafe auth bypasses, authorize every sync mutation, scope pending rows by actor/device/event, and add idempotency.
+2. Move scanner read-side event/ticket/ticket-scan snapshots to Velocious snapshot/change-feed primitives.
+3. Replace scanner `TicketScan` and `Ticket.whereaboutState` attribute sync with a `TicketScan.scanAttempt` domain command.
+4. Add peer-transfer support for scanner devices using signed mutations and grants.
+5. Remove old ad-hoc sync endpoints after supported app versions have migrated.
+
+## AwesomeTasks proof outline
+
+AwesomeTasks is a good proof target for generic resource sync:
+
+- task create/update through model mutations
+- comment create as append-only model mutation
+- labels/assignments through model or command sync depending on conflict needs
+- board move through a `TaskBoard.moveCard` domain command instead of raw `rowNumber` updates
+
+The proof should validate that shared resources, offline grants, local mutation logs, peer forwarding, server replay, and server-sequenced changes are usable outside ticket-app.
+
+## Open implementation decisions
+
+- Exact signing algorithm and key rotation strategy.
+- Whether offline grant persistence is framework-owned or app-owned with framework interfaces.
+- The default conflict strategy for resources without an explicit strategy.
+- How much snapshot integrity data is required for peer bootstrap in v1.
+- Whether frontend-local resources are generated automatically from shared resources or configured explicitly per app.
+
+## Implemented slice: local mutation log
 
 Velocious has a client-side local mutation log for the first local-first/offline write path. It is intentionally small and append-only: frontend code records what the user tried to do, applies the allowed change optimistically to the in-memory model instance, and leaves server replay/conflict resolution to later sync pipeline steps.
 
-## LocalMutationLog
+### LocalMutationLog
 
 `LocalMutationLog` lives in `velocious/build/src/sync/local-mutation-log.js`.
 
@@ -40,7 +306,7 @@ Each appended record contains:
 
 Use `pendingRecords()` to get records that still need reconciliation; storage adapters can service this through a status index rather than loading terminal history. Use `updateStatus(...)` after a replay, conflict, rejection, or successful sync. Use `compact(...)` after successful replay/sync to delete old terminal records while preserving pending/conflict records and records referenced by pending dependencies.
 
-## Offline frontend-model writes
+### Offline frontend-model writes
 
 Frontend models can queue offline mutations by configuring transport-level offline sync:
 
@@ -74,6 +340,6 @@ Nested attributes and attachment payloads are not replayable in this first slice
 
 If the local sync policy does not list the operation, the write is rejected locally and no mutation is queued.
 
-## Current boundaries
+### Current boundaries
 
 This slice does not replay mutations to the backend, resolve conflicts, import peer logs, or persist frontend-model rows into app SQLite tables by itself. Those belong to the later server replay, change feed, conflict, P2P, and app integration tasks. The current contract is the durable local mutation log plus the optimistic frontend-model `save()`/`destroy()` queue path.

--- a/spec/database/drivers/base-process-list-comment-spec.js
+++ b/spec/database/drivers/base-process-list-comment-spec.js
@@ -11,6 +11,9 @@ class ProcessListCommentDriver extends DatabaseDriverBase {
   /** @type {string[]} */
   queries = []
 
+  /** @type {string[]} */
+  hookEvents = []
+
   async connect() {}
 
   /** @returns {string} - Driver type. */
@@ -30,6 +33,22 @@ class ProcessListCommentDriver extends DatabaseDriverBase {
     this.queries.push(sql)
 
     return []
+  }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async beforeQuery(sql) {
+    this.hookEvents.push(`before:${sql}`)
+  }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async afterQuery(sql) {
+    this.hookEvents.push(`after:${sql}`)
   }
 
   /** @returns {void} - No return value. */
@@ -100,5 +119,44 @@ describe("Database drivers - process-list comments", {databaseCleaning: {transac
       "/* velocious checkout=\"migration\" */ CREATE TABLE schema_cache_test(id int)"
     ])
     expect(driver.clearSchemaCacheCalls).toBe(1)
+  })
+
+  it("runs before and after query hooks around executed SQL", async () => {
+    const driver = new ProcessListCommentDriver({}, buildConfiguration())
+
+    await driver.query("SELECT 1")
+
+    expect(driver.hookEvents).toEqual([
+      "before:SELECT 1",
+      "after:SELECT 1"
+    ])
+    expect(driver.queries).toEqual(["SELECT 1"])
+  })
+
+  it("runs after query hooks when the driver query fails", async () => {
+    class FailingProcessListCommentDriver extends ProcessListCommentDriver {
+      /**
+       * @param {string} sql - SQL string.
+       * @returns {Promise<import("../../../src/database/drivers/base.js").QueryResultType>} - Query result.
+       */
+      async _queryActual(sql) {
+        this.queries.push(sql)
+        throw new Error("query failed")
+      }
+    }
+
+    const driver = new FailingProcessListCommentDriver({}, buildConfiguration())
+    const error = await driver.query("SELECT fail").then(
+      () => undefined,
+      (caughtError) => caughtError
+    )
+
+    expect(error.message).toEqual("query failed")
+
+    expect(driver.hookEvents).toEqual([
+      "before:SELECT fail",
+      "after:SELECT fail"
+    ])
+    expect(driver.queries).toEqual(["SELECT fail"])
   })
 })

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -7,6 +7,8 @@ const mysqlConfig = digg(configuration, "database", "test", "default")
 class QueryCapturingMysqlDriver extends DatabaseDriversMysql {
   /** @type {Array<{options: import("../../../../src/database/drivers/base.js").QueryOptions, sql: string}>} */
   queries = []
+  /** @type {string[]} */
+  actualQueries = []
 
   /**
    * @param {string} sql - SQL string.
@@ -15,6 +17,16 @@ class QueryCapturingMysqlDriver extends DatabaseDriversMysql {
    */
   async query(sql, options = {}) {
     this.queries.push({options, sql})
+
+    return []
+  }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @returns {Promise<import("../../../../src/database/drivers/base.js").QueryResultType>} - Query result.
+   */
+  async _queryActual(sql) {
+    this.actualQueries.push(sql)
 
     return []
   }
@@ -82,16 +94,59 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
     ])
   })
 
-  it("sets the session time zone to UTC without process-list comments", async () => {
+  it("sets the session time zone before each query", async () => {
     const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
 
-    await mysql.setSessionTimezoneToUtc()
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 1")
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 2")
 
-    expect(mysql.queries).toEqual([
-      {
-        options: {logName: "Set Session Time Zone", processListComment: false},
-        sql: "SET time_zone = '+00:00'"
+    expect(mysql.actualQueries).toEqual([
+      "SET time_zone = '+00:00'",
+      "SELECT 1",
+      "SET time_zone = '+00:00'",
+      "SELECT 2"
+    ])
+  })
+
+  it("sets the session time zone before retried queries", async () => {
+    class RetryMysqlDriver extends QueryCapturingMysqlDriver {
+      attempts = 0
+
+      /** @returns {Promise<void>} - Resolves when complete. */
+      async reconnect() {
+        // No-op for this retry unit test.
       }
+
+      /**
+       * @param {string} sql - SQL string.
+       * @returns {Promise<import("../../../../src/database/drivers/base.js").QueryResultType>} - Query result.
+       */
+      async _queryActual(sql) {
+        this.actualQueries.push(sql)
+
+        if (sql == "SELECT retry_me") {
+          this.attempts++
+          if (this.attempts == 1) {
+            const error = new Error("Connection lost during query")
+            // @ts-expect-error error code is provided by the mysql package at runtime.
+            error.code = "PROTOCOL_CONNECTION_LOST"
+            throw error
+          }
+        }
+
+        return []
+      }
+    }
+
+    const mysql = new RetryMysqlDriver(mysqlConfig, configuration)
+
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT retry_me")
+
+    expect(mysql.actualQueries).toEqual([
+      "SET time_zone = '+00:00'",
+      "SELECT retry_me",
+      "SET time_zone = '+00:00'",
+      "SELECT retry_me"
     ])
   })
 })

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -7,6 +7,7 @@ const mysqlConfig = digg(configuration, "database", "test", "default")
 class QueryCapturingMysqlDriver extends DatabaseDriversMysql {
   /** @type {Array<{options: import("../../../../src/database/drivers/base.js").QueryOptions, sql: string}>} */
   queries = []
+
   /** @type {string[]} */
   actualQueries = []
 
@@ -94,7 +95,7 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
     ])
   })
 
-  it("sets the session time zone before each query", async () => {
+  it("sets the session time zone once before a query sequence", async () => {
     const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
 
     await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 1")
@@ -103,18 +104,35 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
     expect(mysql.actualQueries).toEqual([
       "SET time_zone = '+00:00'",
       "SELECT 1",
-      "SET time_zone = '+00:00'",
       "SELECT 2"
     ])
   })
 
-  it("sets the session time zone before retried queries", async () => {
+  it("resets the session time zone on each connection checkout", async () => {
+    const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
+
+    await mysql.setConnectionCheckoutName("first checkout")
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 1")
+    await mysql.clearConnectionCheckoutName()
+    await mysql.setConnectionCheckoutName("second checkout")
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 2")
+
+    expect(mysql.actualQueries).toEqual([
+      "SET time_zone = '+00:00'",
+      '/* velocious checkout="first checkout" */ SELECT 1',
+      "SET time_zone = '+00:00'",
+      '/* velocious checkout="second checkout" */ SELECT 2'
+    ])
+  })
+
+  it("sets the session time zone before retried queries after reconnect", async () => {
     class RetryMysqlDriver extends QueryCapturingMysqlDriver {
       attempts = 0
 
       /** @returns {Promise<void>} - Resolves when complete. */
       async reconnect() {
-        // No-op for this retry unit test.
+        // Simulate the base reconnect behavior without touching a real MySQL pool.
+        this._sessionTimezoneSetToUtc = false
       }
 
       /**

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -85,11 +85,11 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
 
     expect(mysql.queries).toEqual([
       {
-        options: {logName: "Set Connection Checkout Name", processListComment: false},
+        options: {logName: "Set Connection Checkout Name", processListComment: false, sessionTimeZone: false},
         sql: "SET @velocious_connection_checkout_name = 'mysql checkout spec'"
       },
       {
-        options: {logName: "Clear Connection Checkout Name", processListComment: false},
+        options: {logName: "Clear Connection Checkout Name", processListComment: false, sessionTimeZone: false},
         sql: "SET @velocious_connection_checkout_name = NULL"
       }
     ])
@@ -108,7 +108,7 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
     ])
   })
 
-  it("resets the session time zone on each connection checkout", async () => {
+  it("does not reset the session time zone on connection checkout", async () => {
     const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
 
     await mysql.setConnectionCheckoutName("first checkout")
@@ -120,8 +120,26 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
     expect(mysql.actualQueries).toEqual([
       "SET time_zone = '+00:00'",
       '/* velocious checkout="first checkout" */ SELECT 1',
-      "SET time_zone = '+00:00'",
       '/* velocious checkout="second checkout" */ SELECT 2'
+    ])
+  })
+
+  it("sets the session time zone lazily when the desired time zone changed", async () => {
+    const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
+
+    mysql.setDesiredSessionTimeZone("+00:00")
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 1")
+    mysql.setDesiredSessionTimeZone("+01:00")
+    await mysql.setConnectionCheckoutName("timezone changed checkout")
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 2")
+    await DatabaseDriversMysql.prototype.query.call(mysql, "SELECT 3")
+
+    expect(mysql.actualQueries).toEqual([
+      "SET time_zone = '+00:00'",
+      "SELECT 1",
+      "SET time_zone = '+01:00'",
+      '/* velocious checkout="timezone changed checkout" */ SELECT 2',
+      '/* velocious checkout="timezone changed checkout" */ SELECT 3'
     ])
   })
 
@@ -132,7 +150,7 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
       /** @returns {Promise<void>} - Resolves when complete. */
       async reconnect() {
         // Simulate the base reconnect behavior without touching a real MySQL pool.
-        this._sessionTimezoneSetToUtc = false
+        this.resetCurrentSessionTimeZone()
       }
 
       /**

--- a/spec/database/drivers/mysql/reconnect-spec.js
+++ b/spec/database/drivers/mysql/reconnect-spec.js
@@ -51,6 +51,11 @@ describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction
       driver.pool = {
         escape: (value) => `'${value}'`,
         query: (sql, callback) => {
+          if (sql == "SET time_zone = '+00:00'") {
+            callback(null, [], [])
+            return
+          }
+
           attempts++
 
           if (attempts < 3) {
@@ -85,6 +90,11 @@ describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction
       driver.pool = {
         escape: (value) => `'${value}'`,
         query: (sql, callback) => {
+          if (sql == "SET time_zone = '+00:00'") {
+            callback(null, [], [])
+            return
+          }
+
           callback(new Error("connect ECONNREFUSED 127.0.0.1:3306"))
         }
       }

--- a/spec/database/drivers/mysql/reconnect-spec.js
+++ b/spec/database/drivers/mysql/reconnect-spec.js
@@ -48,6 +48,7 @@ describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction
 
     driver.connect = async () => {
       connectCount++
+      driver._sessionTimezoneSetToUtc = false
       driver.pool = {
         escape: (value) => `'${value}'`,
         query: (sql, callback) => {

--- a/spec/database/drivers/sqlite/persistence-spec.js
+++ b/spec/database/drivers/sqlite/persistence-spec.js
@@ -62,12 +62,18 @@ async function loadSqlJs() {
  * @returns {Promise<SqliteWebDriver>} - Connected SQLite web driver.
  */
 async function buildSqliteWebDriver({SQL, databaseName, storage}) {
-  const databaseContent = await storage.get(localStorageName(databaseName))
+  const storageKey = localStorageName(databaseName)
+  const persistence = {
+    name: "localstorage",
+    delete: async () => storage.values.delete(storageKey),
+    load: async () => storage.get(storageKey),
+    save: async (content) => storage.set(storageKey, content)
+  }
+  const databaseContent = await persistence.load()
   const driver = new SqliteWebDriver({name: databaseName}, Configuration.current())
 
   driver.args = driver.getArgs()
-  driver.betterLocalStorage = /** @type {import("better-localstorage")} */ (storage)
-  driver._connection = new ConnectionSqlJs(driver, new SQL.Database(databaseContent))
+  driver._connection = new ConnectionSqlJs(driver, new SQL.Database(databaseContent), persistence)
 
   return driver
 }

--- a/spec/database/drivers/sqlite/persistence-spec.js
+++ b/spec/database/drivers/sqlite/persistence-spec.js
@@ -1,0 +1,119 @@
+// @ts-check
+
+import Configuration from "../../../../src/configuration.js"
+import ConnectionSqlJs from "../../../../src/database/drivers/sqlite/connection-sql-js.js"
+import SqliteWebDriver from "../../../../src/database/drivers/sqlite/index.web.js"
+import initSqlJs from "sql.js"
+import path from "path"
+import {describe, expect, it} from "../../../../src/testing/test.js"
+import {fileURLToPath} from "url"
+
+const projectRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "../../../../")
+
+/**
+ * Test storage implementing the async persistence calls the SQL.js connection uses.
+ */
+class InMemorySqlJsStorage {
+  /** @type {Map<string, Uint8Array>} */
+  values = new Map()
+
+  /**
+   * @param {string} key - Storage key.
+   * @param {Uint8Array} value - Database bytes.
+   * @returns {Promise<void>} - Resolves when stored.
+   */
+  async set(key, value) {
+    this.values.set(key, new Uint8Array(value))
+  }
+
+  /**
+   * @param {string} key - Storage key.
+   * @returns {Promise<Uint8Array | undefined>} - Stored database bytes, if present.
+   */
+  async get(key) {
+    const value = this.values.get(key)
+
+    return value ? new Uint8Array(value) : undefined
+  }
+}
+
+/**
+ * @param {string} databaseName - SQL.js local storage database name.
+ * @returns {string} - SQL.js local storage key.
+ */
+function localStorageName(databaseName) {
+  return `VelociousDatabaseDriversSqliteWeb---${databaseName}`
+}
+
+/**
+ * @returns {Promise<import("sql.js").SqlJsStatic>} - SQL.js module.
+ */
+async function loadSqlJs() {
+  return await initSqlJs({
+    locateFile: (file) => path.join(projectRoot, "node_modules/sql.js/dist", file)
+  })
+}
+
+/**
+ * @param {object} args - Driver setup args.
+ * @param {import("sql.js").SqlJsStatic} args.SQL - SQL.js module.
+ * @param {string} args.databaseName - SQL.js local storage database name.
+ * @param {InMemorySqlJsStorage} args.storage - Persistence storage.
+ * @returns {Promise<SqliteWebDriver>} - Connected SQLite web driver.
+ */
+async function buildSqliteWebDriver({SQL, databaseName, storage}) {
+  const databaseContent = await storage.get(localStorageName(databaseName))
+  const driver = new SqliteWebDriver({name: databaseName}, Configuration.current())
+
+  driver.args = driver.getArgs()
+  driver.betterLocalStorage = /** @type {import("better-localstorage")} */ (storage)
+  driver._connection = new ConnectionSqlJs(driver, new SQL.Database(databaseContent))
+
+  return driver
+}
+
+/**
+ * @param {SqliteWebDriver} driver - SQLite web driver.
+ * @returns {Promise<number>} - Persisted test row count.
+ */
+async function persistedItemsCount(driver) {
+  const rows = await driver.query("SELECT COUNT(*) AS count FROM persisted_items")
+  const count = rows[0]?.count
+
+  if (typeof count !== "number") {
+    throw new Error(`Expected numeric persisted item count, got: ${typeof count}`)
+  }
+
+  return count
+}
+
+describe("database - sqlite web driver - persistence", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("persists truncateAllTables before it resolves so immediate reloads see reset rows", async () => {
+    const SQL = await loadSqlJs()
+    const databaseName = `sqlite-web-truncate-flush-${Date.now()}`
+    const storage = new InMemorySqlJsStorage()
+    let setupDriver, truncateDriver, reloadDriver
+
+    try {
+      setupDriver = await buildSqliteWebDriver({SQL, databaseName, storage})
+      await setupDriver.query("CREATE TABLE persisted_items(id INTEGER PRIMARY KEY, name TEXT)")
+      await setupDriver.query("INSERT INTO persisted_items(name) VALUES ('before truncate')")
+      await setupDriver.close()
+      setupDriver = undefined
+
+      truncateDriver = await buildSqliteWebDriver({SQL, databaseName, storage})
+
+      expect(await persistedItemsCount(truncateDriver)).toEqual(1)
+
+      await truncateDriver.truncateAllTables()
+
+      reloadDriver = await buildSqliteWebDriver({SQL, databaseName, storage})
+
+      expect(await persistedItemsCount(reloadDriver)).toEqual(0)
+    } finally {
+      if (reloadDriver) await reloadDriver.close()
+      if (truncateDriver) await truncateDriver.close()
+      if (setupDriver) await setupDriver.close()
+    }
+  })
+})

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -1041,12 +1041,14 @@ export default class VelociousDatabaseDriversBase {
     let result
 
     try {
+      const runQueryActualWithHooks = async () => await this._queryActualWithHooks(querySql, options)
+
       if (requestTiming && tries === 1) {
-        result = await requestTiming.measureDbQuery(async () => await this._queryActual(querySql))
+        result = await requestTiming.measureDbQuery(runQueryActualWithHooks)
       } else if (requestTiming) {
-        result = await requestTiming.measure("db", async () => await this._queryActual(querySql))
+        result = await requestTiming.measure("db", runQueryActualWithHooks)
       } else {
-        result = await this._queryActual(querySql)
+        result = await runQueryActualWithHooks()
       }
     } finally {
       this._activeQuery = previousActiveQuery
@@ -1068,6 +1070,42 @@ export default class VelociousDatabaseDriversBase {
     }
 
     return result
+  }
+
+  /**
+   * Runs query actual with before/after hooks.
+   * @param {string} sql - SQL string.
+   * @param {QueryOptions} options - Query options.
+   * @returns {Promise<QueryResultType>} - Resolves with the query.
+   */
+  async _queryActualWithHooks(sql, options) {
+    await this.beforeQuery(sql, options)
+
+    try {
+      return await this._queryActual(sql)
+    } finally {
+      await this.afterQuery(sql, options)
+    }
+  }
+
+  /**
+   * Hook that runs immediately before a SQL query is sent to the driver.
+   * @param {string} _sql - SQL string.
+   * @param {QueryOptions} _options - Query options.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async beforeQuery(_sql, _options) {
+    // No-op by default
+  }
+
+  /**
+   * Hook that runs immediately after a SQL query has completed or failed.
+   * @param {string} _sql - SQL string.
+   * @param {QueryOptions} _options - Query options.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async afterQuery(_sql, _options) {
+    // No-op by default
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -238,6 +238,14 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Flushes pending writes that the driver delayed for persistence.
+   * @returns {Promise<void>} - Resolves when pending writes are durable.
+   */
+  async flushPendingWrites() {
+    // No-op by default
+  }
+
+  /**
    * Runs set connection checkout name.
    * @param {string | undefined} name - Human-readable name for this active checkout.
    * @returns {Promise<void>} - Resolves when complete.
@@ -1542,6 +1550,7 @@ export default class VelociousDatabaseDriversBase {
         }
       }
     })
+    await this.flushPendingWrites()
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -50,6 +50,7 @@
  * @property {string} [logName] - Query log subject.
  * @property {boolean} [logQuery] - Whether to log the query.
  * @property {boolean} [processListComment] - Whether to add process-list comments to the query.
+ * @property {boolean} [sessionTimeZone] - Whether to ensure the configured database session time zone before the query.
  * @property {string} [sourceStack] - Stack captured at the caller boundary.
  */
 

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -37,8 +37,6 @@ export default class VelociousDatabaseDriversMysql extends Base{
   async connect() {
     this.pool = mysql.createPool(Object.assign({connectionLimit: 1}, this.connectArgs()))
     this.pool.on("error", this.onPoolError)
-
-    await this.setSessionTimezoneToUtc()
   }
 
   /**
@@ -78,11 +76,21 @@ export default class VelociousDatabaseDriversMysql extends Base{
   }
 
   /**
+   * Hook before every query.
+   * @param {string} _sql - SQL string.
+   * @param {import("../base.js").QueryOptions} _options - Query options.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async beforeQuery(_sql, _options) {
+    await this.setSessionTimezoneToUtc()
+  }
+
+  /**
    * Sets the database session timezone to UTC so bare timestamp literals store UTC instants.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async setSessionTimezoneToUtc() {
-    await this.query("SET time_zone = '+00:00'", {logName: "Set Session Time Zone", processListComment: false})
+    await this._queryActual("SET time_zone = '+00:00'")
   }
 
   /**

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -30,11 +30,15 @@ import Update from "./sql/update.js"
 const MYSQL_INDEFINITE_LOCK_TIMEOUT_SECONDS = 60 * 60 * 24 * 365
 
 export default class VelociousDatabaseDriversMysql extends Base{
+  /** @type {boolean} */
+  _sessionTimezoneSetToUtc = false
+
   /**
    * Runs connect.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async connect() {
+    this._sessionTimezoneSetToUtc = false
     this.pool = mysql.createPool(Object.assign({connectionLimit: 1}, this.connectArgs()))
     this.pool.on("error", this.onPoolError)
   }
@@ -54,6 +58,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
   async close() {
     await this.pool?.end()
     this.pool = undefined
+    this._sessionTimezoneSetToUtc = false
   }
 
   /**
@@ -62,6 +67,8 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async setConnectionCheckoutName(name) {
+    this._sessionTimezoneSetToUtc = false
+    await this.setSessionTimezoneToUtc()
     await this.query(`SET @velocious_connection_checkout_name = ${name === undefined ? "NULL" : this.quote(name)}`, {logName: "Set Connection Checkout Name", processListComment: false})
     await super.setConnectionCheckoutName(name)
   }
@@ -82,7 +89,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async beforeQuery(_sql, _options) {
-    await this.setSessionTimezoneToUtc()
+    if (!this._sessionTimezoneSetToUtc) await this.setSessionTimezoneToUtc()
   }
 
   /**
@@ -91,6 +98,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    */
   async setSessionTimezoneToUtc() {
     await this._queryActual("SET time_zone = '+00:00'")
+    this._sessionTimezoneSetToUtc = true
   }
 
   /**

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -30,15 +30,18 @@ import Update from "./sql/update.js"
 const MYSQL_INDEFINITE_LOCK_TIMEOUT_SECONDS = 60 * 60 * 24 * 365
 
 export default class VelociousDatabaseDriversMysql extends Base{
-  /** @type {boolean} */
-  _sessionTimezoneSetToUtc = false
+  /** @type {string | null} */
+  _desiredSessionTimeZone = "+00:00"
+
+  /** @type {string | null} */
+  _currentSessionTimeZone = null
 
   /**
    * Runs connect.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async connect() {
-    this._sessionTimezoneSetToUtc = false
+    this.resetCurrentSessionTimeZone()
     this.pool = mysql.createPool(Object.assign({connectionLimit: 1}, this.connectArgs()))
     this.pool.on("error", this.onPoolError)
   }
@@ -58,7 +61,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
   async close() {
     await this.pool?.end()
     this.pool = undefined
-    this._sessionTimezoneSetToUtc = false
+    this.resetCurrentSessionTimeZone()
   }
 
   /**
@@ -67,9 +70,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async setConnectionCheckoutName(name) {
-    this._sessionTimezoneSetToUtc = false
-    await this.setSessionTimezoneToUtc()
-    await this.query(`SET @velocious_connection_checkout_name = ${name === undefined ? "NULL" : this.quote(name)}`, {logName: "Set Connection Checkout Name", processListComment: false})
+    await this.query(`SET @velocious_connection_checkout_name = ${name === undefined ? "NULL" : this.quote(name)}`, {logName: "Set Connection Checkout Name", processListComment: false, sessionTimeZone: false})
     await super.setConnectionCheckoutName(name)
   }
 
@@ -78,27 +79,77 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async clearConnectionCheckoutName() {
-    await this.query("SET @velocious_connection_checkout_name = NULL", {logName: "Clear Connection Checkout Name", processListComment: false})
+    await this.query("SET @velocious_connection_checkout_name = NULL", {logName: "Clear Connection Checkout Name", processListComment: false, sessionTimeZone: false})
     await super.clearConnectionCheckoutName()
   }
 
   /**
    * Hook before every query.
    * @param {string} _sql - SQL string.
-   * @param {import("../base.js").QueryOptions} _options - Query options.
+   * @param {import("../base.js").QueryOptions} options - Query options.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async beforeQuery(_sql, _options) {
-    if (!this._sessionTimezoneSetToUtc) await this.setSessionTimezoneToUtc()
+  async beforeQuery(_sql, options) {
+    if (options.sessionTimeZone !== false) await this.ensureSessionTimeZone()
   }
 
   /**
-   * Sets the database session timezone to UTC so bare timestamp literals store UTC instants.
-   * @returns {Promise<void>} - Resolves when complete.
+   * Gets the desired database session time zone for this connection context.
+   * @returns {string | null} - Desired session time zone.
    */
-  async setSessionTimezoneToUtc() {
-    await this._queryActual("SET time_zone = '+00:00'")
-    this._sessionTimezoneSetToUtc = true
+  getDesiredSessionTimeZone() {
+    return this._desiredSessionTimeZone
+  }
+
+  /**
+   * Sets the desired database session time zone without querying MySQL immediately.
+   * @param {string | null} timeZone - Desired session time zone.
+   */
+  setDesiredSessionTimeZone(timeZone) {
+    this._desiredSessionTimeZone = timeZone
+  }
+
+  /**
+   * Gets the database session time zone last confirmed through SET time_zone.
+   * @returns {string | null} - Current known session time zone.
+   */
+  getCurrentSessionTimeZone() {
+    return this._currentSessionTimeZone
+  }
+
+  /**
+   * Clears the current known database session time zone when the physical connection changes.
+   */
+  resetCurrentSessionTimeZone() {
+    this._currentSessionTimeZone = null
+  }
+
+  /**
+   * Ensures MySQL has the desired session time zone before user SQL runs.
+   * @returns {Promise<boolean>} - True when SET time_zone was executed.
+   */
+  async ensureSessionTimeZone() {
+    const desiredSessionTimeZone = this.getDesiredSessionTimeZone()
+
+    if (desiredSessionTimeZone === null || this.getCurrentSessionTimeZone() === desiredSessionTimeZone) return false
+
+    await this.setSessionTimeZone(desiredSessionTimeZone)
+
+    return true
+  }
+
+  /**
+   * Sets the database session time zone if it changed from the last confirmed value.
+   * @param {string} timeZone - Session time zone value accepted by MySQL.
+   * @returns {Promise<boolean>} - True when SET time_zone was executed.
+   */
+  async setSessionTimeZone(timeZone) {
+    if (this.getCurrentSessionTimeZone() === timeZone) return false
+
+    await this._queryActual(`SET time_zone = ${this.quote(timeZone)}`)
+    this._currentSessionTimeZone = timeZone
+
+    return true
   }
 
   /**

--- a/src/database/drivers/sqlite/connection-sql-js.js
+++ b/src/database/drivers/sqlite/connection-sql-js.js
@@ -20,6 +20,16 @@ export default class VelociousDatabaseDriversSqliteConnectionSqlJs {
     await this.saveDatabase()
     await this.connection.close()
   }
+
+  /**
+   * Flushes any debounced database save and waits until persistence is complete.
+   * @returns {Promise<void>} - Resolves when the current database bytes are stored.
+   */
+  async flushDatabaseSave() {
+    this.saveDatabaseDebounce.clear()
+    await this.saveDatabase()
+  }
+
   /**
    * Runs query.
    * @param {string} sql - SQL string.

--- a/src/database/drivers/sqlite/connection-sql-js.js
+++ b/src/database/drivers/sqlite/connection-sql-js.js
@@ -17,7 +17,7 @@ export default class VelociousDatabaseDriversSqliteConnectionSqlJs {
   }
 
   async close() {
-    await this.saveDatabase()
+    await this.flushDatabaseSave()
     await this.connection.close()
   }
 

--- a/src/database/drivers/sqlite/index.web.js
+++ b/src/database/drivers/sqlite/index.web.js
@@ -53,6 +53,18 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
   }
 
   /**
+   * Flushes pending SQL.js local persistence writes.
+   * @returns {Promise<void>} - Resolves when pending writes are durable.
+   */
+  async flushPendingWrites() {
+    if (!this.args?.getConnection) {
+      if (!this._connection) throw new Error("SQLite web connection has not been initialized")
+
+      await this._connection.flushDatabaseSave()
+    }
+  }
+
+  /**
    * Runs get connection.
    * @returns {ConnectionSqlJs | SqliteWebConnection} - The connection.
    */


### PR DESCRIPTION
## Summary
- consolidate #793 and #796 into this single active Velocious feature PR, then close/delete the superseded branches
- add generic before/after query hooks around the base driver query execution path
- move MySQL/MariaDB UTC session timezone setup from connect-time to lazy checkout/first-use setup without redundant per-query SQL
- keep SQL.js web persistence flush-safe so truncate/close complete pending writes before reload/teardown
- keep the offline-sync architecture docs/changelog in this consolidated PR

## Verification
- `git diff --check`
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/drivers/mysql spec/database/drivers/base-process-list-comment-spec.js spec/database/drivers/sqlite/persistence-spec.js`
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- --groups 3 --group-number 2` with `configuration.peakflow.sqlite.js`
- `VELOCIOUS_DISABLE_MSSQL=1 npm run typecheck`
- `npm run lint`

Supersedes #793 and #796.
