### PR TITLE
Add frontend sync replay pipeline

### DIFF
--- a/changelog.d/20260625090000-sync-replay-pipeline.md
+++ b/changelog.d/20260625090000-sync-replay-pipeline.md
@@ -1,0 +1,1 @@
+Add a server-side frontend-model sync replay endpoint that verifies signed device mutations, checks current sync policy hashes, and dispatches supported CRUD replays through the normal frontend-model command pipeline.

--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -9,6 +9,7 @@ import Request from "../../src/http-server/client/request.js"
 import Response from "../../src/http-server/client/response.js"
 import frontendModelCommandRouteHook from "../../src/routes/hooks/frontend-model-command-route-hook.js"
 import {createDeviceCertificate, createSignedMutation, generateSyncSigningKeyPair} from "../../src/sync/device-identity.js"
+import {createOfflineGrantFromBootstrap} from "../../src/sync/offline-grant.js"
 import {frontendModelSyncManifestForBackendProjects} from "../../src/frontend-models/resource-definition.js"
 
 /** @typedef {import("../../src/sync/device-identity.js").SignedSyncMutation} SignedSyncMutation */
@@ -29,6 +30,7 @@ describe("frontend-model sync replay", () => {
     const {backendKeys, configuration} = await syncReplayConfiguration()
     const signedMutation = await signedReplayMutation({
       backendKeys,
+      configuration,
       mutation: {
         actorDeviceId: "scanner-1",
         actorUserId: "user-1",
@@ -65,10 +67,172 @@ describe("frontend-model sync replay", () => {
     expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
   })
 
+  it("keeps signed mutation model and attributes authoritative over replay payload", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {id: "ticket-1", scanned: true},
+        clientMutationId: "mutation-override",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        payload: {attributes: {scanned: false}, id: "payload-ticket", model: "OtherModel"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("success")
+    expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "payload-ticket", model: "Ticket"}}])
+  })
+
+  it("reads replay ids from generated mutation attributes", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {id: "ticket-1", scanned: true},
+        clientMutationId: "mutation-generated-id",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("success")
+    expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
+  })
+
+  it("emits framework errors for unexpected replay command failures", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const frameworkErrors = []
+    const allErrors = []
+    configuration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push(payload))
+    configuration.getErrorEvents().on("all-error", (payload) => allErrors.push(payload))
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {scanned: true},
+        clientMutationId: "mutation-command-failure",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        payload: {id: "ticket-1"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+
+    const response = new Response({configuration})
+    const controller = new ThrowingReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("success")
+    expect(payload.results[0].response.status).toEqual("error")
+    expect(payload.results[0].response.errorMessage).toEqual("Request failed.")
+    expect(frameworkErrors.length).toEqual(1)
+    expect(frameworkErrors[0].error.message).toEqual("Replay command exploded")
+    expect(frameworkErrors[0].context.action).toEqual("frontendSyncReplay")
+    expect(allErrors.length).toEqual(1)
+    expect(allErrors[0].errorType).toEqual("framework-error")
+  })
+
+  it("rejects replay when the signed offline grant does not authorize the mutation", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {scanned: true},
+        clientMutationId: "mutation-grant-mismatch",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-2",
+        operation: "update",
+        payload: {id: "ticket-1"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      },
+      offlineGrantId: "grant-1"
+    })
+
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("error")
+    expect(payload.results[0].response.errorMessage).toEqual("Sync replay offline grant does not match mutation")
+    expect(controller.replayedCommands).toEqual([])
+  })
+
   it("rejects replay when the signed policy hash is stale", async () => {
     const {backendKeys, configuration} = await syncReplayConfiguration()
     const signedMutation = await signedReplayMutation({
       backendKeys,
+      configuration,
       mutation: {
         actorDeviceId: "scanner-1",
         actorUserId: "user-1",
@@ -137,6 +301,19 @@ class ReplayTestController extends FrontendModelController {
   }
 }
 
+class ThrowingReplayTestController extends ReplayTestController {
+  /**
+   * Throws an unexpected replay command failure.
+   * @param {"create" | "update" | "destroy"} action - Frontend action.
+   * @returns {Promise<Record<string, ?>>} - Never resolves successfully.
+   */
+  async frontendModelCommandPayload(action) {
+    this.replayedCommands.push({action, params: this.frontendModelParams()})
+
+    throw new Error("Replay command exploded")
+  }
+}
+
 /**
  * Builds test configuration for sync replay specs.
  * @returns {Promise<{backendKeys: {privateKey: import("../../src/sync/device-identity.js").SyncJsonWebKey, publicKey: import("../../src/sync/device-identity.js").SyncJsonWebKey}, configuration: Configuration}>} - Test configuration.
@@ -157,7 +334,7 @@ async function syncReplayConfiguration() {
     sync: {
       deviceCertificateBackendPublicKey: backendKeys.publicKey,
       offlineGrantSigningKeys: [{current: true, id: "key-1", secret: "test-signing-secret"}],
-      offlineGrantTtlMs: 60_000
+      offlineGrantTtlMs: 1000 * 60 * 60 * 24 * 365 * 100
     }
   })
 
@@ -168,10 +345,12 @@ async function syncReplayConfiguration() {
  * Creates a signed replay mutation.
  * @param {object} args - Arguments.
  * @param {{privateKey: import("../../src/sync/device-identity.js").SyncJsonWebKey}} args.backendKeys - Backend signing keys.
+ * @param {Configuration} args.configuration - Test configuration.
  * @param {import("../../src/sync/device-identity.js").SyncMutation} args.mutation - Mutation.
- * @returns {Promise<SignedSyncMutation>} - Signed mutation.
+ * @param {string} [args.offlineGrantId] - Signed grant id override.
+ * @returns {Promise<SignedSyncMutation & {signedOfflineGrant: import("../../src/sync/offline-grant.js").SignedOfflineGrant}>} - Signed mutation.
  */
-async function signedReplayMutation({backendKeys, mutation}) {
+async function signedReplayMutation({backendKeys, configuration, mutation, offlineGrantId}) {
   const deviceKeys = await generateSyncSigningKeyPair()
   const deviceCertificate = await createDeviceCertificate({
     backendPrivateKey: backendKeys.privateKey,
@@ -185,11 +364,27 @@ async function signedReplayMutation({backendKeys, mutation}) {
     }
   })
 
-  return await createSignedMutation({
+  const signedMutation = await createSignedMutation({
     deviceCertificate,
     devicePrivateKey: deviceKeys.privateKey,
     mutation
   })
+  const signingKey = {current: true, id: "key-1", secret: "test-signing-secret"}
+  const signedOfflineGrant = await createOfflineGrantFromBootstrap({
+    deviceId: mutation.actorDeviceId,
+    grantId: offlineGrantId || mutation.offlineGrantId,
+    grantTtlMs: 1000 * 60 * 60 * 24 * 365 * 100,
+    now: new Date("2026-01-02T03:04:05.000Z"),
+    resources: frontendModelSyncManifestForBackendProjects(configuration.getBackendProjects()),
+    scopes: {eventId: "event-1"},
+    signingKey,
+    userId: mutation.actorUserId
+  })
+
+  return {
+    ...signedMutation,
+    signedOfflineGrant
+  }
 }
 
 /**

--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -1,0 +1,225 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
+import FrontendModelController from "../../src/frontend-model-controller.js"
+import Request from "../../src/http-server/client/request.js"
+import Response from "../../src/http-server/client/response.js"
+import frontendModelCommandRouteHook from "../../src/routes/hooks/frontend-model-command-route-hook.js"
+import {createDeviceCertificate, createSignedMutation, generateSyncSigningKeyPair} from "../../src/sync/device-identity.js"
+import {frontendModelSyncManifestForBackendProjects} from "../../src/frontend-models/resource-definition.js"
+
+/** @typedef {import("../../src/sync/device-identity.js").SignedSyncMutation} SignedSyncMutation */
+
+describe("frontend-model sync replay", () => {
+  it("routes the sync replay endpoint through the frontend-model controller", async () => {
+    const {configuration} = await syncReplayConfiguration()
+    const routeMatch = await frontendModelCommandRouteHook({
+      configuration,
+      currentPath: "/frontend-models/sync/replay"
+    })
+
+    expect(routeMatch?.action).toEqual("frontend-sync-replay")
+    expect(routeMatch?.controller).toEqual("velocious/api")
+  })
+
+  it("verifies and replays signed CRUD mutations through frontend-model command payloads", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {scanned: true},
+        clientMutationId: "mutation-1",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        payload: {id: "ticket-1"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.status).toEqual("success")
+    expect(payload.results.length).toEqual(1)
+    expect(payload.results[0].status).toEqual("success")
+    expect(payload.results[0].idempotencyKey).toEqual("user-1:scanner-1:mutation-1")
+    expect(payload.results[0].response).toEqual({status: "success", replayed: true})
+    expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
+  })
+
+  it("rejects replay when the signed policy hash is stale", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {scanned: true},
+        clientMutationId: "mutation-2",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        payload: {id: "ticket-1"},
+        policyHash: "sha256-stale"
+      }
+    })
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("error")
+    expect(payload.results[0].response.errorMessage).toEqual("Sync replay policy hash mismatch for Ticket")
+    expect(controller.replayedCommands).toEqual([])
+  })
+})
+
+class TicketResource extends FrontendModelBaseResource {
+  static attributes = ["id", "scanned"]
+  static sync = {
+    metadata: {scope: "event"},
+    operations: ["find", "update"],
+    policy: {grantScopeAttributes: ["eventId"]},
+    policyVersion: "scanner-v1"
+  }
+}
+
+class ReplayTestController extends FrontendModelController {
+  /**
+   * Builds replay test controller.
+   * @param {ConstructorParameters<typeof FrontendModelController>[0]} args - Controller args.
+   */
+  constructor(args) {
+    super(args)
+
+    /** @type {Array<{action: string, params: Record<string, ?>}>} */
+    this.replayedCommands = []
+  }
+
+  /**
+   * Records replayed command payloads.
+   * @param {"create" | "update" | "destroy"} action - Frontend action.
+   * @returns {Promise<Record<string, ?>>} - Replay result.
+   */
+  async frontendModelCommandPayload(action) {
+    this.replayedCommands.push({action, params: this.frontendModelParams()})
+
+    return {status: "success", replayed: true}
+  }
+}
+
+/**
+ * Builds test configuration for sync replay specs.
+ * @returns {Promise<{backendKeys: {privateKey: import("../../src/sync/device-identity.js").SyncJsonWebKey, publicKey: import("../../src/sync/device-identity.js").SyncJsonWebKey}, configuration: Configuration}>} - Test configuration.
+ */
+async function syncReplayConfiguration() {
+  const backendKeys = await generateSyncSigningKeyPair()
+
+  const configuration = new Configuration({
+    database: {test: {}},
+    directory: "/tmp",
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    backendProjects: [{frontendModels: {Ticket: TicketResource}, path: "/tmp/backend"}],
+    sync: {
+      deviceCertificateBackendPublicKey: backendKeys.publicKey,
+      offlineGrantSigningKeys: [{current: true, id: "key-1", secret: "test-signing-secret"}],
+      offlineGrantTtlMs: 60_000
+    }
+  })
+
+  return {backendKeys, configuration}
+}
+
+/**
+ * Creates a signed replay mutation.
+ * @param {object} args - Arguments.
+ * @param {{privateKey: import("../../src/sync/device-identity.js").SyncJsonWebKey}} args.backendKeys - Backend signing keys.
+ * @param {import("../../src/sync/device-identity.js").SyncMutation} args.mutation - Mutation.
+ * @returns {Promise<SignedSyncMutation>} - Signed mutation.
+ */
+async function signedReplayMutation({backendKeys, mutation}) {
+  const deviceKeys = await generateSyncSigningKeyPair()
+  const deviceCertificate = await createDeviceCertificate({
+    backendPrivateKey: backendKeys.privateKey,
+    certificate: {
+      actorDeviceId: mutation.actorDeviceId,
+      actorUserId: mutation.actorUserId,
+      certificateId: "certificate-1",
+      devicePublicKey: deviceKeys.publicKey,
+      expiresAt: "2099-01-03T03:04:05.000Z",
+      issuedAt: "2026-01-02T03:04:05.000Z"
+    }
+  })
+
+  return await createSignedMutation({
+    deviceCertificate,
+    devicePrivateKey: deviceKeys.privateKey,
+    mutation
+  })
+}
+
+/**
+ * Resolves current policy hash for a model.
+ * @param {Configuration} configuration - Configuration.
+ * @param {string} model - Model name.
+ * @returns {string} - Policy hash.
+ */
+function syncPolicyHash(configuration, model) {
+  const manifest = frontendModelSyncManifestForBackendProjects(configuration.getBackendProjects())
+
+  return manifest[model].policyHash
+}
+
+/**
+ * Builds a minimal request object for sync replay specs.
+ * @param {Configuration} configuration - Test configuration.
+ * @returns {Request} - Request.
+ */
+function requestFor(configuration) {
+  const client = /** @type {any} */ ({remoteAddress: "127.0.0.1"})
+  const request = new Request({client, configuration})
+
+  request.feed(Buffer.from([
+    "POST /frontend-models/sync/replay HTTP/1.1",
+    "Host: example.com",
+    "Content-Length: 0",
+    "",
+    ""
+  ].join("\r\n"), "utf8"))
+
+  return request
+}

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -358,6 +358,7 @@
 /**
  * Velocious sync configuration.
  * @typedef {object} VelociousSyncConfiguration
+ * @property {import("./sync/device-identity.js").SyncJsonWebKey | null} [deviceCertificateBackendPublicKey] - Public backend key used to verify offline device certificates for sync replay.
  * @property {Array<import("./sync/offline-grant.js").OfflineGrantSigningKey>} offlineGrantSigningKeys - Signing keys used to issue and verify offline grants. Secrets must never be exposed to clients.
  * @property {number} [offlineGrantTtlMs] - Default offline grant TTL in milliseconds. Defaults to 24 hours.
  */

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -406,15 +406,20 @@ export default class VelociousConfiguration {
    * @returns {import("./configuration-types.js").VelociousSyncConfiguration} - Normalized sync configuration.
    */
   _normalizeSyncConfiguration(sync) {
+    const deviceCertificateBackendPublicKey = sync?.deviceCertificateBackendPublicKey || null
     const offlineGrantSigningKeys = sync?.offlineGrantSigningKeys || []
     const offlineGrantTtlMs = sync?.offlineGrantTtlMs
 
+    if (deviceCertificateBackendPublicKey !== null && (typeof deviceCertificateBackendPublicKey !== "object" || Array.isArray(deviceCertificateBackendPublicKey))) {
+      throw new Error("sync.deviceCertificateBackendPublicKey must be a public JSON Web Key object")
+    }
     if (!Array.isArray(offlineGrantSigningKeys)) throw new Error("sync.offlineGrantSigningKeys must be an array")
     if (offlineGrantTtlMs !== undefined && (!Number.isInteger(offlineGrantTtlMs) || offlineGrantTtlMs <= 0)) {
       throw new Error("sync.offlineGrantTtlMs must be a positive integer number of milliseconds")
     }
 
     return {
+      deviceCertificateBackendPublicKey,
       offlineGrantSigningKeys: offlineGrantSigningKeys.map((key) => normalizeOfflineGrantSigningKey(key)),
       offlineGrantTtlMs: offlineGrantTtlMs || 24 * 60 * 60 * 1000
     }

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -6,7 +6,7 @@ import FrontendModelBaseResource from "./frontend-model-resource/base-resource.j
 import Response from "./http-server/client/response.js"
 import {frontendModelResourcesWithBuiltInsForBackendProject} from "./frontend-models/built-in-resources.js"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject, frontendModelSyncManifestForBackendProjects} from "./frontend-models/resource-definition.js"
-import {createOfflineGrantFromBootstrap} from "./sync/offline-grant.js"
+import {createOfflineGrantFromBootstrap, verifyOfflineGrant} from "./sync/offline-grant.js"
 import {mutationIdempotencyKey, verifySignedMutation} from "./sync/device-identity.js"
 import {FrontendModelQueryError, normalizeGroup as normalizeQueryGroup, normalizeJoins as normalizeQueryJoins, normalizePluck as normalizeQueryPluck, normalizePreload as normalizeQueryPreload, normalizeSearchOperator as normalizeQuerySearchOperator, normalizeSort as normalizeQuerySort} from "./frontend-models/query.js"
 import {assignSafeProperty, deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
@@ -172,6 +172,19 @@ const frontendModelGroupedColumnsSymbol = Symbol("frontendModelGroupedColumns")
 const frontendModelWhereNoMatchSymbol = Symbol("frontendModelWhereNoMatch")
 const frontendModelClientSafeErrorMessage = "Request failed."
 const frontendModelDebugErrorEnvironments = new Set(["development", "test"])
+
+/**
+ * Builds a client-safe sync replay validation error.
+ * @param {string} message - Client-safe validation message.
+ * @param {unknown} [cause] - Original cause.
+ * @returns {VelociousError} - Client-safe replay error.
+ */
+function frontendSyncReplaySafeError(message, cause) {
+  return VelociousError.safe(message, {
+    cause,
+    code: "frontend_sync_replay_error"
+  })
+}
 
 /**
  * Runs frontend model query metadata.
@@ -3585,9 +3598,27 @@ export default class FrontendModelController extends Controller {
 
         results.push({idempotencyKey, response, status: "success"})
       } catch (error) {
+        const errorContext = this.frontendModelEndpointErrorContext({
+          action: "frontendSyncReplay",
+          commandType: signedMutation && typeof signedMutation === "object" && "mutation" in signedMutation
+            ? /** @type {{mutation?: {operation?: ?}}} */ (signedMutation).mutation?.operation
+            : undefined,
+          error,
+          model: signedMutation && typeof signedMutation === "object" && "mutation" in signedMutation
+            ? /** @type {{mutation?: {model?: ?}}} */ (signedMutation).mutation?.model
+            : undefined
+        })
+
+        await this.frontendModelLogEndpointError({
+          action: errorContext.action,
+          commandType: errorContext.commandType,
+          error,
+          model: errorContext.model
+        })
+
         results.push({
           idempotencyKey,
-          response: this.frontendModelErrorPayload(error instanceof Error ? error.message : String(error)),
+          response: await this.frontendModelClientErrorPayloadForError(error, errorContext),
           status: "error"
         })
       }
@@ -3620,59 +3651,188 @@ export default class FrontendModelController extends Controller {
    */
   async frontendSyncReplaySignedMutation(signedMutation) {
     const configuration = this.getConfiguration()
-    const backendPublicKey = configuration.getSyncConfiguration().deviceCertificateBackendPublicKey
+    const syncConfiguration = configuration.getSyncConfiguration()
+    const backendPublicKey = syncConfiguration.deviceCertificateBackendPublicKey
 
-    if (!backendPublicKey) throw new Error("sync.deviceCertificateBackendPublicKey is required for sync replay")
+    if (!backendPublicKey) throw frontendSyncReplaySafeError("sync.deviceCertificateBackendPublicKey is required for sync replay")
 
-    const mutation = await verifySignedMutation({
-      backendPublicKey,
-      signedMutation: /** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation)
-    })
+    let mutation
+
+    try {
+      mutation = await verifySignedMutation({
+        backendPublicKey,
+        signedMutation: /** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation)
+      })
+    } catch (error) {
+      throw frontendSyncReplaySafeError(error instanceof Error ? error.message : String(error), error)
+    }
+
     const syncManifest = frontendModelSyncManifestForBackendProjects(configuration.getBackendProjects())
     const syncResource = syncManifest[mutation.model]
 
-    if (!syncResource) throw new Error(`Sync replay model is not enabled: ${mutation.model}`)
+    if (!syncResource) throw frontendSyncReplaySafeError(`Sync replay model is not enabled: ${mutation.model}`)
     if (!syncResource.operations.includes(mutation.operation)) {
-      throw new Error(`Sync replay operation is not enabled for ${mutation.model}: ${mutation.operation}`)
+      throw frontendSyncReplaySafeError(`Sync replay operation is not enabled for ${mutation.model}: ${mutation.operation}`)
     }
     if (syncResource.policyHash !== mutation.policyHash) {
-      throw new Error(`Sync replay policy hash mismatch for ${mutation.model}`)
+      throw frontendSyncReplaySafeError(`Sync replay policy hash mismatch for ${mutation.model}`)
     }
     if (!["create", "update", "destroy"].includes(mutation.operation)) {
-      throw new Error(`Sync replay operation is not supported yet: ${mutation.operation}`)
+      throw frontendSyncReplaySafeError(`Sync replay operation is not supported yet: ${mutation.operation}`)
     }
 
-    const commandParams = this.frontendSyncReplayCommandParams(mutation)
-
-    return await this.withFrontendModelParams(commandParams, async () => {
-      return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
-        return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
-      })
+    const signedOfflineGrant = this.frontendSyncReplaySignedOfflineGrant(signedMutation)
+    const offlineGrant = await this.frontendSyncReplayVerifiedOfflineGrant({
+      signedOfflineGrant,
+      signingKeys: syncConfiguration.offlineGrantSigningKeys
     })
+
+    this.frontendSyncReplayValidateOfflineGrant({mutation, offlineGrant, syncResource})
+
+    const commandParams = await this.frontendSyncReplayCommandParams(mutation)
+
+    try {
+      return await this.withFrontendModelParams(commandParams, async () => {
+        return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
+          return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
+        })
+      })
+    } catch (error) {
+      const errorContext = this.frontendModelEndpointErrorContext({
+        action: "frontendSyncReplay",
+        commandType: /** @type {"create" | "update" | "destroy"} */ (mutation.operation),
+        error,
+        model: mutation.model
+      })
+
+      await this.frontendModelLogEndpointError({
+        action: errorContext.action,
+        commandType: errorContext.commandType,
+        error,
+        model: errorContext.model
+      })
+
+      return await this.frontendModelClientErrorPayloadForError(error, errorContext)
+    }
+  }
+
+  /**
+   * Resolves the signed offline grant carried by a replay request.
+   * @param {?} signedMutation - Signed mutation envelope.
+   * @returns {?} - Signed offline grant envelope.
+   */
+  frontendSyncReplaySignedOfflineGrant(signedMutation) {
+    if (!signedMutation || typeof signedMutation !== "object" || Array.isArray(signedMutation)) {
+      throw frontendSyncReplaySafeError("Expected sync replay signed offline grant")
+    }
+
+    const signedMutationRecord = /** @type {Record<string, ?>} */ (signedMutation)
+    const signedOfflineGrant = signedMutationRecord.signedOfflineGrant || signedMutationRecord.offlineGrant || signedMutationRecord.signedGrant
+
+    if (!signedOfflineGrant) throw frontendSyncReplaySafeError("Expected sync replay signed offline grant")
+
+    return signedOfflineGrant
+  }
+
+  /**
+   * Verifies a sync replay signed offline grant.
+   * @param {object} args - Arguments.
+   * @param {?} args.signedOfflineGrant - Signed offline grant envelope.
+   * @param {import("./sync/offline-grant.js").OfflineGrantSigningKey[]} args.signingKeys - Available signing keys.
+   * @returns {Promise<import("./sync/offline-grant.js").OfflineGrant>} - Verified offline grant.
+   */
+  async frontendSyncReplayVerifiedOfflineGrant({signedOfflineGrant, signingKeys}) {
+    try {
+      return await verifyOfflineGrant({
+        now: new Date(),
+        signedGrant: /** @type {import("./sync/offline-grant.js").SignedOfflineGrant} */ (signedOfflineGrant),
+        signingKeys
+      })
+    } catch (error) {
+      throw frontendSyncReplaySafeError(error instanceof Error ? error.message : String(error), error)
+    }
+  }
+
+  /**
+   * Validates that a verified offline grant authorizes a replayed mutation.
+   * @param {object} args - Arguments.
+   * @param {import("./sync/device-identity.js").SyncMutation} args.mutation - Verified mutation.
+   * @param {import("./sync/offline-grant.js").OfflineGrant} args.offlineGrant - Verified grant.
+   * @param {Record<string, ?>} args.syncResource - Current sync resource entry.
+   * @returns {void} - Throws when unauthorized.
+   */
+  frontendSyncReplayValidateOfflineGrant({mutation, offlineGrant, syncResource}) {
+    if (offlineGrant.grantId !== mutation.offlineGrantId) {
+      throw frontendSyncReplaySafeError("Sync replay offline grant does not match mutation")
+    }
+    if (offlineGrant.deviceId !== mutation.actorDeviceId) {
+      throw frontendSyncReplaySafeError("Sync replay offline grant device does not match mutation")
+    }
+    if (offlineGrant.userId !== mutation.actorUserId) {
+      throw frontendSyncReplaySafeError("Sync replay offline grant user does not match mutation")
+    }
+
+    const grantResource = /** @type {Record<string, ?> | undefined} */ (offlineGrant.resources[mutation.model])
+    const grantOperations = Array.isArray(grantResource?.operations) ? grantResource.operations : []
+    const grantPolicyHash = grantResource?.policyHash
+
+    if (!grantResource || grantResource.enabled !== true) throw frontendSyncReplaySafeError(`Sync replay offline grant does not authorize ${mutation.model}`)
+    if (!grantOperations.includes(mutation.operation)) {
+      throw frontendSyncReplaySafeError(`Sync replay offline grant does not authorize ${mutation.model}: ${mutation.operation}`)
+    }
+    if (grantPolicyHash !== mutation.policyHash || grantPolicyHash !== syncResource.policyHash) {
+      throw frontendSyncReplaySafeError(`Sync replay offline grant policy hash mismatch for ${mutation.model}`)
+    }
+    if (!offlineGrant.scopes || typeof offlineGrant.scopes !== "object" || Array.isArray(offlineGrant.scopes)) {
+      throw frontendSyncReplaySafeError("Sync replay offline grant scopes are invalid")
+    }
   }
 
   /**
    * Builds frontend-model command params for a verified replay mutation.
    * @param {import("./sync/device-identity.js").SyncMutation} mutation - Verified mutation.
-   * @returns {Record<string, ?>} - Frontend-model command params.
+   * @returns {Promise<Record<string, ?>>} - Frontend-model command params.
    */
-  frontendSyncReplayCommandParams(mutation) {
+  async frontendSyncReplayCommandParams(mutation) {
     const payload = mutation.payload && typeof mutation.payload === "object" && !Array.isArray(mutation.payload) ? mutation.payload : {}
+    const {attributes, primaryKeyValue} = await this.frontendSyncReplayCommandAttributes(mutation)
     const commandParams = /** @type {Record<string, ?>} */ ({
-      attributes: mutation.attributes || {},
-      model: mutation.model,
-      ...payload
+      ...payload,
+      attributes,
+      model: mutation.model
     })
 
     if (mutation.operation !== "create") {
-      const id = commandParams.id || commandParams.recordId
+      const id = commandParams.id || commandParams.recordId || primaryKeyValue
 
-      if (typeof id !== "string" && typeof id !== "number") throw new Error(`Sync replay ${mutation.operation} requires an id`)
+      if (typeof id !== "string" && typeof id !== "number") throw frontendSyncReplaySafeError(`Sync replay ${mutation.operation} requires an id`)
 
       commandParams.id = id
     }
 
     return commandParams
+  }
+
+  /**
+   * Resolves command attributes and primary key from a replay mutation.
+   * @param {import("./sync/device-identity.js").SyncMutation} mutation - Verified mutation.
+   * @returns {Promise<{attributes: Record<string, ?>, primaryKeyValue: string | number | undefined}>} - Command attributes and primary key value.
+   */
+  async frontendSyncReplayCommandAttributes(mutation) {
+    const attributes = /** @type {Record<string, ?>} */ ({...(mutation.attributes || {})})
+    const frontendModelResource = this.getConfiguration().getBackendProjects()
+      .map((backendProject) => this.frontendModelResourceConfigurationForBackendProjectModelName({backendProject, modelName: mutation.model}))
+      .find((resourceConfiguration) => resourceConfiguration)
+
+    if (!frontendModelResource) return {attributes, primaryKeyValue: undefined}
+
+    const primaryKey = typeof frontendModelResource.resourceConfiguration.primaryKey === "string" ? frontendModelResource.resourceConfiguration.primaryKey : "id"
+    const primaryKeyAttribute = attributes[primaryKey]
+    const primaryKeyValue = typeof primaryKeyAttribute === "string" || typeof primaryKeyAttribute === "number" ? primaryKeyAttribute : undefined
+
+    if (primaryKeyValue !== undefined && mutation.operation !== "create") delete attributes[primaryKey]
+
+    return {attributes, primaryKeyValue}
   }
 
   /**

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -7,6 +7,7 @@ import Response from "./http-server/client/response.js"
 import {frontendModelResourcesWithBuiltInsForBackendProject} from "./frontend-models/built-in-resources.js"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject, frontendModelSyncManifestForBackendProjects} from "./frontend-models/resource-definition.js"
 import {createOfflineGrantFromBootstrap} from "./sync/offline-grant.js"
+import {mutationIdempotencyKey, verifySignedMutation} from "./sync/device-identity.js"
 import {FrontendModelQueryError, normalizeGroup as normalizeQueryGroup, normalizeJoins as normalizeQueryJoins, normalizePluck as normalizeQueryPluck, normalizePreload as normalizeQueryPreload, normalizeSearchOperator as normalizeQuerySearchOperator, normalizeSort as normalizeQuerySort} from "./frontend-models/query.js"
 import {assignSafeProperty, deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
 import {requestDetails} from "./error-reporting/request-details.js"
@@ -3559,6 +3560,119 @@ export default class FrontendModelController extends Controller {
     }
 
     throw new Error("Expected sync bootstrap current user")
+  }
+
+  /**
+   * Runs frontend sync replay.
+   * @returns {Promise<void>} - Sync replay response with per-mutation results.
+   */
+  async frontendSyncReplay() {
+    if (this.request().httpMethod() === "OPTIONS") {
+      await this.render({status: 204, json: {}})
+      return
+    }
+
+    const params = /** @type {Record<string, ?>} */ (deserializeFrontendModelTransportValue(this.params()))
+    const signedMutations = this.frontendSyncReplaySignedMutations(params)
+    const results = []
+
+    for (const signedMutation of signedMutations) {
+      let idempotencyKey = null
+
+      try {
+        idempotencyKey = mutationIdempotencyKey(/** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation))
+        const response = await this.frontendSyncReplaySignedMutation(signedMutation)
+
+        results.push({idempotencyKey, response, status: "success"})
+      } catch (error) {
+        results.push({
+          idempotencyKey,
+          response: this.frontendModelErrorPayload(error instanceof Error ? error.message : String(error)),
+          status: "error"
+        })
+      }
+    }
+
+    await this.render({
+      json: /** @type {Record<string, ?>} */ (serializeFrontendModelTransportValue({
+        results,
+        status: "success"
+      }, this.transportSerializationOptions()))
+    })
+  }
+
+  /**
+   * Resolves signed replay mutations from request params.
+   * @param {Record<string, ?>} params - Request params.
+   * @returns {Array<?>} - Signed mutation envelopes.
+   */
+  frontendSyncReplaySignedMutations(params) {
+    if (Array.isArray(params.mutations)) return params.mutations
+    if (params.mutation) return [params.mutation]
+
+    throw new Error("Expected sync replay mutation or mutations")
+  }
+
+  /**
+   * Verifies and replays one signed sync mutation.
+   * @param {?} signedMutation - Signed mutation envelope.
+   * @returns {Promise<Record<string, ?>>} - Frontend-model command response.
+   */
+  async frontendSyncReplaySignedMutation(signedMutation) {
+    const configuration = this.getConfiguration()
+    const backendPublicKey = configuration.getSyncConfiguration().deviceCertificateBackendPublicKey
+
+    if (!backendPublicKey) throw new Error("sync.deviceCertificateBackendPublicKey is required for sync replay")
+
+    const mutation = await verifySignedMutation({
+      backendPublicKey,
+      signedMutation: /** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation)
+    })
+    const syncManifest = frontendModelSyncManifestForBackendProjects(configuration.getBackendProjects())
+    const syncResource = syncManifest[mutation.model]
+
+    if (!syncResource) throw new Error(`Sync replay model is not enabled: ${mutation.model}`)
+    if (!syncResource.operations.includes(mutation.operation)) {
+      throw new Error(`Sync replay operation is not enabled for ${mutation.model}: ${mutation.operation}`)
+    }
+    if (syncResource.policyHash !== mutation.policyHash) {
+      throw new Error(`Sync replay policy hash mismatch for ${mutation.model}`)
+    }
+    if (!["create", "update", "destroy"].includes(mutation.operation)) {
+      throw new Error(`Sync replay operation is not supported yet: ${mutation.operation}`)
+    }
+
+    const commandParams = this.frontendSyncReplayCommandParams(mutation)
+
+    return await this.withFrontendModelParams(commandParams, async () => {
+      return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
+        return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
+      })
+    })
+  }
+
+  /**
+   * Builds frontend-model command params for a verified replay mutation.
+   * @param {import("./sync/device-identity.js").SyncMutation} mutation - Verified mutation.
+   * @returns {Record<string, ?>} - Frontend-model command params.
+   */
+  frontendSyncReplayCommandParams(mutation) {
+    const payload = mutation.payload && typeof mutation.payload === "object" && !Array.isArray(mutation.payload) ? mutation.payload : {}
+    const commandParams = /** @type {Record<string, ?>} */ ({
+      attributes: mutation.attributes || {},
+      model: mutation.model,
+      ...payload
+    })
+
+    if (mutation.operation !== "create") {
+      const id = commandParams.id || commandParams.recordId
+
+      if (typeof id !== "string" && typeof id !== "number") throw new Error(`Sync replay ${mutation.operation} requires an id`)
+
+      commandParams.id = id
+    }
+
+    return commandParams
   }
 
   /**

--- a/src/routes/hooks/frontend-model-command-route-hook.js
+++ b/src/routes/hooks/frontend-model-command-route-hook.js
@@ -25,6 +25,14 @@ export default async function frontendModelCommandRouteHook({configuration, curr
     }
   }
 
+  if (normalizedCurrentPath === "/frontend-models/sync/replay") {
+    return {
+      action: "frontend-sync-replay",
+      controller: "velocious/api",
+      controllerPath: FRONTEND_MODEL_CONTROLLER_PATH
+    }
+  }
+
   if (normalizedCurrentPath === SHARED_FRONTEND_MODEL_API_PATH) {
     return {
       action: "frontend-api",


### PR DESCRIPTION
## Summary
- add /frontend-models/sync/replay routing and controller handling
- verify signed device mutations against configured backend public key
- check current sync policy hashes before dispatching supported CRUD mutations through frontend-model command handling
- add replay coverage and changelog entry

## Tests
- npm run lint
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/controller/frontend-model-sync-replay-spec.js spec/controller/frontend-model-sync-bootstrap-spec.js
- VELOCIOUS_DISABLE_MSSQL=1 npm run typecheck