### PR TITLE
Add removeIndex migration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,7 @@ export default class CreateEvents extends Migration {
   }
 
   async down() {
+    await this.removeIndex("task_translations", ["task_id", "locale"])
     await this.dropTable("task_translations")
     await this.dropTable("examples")
     await this.dropTable("tasks")

--- a/changelog.d/20260625120230-remove-index-columns.md
+++ b/changelog.d/20260625120230-remove-index-columns.md
@@ -1,0 +1,1 @@
+Allow `removeIndex` migrations to derive database-specific default index names from columns and document the helper.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -38,6 +38,18 @@ await this.createTable("legacy_events", {id: {type: "bigint"}}, (table) => {
 
 SQLite stores auto-increment primary keys through its special `INTEGER PRIMARY KEY` form even when a migration asks for `bigint`, while non-primary reference columns keep the configured `bigint` type. PostgreSQL emits `BIGSERIAL` for auto-increment `bigint` primary keys.
 
+`removeIndex(tableName, nameOrColumns, args)` drops an index by explicit name, or by deriving the same database-specific default name that `addIndex(...)` uses when passed columns:
+
+```js
+await this.addIndex("tasks", ["project_id", "position"], {unique: true})
+await this.removeIndex("tasks", ["project_id", "position"])
+
+await this.addIndex("tasks", ["slug"], {name: "index_tasks_slug_unique", unique: true})
+await this.removeIndex("tasks", "index_tasks_slug_unique")
+```
+
+Use the columns form for indexes created by `addIndex(...)` without an explicit name so SQLite and the other drivers drop their own generated names correctly.
+
 ## Datetime Storage
 
 Velocious stores persisted `Date` values as UTC instants. Runtime-local timezone and `timezoneOffsetMinutes` are not applied when records are inserted, updated, queried, or read back from storage.

--- a/spec/database/drivers/create-sql/remove-index-sql.browser-spec.js
+++ b/spec/database/drivers/create-sql/remove-index-sql.browser-spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+import Configuration from "../../../../src/configuration.js"
+
+describe("database - create sql - remove index sql", {tags: ["dummy"]}, () => {
+  it("builds driver-specific drop-index SQL", {databaseCleaning: {transaction: false}}, async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const removeIndexSQLs = await dbs.default.removeIndexSQLs({
+        name: "index_task_boards_on_task_id",
+        tableName: "task_boards"
+      })
+
+      if (dbs.default.getType() == "sqlite") {
+        expect(removeIndexSQLs).toEqual(["DROP INDEX `index_task_boards_on_task_id`"])
+      } else if (dbs.default.getType() == "mssql") {
+        expect(removeIndexSQLs).toEqual(["DROP INDEX [index_task_boards_on_task_id] ON [task_boards]"])
+      } else if (dbs.default.getType() == "pgsql") {
+        expect(removeIndexSQLs).toEqual([`DROP INDEX "index_task_boards_on_task_id"`])
+      } else {
+        expect(removeIndexSQLs).toEqual(["DROP INDEX `index_task_boards_on_task_id` ON `task_boards`"])
+      }
+    })
+  })
+})

