### PR TITLE
feat: add sync conflict strategy support

### DIFF
--- a/spec/frontend-models/resource-definition-spec.js
+++ b/spec/frontend-models/resource-definition-spec.js
@@ -70,6 +70,7 @@ describe("frontendModelResourceConfigurationFromDefinition sync policy normaliza
     class FooResource extends FrontendModelBaseResource {
       static attributes = ["id", "name"]
       static sync = {
+        conflictStrategy: "fieldThreeWay",
         metadata: {scope: "event", strategy: "snapshot"},
         operations: ["update", "index", "update"],
         policy: {grantScopeAttributes: ["eventId"], writableAttributes: ["name"]},
@@ -80,6 +81,7 @@ describe("frontendModelResourceConfigurationFromDefinition sync policy normaliza
     class SamePolicyResource extends FrontendModelBaseResource {
       static attributes = ["id", "name"]
       static sync = {
+        conflictStrategy: "fieldThreeWay",
         operations: ["index", "update"],
         policyVersion: "scanner-v1",
         policy: {writableAttributes: ["name"], grantScopeAttributes: ["eventId"]},
@@ -101,6 +103,7 @@ describe("frontendModelResourceConfigurationFromDefinition sync policy normaliza
     const changedConfig = frontendModelResourceConfigurationFromDefinition(ChangedPolicyResource)
 
     expect(config?.sync).toEqual({
+      conflictStrategy: "fieldThreeWay",
       enabled: true,
       metadata: {scope: "event", strategy: "snapshot"},
       operations: ["index", "update"],
@@ -138,6 +141,7 @@ describe("frontendModelResourceConfigurationFromDefinition sync policy normaliza
       static attributes = ["id"]
       static modelName = "Ticket"
       static sync = {
+        conflictStrategy: "fieldThreeWay",
         metadata: {scope: "event"},
         operations: ["index", "update"],
         policyVersion: "scanner-v1"
@@ -157,6 +161,7 @@ describe("frontendModelResourceConfigurationFromDefinition sync policy normaliza
     expect(Object.keys(manifest)).toEqual(["Ticket"])
     expect(manifest.Ticket).toEqual({
       enabled: true,
+      conflictStrategy: "fieldThreeWay",
       metadata: {scope: "event"},
       operations: ["index", "update"],
       policyHash: manifest.Ticket.policyHash,

--- a/spec/sync/local-mutation-log-spec.js
+++ b/spec/sync/local-mutation-log-spec.js
@@ -161,9 +161,15 @@ describe("local sync mutation log", () => {
 
   it("maps server replay result statuses onto durable local mutation statuses", async () => {
     expect(replayResultLocalStatus({status: "success"})).toEqual("synced")
+    expect(replayResultLocalStatus({response: {status: "success"}, serverSequence: 42, status: "success"})).toEqual("synced")
     expect(replayResultLocalStatus({status: "duplicate"})).toEqual("synced")
     expect(replayResultLocalStatus({status: "conflict"})).toEqual("conflict")
     expect(replayResultLocalStatus({status: "error"})).toEqual("rejected")
+  })
+
+  it("keeps failed replay command responses unsynced", async () => {
+    expect(replayResultLocalStatus({response: {errorMessage: "Request failed.", status: "error"}, serverSequence: null, status: "success"})).toEqual("rejected")
+    expect(replayResultLocalStatus({response: {status: "success"}, serverChangeFeedStatus: "error", serverSequence: null, status: "success"})).toEqual("rejected")
   })
 
   it("persists conflict replay results on the local mutation log for UI resolution", async () => {

--- a/spec/sync/local-mutation-log-spec.js
+++ b/spec/sync/local-mutation-log-spec.js
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "../../src/testing/test.js"
 import LocalMutationLog from "../../src/sync/local-mutation-log.js"
+import {applySyncReplayResultToLocalMutationLog, replayResultLocalStatus, resolveSyncConflict} from "../../src/sync/conflict-strategy.js"
 
 describe("local sync mutation log", () => {
   it("appends pending mutations with actor device grant policy and dependency metadata", async () => {
@@ -156,6 +157,79 @@ describe("local sync mutation log", () => {
 
     expect(result.deletedRecordIds).toEqual([prunable.id])
     expect((await mutationLog.records()).map((record) => record.id)).toEqual([dependency.id, newestTerminal.id, pending.id])
+  })
+
+  it("maps server replay result statuses onto durable local mutation statuses", async () => {
+    expect(replayResultLocalStatus({status: "success"})).toEqual("synced")
+    expect(replayResultLocalStatus({status: "duplicate"})).toEqual("synced")
+    expect(replayResultLocalStatus({status: "conflict"})).toEqual("conflict")
+    expect(replayResultLocalStatus({status: "error"})).toEqual("rejected")
+  })
+
+  it("persists conflict replay results on the local mutation log for UI resolution", async () => {
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({
+      idGenerator: () => "log-1",
+      now: nextNow(["2026-06-24T10:00:00.000Z", "2026-06-24T10:01:00.000Z"]),
+      storage
+    })
+    const record = await mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-1"})})
+    const syncResult = {
+      conflict: {affectedFields: ["name"], serverModel: {id: "task-1", name: "Server task"}},
+      idempotencyKey: "user-1:device-1:mutation-1",
+      status: "conflict"
+    }
+
+    const updated = await applySyncReplayResultToLocalMutationLog({mutationLog, record, result: syncResult})
+
+    expect(updated.status).toEqual("conflict")
+    expect(updated.syncResult).toEqual(syncResult)
+    expect(updated.updatedAt).toEqual("2026-06-24T10:01:00.000Z")
+  })
+
+  it("detects optimistic-version conflicts and returns structured server/local state", async () => {
+    const result = await resolveSyncConflict({
+      mutation: buildMutation({attributes: {name: "Offline edit"}, baseVersion: "v1", clientMutationId: "mutation-1", operation: "update", payload: {id: "task-1"}}),
+      serverRecord: {attributes: {id: "task-1", name: "Server edit", updatedAt: "v2"}}
+    })
+
+    expect(result.status).toEqual("conflict")
+    expect(result.strategy).toEqual("optimisticVersion")
+    expect(result.conflict).toEqual({
+      affectedFields: ["name"],
+      baseRecord: null,
+      baseVersion: "v1",
+      localMutation: {
+        attributes: {name: "Offline edit"},
+        clientMutationId: "mutation-1",
+        model: "Task",
+        operation: "update",
+        payload: {id: "task-1"}
+      },
+      serverModel: {id: "task-1", name: "Server edit", updatedAt: "v2"},
+      serverVersion: "v2",
+      suggestedResolution: "manual",
+      versionAttribute: "updatedAt"
+    })
+  })
+
+  it("three-way merges non-overlapping field edits while reporting overlapping conflicts", async () => {
+    const nonOverlapping = await resolveSyncConflict({
+      baseRecord: {attributes: {id: "task-1", name: "Original", scanned: false}},
+      mutation: buildMutation({attributes: {scanned: true}, clientMutationId: "mutation-1", operation: "update", payload: {id: "task-1"}}),
+      serverRecord: {attributes: {id: "task-1", name: "Server edit", scanned: false}},
+      strategy: "fieldThreeWay"
+    })
+    const overlapping = await resolveSyncConflict({
+      baseRecord: {attributes: {id: "task-1", name: "Original"}},
+      mutation: buildMutation({attributes: {name: "Offline edit"}, clientMutationId: "mutation-2", operation: "update", payload: {id: "task-1"}}),
+      serverRecord: {attributes: {id: "task-1", name: "Server edit"}},
+      strategy: "fieldThreeWay"
+    })
+
+    expect(nonOverlapping).toEqual({attributes: {scanned: true}, status: "applied", strategy: "fieldThreeWay"})
+    expect(overlapping.status).toEqual("conflict")
+    expect(overlapping.conflict?.affectedFields).toEqual(["name"])
   })
 })
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -348,6 +348,7 @@
  * frontends and peers; `policy` is hashed but intentionally omitted from
  * frontend-safe manifests.
  * @typedef {object} FrontendModelResourceSyncConfiguration
+ * @property {"optimisticVersion" | "serverWins" | "lastWriterWins" | "fieldThreeWay" | "appendOnly"} [conflictStrategy] - Strategy used when replay detects server/client divergence. Defaults to `optimisticVersion`.
  * @property {boolean} [enabled] - Whether the resource is sync-enabled. Defaults to true when `sync` is configured.
  * @property {string[]} [operations] - Sync operation names such as `index`, `find`, `create`, `update`, custom domain commands, etc.
  * @property {string | number} [policyVersion] - App-controlled policy version used as a stable change signal.
@@ -367,6 +368,7 @@
 /**
  * Frontend-safe normalized sync metadata.
  * @typedef {object} NormalizedFrontendModelResourceSyncConfiguration
+ * @property {"optimisticVersion" | "serverWins" | "lastWriterWins" | "fieldThreeWay" | "appendOnly"} conflictStrategy - Normalized replay conflict strategy.
  * @property {boolean} enabled - Whether the resource is sync-enabled.
  * @property {string[]} operations - Sorted, duplicate-free sync operation names.
  * @property {string | null} policyVersion - App-controlled policy version, or null.

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -62,7 +62,11 @@ import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQuer
  */
 /**
  * Defines this typedef.
- * @typedef {{enabled: boolean, operations: string[], policyHash: string, policyVersion: string | null, metadata?: FrontendModelSyncMetadata}} FrontendModelSyncConfig
+ * @typedef {"optimisticVersion" | "serverWins" | "lastWriterWins" | "fieldThreeWay" | "appendOnly"} FrontendModelSyncConflictStrategy
+ */
+/**
+ * Defines this typedef.
+ * @typedef {{enabled: boolean, operations: string[], policyHash: string, policyVersion: string | null, conflictStrategy?: FrontendModelSyncConflictStrategy, metadata?: FrontendModelSyncMetadata}} FrontendModelSyncConfig
  */
 /**
  * Defines this typedef.

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -288,7 +288,7 @@ function normalizeFrontendModelResourceSync(resourceConfiguration) {
   const sync = resourceConfiguration.sync
 
   if (sync === undefined || sync === null) return undefined
-  if (sync === false) return {enabled: false, operations: [], policyHash: syncPolicyHash({enabled: false}), policyVersion: null}
+  if (sync === false) return {conflictStrategy: "optimisticVersion", enabled: false, operations: [], policyHash: syncPolicyHash({conflictStrategy: "optimisticVersion", enabled: false}), policyVersion: null}
   if (sync === true) {
     return normalizeFrontendModelResourceSync({
       ...resourceConfiguration,
@@ -299,18 +299,20 @@ function normalizeFrontendModelResourceSync(resourceConfiguration) {
     throw new Error("Resource sync configuration must be true, false, or an object.")
   }
 
-  const {enabled = true, metadata, operations, policy, policyVersion, ...rest} = /** @type {import("../configuration-types.js").FrontendModelResourceSyncConfiguration} */ (sync)
+  const {conflictStrategy, enabled = true, metadata, operations, policy, policyVersion, ...rest} = /** @type {import("../configuration-types.js").FrontendModelResourceSyncConfiguration} */ (sync)
 
   if (Object.keys(rest).length > 0) {
-    throw new Error(`Unexpected sync keys: ${Object.keys(rest).join(", ")}. Allowed: enabled, metadata, operations, policy, policyVersion`)
+    throw new Error(`Unexpected sync keys: ${Object.keys(rest).join(", ")}. Allowed: conflictStrategy, enabled, metadata, operations, policy, policyVersion`)
   }
   if (enabled !== true && enabled !== false) throw new Error("Resource sync enabled must be true or false when provided.")
 
+  const normalizedConflictStrategy = normalizeSyncConflictStrategy(conflictStrategy)
   const normalizedOperations = normalizeSyncOperations(operations)
   const normalizedMetadata = metadata === undefined ? undefined : deterministicSyncJson({label: "metadata", value: metadata})
   const normalizedPolicy = policy === undefined ? undefined : deterministicSyncJson({label: "policy", value: policy})
   const normalizedPolicyVersion = policyVersion === undefined || policyVersion === null ? null : String(policyVersion)
   const hashInput = {
+    conflictStrategy: normalizedConflictStrategy,
     enabled,
     metadata: normalizedMetadata,
     modelName: resourceConfiguration.modelName || null,
@@ -320,6 +322,7 @@ function normalizeFrontendModelResourceSync(resourceConfiguration) {
   }
   /** @type {import("../configuration-types.js").NormalizedFrontendModelResourceSyncConfiguration} */
   const normalized = {
+    conflictStrategy: normalizedConflictStrategy,
     enabled,
     operations: normalizedOperations,
     policyHash: syncPolicyHash(hashInput),
@@ -329,6 +332,20 @@ function normalizeFrontendModelResourceSync(resourceConfiguration) {
   if (normalizedMetadata !== undefined) normalized.metadata = /** @type {Record<string, import("../configuration-types.js").FrontendModelSyncJsonValue>} */ (normalizedMetadata)
 
   return normalized
+}
+
+/**
+ * Normalizes the sync conflict strategy for replay clients/servers.
+ * @param {unknown} conflictStrategy - Raw strategy.
+ * @returns {"optimisticVersion" | "serverWins" | "lastWriterWins" | "fieldThreeWay" | "appendOnly"} - Normalized strategy.
+ */
+function normalizeSyncConflictStrategy(conflictStrategy) {
+  if (conflictStrategy === undefined || conflictStrategy === null) return "optimisticVersion"
+  if (["optimisticVersion", "serverWins", "lastWriterWins", "fieldThreeWay", "appendOnly"].includes(String(conflictStrategy))) {
+    return /** @type {"optimisticVersion" | "serverWins" | "lastWriterWins" | "fieldThreeWay" | "appendOnly"} */ (conflictStrategy)
+  }
+
+  throw new Error(`Unknown resource sync conflictStrategy: ${String(conflictStrategy)}`)
 }
 
 /**

--- a/src/sync/conflict-strategy.js
+++ b/src/sync/conflict-strategy.js
@@ -68,9 +68,23 @@ export async function applySyncReplayResultToLocalMutationLog({mutationLog, reco
 export function replayResultLocalStatus(result) {
   if (result.status === "conflict") return "conflict"
   if (result.status === "error" || result.status === "rejected") return "rejected"
+  if (result.status === "success" && replayResultHasFailedApplication(result)) return "rejected"
   if (result.status === "success" || result.status === "applied" || result.status === "duplicate") return "synced"
 
   throw new Error(`Unknown sync replay result status '${String(result.status)}'`)
+}
+
+/**
+ * Checks whether an otherwise successful replay result contains a failed
+ * frontend-model command or change-feed write.
+ * @param {Record<string, SyncJsonValue>} result - Replay result.
+ * @returns {boolean} - Whether the local mutation must stay unsynced.
+ */
+function replayResultHasFailedApplication(result) {
+  if (result.serverSequence === null || result.serverChangeFeedStatus === "error") return true
+  if (!result.response || typeof result.response !== "object" || Array.isArray(result.response)) return false
+
+  return /** @type {Record<string, SyncJsonValue>} */ (result.response).status === "error"
 }
 
 /**

--- a/src/sync/conflict-strategy.js
+++ b/src/sync/conflict-strategy.js
@@ -1,0 +1,211 @@
+// @ts-check
+
+const CONFLICT_STRATEGIES = new Set(["optimisticVersion", "serverWins", "lastWriterWins", "fieldThreeWay", "appendOnly"])
+
+/**
+ * @typedef {null | string | number | boolean | unknown[] | Record<string, unknown>} SyncJsonValue
+ */
+
+/**
+ * @typedef {object} SyncConflictRecord
+ * @property {Record<string, SyncJsonValue>} attributes - Record attributes.
+ * @property {string | number | boolean | null} [version] - Record version value.
+ */
+
+/**
+ * @typedef {object} SyncConflictResult
+ * @property {Record<string, SyncJsonValue>} [attributes] - Attributes to apply when replay may continue.
+ * @property {Record<string, SyncJsonValue>} [conflict] - Structured conflict payload for the client/local log.
+ * @property {"applied" | "conflict" | "rejected"} status - Conflict decision.
+ * @property {string} strategy - Strategy that produced the decision.
+ */
+
+/**
+ * Evaluates a replay mutation against server/base state using a sync conflict strategy.
+ * @param {object} args - Arguments.
+ * @param {SyncConflictRecord | null} [args.baseRecord] - Record state observed when the mutation was made.
+ * @param {function(object): (SyncConflictResult | Promise<SyncConflictResult>)} [args.customHandler] - Resource-specific conflict hook.
+ * @param {import("./device-identity.js").SyncMutation} args.mutation - Replayed mutation.
+ * @param {SyncConflictRecord | null} [args.serverRecord] - Current authoritative server record.
+ * @param {string} [args.strategy] - Conflict strategy.
+ * @param {string} [args.versionAttribute] - Attribute used for optimistic version checks.
+ * @returns {Promise<SyncConflictResult>} - Conflict decision.
+ */
+export async function resolveSyncConflict({baseRecord = null, customHandler, mutation, serverRecord = null, strategy = "optimisticVersion", versionAttribute = "updatedAt"}) {
+  if (customHandler) return normalizeConflictResult(await customHandler({baseRecord, mutation, serverRecord, strategy, versionAttribute}), strategy)
+  if (!CONFLICT_STRATEGIES.has(strategy)) throw new Error(`Unknown sync conflict strategy '${strategy}'`)
+
+  const mutationAttributes = mutationAttributesFor(mutation)
+
+  if (strategy === "appendOnly" || strategy === "lastWriterWins") return {attributes: mutationAttributes, status: "applied", strategy}
+  if (strategy === "fieldThreeWay") return fieldThreeWayResult({baseRecord, mutation, serverRecord, strategy, versionAttribute})
+  if (hasVersionConflict({mutation, serverRecord, versionAttribute})) return conflictResult({baseRecord, mutation, serverRecord, strategy, versionAttribute})
+
+  return {attributes: mutationAttributes, status: "applied", strategy}
+}
+
+/**
+ * Applies a server replay result to a local mutation-log record.
+ * @param {object} args - Arguments.
+ * @param {import("./local-mutation-log.js").default} args.mutationLog - Local mutation log.
+ * @param {import("./local-mutation-log.js").LocalMutationLogRecord} args.record - Local mutation-log record.
+ * @param {Record<string, SyncJsonValue>} args.result - Server replay result payload.
+ * @returns {Promise<import("./local-mutation-log.js").LocalMutationLogRecord>} - Updated local record.
+ */
+export async function applySyncReplayResultToLocalMutationLog({mutationLog, record, result}) {
+  return await mutationLog.updateStatus({
+    id: record.id,
+    status: replayResultLocalStatus(result),
+    syncResult: result
+  })
+}
+
+/**
+ * Maps a server replay result to a local mutation-log status.
+ * @param {Record<string, SyncJsonValue>} result - Replay result.
+ * @returns {import("./local-mutation-log.js").LocalMutationStatus} - Local mutation-log status.
+ */
+export function replayResultLocalStatus(result) {
+  if (result.status === "conflict") return "conflict"
+  if (result.status === "error" || result.status === "rejected") return "rejected"
+  if (result.status === "success" || result.status === "applied" || result.status === "duplicate") return "synced"
+
+  throw new Error(`Unknown sync replay result status '${String(result.status)}'`)
+}
+
+/**
+ * Runs a field-level three-way merge.
+ * @param {object} args - Arguments.
+ * @param {SyncConflictRecord | null} args.baseRecord - Base record.
+ * @param {import("./device-identity.js").SyncMutation} args.mutation - Mutation.
+ * @param {SyncConflictRecord | null} args.serverRecord - Server record.
+ * @param {string} args.strategy - Strategy.
+ * @param {string} args.versionAttribute - Version attribute.
+ * @returns {SyncConflictResult} - Conflict decision.
+ */
+function fieldThreeWayResult({baseRecord, mutation, serverRecord, strategy, versionAttribute}) {
+  if (!baseRecord || !serverRecord) return {attributes: mutationAttributesFor(mutation), status: "applied", strategy}
+
+  const mutationAttributes = mutationAttributesFor(mutation)
+  /** @type {string[]} */
+  const affectedFields = []
+  /** @type {Record<string, SyncJsonValue>} */
+  const mergedAttributes = {}
+
+  for (const [field, localValue] of Object.entries(mutationAttributes)) {
+    const baseValue = baseRecord.attributes[field]
+    const serverValue = serverRecord.attributes[field]
+
+    if (jsonValuesEqual(serverValue, baseValue) || jsonValuesEqual(serverValue, localValue)) {
+      mergedAttributes[field] = localValue
+    } else {
+      affectedFields.push(field)
+    }
+  }
+
+  if (affectedFields.length > 0) return conflictResult({affectedFields, baseRecord, mutation, serverRecord, strategy, versionAttribute})
+
+  return {attributes: mergedAttributes, status: "applied", strategy}
+}
+
+/**
+ * Checks whether current server state conflicts with a mutation base version.
+ * @param {object} args - Arguments.
+ * @param {import("./device-identity.js").SyncMutation} args.mutation - Mutation.
+ * @param {SyncConflictRecord | null} args.serverRecord - Server record.
+ * @param {string} args.versionAttribute - Version attribute.
+ * @returns {boolean} - Whether versions conflict.
+ */
+function hasVersionConflict({mutation, serverRecord, versionAttribute}) {
+  if (!serverRecord) return false
+  if (mutation.baseVersion === undefined || mutation.baseVersion === null) return false
+
+  const serverVersion = serverRecord.version ?? serverRecord.attributes[versionAttribute] ?? null
+
+  return !jsonValuesEqual(serverVersion, mutation.baseVersion)
+}
+
+/**
+ * Builds a structured conflict result.
+ * @param {object} args - Arguments.
+ * @param {string[]} [args.affectedFields] - Explicit affected fields.
+ * @param {SyncConflictRecord | null} args.baseRecord - Base record.
+ * @param {import("./device-identity.js").SyncMutation} args.mutation - Mutation.
+ * @param {SyncConflictRecord | null} args.serverRecord - Server record.
+ * @param {string} args.strategy - Strategy.
+ * @param {string} args.versionAttribute - Version attribute.
+ * @returns {SyncConflictResult} - Conflict result.
+ */
+function conflictResult({affectedFields, baseRecord, mutation, serverRecord, strategy, versionAttribute}) {
+  const mutationAttributes = mutationAttributesFor(mutation)
+
+  return {
+    conflict: {
+      affectedFields: affectedFields || Object.keys(mutationAttributes),
+      baseRecord: baseRecord ? baseRecord.attributes : null,
+      baseVersion: /** @type {SyncJsonValue} */ (mutation.baseVersion ?? null),
+      localMutation: {
+        attributes: mutationAttributes,
+        clientMutationId: mutation.clientMutationId,
+        model: mutation.model,
+        operation: mutation.operation,
+        payload: /** @type {SyncJsonValue} */ (mutation.payload || null)
+      },
+      serverModel: serverRecord ? serverRecord.attributes : null,
+      serverVersion: serverRecord ? /** @type {SyncJsonValue} */ (serverRecord.version ?? serverRecord.attributes[versionAttribute] ?? null) : null,
+      suggestedResolution: strategy === "serverWins" ? "keep_server" : "manual",
+      versionAttribute
+    },
+    status: "conflict",
+    strategy
+  }
+}
+
+/**
+ * Normalizes a custom resource conflict result.
+ * @param {unknown} result - Raw result.
+ * @param {string} strategy - Requested strategy.
+ * @returns {SyncConflictResult} - Normalized result.
+ */
+function normalizeConflictResult(result, strategy) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) throw new Error("Sync conflict handler must return an object")
+  const resultRecord = /** @type {Record<string, unknown>} */ (result)
+  if (!["applied", "conflict", "rejected"].includes(String(resultRecord.status))) throw new Error("Sync conflict handler returned an unknown status")
+
+  return /** @type {SyncConflictResult} */ ({strategy, ...resultRecord})
+}
+
+/**
+ * Returns mutation attributes as a JSON object.
+ * @param {import("./device-identity.js").SyncMutation} mutation - Mutation.
+ * @returns {Record<string, SyncJsonValue>} - Attributes.
+ */
+function mutationAttributesFor(mutation) {
+  if (!mutation.attributes || typeof mutation.attributes !== "object" || Array.isArray(mutation.attributes)) return {}
+
+  return /** @type {Record<string, SyncJsonValue>} */ (JSON.parse(JSON.stringify(mutation.attributes)))
+}
+
+/**
+ * Compares JSON values by stable serialization.
+ * @param {unknown} left - Left value.
+ * @param {unknown} right - Right value.
+ * @returns {boolean} - Whether values match.
+ */
+function jsonValuesEqual(left, right) {
+  return stableJsonStringify(left) === stableJsonStringify(right)
+}
+
+/**
+ * Stable JSON stringify helper.
+ * @param {unknown} value - Value.
+ * @returns {string} - Stable JSON.
+ */
+function stableJsonStringify(value) {
+  if (Array.isArray(value)) return `[${value.map((entry) => stableJsonStringify(entry)).join(",")}]`
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJsonStringify(/** @type {Record<string, unknown>} */ (value)[key])}`).join(",")}}`
+  }
+
+  return JSON.stringify(value)
+}


### PR DESCRIPTION
## Summary
- add sync conflict strategy constants/helpers and configuration exposure
- wire frontend resource definitions to resolve sync conflicts
- add specs covering default/explicit conflict strategies and sync result handling

## Test Plan
- [ ] npm test -- spec/sync/local-mutation-log-spec.js spec/frontend-models/resource-definition-spec.js

Draft because the implementation was pushed immediately to restore the required PR workflow; local verification/CI follow-up is still pending.