### PR TITLE
Add server sync change feed

### DIFF
--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -98,6 +98,21 @@ describe("frontend-model sync replay", () => {
     expect(expiredPage.oldestSequence).toEqual(3)
   })
 
+  it("filters server change-feed pages to the verified offline grant scope", async () => {
+    const {configuration} = await syncReplayConfiguration()
+    const store = new ServerChangeFeedStore({configuration})
+
+    await appendTestChange(store, {clientMutationId: "mutation-event-1", recordId: "ticket-1", scope: {eventId: "event-1", userId: "user-1"}})
+    await appendTestChange(store, {clientMutationId: "mutation-event-2", recordId: "ticket-2", scope: {eventId: "event-2", userId: "user-1"}})
+    await appendTestChange(store, {clientMutationId: "mutation-event-1b", recordId: "ticket-3", scope: {userId: "user-1", eventId: "event-1"}})
+
+    const page = await store.changesAfter({afterSequence: 0, limit: 10, scope: {userId: "user-1", eventId: "event-1"}})
+
+    expect(page.changes.map((change) => change.recordId)).toEqual(["ticket-1", "ticket-3"])
+    expect(page.changes.every((change) => change.scope?.eventId === "event-1" && change.scope?.userId === "user-1")).toEqual(true)
+    expect(page.nextSequence).toEqual(3)
+  })
+
   it("assigns server sequences to replayed mutations and returns snapshot/change-feed cursors", async () => {
     const {backendKeys, configuration} = await syncReplayConfiguration()
     const signedMutation = await signedReplayMutation({
@@ -143,7 +158,7 @@ describe("frontend-model sync replay", () => {
       action: "frontendSyncChangeFeed",
       configuration,
       controller: "velocious/api",
-      params: {afterSequence: 0},
+      params: {afterSequence: 0, signedOfflineGrant: signedMutation.signedOfflineGrant},
       request: requestFor(configuration, "/frontend-models/sync/change-feed"),
       response: snapshotResponse,
       viewPath: "/tmp"
@@ -166,7 +181,7 @@ describe("frontend-model sync replay", () => {
       action: "frontendSyncChangeFeed",
       configuration,
       controller: "velocious/api",
-      params: {afterSequence: 1},
+      params: {afterSequence: 1, signedOfflineGrant: signedMutation.signedOfflineGrant},
       request: requestFor(configuration, "/frontend-models/sync/change-feed"),
       response: changesResponse,
       viewPath: "/tmp"
@@ -304,6 +319,48 @@ describe("frontend-model sync replay", () => {
     expect(allErrors[0].errorType).toEqual("framework-error")
   })
 
+  it("keeps successful replay responses visible when the change-feed append fails", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        attributes: {scanned: true},
+        clientMutationId: "mutation-feed-failure",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "update",
+        payload: {id: "ticket-1"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+
+    const response = new Response({configuration})
+    const controller = new FeedAppendFailingReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("success")
+    expect(payload.results[0].response).toEqual({status: "success", replayed: true})
+    expect(payload.results[0].serverSequence).toEqual(null)
+    expect(payload.results[0].serverChangeFeedStatus).toEqual("error")
+    expect(payload.results[0].serverChangeFeedError.errorMessage).toEqual("Request failed.")
+    expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
+  })
+
   it("rejects replay when the signed offline grant does not authorize the mutation", async () => {
     const {backendKeys, configuration} = await syncReplayConfiguration()
     const signedMutation = await signedReplayMutation({
@@ -389,9 +446,10 @@ describe("frontend-model sync replay", () => {
  * @param {object} args - Arguments.
  * @param {string} args.clientMutationId - Client mutation id.
  * @param {string} args.recordId - Record id.
+ * @param {Record<string, ?>} [args.scope] - Change scope.
  * @returns {Promise<void>} - Resolves when appended.
  */
-async function appendTestChange(store, {clientMutationId, recordId}) {
+async function appendTestChange(store, {clientMutationId, recordId, scope = {eventId: "event-1"}}) {
   await store.append({
     actorDeviceId: "scanner-1",
     actorUserId: "user-1",
@@ -402,7 +460,7 @@ async function appendTestChange(store, {clientMutationId, recordId}) {
     payload: {id: recordId},
     recordId,
     response: {status: "success", replayed: true},
-    scope: {eventId: "event-1"}
+    scope
   })
 }
 
@@ -441,6 +499,16 @@ class ReplayTestController extends FrontendModelController {
     this.replayedCommands.push({action, params: this.frontendModelParams()})
 
     return {status: "success", replayed: true}
+  }
+}
+
+class FeedAppendFailingReplayTestController extends ReplayTestController {
+  /**
+   * Simulates a change-feed append failure after the replay command succeeds.
+   * @returns {Promise<number | null>} - Never resolves successfully.
+   */
+  async frontendSyncAppendServerChange() {
+    throw new Error("Change feed exploded")
   }
 }
 

--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -11,6 +11,7 @@ import frontendModelCommandRouteHook from "../../src/routes/hooks/frontend-model
 import {createDeviceCertificate, createSignedMutation, generateSyncSigningKeyPair} from "../../src/sync/device-identity.js"
 import {createOfflineGrantFromBootstrap} from "../../src/sync/offline-grant.js"
 import {frontendModelSyncManifestForBackendProjects} from "../../src/frontend-models/resource-definition.js"
+import ServerChangeFeedStore from "../../src/sync/server-change-feed.js"
 
 /** @typedef {import("../../src/sync/device-identity.js").SignedSyncMutation} SignedSyncMutation */
 
@@ -26,7 +27,78 @@ describe("frontend-model sync replay", () => {
     expect(routeMatch?.controller).toEqual("velocious/api")
   })
 
-  it("verifies and replays signed CRUD mutations through frontend-model command payloads", async () => {
+  it("routes the sync change-feed endpoint through the frontend-model controller", async () => {
+    const {configuration} = await syncReplayConfiguration()
+
+    for (const currentPath of ["/frontend-models/sync/change-feed", "/frontend-models/sync/changes", "/sync/changes"]) {
+      const routeMatch = await frontendModelCommandRouteHook({
+        configuration,
+        currentPath
+      })
+
+      expect(routeMatch?.action).toEqual("frontend-sync-change-feed")
+      expect(routeMatch?.controller).toEqual("velocious/api")
+    }
+  })
+
+  it("routes the sync snapshot endpoint through the frontend-model controller", async () => {
+    const {configuration} = await syncReplayConfiguration()
+
+    for (const currentPath of ["/frontend-models/sync/snapshot", "/sync/snapshot"]) {
+      const routeMatch = await frontendModelCommandRouteHook({
+        configuration,
+        currentPath
+      })
+
+      expect(routeMatch?.action).toEqual("frontend-sync-snapshot")
+      expect(routeMatch?.controller).toEqual("velocious/api")
+    }
+  })
+
+  it("pages stable server-sequenced changes without skipping newly inserted changes", async () => {
+    const {configuration} = await syncReplayConfiguration()
+    const store = new ServerChangeFeedStore({configuration})
+
+    await appendTestChange(store, {clientMutationId: "mutation-1", recordId: "ticket-1"})
+    await appendTestChange(store, {clientMutationId: "mutation-2", recordId: "ticket-2"})
+
+    const firstPage = await store.changesAfter({afterSequence: 0, limit: 1})
+
+    expect(firstPage.changes.map((change) => change.recordId)).toEqual(["ticket-1"])
+    expect(firstPage.hasMore).toEqual(true)
+    expect(firstPage.nextSequence).toEqual(1)
+    expect(firstPage.upToSequence).toEqual(2)
+
+    await appendTestChange(store, {clientMutationId: "mutation-3", recordId: "ticket-3"})
+
+    const secondPage = await store.changesAfter({afterSequence: firstPage.nextSequence, limit: 1, upToSequence: firstPage.upToSequence})
+    const catchUpPage = await store.changesAfter({afterSequence: secondPage.nextSequence, limit: 10})
+
+    expect(secondPage.changes.map((change) => change.recordId)).toEqual(["ticket-2"])
+    expect(secondPage.hasMore).toEqual(false)
+    expect(secondPage.upToSequence).toEqual(2)
+    expect(catchUpPage.changes.map((change) => change.recordId)).toEqual(["ticket-3"])
+    expect(catchUpPage.upToSequence).toEqual(3)
+  })
+
+  it("requires snapshots when retention no longer covers the requested sequence", async () => {
+    const {configuration} = await syncReplayConfiguration({changeFeedRetentionSize: 1})
+    const store = new ServerChangeFeedStore({configuration})
+
+    await appendTestChange(store, {clientMutationId: "mutation-1", recordId: "ticket-1"})
+    await appendTestChange(store, {clientMutationId: "mutation-2", recordId: "ticket-2"})
+    await appendTestChange(store, {clientMutationId: "mutation-3", recordId: "ticket-3"})
+
+    const page = await store.changesAfter({afterSequence: 0, limit: 10})
+    const expiredPage = await store.changesAfter({afterSequence: 1, limit: 10})
+
+    expect(page.changes.map((change) => change.serverSequence)).toEqual([3])
+    expect(expiredPage.status).toEqual(undefined)
+    expect(expiredPage.snapshotRequired).toEqual(true)
+    expect(expiredPage.oldestSequence).toEqual(3)
+  })
+
+  it("assigns server sequences to replayed mutations and returns snapshot/change-feed cursors", async () => {
     const {backendKeys, configuration} = await syncReplayConfiguration()
     const signedMutation = await signedReplayMutation({
       backendKeys,
@@ -64,6 +136,50 @@ describe("frontend-model sync replay", () => {
     expect(payload.results[0].status).toEqual("success")
     expect(payload.results[0].idempotencyKey).toEqual("user-1:scanner-1:mutation-1")
     expect(payload.results[0].response).toEqual({status: "success", replayed: true})
+    expect(payload.results[0].serverSequence).toEqual(1)
+
+    const snapshotResponse = new Response({configuration})
+    const snapshotController = new ReplayTestController({
+      action: "frontendSyncChangeFeed",
+      configuration,
+      controller: "velocious/api",
+      params: {afterSequence: 0},
+      request: requestFor(configuration, "/frontend-models/sync/change-feed"),
+      response: snapshotResponse,
+      viewPath: "/tmp"
+    })
+
+    await snapshotController.frontendSyncChangeFeed()
+
+    const snapshotPayload = JSON.parse(String(snapshotResponse.getBody()))
+
+    expect(snapshotPayload.status).toEqual("success")
+    expect(snapshotPayload.serverSequence).toEqual(1)
+    expect(snapshotPayload.hasMore).toEqual(false)
+    expect(snapshotPayload.nextSequence).toEqual(1)
+    expect(snapshotPayload.upToSequence).toEqual(1)
+    expect(snapshotPayload.changes).toEqual([{actorDeviceId: "scanner-1", actorUserId: "user-1", attributes: {scanned: true}, createdAt: snapshotPayload.changes[0].createdAt, id: snapshotPayload.changes[0].id, idempotencyKey: "user-1:scanner-1:mutation-1", model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1", response: {status: "success", replayed: true}, scope: {eventId: "event-1"}, serverSequence: 1}])
+    expect(snapshotPayload.snapshot).toEqual({resources: {Ticket: {models: [{id: "ticket-1", scanned: true}], status: "success"}}, serverSequence: 1})
+
+    const changesResponse = new Response({configuration})
+    const changesController = new ReplayTestController({
+      action: "frontendSyncChangeFeed",
+      configuration,
+      controller: "velocious/api",
+      params: {afterSequence: 1},
+      request: requestFor(configuration, "/frontend-models/sync/change-feed"),
+      response: changesResponse,
+      viewPath: "/tmp"
+    })
+
+    await changesController.frontendSyncChangeFeed()
+
+    const changesPayload = JSON.parse(String(changesResponse.getBody()))
+
+    expect(changesPayload.status).toEqual("success")
+    expect(changesPayload.serverSequence).toEqual(1)
+    expect(changesPayload.changes).toEqual([])
+    expect(changesPayload.snapshot).toEqual(undefined)
     expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
   })
 
@@ -267,6 +383,29 @@ describe("frontend-model sync replay", () => {
   })
 })
 
+/**
+ * Appends a deterministic test change.
+ * @param {ServerChangeFeedStore} store - Change-feed store.
+ * @param {object} args - Arguments.
+ * @param {string} args.clientMutationId - Client mutation id.
+ * @param {string} args.recordId - Record id.
+ * @returns {Promise<void>} - Resolves when appended.
+ */
+async function appendTestChange(store, {clientMutationId, recordId}) {
+  await store.append({
+    actorDeviceId: "scanner-1",
+    actorUserId: "user-1",
+    attributes: {scanned: true},
+    idempotencyKey: `user-1:scanner-1:${clientMutationId}`,
+    model: "Ticket",
+    operation: "update",
+    payload: {id: recordId},
+    recordId,
+    response: {status: "success", replayed: true},
+    scope: {eventId: "event-1"}
+  })
+}
+
 class TicketResource extends FrontendModelBaseResource {
   static attributes = ["id", "scanned"]
   static sync = {
@@ -295,6 +434,10 @@ class ReplayTestController extends FrontendModelController {
    * @returns {Promise<Record<string, ?>>} - Replay result.
    */
   async frontendModelCommandPayload(action) {
+    if (action === "index") {
+      return {models: [{id: "ticket-1", scanned: true}], status: "success"}
+    }
+
     this.replayedCommands.push({action, params: this.frontendModelParams()})
 
     return {status: "success", replayed: true}
@@ -316,9 +459,11 @@ class ThrowingReplayTestController extends ReplayTestController {
 
 /**
  * Builds test configuration for sync replay specs.
+ * @param {object} [options] - Configuration options.
+ * @param {number} [options.changeFeedRetentionSize] - Change-feed retention size.
  * @returns {Promise<{backendKeys: {privateKey: import("../../src/sync/device-identity.js").SyncJsonWebKey, publicKey: import("../../src/sync/device-identity.js").SyncJsonWebKey}, configuration: Configuration}>} - Test configuration.
  */
-async function syncReplayConfiguration() {
+async function syncReplayConfiguration({changeFeedRetentionSize} = {}) {
   const backendKeys = await generateSyncSigningKeyPair()
 
   const configuration = new Configuration({
@@ -332,6 +477,7 @@ async function syncReplayConfiguration() {
     locales: ["en"],
     backendProjects: [{frontendModels: {Ticket: TicketResource}, path: "/tmp/backend"}],
     sync: {
+      changeFeedRetentionSize,
       deviceCertificateBackendPublicKey: backendKeys.publicKey,
       offlineGrantSigningKeys: [{current: true, id: "key-1", secret: "test-signing-secret"}],
       offlineGrantTtlMs: 1000 * 60 * 60 * 24 * 365 * 100
@@ -402,14 +548,15 @@ function syncPolicyHash(configuration, model) {
 /**
  * Builds a minimal request object for sync replay specs.
  * @param {Configuration} configuration - Test configuration.
+ * @param {string} [path] - Request path.
  * @returns {Request} - Request.
  */
-function requestFor(configuration) {
+function requestFor(configuration, path = "/frontend-models/sync/replay") {
   const client = /** @type {any} */ ({remoteAddress: "127.0.0.1"})
   const request = new Request({client, configuration})
 
   request.feed(Buffer.from([
-    "POST /frontend-models/sync/replay HTTP/1.1",
+    `POST ${path} HTTP/1.1`,
     "Host: example.com",
     "Content-Length: 0",
     "",

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -359,6 +359,7 @@
  * Velocious sync configuration.
  * @typedef {object} VelociousSyncConfiguration
  * @property {import("./sync/device-identity.js").SyncJsonWebKey | null} [deviceCertificateBackendPublicKey] - Public backend key used to verify offline device certificates for sync replay.
+ * @property {number} [changeFeedRetentionSize] - Number of accepted server changes retained before clients must refresh from snapshot.
  * @property {Array<import("./sync/offline-grant.js").OfflineGrantSigningKey>} offlineGrantSigningKeys - Signing keys used to issue and verify offline grants. Secrets must never be exposed to clients.
  * @property {number} [offlineGrantTtlMs] - Default offline grant TTL in milliseconds. Defaults to 24 hours.
  */

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -407,11 +407,15 @@ export default class VelociousConfiguration {
    */
   _normalizeSyncConfiguration(sync) {
     const deviceCertificateBackendPublicKey = sync?.deviceCertificateBackendPublicKey || null
+    const changeFeedRetentionSize = sync?.changeFeedRetentionSize
     const offlineGrantSigningKeys = sync?.offlineGrantSigningKeys || []
     const offlineGrantTtlMs = sync?.offlineGrantTtlMs
 
     if (deviceCertificateBackendPublicKey !== null && (typeof deviceCertificateBackendPublicKey !== "object" || Array.isArray(deviceCertificateBackendPublicKey))) {
       throw new Error("sync.deviceCertificateBackendPublicKey must be a public JSON Web Key object")
+    }
+    if (changeFeedRetentionSize !== undefined && (!Number.isInteger(changeFeedRetentionSize) || changeFeedRetentionSize <= 0)) {
+      throw new Error("sync.changeFeedRetentionSize must be a positive integer")
     }
     if (!Array.isArray(offlineGrantSigningKeys)) throw new Error("sync.offlineGrantSigningKeys must be an array")
     if (offlineGrantTtlMs !== undefined && (!Number.isInteger(offlineGrantTtlMs) || offlineGrantTtlMs <= 0)) {
@@ -419,6 +423,7 @@ export default class VelociousConfiguration {
     }
 
     return {
+      changeFeedRetentionSize: changeFeedRetentionSize || 10000,
       deviceCertificateBackendPublicKey,
       offlineGrantSigningKeys: offlineGrantSigningKeys.map((key) => normalizeOfflineGrantSigningKey(key)),
       offlineGrantTtlMs: offlineGrantTtlMs || 24 * 60 * 60 * 1000

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -7,6 +7,7 @@ import Response from "./http-server/client/response.js"
 import {frontendModelResourcesWithBuiltInsForBackendProject} from "./frontend-models/built-in-resources.js"
 import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcePath, frontendModelResourcesForBackendProject, frontendModelSyncManifestForBackendProjects} from "./frontend-models/resource-definition.js"
 import {createOfflineGrantFromBootstrap, verifyOfflineGrant} from "./sync/offline-grant.js"
+import {serverChangeFeedStoreForConfiguration} from "./sync/server-change-feed.js"
 import {mutationIdempotencyKey, verifySignedMutation} from "./sync/device-identity.js"
 import {FrontendModelQueryError, normalizeGroup as normalizeQueryGroup, normalizeJoins as normalizeQueryJoins, normalizePluck as normalizeQueryPluck, normalizePreload as normalizeQueryPreload, normalizeSearchOperator as normalizeQuerySearchOperator, normalizeSort as normalizeQuerySort} from "./frontend-models/query.js"
 import {assignSafeProperty, deserializeFrontendModelTransportValue, isBackendModelInstance, serializeFrontendModelTransportValue} from "./frontend-models/transport-serialization.js"
@@ -3594,9 +3595,14 @@ export default class FrontendModelController extends Controller {
 
       try {
         idempotencyKey = mutationIdempotencyKey(/** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation))
-        const response = await this.frontendSyncReplaySignedMutation(signedMutation)
+        const {response, serverSequence} = await this.frontendSyncReplaySignedMutation(signedMutation)
 
-        results.push({idempotencyKey, response, status: "success"})
+        results.push({
+          idempotencyKey,
+          response,
+          serverSequence,
+          status: "success"
+        })
       } catch (error) {
         const errorContext = this.frontendModelEndpointErrorContext({
           action: "frontendSyncReplay",
@@ -3647,7 +3653,7 @@ export default class FrontendModelController extends Controller {
   /**
    * Verifies and replays one signed sync mutation.
    * @param {?} signedMutation - Signed mutation envelope.
-   * @returns {Promise<Record<string, ?>>} - Frontend-model command response.
+   * @returns {Promise<{response: Record<string, ?>, serverSequence: number | null}>} - Frontend-model command response and appended server sequence.
    */
   async frontendSyncReplaySignedMutation(signedMutation) {
     const configuration = this.getConfiguration()
@@ -3692,11 +3698,19 @@ export default class FrontendModelController extends Controller {
     const commandParams = await this.frontendSyncReplayCommandParams(mutation)
 
     try {
-      return await this.withFrontendModelParams(commandParams, async () => {
+      const response = await this.withFrontendModelParams(commandParams, async () => {
         return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
           return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
         })
       })
+      const serverSequence = await this.frontendSyncAppendServerChange({
+        idempotencyKey: mutationIdempotencyKey(/** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation)),
+        mutation,
+        offlineGrant,
+        response
+      })
+
+      return {response, serverSequence}
     } catch (error) {
       const errorContext = this.frontendModelEndpointErrorContext({
         action: "frontendSyncReplay",
@@ -3712,7 +3726,10 @@ export default class FrontendModelController extends Controller {
         model: errorContext.model
       })
 
-      return await this.frontendModelClientErrorPayloadForError(error, errorContext)
+      return {
+        response: await this.frontendModelClientErrorPayloadForError(error, errorContext),
+        serverSequence: null
+      }
     }
   }
 
@@ -3833,6 +3850,178 @@ export default class FrontendModelController extends Controller {
     if (primaryKeyValue !== undefined && mutation.operation !== "create") delete attributes[primaryKey]
 
     return {attributes, primaryKeyValue}
+  }
+
+  /**
+   * Appends a successfully replayed mutation to the server change feed.
+   * @param {object} args - Arguments.
+   * @param {string | null} args.idempotencyKey - Mutation idempotency key.
+   * @param {import("./sync/device-identity.js").SyncMutation} args.mutation - Verified mutation.
+   * @param {import("./sync/offline-grant.js").OfflineGrant} args.offlineGrant - Verified offline grant.
+   * @param {Record<string, ?>} args.response - Replay command response.
+   * @returns {Promise<number | null>} - Assigned server sequence, or null when no change was appended.
+   */
+  async frontendSyncAppendServerChange({idempotencyKey, mutation, offlineGrant, response}) {
+    if (response.status !== "success") return null
+
+    const payload = /** @type {Record<string, ?>} */ (mutation.payload && typeof mutation.payload === "object" && !Array.isArray(mutation.payload) ? mutation.payload : {})
+    const attributes = /** @type {Record<string, ?>} */ (mutation.attributes && typeof mutation.attributes === "object" && !Array.isArray(mutation.attributes) ? mutation.attributes : {})
+    const rawRecordId = payload.id || payload.recordId || attributes.id || null
+    const recordId = rawRecordId === null || rawRecordId === undefined ? null : String(rawRecordId)
+    const change = await serverChangeFeedStoreForConfiguration(this.getConfiguration()).append({
+      actorDeviceId: mutation.actorDeviceId,
+      actorUserId: mutation.actorUserId,
+      attributes,
+      idempotencyKey,
+      model: mutation.model,
+      operation: mutation.operation,
+      payload,
+      recordId,
+      response,
+      scope: offlineGrant.scopes
+    })
+
+    return change.serverSequence
+  }
+
+  /**
+   * Runs frontend sync change feed.
+   * @returns {Promise<void>} - Sync change-feed response.
+   */
+  async frontendSyncChangeFeed() {
+    if (this.request().httpMethod() === "OPTIONS") {
+      await this.render({status: 204, json: {}})
+      return
+    }
+
+    const params = /** @type {Record<string, ?>} */ (deserializeFrontendModelTransportValue(this.params()))
+    const afterSequence = this.frontendSyncChangeFeedAfterSequence(params)
+    const store = serverChangeFeedStoreForConfiguration(this.getConfiguration())
+    const limit = this.frontendSyncChangeFeedLimit(params)
+    const currentServerSequence = await store.latestSequence()
+    const serverSequence = this.frontendSyncChangeFeedUpToSequence(params, currentServerSequence)
+    const page = await store.changesAfter({afterSequence, limit, upToSequence: serverSequence})
+
+    if (page.snapshotRequired) {
+      await this.render({
+        json: /** @type {Record<string, ?>} */ (serializeFrontendModelTransportValue({
+          changes: [],
+          oldestSequence: page.oldestSequence,
+          requestedAfterSequence: afterSequence,
+          serverSequence,
+          snapshot: await this.frontendSyncSnapshotPayload({serverSequence}),
+          status: "snapshot_required"
+        }, this.transportSerializationOptions()))
+      })
+      return
+    }
+
+    const changes = page.changes
+    const includeSnapshot = params.snapshot === true || params.includeSnapshot === true || afterSequence === 0
+    const snapshot = includeSnapshot ? await this.frontendSyncSnapshotPayload({serverSequence}) : undefined
+
+    const payload = /** @type {Record<string, ?>} */ ({
+      changes,
+      hasMore: page.hasMore,
+      nextSequence: page.nextSequence,
+      serverSequence,
+      status: "success",
+      upToSequence: page.upToSequence
+    })
+
+    if (snapshot) payload.snapshot = snapshot
+
+    await this.render({
+      json: /** @type {Record<string, ?>} */ (serializeFrontendModelTransportValue(payload, this.transportSerializationOptions()))
+    })
+  }
+
+  /**
+   * Resolves sync change-feed cursor.
+   * @param {Record<string, ?>} params - Request params.
+   * @returns {number} - Exclusive lower-bound sequence.
+   */
+  frontendSyncChangeFeedAfterSequence(params) {
+    const afterSequence = params.afterSequence ?? params.cursor ?? 0
+
+    if (typeof afterSequence === "number" && Number.isInteger(afterSequence) && afterSequence >= 0) return afterSequence
+    if (typeof afterSequence === "string" && /^\d+$/.test(afterSequence)) return Number(afterSequence)
+
+    throw new Error("Expected sync change-feed afterSequence")
+  }
+
+  /**
+   * Resolves sync change-feed page limit.
+   * @param {Record<string, ?>} params - Request params.
+   * @returns {number} - Page limit.
+   */
+  frontendSyncChangeFeedLimit(params) {
+    const limit = params.limit ?? params.pageSize ?? 100
+
+    if (typeof limit === "number" && Number.isInteger(limit) && limit > 0) return limit
+    if (typeof limit === "string" && /^\d+$/.test(limit)) return Number(limit)
+
+    throw new Error("Expected sync change-feed positive limit")
+  }
+
+  /**
+   * Resolves sync change-feed stable high-water mark.
+   * @param {Record<string, ?>} params - Request params.
+   * @param {number} currentServerSequence - Current latest server sequence.
+   * @returns {number} - Inclusive upper-bound sequence.
+   */
+  frontendSyncChangeFeedUpToSequence(params, currentServerSequence) {
+    const upToSequence = params.upToSequence ?? params.serverSequence ?? currentServerSequence
+
+    if (typeof upToSequence === "number" && Number.isInteger(upToSequence) && upToSequence >= 0) return Math.min(upToSequence, currentServerSequence)
+    if (typeof upToSequence === "string" && /^\d+$/.test(upToSequence)) return Math.min(Number(upToSequence), currentServerSequence)
+
+    throw new Error("Expected sync change-feed upToSequence")
+  }
+
+  /**
+   * Runs frontend sync snapshot endpoint.
+   * @returns {Promise<void>} - Sync snapshot response.
+   */
+  async frontendSyncSnapshot() {
+    if (this.request().httpMethod() === "OPTIONS") {
+      await this.render({status: 204, json: {}})
+      return
+    }
+
+    const store = serverChangeFeedStoreForConfiguration(this.getConfiguration())
+    const serverSequence = await store.latestSequence()
+    const snapshot = await this.frontendSyncSnapshotPayload({serverSequence})
+
+    await this.render({
+      json: /** @type {Record<string, ?>} */ (serializeFrontendModelTransportValue({
+        snapshot,
+        status: "success"
+      }, this.transportSerializationOptions()))
+    })
+  }
+
+  /**
+   * Builds a snapshot of sync-enabled frontend model resources at a stable server sequence.
+   * @param {object} args - Arguments.
+   * @param {number} args.serverSequence - Snapshot sequence.
+   * @returns {Promise<{resources: Record<string, ?>, serverSequence: number}>} - Snapshot payload.
+   */
+  async frontendSyncSnapshotPayload({serverSequence}) {
+    const syncManifest = frontendModelSyncManifestForBackendProjects(this.getConfiguration().getBackendProjects())
+    const resources = /** @type {Record<string, ?>} */ ({})
+
+    for (const modelName of Object.keys(syncManifest).sort()) {
+      const commandParams = {model: modelName}
+
+      resources[modelName] = await this.withFrontendModelParams(commandParams, async () => {
+        return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
+          return await this.frontendModelCommandPayload("index") || this.frontendModelErrorPayload("Action halted by beforeAction.")
+        })
+      })
+    }
+
+    return {resources, serverSequence}
   }
 
   /**

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -3595,11 +3595,13 @@ export default class FrontendModelController extends Controller {
 
       try {
         idempotencyKey = mutationIdempotencyKey(/** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation))
-        const {response, serverSequence} = await this.frontendSyncReplaySignedMutation(signedMutation)
+        const {response, serverChangeFeedError, serverChangeFeedStatus, serverSequence} = await this.frontendSyncReplaySignedMutation(signedMutation)
 
         results.push({
           idempotencyKey,
           response,
+          serverChangeFeedError,
+          serverChangeFeedStatus,
           serverSequence,
           status: "success"
         })
@@ -3653,7 +3655,7 @@ export default class FrontendModelController extends Controller {
   /**
    * Verifies and replays one signed sync mutation.
    * @param {?} signedMutation - Signed mutation envelope.
-   * @returns {Promise<{response: Record<string, ?>, serverSequence: number | null}>} - Frontend-model command response and appended server sequence.
+   * @returns {Promise<{response: Record<string, ?>, serverChangeFeedError?: Record<string, ?>, serverChangeFeedStatus?: "error", serverSequence: number | null}>} - Frontend-model command response and appended server sequence.
    */
   async frontendSyncReplaySignedMutation(signedMutation) {
     const configuration = this.getConfiguration()
@@ -3697,12 +3699,36 @@ export default class FrontendModelController extends Controller {
 
     const commandParams = await this.frontendSyncReplayCommandParams(mutation)
 
+    let response
+
     try {
-      const response = await this.withFrontendModelParams(commandParams, async () => {
+      response = await this.withFrontendModelParams(commandParams, async () => {
         return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
           return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
         })
       })
+    } catch (error) {
+      const errorContext = this.frontendModelEndpointErrorContext({
+        action: "frontendSyncReplay",
+        commandType: /** @type {"create" | "update" | "destroy"} */ (mutation.operation),
+        error,
+        model: mutation.model
+      })
+
+      await this.frontendModelLogEndpointError({
+        action: errorContext.action,
+        commandType: errorContext.commandType,
+        error,
+        model: errorContext.model
+      })
+
+      return {
+        response: await this.frontendModelClientErrorPayloadForError(error, errorContext),
+        serverSequence: null
+      }
+    }
+
+    try {
       const serverSequence = await this.frontendSyncAppendServerChange({
         idempotencyKey: mutationIdempotencyKey(/** @type {import("./sync/device-identity.js").SignedSyncMutation} */ (signedMutation)),
         mutation,
@@ -3727,7 +3753,9 @@ export default class FrontendModelController extends Controller {
       })
 
       return {
-        response: await this.frontendModelClientErrorPayloadForError(error, errorContext),
+        response,
+        serverChangeFeedError: await this.frontendModelClientErrorPayloadForError(error, errorContext),
+        serverChangeFeedStatus: "error",
         serverSequence: null
       }
     }
@@ -3885,6 +3913,20 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
+   * Verifies the signed offline grant used to scope sync read endpoints.
+   * @param {Record<string, ?>} params - Request params.
+   * @returns {Promise<import("./sync/offline-grant.js").OfflineGrant>} - Verified offline grant.
+   */
+  async frontendSyncRequestVerifiedOfflineGrant(params) {
+    const signedOfflineGrant = this.frontendSyncReplaySignedOfflineGrant(params)
+
+    return await this.frontendSyncReplayVerifiedOfflineGrant({
+      signedOfflineGrant,
+      signingKeys: this.getConfiguration().getSyncConfiguration().offlineGrantSigningKeys
+    })
+  }
+
+  /**
    * Runs frontend sync change feed.
    * @returns {Promise<void>} - Sync change-feed response.
    */
@@ -3895,12 +3937,13 @@ export default class FrontendModelController extends Controller {
     }
 
     const params = /** @type {Record<string, ?>} */ (deserializeFrontendModelTransportValue(this.params()))
+    const offlineGrant = await this.frontendSyncRequestVerifiedOfflineGrant(params)
     const afterSequence = this.frontendSyncChangeFeedAfterSequence(params)
     const store = serverChangeFeedStoreForConfiguration(this.getConfiguration())
     const limit = this.frontendSyncChangeFeedLimit(params)
     const currentServerSequence = await store.latestSequence()
     const serverSequence = this.frontendSyncChangeFeedUpToSequence(params, currentServerSequence)
-    const page = await store.changesAfter({afterSequence, limit, upToSequence: serverSequence})
+    const page = await store.changesAfter({afterSequence, limit, scope: offlineGrant.scopes, upToSequence: serverSequence})
 
     if (page.snapshotRequired) {
       await this.render({
@@ -3909,7 +3952,7 @@ export default class FrontendModelController extends Controller {
           oldestSequence: page.oldestSequence,
           requestedAfterSequence: afterSequence,
           serverSequence,
-          snapshot: await this.frontendSyncSnapshotPayload({serverSequence}),
+          snapshot: await this.frontendSyncSnapshotPayload({scope: offlineGrant.scopes, serverSequence}),
           status: "snapshot_required"
         }, this.transportSerializationOptions()))
       })
@@ -3918,7 +3961,7 @@ export default class FrontendModelController extends Controller {
 
     const changes = page.changes
     const includeSnapshot = params.snapshot === true || params.includeSnapshot === true || afterSequence === 0
-    const snapshot = includeSnapshot ? await this.frontendSyncSnapshotPayload({serverSequence}) : undefined
+    const snapshot = includeSnapshot ? await this.frontendSyncSnapshotPayload({scope: offlineGrant.scopes, serverSequence}) : undefined
 
     const payload = /** @type {Record<string, ?>} */ ({
       changes,
@@ -3989,9 +4032,11 @@ export default class FrontendModelController extends Controller {
       return
     }
 
+    const params = /** @type {Record<string, ?>} */ (deserializeFrontendModelTransportValue(this.params()))
+    const offlineGrant = await this.frontendSyncRequestVerifiedOfflineGrant(params)
     const store = serverChangeFeedStoreForConfiguration(this.getConfiguration())
     const serverSequence = await store.latestSequence()
-    const snapshot = await this.frontendSyncSnapshotPayload({serverSequence})
+    const snapshot = await this.frontendSyncSnapshotPayload({scope: offlineGrant.scopes, serverSequence})
 
     await this.render({
       json: /** @type {Record<string, ?>} */ (serializeFrontendModelTransportValue({
@@ -4005,14 +4050,15 @@ export default class FrontendModelController extends Controller {
    * Builds a snapshot of sync-enabled frontend model resources at a stable server sequence.
    * @param {object} args - Arguments.
    * @param {number} args.serverSequence - Snapshot sequence.
+   * @param {Record<string, ?>} [args.scope] - Caller sync scope.
    * @returns {Promise<{resources: Record<string, ?>, serverSequence: number}>} - Snapshot payload.
    */
-  async frontendSyncSnapshotPayload({serverSequence}) {
+  async frontendSyncSnapshotPayload({scope, serverSequence}) {
     const syncManifest = frontendModelSyncManifestForBackendProjects(this.getConfiguration().getBackendProjects())
     const resources = /** @type {Record<string, ?>} */ ({})
 
     for (const modelName of Object.keys(syncManifest).sort()) {
-      const commandParams = {model: modelName}
+      const commandParams = {...(scope || {}), model: modelName}
 
       resources[modelName] = await this.withFrontendModelParams(commandParams, async () => {
         return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {

--- a/src/routes/hooks/frontend-model-command-route-hook.js
+++ b/src/routes/hooks/frontend-model-command-route-hook.js
@@ -33,6 +33,22 @@ export default async function frontendModelCommandRouteHook({configuration, curr
     }
   }
 
+  if (["/frontend-models/sync/change-feed", "/frontend-models/sync/changes", "/sync/changes"].includes(normalizedCurrentPath)) {
+    return {
+      action: "frontend-sync-change-feed",
+      controller: "velocious/api",
+      controllerPath: FRONTEND_MODEL_CONTROLLER_PATH
+    }
+  }
+
+  if (["/frontend-models/sync/snapshot", "/sync/snapshot"].includes(normalizedCurrentPath)) {
+    return {
+      action: "frontend-sync-snapshot",
+      controller: "velocious/api",
+      controllerPath: FRONTEND_MODEL_CONTROLLER_PATH
+    }
+  }
+
   if (normalizedCurrentPath === SHARED_FRONTEND_MODEL_API_PATH) {
     return {
       action: "frontend-api",

--- a/src/sync/server-change-feed.js
+++ b/src/sync/server-change-feed.js
@@ -102,7 +102,7 @@ export default class ServerChangeFeedStore {
           payload_json: JSON.stringify(change.payload || null),
           record_id: change.recordId === null || change.recordId === undefined ? null : String(change.recordId),
           response_json: JSON.stringify(change.response || null),
-          scope_json: JSON.stringify(change.scope || null)
+          scope_json: stableJsonStringify(change.scope || null)
         }
       })
 
@@ -155,14 +155,15 @@ export default class ServerChangeFeedStore {
    * @param {number} args.afterSequence - Exclusive lower bound.
    * @param {number} [args.limit] - Maximum number of changes.
    * @param {number} [args.upToSequence] - Inclusive upper bound.
+   * @param {Record<string, ?>} [args.scope] - Caller sync scope.
    * @returns {Promise<{changes: ServerChangeFeedEntry[], hasMore: boolean, nextSequence: number, oldestSequence: number | null, snapshotRequired: boolean, upToSequence: number}>} - Ordered page.
    */
-  async changesAfter({afterSequence, limit = DEFAULT_PAGE_SIZE, upToSequence}) {
+  async changesAfter({afterSequence, limit = DEFAULT_PAGE_SIZE, scope, upToSequence}) {
     await this.ensureReady()
 
     const pageSize = normalizeLimit(limit)
 
-    if (this._usesMemoryStorage()) return this._memoryChangesAfter({afterSequence, limit: pageSize, upToSequence})
+    if (this._usesMemoryStorage()) return this._memoryChangesAfter({afterSequence, limit: pageSize, scope, upToSequence})
 
     return await this._withDb(async (db) => {
       const latestSequence = typeof upToSequence === "number" ? upToSequence : await this._latestSequence(db)
@@ -185,6 +186,7 @@ export default class ServerChangeFeedStore {
         .from(TABLE_NAME)
         .where(`server_sequence > ${db.quote(afterSequence)}`)
         .where(`server_sequence <= ${db.quote(latestSequence)}`)
+        .where(scope === undefined ? "1 = 1" : {scope_json: stableJsonStringify(scope)})
         .order("server_sequence ASC")
         .limit(pageSize + 1)
         .results())
@@ -389,9 +391,10 @@ export default class ServerChangeFeedStore {
    * @param {number} args.afterSequence - Exclusive lower bound.
    * @param {number} args.limit - Page size.
    * @param {number} [args.upToSequence] - Inclusive upper bound.
+   * @param {Record<string, ?>} [args.scope] - Caller sync scope.
    * @returns {{changes: ServerChangeFeedEntry[], hasMore: boolean, nextSequence: number, oldestSequence: number | null, snapshotRequired: boolean, upToSequence: number}} - Ordered page.
    */
-  _memoryChangesAfter({afterSequence, limit, upToSequence}) {
+  _memoryChangesAfter({afterSequence, limit, scope, upToSequence}) {
     const latestSequence = typeof upToSequence === "number" ? upToSequence : this._memorySequence
     const oldestSequence = this._memoryChanges[0]?.serverSequence || null
     const snapshotRequired = afterSequence > 0 && oldestSequence !== null && oldestSequence > afterSequence + 1
@@ -400,7 +403,9 @@ export default class ServerChangeFeedStore {
       return {changes: [], hasMore: false, nextSequence: afterSequence, oldestSequence, snapshotRequired: true, upToSequence: latestSequence}
     }
 
-    const rows = this._memoryChanges.filter((change) => change.serverSequence > afterSequence && change.serverSequence <= latestSequence)
+    const rows = this._memoryChanges.filter((change) => {
+      return change.serverSequence > afterSequence && change.serverSequence <= latestSequence && scopesEqual(change.scope, scope)
+    })
     const hasMore = rows.length > limit
     const changes = rows.slice(0, limit)
     const lastChange = changes[changes.length - 1]
@@ -445,6 +450,43 @@ function parseJsonOrNull(value) {
   if (typeof value !== "string" || value.length < 1) return null
 
   return JSON.parse(value)
+}
+
+/**
+ * Compares sync scopes by stable JSON representation.
+ * @param {Record<string, ?> | null} changeScope - Persisted change scope.
+ * @param {Record<string, ?> | undefined} requestedScope - Caller scope.
+ * @returns {boolean} - Whether the change is visible for the requested scope.
+ */
+function scopesEqual(changeScope, requestedScope) {
+  if (requestedScope === undefined) return true
+
+  return stableJsonStringify(changeScope || null) === stableJsonStringify(requestedScope)
+}
+
+/**
+ * Stable JSON serialization for persisted sync scopes.
+ * @param {?} value - JSON-compatible value.
+ * @returns {string} - Stable JSON representation.
+ */
+function stableJsonStringify(value) {
+  return JSON.stringify(stableJsonValue(value))
+}
+
+/**
+ * Produces a recursively key-sorted JSON value.
+ * @param {?} value - JSON-compatible value.
+ * @returns {?} - Stable JSON-compatible value.
+ */
+function stableJsonValue(value) {
+  if (Array.isArray(value)) return value.map((item) => stableJsonValue(item))
+  if (!value || typeof value !== "object") return value
+
+  return Object.keys(value).sort().reduce((memo, key) => {
+    memo[key] = stableJsonValue(value[key])
+
+    return memo
+  }, /** @type {Record<string, ?>} */ ({}))
 }
 
 /**

--- a/src/sync/server-change-feed.js
+++ b/src/sync/server-change-feed.js
@@ -1,0 +1,482 @@
+// @ts-check
+
+import {randomUUID} from "crypto"
+import TableData from "../database/table-data/index.js"
+
+const DEFAULT_RETENTION_SIZE = 10000
+const DEFAULT_PAGE_SIZE = 100
+const MAX_PAGE_SIZE = 1000
+const TABLE_NAME = "frontend_model_sync_changes"
+const stores = new WeakMap()
+
+/**
+ * Shared server change-feed store for a configuration.
+ * @param {import("../configuration.js").default} configuration - Configuration.
+ * @returns {ServerChangeFeedStore} - Store.
+ */
+export function serverChangeFeedStoreForConfiguration(configuration) {
+  let store = stores.get(configuration)
+
+  if (!store) {
+    store = new ServerChangeFeedStore({configuration})
+    stores.set(configuration, store)
+  }
+
+  return store
+}
+
+export default class ServerChangeFeedStore {
+  /**
+   * Runs constructor.
+   * @param {object} args - Options.
+   * @param {import("../configuration.js").default} args.configuration - Configuration.
+   * @param {string} [args.databaseIdentifier] - Database identifier.
+   * @param {number} [args.retentionSize] - Number of feed entries to retain.
+   */
+  constructor({configuration, databaseIdentifier = "default", retentionSize}) {
+    const syncConfiguration = configuration.getSyncConfiguration()
+
+    this.configuration = configuration
+    this.databaseIdentifier = databaseIdentifier
+    this.retentionSize = retentionSize || syncConfiguration.changeFeedRetentionSize || DEFAULT_RETENTION_SIZE
+    /** @type {ServerChangeFeedEntry[]} */
+    this._memoryChanges = []
+    this._memorySequence = 0
+    this._isReady = false
+    this._readyPromise = null
+  }
+
+  /**
+   * Ensures the backing table exists.
+   * @returns {Promise<void>} - Resolves when ready.
+   */
+  async ensureReady() {
+    if (this._usesMemoryStorage()) {
+      this._isReady = true
+      return
+    }
+
+    if (await this._schemaReady()) return
+    if (this._readyPromise) return await this._readyPromise
+
+    this._readyPromise = (async () => {
+      this.configuration.setCurrent()
+      await this._withDb(async (db) => {
+        await this._ensureChangesTable(db)
+      })
+      this._isReady = true
+    })()
+
+    try {
+      await this._readyPromise
+    } finally {
+      if (!this._isReady) this._readyPromise = null
+    }
+  }
+
+  /**
+   * Appends a change and assigns the next server sequence.
+   * @param {Omit<ServerChangeFeedEntry, "createdAt" | "id" | "serverSequence"> & {createdAt?: string, id?: string}} change - Change payload.
+   * @returns {Promise<ServerChangeFeedEntry>} - Persisted change.
+   */
+  async append(change) {
+    await this.ensureReady()
+
+    const id = change.id || randomUUID()
+    const createdAt = change.createdAt || new Date().toISOString()
+
+    if (this._usesMemoryStorage()) return this._appendMemory({...change, createdAt, id})
+
+    return await this._withDb(async (db) => {
+      await db.insert({
+        tableName: TABLE_NAME,
+        data: {
+          actor_device_id: change.actorDeviceId,
+          actor_user_id: change.actorUserId,
+          attributes_json: JSON.stringify(change.attributes || null),
+          created_at: new Date(createdAt),
+          id,
+          idempotency_key: change.idempotencyKey,
+          model: change.model,
+          operation: change.operation,
+          payload_json: JSON.stringify(change.payload || null),
+          record_id: change.recordId === null || change.recordId === undefined ? null : String(change.recordId),
+          response_json: JSON.stringify(change.response || null),
+          scope_json: JSON.stringify(change.scope || null)
+        }
+      })
+
+      const row = await this._changeById(db, id)
+      if (!row) throw new Error("Failed to persist server change-feed entry")
+
+      await this._pruneRetainedChanges(db, row.serverSequence)
+
+      return row
+    })
+  }
+
+  /**
+   * Returns current latest server sequence.
+   * @returns {Promise<number>} - Latest sequence.
+   */
+  async latestSequence() {
+    await this.ensureReady()
+
+    if (this._usesMemoryStorage()) return this._memorySequence
+
+    return await this._withDb(async (db) => {
+      const rows = await db
+        .newQuery()
+        .from(TABLE_NAME)
+        .order("server_sequence DESC")
+        .limit(1)
+        .results()
+      const row = /** @type {{server_sequence?: number | string} | undefined} */ (rows[0])
+
+      return row ? Number(row.server_sequence) : 0
+    })
+  }
+
+  /**
+   * Returns oldest retained server sequence.
+   * @returns {Promise<number | null>} - Oldest retained sequence.
+   */
+  async oldestSequence() {
+    await this.ensureReady()
+
+    if (this._usesMemoryStorage()) return this._memoryChanges[0]?.serverSequence || null
+
+    return await this._withDb(async (db) => await this._oldestSequence(db))
+  }
+
+  /**
+   * Returns ordered changes after a cursor.
+   * @param {object} args - Arguments.
+   * @param {number} args.afterSequence - Exclusive lower bound.
+   * @param {number} [args.limit] - Maximum number of changes.
+   * @param {number} [args.upToSequence] - Inclusive upper bound.
+   * @returns {Promise<{changes: ServerChangeFeedEntry[], hasMore: boolean, nextSequence: number, oldestSequence: number | null, snapshotRequired: boolean, upToSequence: number}>} - Ordered page.
+   */
+  async changesAfter({afterSequence, limit = DEFAULT_PAGE_SIZE, upToSequence}) {
+    await this.ensureReady()
+
+    const pageSize = normalizeLimit(limit)
+
+    if (this._usesMemoryStorage()) return this._memoryChangesAfter({afterSequence, limit: pageSize, upToSequence})
+
+    return await this._withDb(async (db) => {
+      const latestSequence = typeof upToSequence === "number" ? upToSequence : await this._latestSequence(db)
+      const oldestSequence = await this._oldestSequence(db)
+      const snapshotRequired = afterSequence > 0 && oldestSequence !== null && oldestSequence > afterSequence + 1
+
+      if (snapshotRequired) {
+        return {
+          changes: [],
+          hasMore: false,
+          nextSequence: afterSequence,
+          oldestSequence,
+          snapshotRequired: true,
+          upToSequence: latestSequence
+        }
+      }
+
+      const rows = /** @type {ServerChangeFeedRow[]} */ (await db
+        .newQuery()
+        .from(TABLE_NAME)
+        .where(`server_sequence > ${db.quote(afterSequence)}`)
+        .where(`server_sequence <= ${db.quote(latestSequence)}`)
+        .order("server_sequence ASC")
+        .limit(pageSize + 1)
+        .results())
+      const hasMore = rows.length > pageSize
+      const pageRows = rows.slice(0, pageSize)
+      const changes = pageRows.map((row) => this._normalizeChangeRow(row))
+      const lastChange = changes[changes.length - 1]
+
+      return {
+        changes,
+        hasMore,
+        nextSequence: lastChange ? lastChange.serverSequence : afterSequence,
+        oldestSequence,
+        snapshotRequired: false,
+        upToSequence: latestSequence
+      }
+    })
+  }
+
+  /**
+   * Ensures schema is still present.
+   * @returns {Promise<boolean>} - Whether ready.
+   */
+  async _schemaReady() {
+    if (this._usesMemoryStorage()) return this._isReady
+    if (!this._isReady) return false
+    if (await this._withDb(async (db) => await db.tableExists(TABLE_NAME))) return true
+
+    this._isReady = false
+    this._readyPromise = null
+
+    return false
+  }
+
+  /**
+   * Ensures changes table exists.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _ensureChangesTable(db) {
+    if (await db.tableExists(TABLE_NAME)) return
+
+    const table = new TableData(TABLE_NAME, {ifNotExists: true})
+
+    table.integer("server_sequence", {autoIncrement: true, null: false, primaryKey: true})
+    table.string("id", {index: true, null: false})
+    table.string("model", {index: true, null: false})
+    table.string("operation", {null: false})
+    table.string("record_id", {index: true, null: true})
+    table.text("payload_json", {null: true})
+    table.text("attributes_json", {null: true})
+    table.string("idempotency_key", {index: true, null: true})
+    table.string("actor_user_id", {index: true, null: true})
+    table.string("actor_device_id", {index: true, null: true})
+    table.text("scope_json", {null: true})
+    table.text("response_json", {null: true})
+    table.datetime("created_at", {index: true, null: false})
+
+    await db.createTable(table)
+  }
+
+  /**
+   * Resolves a persisted change by id.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {string} id - Entry id.
+   * @returns {Promise<ServerChangeFeedEntry | null>} - Entry or null.
+   */
+  async _changeById(db, id) {
+    const rows = /** @type {ServerChangeFeedRow[]} */ (await db
+      .newQuery()
+      .from(TABLE_NAME)
+      .where({id})
+      .limit(1)
+      .results())
+
+    return rows[0] ? this._normalizeChangeRow(rows[0]) : null
+  }
+
+  /**
+   * Resolves current latest sequence without readiness checks.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<number>} - Latest sequence.
+   */
+  async _latestSequence(db) {
+    const rows = /** @type {Array<{server_sequence?: number | string}>} */ (await db
+      .newQuery()
+      .from(TABLE_NAME)
+      .order("server_sequence DESC")
+      .limit(1)
+      .results())
+
+    return rows[0] ? Number(rows[0].server_sequence) : 0
+  }
+
+  /**
+   * Resolves current oldest sequence without readiness checks.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<number | null>} - Oldest sequence.
+   */
+  async _oldestSequence(db) {
+    const rows = /** @type {Array<{server_sequence?: number | string}>} */ (await db
+      .newQuery()
+      .from(TABLE_NAME)
+      .order("server_sequence ASC")
+      .limit(1)
+      .results())
+
+    return rows[0] ? Number(rows[0].server_sequence) : null
+  }
+
+  /**
+   * Prunes old retained changes.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {number} latestSequence - Latest sequence after append.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _pruneRetainedChanges(db, latestSequence) {
+    if (!Number.isInteger(this.retentionSize) || this.retentionSize < 1) return
+
+    const pruneBeforeOrAt = latestSequence - this.retentionSize
+    if (pruneBeforeOrAt < 1) return
+
+    const rows = /** @type {Array<{id: string}>} */ (await db
+      .newQuery()
+      .from(TABLE_NAME)
+      .where(`server_sequence <= ${db.quote(pruneBeforeOrAt)}`)
+      .results())
+
+    for (const row of rows) {
+      await db.delete({conditions: {id: row.id}, tableName: TABLE_NAME})
+    }
+  }
+
+  /**
+   * Normalizes a change row.
+   * @param {ServerChangeFeedRow} row - Raw database row.
+   * @returns {ServerChangeFeedEntry} - Normalized change.
+   */
+  _normalizeChangeRow(row) {
+    const createdAtValue = row.created_at
+
+    return {
+      actorDeviceId: row.actor_device_id || null,
+      actorUserId: row.actor_user_id || null,
+      attributes: parseJsonOrNull(row.attributes_json),
+      createdAt: createdAtValue instanceof Date ? createdAtValue.toISOString() : new Date(createdAtValue).toISOString(),
+      id: row.id,
+      idempotencyKey: row.idempotency_key || null,
+      model: row.model,
+      operation: row.operation,
+      payload: parseJsonOrNull(row.payload_json),
+      recordId: row.record_id || null,
+      response: parseJsonOrNull(row.response_json),
+      scope: parseJsonOrNull(row.scope_json),
+      serverSequence: Number(row.server_sequence)
+    }
+  }
+
+  /**
+   * Whether this store should use process-local memory because no database identifier is configured.
+   * @returns {boolean} - Whether memory storage is active.
+   */
+  _usesMemoryStorage() {
+    try {
+      return !this.configuration.getDatabaseConfiguration()[this.databaseIdentifier]
+    } catch {
+      return true
+    }
+  }
+
+  /**
+   * Appends a process-local memory entry when no database is configured.
+   * @param {Omit<ServerChangeFeedEntry, "serverSequence">} change - Change payload.
+   * @returns {ServerChangeFeedEntry} - Appended entry.
+   */
+  _appendMemory(change) {
+    const entry = /** @type {ServerChangeFeedEntry} */ ({
+      actorDeviceId: change.actorDeviceId,
+      actorUserId: change.actorUserId,
+      attributes: change.attributes || null,
+      createdAt: change.createdAt,
+      id: change.id,
+      idempotencyKey: change.idempotencyKey,
+      model: change.model,
+      operation: change.operation,
+      payload: change.payload || null,
+      recordId: change.recordId === null || change.recordId === undefined ? null : String(change.recordId),
+      response: change.response || null,
+      scope: change.scope || null,
+      serverSequence: ++this._memorySequence
+    })
+
+    this._memoryChanges.push(entry)
+    if (this._memoryChanges.length > this.retentionSize) this._memoryChanges.splice(0, this._memoryChanges.length - this.retentionSize)
+
+    return entry
+  }
+
+  /**
+   * Returns a process-local memory change page.
+   * @param {object} args - Arguments.
+   * @param {number} args.afterSequence - Exclusive lower bound.
+   * @param {number} args.limit - Page size.
+   * @param {number} [args.upToSequence] - Inclusive upper bound.
+   * @returns {{changes: ServerChangeFeedEntry[], hasMore: boolean, nextSequence: number, oldestSequence: number | null, snapshotRequired: boolean, upToSequence: number}} - Ordered page.
+   */
+  _memoryChangesAfter({afterSequence, limit, upToSequence}) {
+    const latestSequence = typeof upToSequence === "number" ? upToSequence : this._memorySequence
+    const oldestSequence = this._memoryChanges[0]?.serverSequence || null
+    const snapshotRequired = afterSequence > 0 && oldestSequence !== null && oldestSequence > afterSequence + 1
+
+    if (snapshotRequired) {
+      return {changes: [], hasMore: false, nextSequence: afterSequence, oldestSequence, snapshotRequired: true, upToSequence: latestSequence}
+    }
+
+    const rows = this._memoryChanges.filter((change) => change.serverSequence > afterSequence && change.serverSequence <= latestSequence)
+    const hasMore = rows.length > limit
+    const changes = rows.slice(0, limit)
+    const lastChange = changes[changes.length - 1]
+
+    return {changes, hasMore, nextSequence: lastChange ? lastChange.serverSequence : afterSequence, oldestSequence, snapshotRequired: false, upToSequence: latestSequence}
+  }
+
+  /**
+   * Runs with db.
+   * @param {(db: import("../database/drivers/base.js").default) => Promise<?>} callback - Callback.
+   * @returns {Promise<?>} - Callback result.
+   */
+  async _withDb(callback) {
+    return await this.configuration.ensureConnections({name: "Server change-feed store"}, async (dbs) => {
+      const db = dbs[this.databaseIdentifier]
+
+      if (!db) throw new Error(`No database connection available for identifier: ${this.databaseIdentifier}`)
+
+      return await callback(db)
+    })
+  }
+}
+
+/**
+ * Normalizes page limit.
+ * @param {?} limit - Requested limit.
+ * @returns {number} - Page size.
+ */
+function normalizeLimit(limit) {
+  if (typeof limit === "number" && Number.isInteger(limit) && limit > 0) return Math.min(limit, MAX_PAGE_SIZE)
+  if (typeof limit === "string" && /^\d+$/.test(limit)) return Math.min(Number(limit), MAX_PAGE_SIZE)
+
+  return DEFAULT_PAGE_SIZE
+}
+
+/**
+ * Parses JSON-ish values.
+ * @param {?} value - JSON string.
+ * @returns {?} - Parsed value.
+ */
+function parseJsonOrNull(value) {
+  if (typeof value !== "string" || value.length < 1) return null
+
+  return JSON.parse(value)
+}
+
+/**
+ * @typedef {object} ServerChangeFeedEntry
+ * @property {string | null} actorDeviceId - Signed mutation actor device id when available.
+ * @property {string | null} actorUserId - Signed mutation actor user id when available.
+ * @property {Record<string, ?> | null} attributes - Serialized mutation attributes.
+ * @property {string} createdAt - Server change creation timestamp.
+ * @property {string} id - Server change id.
+ * @property {string | null} idempotencyKey - Mutation idempotency key when available.
+ * @property {string} model - Frontend model name.
+ * @property {string} operation - Mutation operation.
+ * @property {Record<string, ?> | null} payload - Serialized mutation payload.
+ * @property {string | null} recordId - Changed record id when known.
+ * @property {Record<string, ?> | null} response - Command response payload.
+ * @property {Record<string, ?> | null} scope - Offline grant scope.
+ * @property {number} serverSequence - Monotonic server sequence.
+ */
+
+/**
+ * @typedef {object} ServerChangeFeedRow
+ * @property {string | null} actor_device_id - Actor device id.
+ * @property {string | null} actor_user_id - Actor user id.
+ * @property {string | null} attributes_json - Attributes JSON.
+ * @property {Date | string} created_at - Creation time.
+ * @property {string} id - Entry id.
+ * @property {string | null} idempotency_key - Mutation idempotency key.
+ * @property {string} model - Frontend model name.
+ * @property {string} operation - Mutation operation.
+ * @property {string | null} payload_json - Mutation payload JSON.
+ * @property {string | null} record_id - Record id.
+ * @property {string | null} response_json - Response JSON.
+ * @property {string | null} scope_json - Scope JSON.
+ * @property {number | string} server_sequence - Server sequence.
+ */


### PR DESCRIPTION
## Summary
- add append-only server-sequenced sync change-feed storage
- expose sync changes/snapshot route aliases with pagination and retention fallback
- include serverSequence in successful replay results and add snapshot catch-up metadata

## Test Plan
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/controller/frontend-model-sync-replay-spec.js
- VELOCIOUS_DISABLE_MSSQL=1 npm run typecheck
- VELOCIOUS_DISABLE_MSSQL=1 npm run lint
- git diff --check

Task: #9996