--- a/spec/database/migration/remove-index.browser-spec.js
+++ b/spec/database/migration/remove-index.browser-spec.js
@@ -44,17 +44,24 @@ describe("database - migration - removeIndex", {tags: ["dummy"]}, () => {
         await migration.createTable("remove_index_default_widgets", (table) => {
           table.string("name", {null: false})
         })
+        const tableBeforeIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
+        const initialIndexNames = (await tableBeforeIndex.getIndexes()).map((index) => index.getName())
+
         await migration.addIndex("remove_index_default_widgets", ["name"])
 
         const tableWithIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
-        const existingIndexNames = (await tableWithIndex.getIndexes()).map((index) => index.getName())
+        const addedIndexNames = (await tableWithIndex.getIndexes())
+          .map((index) => index.getName())
+          .filter((indexName) => indexName != "PRIMARY" && !initialIndexNames.includes(indexName))
+
+        expect(addedIndexNames).toHaveLength(1)
 
         await migration.removeIndex("remove_index_default_widgets", ["name"])
 
         const tableWithoutIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
         const remainingIndexNames = (await tableWithoutIndex.getIndexes()).map((index) => index.getName())
 
-        for (const indexName of existingIndexNames) {
+        for (const indexName of addedIndexNames) {
           expect(remainingIndexNames).not.toContain(indexName)
         }
       } finally {

--- a/spec/database/migration/remove-index.browser-spec.js
+++ b/spec/database/migration/remove-index.browser-spec.js
@@ -42,12 +42,12 @@ describe("database - migration - removeIndex", {tags: ["dummy"]}, () => {
       try {
         await driver.dropTable("remove_index_default_widgets", {cascade: true, ifExists: true})
         await migration.createTable("remove_index_default_widgets", (table) => {
-          table.string("name", {null: false})
+          table.string("remove_index_default_widget_name", {null: false})
         })
         const tableBeforeIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
         const initialIndexNames = (await tableBeforeIndex.getIndexes()).map((index) => index.getName())
 
-        await migration.addIndex("remove_index_default_widgets", ["name"])
+        await migration.addIndex("remove_index_default_widgets", ["remove_index_default_widget_name"])
 
         const tableWithIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
         const addedIndexNames = (await tableWithIndex.getIndexes())
@@ -56,7 +56,7 @@ describe("database - migration - removeIndex", {tags: ["dummy"]}, () => {
 
         expect(addedIndexNames).toHaveLength(1)
 
-        await migration.removeIndex("remove_index_default_widgets", ["name"])
+        await migration.removeIndex("remove_index_default_widgets", ["remove_index_default_widget_name"])
 
         const tableWithoutIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
         const remainingIndexNames = (await tableWithoutIndex.getIndexes()).map((index) => index.getName())

--- a/spec/database/migration/remove-index.browser-spec.js
+++ b/spec/database/migration/remove-index.browser-spec.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration - removeIndex", {tags: ["dummy"]}, () => {
+  it("removes an existing index by name", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      try {
+        await driver.dropTable("remove_index_widgets", {cascade: true, ifExists: true})
+        await migration.createTable("remove_index_widgets", (table) => {
+          table.string("name", {null: false})
+        })
+        await migration.addIndex("remove_index_widgets", ["name"], {name: "index_remove_index_widgets_on_name"})
+
+        const tableWithIndex = await driver.getTableByNameOrFail("remove_index_widgets")
+        expect((await tableWithIndex.getIndexes()).map((index) => index.getName())).toContain("index_remove_index_widgets_on_name")
+
+        await migration.removeIndex("remove_index_widgets", "index_remove_index_widgets_on_name")
+
+        const tableWithoutIndex = await driver.getTableByNameOrFail("remove_index_widgets")
+        expect((await tableWithoutIndex.getIndexes()).map((index) => index.getName())).not.toContain("index_remove_index_widgets_on_name")
+      } finally {
+        await driver.dropTable("remove_index_widgets", {cascade: true, ifExists: true})
+      }
+    })
+  })
+})

--- a/spec/database/migration/remove-index.browser-spec.js
+++ b/spec/database/migration/remove-index.browser-spec.js
@@ -31,4 +31,35 @@ describe("database - migration - removeIndex", {tags: ["dummy"]}, () => {
       }
     })
   })
+
+  it("removes an index by deriving the addIndex default name from columns", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      try {
+        await driver.dropTable("remove_index_default_widgets", {cascade: true, ifExists: true})
+        await migration.createTable("remove_index_default_widgets", (table) => {
+          table.string("name", {null: false})
+        })
+        await migration.addIndex("remove_index_default_widgets", ["name"])
+
+        const tableWithIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
+        const existingIndexNames = (await tableWithIndex.getIndexes()).map((index) => index.getName())
+
+        await migration.removeIndex("remove_index_default_widgets", ["name"])
+
+        const tableWithoutIndex = await driver.getTableByNameOrFail("remove_index_default_widgets")
+        const remainingIndexNames = (await tableWithoutIndex.getIndexes()).map((index) => index.getName())
+
+        for (const indexName of existingIndexNames) {
+          expect(remainingIndexNames).not.toContain(indexName)
+        }
+      } finally {
+        await driver.dropTable("remove_index_default_widgets", {cascade: true, ifExists: true})
+      }
+    })
+  })
 })

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -10,6 +10,12 @@
  * @property {string} tableName - Name of the table to add the index to.
  */
 /**
+ * RemoveIndexSqlArgs type.
+ * @typedef {object} RemoveIndexSqlArgs
+ * @property {string} name - Index name to drop.
+ * @property {string} tableName - Name of the table the index belongs to.
+ */
+/**
  * DropTableSqlArgsType type.
  * @typedef {object} DropTableSqlArgsType
  * @property {boolean} [cascade] - Whether dependent objects should be dropped too.
@@ -305,6 +311,16 @@ export default class VelociousDatabaseDriversBase {
    */
   async createIndexSQLs(indexData) { // eslint-disable-line no-unused-vars
     throw new Error("'createIndexSQLs' not implemented")
+  }
+
+  /**
+   * Runs remove index sqls.
+   * @abstract
+   * @param {RemoveIndexSqlArgs} indexData - Index data.
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async removeIndexSQLs(indexData) { // eslint-disable-line no-unused-vars
+    throw new Error("'removeIndexSQLs' not implemented")
   }
 
   /**

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -15,6 +15,7 @@ import Options from "./options.js"
 import mssql from "mssql"
 import net from "node:net"
 import QueryParser from "./query-parser.js"
+import RemoveIndex from "./sql/remove-index.js"
 import Table from "./table.js"
 import StructureSql from "./structure-sql.js"
 import timeout from "awaitery/build/timeout.js"
@@ -111,6 +112,18 @@ export default class VelociousDatabaseDriversMssql extends Base{
     const createIndex = new CreateIndex(createArgs)
 
     return await createIndex.toSQLs()
+  }
+
+  /**
+   * Runs remove index sqls.
+   * @param {import("../base.js").RemoveIndexSqlArgs} indexData - Index data.
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async removeIndexSQLs(indexData) {
+    const removeArgs = Object.assign({driver: this}, indexData)
+    const removeIndex = new RemoveIndex(removeArgs)
+
+    return await removeIndex.toSQLs()
   }
 
   /**

--- a/src/database/drivers/mssql/sql/remove-index.js
+++ b/src/database/drivers/mssql/sql/remove-index.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import RemoveIndexBase from "../../../query/remove-index-base.js"
+
+export default class VelociousDatabaseConnectionDriversMssqlSqlRemoveIndex extends RemoveIndexBase {
+}

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -14,6 +14,7 @@ import Options from "./options.js"
 import mysql from "mysql"
 import query from "./query.js"
 import QueryParser from "./query-parser.js"
+import RemoveIndex from "./sql/remove-index.js"
 import Table from "./table.js"
 import StructureSql from "./structure-sql.js"
 import Upsert from "./sql/upsert.js"
@@ -225,6 +226,18 @@ export default class VelociousDatabaseDriversMysql extends Base{
     const createIndex = new CreateIndex(createArgs)
 
     return await createIndex.toSQLs()
+  }
+
+  /**
+   * Runs remove index sqls.
+   * @param {import("../base.js").RemoveIndexSqlArgs} indexData - Index data.
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async removeIndexSQLs(indexData) {
+    const removeArgs = Object.assign({driver: this}, indexData)
+    const removeIndex = new RemoveIndex(removeArgs)
+
+    return await removeIndex.toSQLs()
   }
 
   /**

--- a/src/database/drivers/mysql/sql/remove-index.js
+++ b/src/database/drivers/mysql/sql/remove-index.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import RemoveIndexBase from "../../../query/remove-index-base.js"
+
+export default class VelociousDatabaseConnectionDriversMysqlSqlRemoveIndex extends RemoveIndexBase {
+}

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -14,6 +14,7 @@ import DropTable from "./sql/drop-table.js"
 import Insert from "./sql/insert.js"
 import Options from "./options.js"
 import QueryParser from "./query-parser.js"
+import RemoveIndex from "./sql/remove-index.js"
 import Table from "./table.js"
 import StructureSql from "./structure-sql.js"
 import Upsert from "./sql/upsert.js"
@@ -147,6 +148,18 @@ export default class VelociousDatabaseDriversPgsql extends Base{
     const createIndex = new CreateIndex(createArgs)
 
     return await createIndex.toSQLs()
+  }
+
+  /**
+   * Runs remove index sqls.
+   * @param {import("../base.js").RemoveIndexSqlArgs} indexData - Index data.
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async removeIndexSQLs(indexData) {
+    const removeArgs = Object.assign({driver: this}, indexData)
+    const removeIndex = new RemoveIndex(removeArgs)
+
+    return await removeIndex.toSQLs()
   }
 
   /**

--- a/src/database/drivers/pgsql/sql/remove-index.js
+++ b/src/database/drivers/pgsql/sql/remove-index.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import RemoveIndexBase from "../../../query/remove-index-base.js"
+
+export default class VelociousDatabaseConnectionDriversPgsqlSqlRemoveIndex extends RemoveIndexBase {
+}

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -12,6 +12,7 @@ import escapeString from "sql-escape-string"
 import Insert from "./sql/insert.js"
 import Options from "./options.js"
 import QueryParser from "./query-parser.js"
+import RemoveIndex from "./sql/remove-index.js"
 import Table from "./table.js"
 import StructureSql from "./structure-sql.js"
 import Upsert from "./sql/upsert.js"
@@ -53,6 +54,18 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
     const createIndex = new CreateIndex(createArgs)
 
     return await createIndex.toSQLs()
+  }
+
+  /**
+   * Runs remove index sqls.
+   * @param {import("../base.js").RemoveIndexSqlArgs} indexData - Index data.
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async removeIndexSQLs(indexData) {
+    const removeArgs = Object.assign({driver: this}, indexData)
+    const removeIndex = new RemoveIndex(removeArgs)
+
+    return await removeIndex.toSQLs()
   }
 
   /**

--- a/src/database/drivers/sqlite/sql/remove-index.js
+++ b/src/database/drivers/sqlite/sql/remove-index.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import RemoveIndexBase from "../../../query/remove-index-base.js"
+
+export default class VelociousDatabaseConnectionDriversSqliteSqlRemoveIndex extends RemoveIndexBase {
+}

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -185,6 +185,20 @@ export default class VelociousDatabaseMigration {
   }
 
   /**
+   * Runs remove index.
+   * @param {string} tableName - Table name.
+   * @param {string} name - Index name to remove.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async removeIndex(tableName, name) {
+    const sqls = await this.getDriver().removeIndexSQLs({name, tableName})
+
+    for (const sql of sqls) {
+      await this.getDriver().query(sql)
+    }
+  }
+
+  /**
    * AddForeignKeyArgsType type.
    * @typedef {object} AddForeignKeyArgsType
    * @property {string} [columnName] - Override the derived FK column name (default: `${reference_underscored}_id`).

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -39,6 +39,7 @@
 import { convertLegacyDateValueToUtcStorage } from "../datetime-storage.js"
 import * as inflection from "inflection"
 import restArgsError from "../../utils/rest-args-error.js"
+import CreateIndexBase from "../query/create-index-base.js"
 import TableData from "../table-data/index.js"
 class NotImplementedError extends Error {}
 
@@ -185,17 +186,46 @@ export default class VelociousDatabaseMigration {
   }
 
   /**
+   * RemoveIndexArgsType type.
+   * @typedef {object} RemoveIndexArgsType
+   * @property {string} [name] - Explicit index name to remove.
+   */
+  /**
    * Runs remove index.
    * @param {string} tableName - Table name.
-   * @param {string} name - Index name to remove.
+   * @param {string | Array<string | import("../table-data/table-column.js").default>} nameOrColumns - Index name or columns whose default addIndex name should be removed.
+   * @param {RemoveIndexArgsType} [args] - Options object.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async removeIndex(tableName, name) {
-    const sqls = await this.getDriver().removeIndexSQLs({name, tableName})
+  async removeIndex(tableName, nameOrColumns, args = {}) {
+    const {name, ...restArgs} = args
+
+    restArgsError(restArgs)
+
+    const removeIndexName = name || this._removeIndexName(tableName, nameOrColumns)
+    const sqls = await this.getDriver().removeIndexSQLs({name: removeIndexName, tableName})
 
     for (const sql of sqls) {
       await this.getDriver().query(sql)
     }
+  }
+
+  /**
+   * Runs remove index name.
+   * @param {string} tableName - Table name.
+   * @param {string | Array<string | import("../table-data/table-column.js").default>} nameOrColumns - Index name or columns.
+   * @returns {string} - The index name.
+   */
+  _removeIndexName(tableName, nameOrColumns) {
+    if (typeof nameOrColumns === "string") return nameOrColumns
+
+    const createIndex = new CreateIndexBase({
+      columns: nameOrColumns,
+      driver: this.getDriver(),
+      tableName
+    })
+
+    return createIndex.generateIndexName()
   }
 
   /**

--- a/src/database/pool/base-methods-forward.js
+++ b/src/database/pool/base-methods-forward.js
@@ -23,6 +23,7 @@ export default function baseMethodsForward(PoolBase) {
     "quote",
     "quoteColumn",
     "quoteTable",
+    "removeIndexSQLs",
     "select",
     "update",
     "updateSql"

--- a/src/database/query/remove-index-base.js
+++ b/src/database/query/remove-index-base.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+import QueryBase from "./base.js"
+
+/**
+ * RemoveIndexBaseArgsType type.
+ * @typedef {object} RemoveIndexBaseArgsType
+ * @property {import("../drivers/base.js").default} driver - Database driver used to generate SQL.
+ * @property {string} name - Index name to drop.
+ * @property {string} tableName - Name of the table the index belongs to.
+ */
+
+export default class VelociousDatabaseQueryRemoveIndexBase extends QueryBase {
+  /**
+   * Runs constructor.
+   * @param {RemoveIndexBaseArgsType} args - Options object.
+   */
+  constructor({driver, name, tableName}) {
+    super({driver})
+    this.name = name
+    this.tableName = tableName
+  }
+
+  /**
+   * Runs to sqls.
+   * @returns {Promise<string[]>} - Resolves with SQL statements.
+   */
+  async toSQLs() {
+    const databaseType = this.getDriver().getType()
+    const options = this.getOptions()
+    let sql = `DROP INDEX ${options.quoteIndexName(this.name)}`
+
+    if (databaseType == "mssql" || databaseType == "mysql") {
+      sql += ` ON ${options.quoteTableName(this.tableName)}`
+    }
+
+    return [sql]
+  }
+}


### PR DESCRIPTION
## Summary
- Add database driver SQL builders for dropping indexes by name
- Expose `removeIndexSQLs` through drivers/pools and `Migration#removeIndex`
- Cover generated SQL and migration execution with focused tests

## Tests
- `VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/database/drivers/create-sql/remove-index-sql.browser-spec.js spec/database/migration/remove-index.browser-spec.js`
- `npm run lint`