### PR TITLE
Add peer mutation bundle import/export

### DIFF
--- a/spec/sync/peer-mutation-bundle-spec.js
+++ b/spec/sync/peer-mutation-bundle-spec.js
@@ -139,6 +139,84 @@ describe("sync peer mutation import/export", () => {
     expect(result.rejected).toEqual([{errorMessage: "Sync mutation signature did not match", index: 0}])
     expect(await mutationLog.records()).toEqual([])
   })
+
+  it("does not re-export imported peer-applied mutations with the local device certificate", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const localKeys = await generateSyncSigningKeyPair()
+    const peerKeys = await generateSyncSigningKeyPair()
+    const localCertificate = await buildDeviceCertificate({backendKeys, deviceKeys: localKeys})
+    const peerCertificate = await buildDeviceCertificate({
+      actorDeviceId: "peer-device-1",
+      actorUserId: "peer-user-1",
+      backendKeys,
+      deviceKeys: peerKeys
+    })
+    const mutationLog = new LocalMutationLog({idGenerator: nextValue(["local-1", "peer-1"]), storage: buildMemoryStorage()})
+    const localRecord = await mutationLog.append({mutation: buildMutation({clientMutationId: "local-mutation-1"})})
+    const peerSignedMutation = await createSignedMutation({
+      deviceCertificate: peerCertificate,
+      devicePrivateKey: peerKeys.privateKey,
+      mutation: buildMutation({
+        actorDeviceId: "peer-device-1",
+        actorUserId: "peer-user-1",
+        clientMutationId: "peer-mutation-1"
+      })
+    })
+    await importPeerMutationBundle({
+      backendPublicKey: backendKeys.publicKey,
+      bundle: {
+        exportedAt: "2026-06-25T10:00:00.000Z",
+        format: "velocious.sync.peer-mutation-bundle.v1",
+        mutations: [{signedMutation: peerSignedMutation}]
+      },
+      mutationLog,
+      now: new Date("2026-06-25T10:00:00.000Z")
+    })
+
+    const bundle = await exportPeerMutationBundle({
+      deviceCertificate: localCertificate,
+      devicePrivateKey: localKeys.privateKey,
+      mutationLog,
+      now: () => new Date("2026-06-25T11:00:00.000Z")
+    })
+
+    expect(bundle.mutations.map((entry) => entry.localRecordId)).toEqual([localRecord.id])
+    expect(bundle.mutations.map((entry) => entry.signedMutation.mutation.clientMutationId)).toEqual(["local-mutation-1"])
+  })
+
+  it("lets storage failures escape peer import after signature verification", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const peerKeys = await generateSyncSigningKeyPair()
+    const peerCertificate = await buildDeviceCertificate({backendKeys, deviceKeys: peerKeys})
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({idGenerator: () => "import-1", storage: {
+      ...storage,
+      updateRecord() {
+        throw new Error("storage unavailable")
+      }
+    }})
+    const signedMutation = await createSignedMutation({
+      deviceCertificate: peerCertificate,
+      devicePrivateKey: peerKeys.privateKey,
+      mutation: buildMutation({clientMutationId: "peer-mutation-1"})
+    })
+
+    try {
+      await importPeerMutationBundle({
+        backendPublicKey: backendKeys.publicKey,
+        bundle: {
+          exportedAt: "2026-06-25T10:00:00.000Z",
+          format: "velocious.sync.peer-mutation-bundle.v1",
+          mutations: [{signedMutation}]
+        },
+        mutationLog,
+        now: new Date("2026-06-25T10:00:00.000Z")
+      })
+      throw new Error("Expected peer import to reject")
+    } catch (error) {
+      expect(error instanceof Error ? error.message : String(error)).toEqual("storage unavailable")
+    }
+  })
 })
 
 async function buildDeviceCertificate({actorDeviceId = "device-1", actorUserId = "user-1", backendKeys, deviceKeys}) {

--- a/spec/sync/peer-mutation-bundle-spec.js
+++ b/spec/sync/peer-mutation-bundle-spec.js
@@ -1,0 +1,214 @@
+import {describe, expect, it} from "../../src/testing/test.js"
+import LocalMutationLog from "../../src/sync/local-mutation-log.js"
+import {
+  createDeviceCertificate,
+  createSignedMutation,
+  generateSyncSigningKeyPair,
+  verifySignedMutation
+} from "../../src/sync/device-identity.js"
+import {
+  exportPeerMutationBundle,
+  importPeerMutationBundle
+} from "../../src/sync/peer-mutation-bundle.js"
+
+describe("sync peer mutation import/export", () => {
+  it("exports pending local mutations as verifiable signed peer bundles in sequence order", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const deviceKeys = await generateSyncSigningKeyPair()
+    const deviceCertificate = await buildDeviceCertificate({backendKeys, deviceKeys})
+    const mutationLog = new LocalMutationLog({idGenerator: nextValue(["log-1", "log-2", "log-3"]), storage: buildMemoryStorage()})
+    const first = await mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-1"})})
+    const second = await mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-2"})})
+    const synced = await mutationLog.append({mutation: buildMutation({clientMutationId: "mutation-3"})})
+    await mutationLog.updateStatus({id: synced.id, status: "synced"})
+
+    const bundle = await exportPeerMutationBundle({
+      deviceCertificate,
+      devicePrivateKey: deviceKeys.privateKey,
+      mutationLog,
+      now: () => new Date("2026-06-25T10:00:00.000Z")
+    })
+
+    expect(bundle).toMatchObject({
+      exportedAt: "2026-06-25T10:00:00.000Z",
+      format: "velocious.sync.peer-mutation-bundle.v1"
+    })
+    expect(bundle.mutations.map((entry) => entry.localRecordId)).toEqual([first.id, second.id])
+    expect(bundle.mutations.map((entry) => entry.localSequence)).toEqual([1, 2])
+
+    const verifiedMutations = []
+    for (const entry of bundle.mutations) {
+      verifiedMutations.push(await verifySignedMutation({
+        backendPublicKey: backendKeys.publicKey,
+        now: new Date("2026-06-25T10:00:00.000Z"),
+        signedMutation: entry.signedMutation
+      }))
+    }
+    expect(verifiedMutations.map((mutation) => mutation.clientMutationId)).toEqual(["mutation-1", "mutation-2"])
+  })
+
+  it("imports verified peer mutations as peer-applied records and skips existing idempotency keys", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const peerKeys = await generateSyncSigningKeyPair()
+    const peerCertificate = await buildDeviceCertificate({
+      actorDeviceId: "peer-device-1",
+      actorUserId: "peer-user-1",
+      backendKeys,
+      deviceKeys: peerKeys
+    })
+    const storage = buildMemoryStorage()
+    const mutationLog = new LocalMutationLog({idGenerator: nextValue(["local-1", "import-1", "import-2"]), storage})
+    const existing = await mutationLog.append({
+      mutation: buildMutation({
+        actorDeviceId: "peer-device-1",
+        actorUserId: "peer-user-1",
+        clientMutationId: "peer-mutation-1"
+      })
+    })
+    const firstSignedMutation = await createSignedMutation({
+      deviceCertificate: peerCertificate,
+      devicePrivateKey: peerKeys.privateKey,
+      mutation: buildMutation({
+        actorDeviceId: "peer-device-1",
+        actorUserId: "peer-user-1",
+        clientMutationId: "peer-mutation-1"
+      })
+    })
+    const secondSignedMutation = await createSignedMutation({
+      deviceCertificate: peerCertificate,
+      devicePrivateKey: peerKeys.privateKey,
+      mutation: buildMutation({
+        actorDeviceId: "peer-device-1",
+        actorUserId: "peer-user-1",
+        clientMutationId: "peer-mutation-2"
+      })
+    })
+
+    const result = await importPeerMutationBundle({
+      backendPublicKey: backendKeys.publicKey,
+      bundle: {
+        exportedAt: "2026-06-25T10:00:00.000Z",
+        format: "velocious.sync.peer-mutation-bundle.v1",
+        mutations: [
+          {signedMutation: firstSignedMutation},
+          {signedMutation: secondSignedMutation}
+        ]
+      },
+      mutationLog,
+      now: new Date("2026-06-25T10:00:00.000Z")
+    })
+
+    expect(result).toEqual({
+      imported: [{clientMutationId: "peer-mutation-2", idempotencyKey: "peer-user-1:peer-device-1:peer-mutation-2", localRecordId: "import-1"}],
+      rejected: [],
+      skipped: [{clientMutationId: "peer-mutation-1", idempotencyKey: "peer-user-1:peer-device-1:peer-mutation-1", localRecordId: existing.id, reason: "duplicate"}]
+    })
+    expect((await mutationLog.records()).map((record) => ({
+      clientMutationId: record.mutation.clientMutationId,
+      status: record.status
+    }))).toEqual([
+      {clientMutationId: "peer-mutation-1", status: "pending"},
+      {clientMutationId: "peer-mutation-2", status: "peer-applied"}
+    ])
+  })
+
+  it("rejects invalid peer mutations without appending them", async () => {
+    const backendKeys = await generateSyncSigningKeyPair()
+    const peerKeys = await generateSyncSigningKeyPair()
+    const peerCertificate = await buildDeviceCertificate({backendKeys, deviceKeys: peerKeys})
+    const mutationLog = new LocalMutationLog({idGenerator: () => "import-1", storage: buildMemoryStorage()})
+    const signedMutation = await createSignedMutation({
+      deviceCertificate: peerCertificate,
+      devicePrivateKey: peerKeys.privateKey,
+      mutation: buildMutation({clientMutationId: "peer-mutation-1"})
+    })
+
+    const result = await importPeerMutationBundle({
+      backendPublicKey: backendKeys.publicKey,
+      bundle: {
+        exportedAt: "2026-06-25T10:00:00.000Z",
+        format: "velocious.sync.peer-mutation-bundle.v1",
+        mutations: [{signedMutation: {...signedMutation, mutation: {...signedMutation.mutation, attributes: {name: "Tampered"}}}}]
+      },
+      mutationLog,
+      now: new Date("2026-06-25T10:00:00.000Z")
+    })
+
+    expect(result.imported).toEqual([])
+    expect(result.skipped).toEqual([])
+    expect(result.rejected).toEqual([{errorMessage: "Sync mutation signature did not match", index: 0}])
+    expect(await mutationLog.records()).toEqual([])
+  })
+})
+
+async function buildDeviceCertificate({actorDeviceId = "device-1", actorUserId = "user-1", backendKeys, deviceKeys}) {
+  return await createDeviceCertificate({
+    backendPrivateKey: backendKeys.privateKey,
+    certificate: {
+      actorDeviceId,
+      actorUserId,
+      certificateId: `${actorDeviceId}-certificate-1`,
+      devicePublicKey: deviceKeys.publicKey,
+      expiresAt: "2026-06-26T10:00:00.000Z",
+      issuedAt: "2026-06-25T09:00:00.000Z"
+    }
+  })
+}
+
+function buildMutation(overrides = {}) {
+  return {
+    actorDeviceId: "device-1",
+    actorUserId: "user-1",
+    attributes: {name: "Offline task"},
+    baseVersion: null,
+    clientMutationId: "mutation-1",
+    model: "Task",
+    occurredAt: "2026-06-25T09:30:00.000Z",
+    offlineGrantId: "grant-1",
+    operation: "update",
+    policyHash: "sha256-task",
+    ...overrides
+  }
+}
+
+function buildMemoryStorage() {
+  const recordsByKey = new Map()
+
+  return {
+    appendRecord(storageKey, record) {
+      recordsFor(storageKey).push(JSON.parse(JSON.stringify(record)))
+    },
+    deleteRecords(storageKey, ids) {
+      recordsByKey.set(storageKey, recordsFor(storageKey).filter((record) => !ids.includes(record.id)))
+    },
+    nextSequence(storageKey) {
+      return recordsFor(storageKey).length + 1
+    },
+    record(storageKey, id) {
+      const record = recordsFor(storageKey).find((entry) => entry.id === id)
+      return record ? JSON.parse(JSON.stringify(record)) : null
+    },
+    records(storageKey, options = {}) {
+      let records = recordsFor(storageKey)
+      if (options.statuses) records = records.filter((record) => options.statuses.includes(record.status))
+      return JSON.parse(JSON.stringify(records))
+    },
+    updateRecord(storageKey, record) {
+      const records = recordsFor(storageKey)
+      const index = records.findIndex((entry) => entry.id === record.id)
+      if (index < 0) throw new Error(`No record ${record.id}`)
+      records[index] = JSON.parse(JSON.stringify(record))
+    }
+  }
+
+  function recordsFor(storageKey) {
+    if (!recordsByKey.has(storageKey)) recordsByKey.set(storageKey, [])
+    return recordsByKey.get(storageKey)
+  }
+}
+
+function nextValue(values) {
+  let index = 0
+
+  return () => values[index++]
+}

--- a/src/sync/peer-mutation-bundle.js
+++ b/src/sync/peer-mutation-bundle.js
@@ -1,0 +1,209 @@
+// @ts-check
+
+import {createSignedMutation, mutationIdempotencyKey, verifySignedMutation} from "./device-identity.js"
+
+const PEER_MUTATION_BUNDLE_FORMAT = "velocious.sync.peer-mutation-bundle.v1"
+const EXPORTABLE_STATUSES = new Set(["pending", "applied-locally", "peer-applied", "conflict"])
+
+/**
+ * Peer mutation bundle exported by a device for offline/P2P transfer.
+ * @typedef {object} PeerMutationBundle
+ * @property {string} exportedAt - ISO timestamp when the bundle was exported.
+ * @property {"velocious.sync.peer-mutation-bundle.v1"} format - Bundle format identifier.
+ * @property {PeerMutationBundleEntry[]} mutations - Signed mutations in local sequence order.
+ */
+
+/**
+ * One peer mutation bundle entry.
+ * @typedef {object} PeerMutationBundleEntry
+ * @property {string} [localRecordId] - Exporting device's local mutation record id.
+ * @property {number} [localSequence] - Exporting device's local mutation sequence.
+ * @property {import("./device-identity.js").SignedSyncMutation} signedMutation - Device-signed mutation envelope.
+ */
+
+/**
+ * Exports local non-terminal mutations as a signed peer-transfer bundle.
+ * @param {object} args - Arguments.
+ * @param {import("./device-identity.js").DeviceCertificate} args.deviceCertificate - Device certificate for signing records.
+ * @param {import("./device-identity.js").SyncJsonWebKey} args.devicePrivateKey - Device private key for signing records.
+ * @param {import("./local-mutation-log.js").default} args.mutationLog - Local mutation log.
+ * @param {() => Date} [args.now] - Export clock.
+ * @param {import("./local-mutation-log.js").LocalMutationStatus[]} [args.statuses] - Statuses to export.
+ * @returns {Promise<PeerMutationBundle>} - Signed peer mutation bundle.
+ */
+export async function exportPeerMutationBundle({deviceCertificate, devicePrivateKey, mutationLog, now = () => new Date(), statuses}) {
+  const selectedStatuses = normalizeExportStatuses(statuses)
+  const timestamp = isoTimestamp(now(), "exportedAt")
+  const records = (await mutationLog.records())
+    .filter((record) => selectedStatuses.has(record.status))
+    .sort((left, right) => left.sequence - right.sequence)
+  const mutations = []
+
+  for (const record of records) {
+    mutations.push({
+      localRecordId: record.id,
+      localSequence: record.sequence,
+      signedMutation: await createSignedMutation({
+        deviceCertificate,
+        devicePrivateKey,
+        mutation: record.mutation
+      })
+    })
+  }
+
+  return {
+    exportedAt: timestamp,
+    format: PEER_MUTATION_BUNDLE_FORMAT,
+    mutations
+  }
+}
+
+/**
+ * Imports verified peer mutations into the local mutation log.
+ * @param {object} args - Arguments.
+ * @param {import("./device-identity.js").SyncJsonWebKey} args.backendPublicKey - Backend public key for verifying peer certificates.
+ * @param {PeerMutationBundle} args.bundle - Peer bundle to import.
+ * @param {import("./local-mutation-log.js").default} args.mutationLog - Local mutation log.
+ * @param {Date} [args.now] - Verification time.
+ * @returns {Promise<{imported: {clientMutationId: string, idempotencyKey: string, localRecordId: string}[], rejected: {errorMessage: string, index: number}[], skipped: {clientMutationId: string, idempotencyKey: string, localRecordId: string, reason: "duplicate"}[]}>} - Import result.
+ */
+export async function importPeerMutationBundle({backendPublicKey, bundle, mutationLog, now = new Date()}) {
+  const normalizedBundle = normalizePeerMutationBundle(bundle)
+  const existingRecords = await mutationLog.records()
+  const existingByIdempotencyKey = new Map(existingRecords.map((record) => [mutationIdempotencyKey({mutation: record.mutation}), record]))
+  const imported = []
+  const rejected = []
+  const skipped = []
+
+  for (const [index, entry] of normalizedBundle.mutations.entries()) {
+    try {
+      const mutation = await verifySignedMutation({backendPublicKey, now, signedMutation: entry.signedMutation})
+      const idempotencyKey = mutationIdempotencyKey(entry.signedMutation)
+      const duplicateRecord = existingByIdempotencyKey.get(idempotencyKey)
+
+      if (duplicateRecord) {
+        skipped.push({
+          clientMutationId: mutation.clientMutationId,
+          idempotencyKey,
+          localRecordId: duplicateRecord.id,
+          reason: "duplicate"
+        })
+        continue
+      }
+
+      const record = await mutationLog.append({mutation})
+      const updated = await mutationLog.updateStatus({id: record.id, status: "peer-applied"})
+      existingByIdempotencyKey.set(idempotencyKey, updated)
+      imported.push({clientMutationId: mutation.clientMutationId, idempotencyKey, localRecordId: updated.id})
+    } catch (error) {
+      rejected.push({errorMessage: errorMessage(error), index})
+    }
+  }
+
+  return {imported, rejected, skipped}
+}
+
+/**
+ * Normalizes export status filters.
+ * @param {import("./local-mutation-log.js").LocalMutationStatus[] | undefined} statuses - Optional statuses.
+ * @returns {Set<import("./local-mutation-log.js").LocalMutationStatus>} - Status set.
+ */
+function normalizeExportStatuses(statuses) {
+  if (statuses === undefined) return /** @type {Set<import("./local-mutation-log.js").LocalMutationStatus>} */ (new Set(EXPORTABLE_STATUSES))
+  if (!Array.isArray(statuses)) throw new Error("Expected peer mutation export statuses array")
+
+  const normalized = new Set()
+
+  for (const status of statuses) {
+    if (!EXPORTABLE_STATUSES.has(status)) throw new Error(`Unsupported peer mutation export status '${String(status)}'`)
+    normalized.add(status)
+  }
+
+  return /** @type {Set<import("./local-mutation-log.js").LocalMutationStatus>} */ (normalized)
+}
+
+/**
+ * Normalizes a peer mutation bundle.
+ * @param {PeerMutationBundle} bundle - Bundle value.
+ * @returns {PeerMutationBundle} - Normalized bundle.
+ */
+function normalizePeerMutationBundle(bundle) {
+  if (!bundle || typeof bundle !== "object" || Array.isArray(bundle)) throw new Error("Expected peer mutation bundle object")
+  if (bundle.format !== PEER_MUTATION_BUNDLE_FORMAT) throw new Error(`Unsupported peer mutation bundle format '${String(bundle.format)}'`)
+  isoTimestamp(new Date(requiredString(bundle.exportedAt, "exportedAt")), "exportedAt")
+  if (!Array.isArray(bundle.mutations)) throw new Error("Expected peer mutation bundle mutations array")
+
+  return {
+    exportedAt: bundle.exportedAt,
+    format: bundle.format,
+    mutations: bundle.mutations.map((entry, index) => normalizePeerMutationBundleEntry(entry, index))
+  }
+}
+
+/**
+ * Normalizes one peer mutation bundle entry.
+ * @param {PeerMutationBundleEntry} entry - Bundle entry.
+ * @param {number} index - Entry index.
+ * @returns {PeerMutationBundleEntry} - Normalized entry.
+ */
+function normalizePeerMutationBundleEntry(entry, index) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw new Error(`Expected peer mutation bundle entry ${index} object`)
+  if (!entry.signedMutation || typeof entry.signedMutation !== "object" || Array.isArray(entry.signedMutation)) throw new Error(`Expected peer mutation bundle entry ${index} signedMutation object`)
+
+  /** @type {PeerMutationBundleEntry} */
+  const normalized = {
+    signedMutation: entry.signedMutation
+  }
+
+  if (entry.localRecordId !== undefined) normalized.localRecordId = requiredString(entry.localRecordId, `entry ${index} localRecordId`)
+  if (entry.localSequence !== undefined) normalized.localSequence = positiveInteger(entry.localSequence, `entry ${index} localSequence`)
+
+  return normalized
+}
+
+/**
+ * Requires a non-empty string.
+ * @param {unknown} value - Value.
+ * @param {string} label - Label.
+ * @returns {string} - String.
+ */
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length < 1) throw new Error(`Expected peer mutation bundle ${label}`)
+
+  return value
+}
+
+/**
+ * Requires a positive integer.
+ * @param {unknown} value - Value.
+ * @param {string} label - Label.
+ * @returns {number} - Integer.
+ */
+function positiveInteger(value, label) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) throw new Error(`Expected peer mutation bundle ${label} positive integer`)
+
+  return value
+}
+
+/**
+ * Returns an ISO timestamp from a valid Date.
+ * @param {Date} date - Date.
+ * @param {string} label - Label.
+ * @returns {string} - ISO timestamp.
+ */
+function isoTimestamp(date, label) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) throw new Error(`Invalid peer mutation bundle ${label}`)
+
+  return date.toISOString()
+}
+
+/**
+ * Returns a safe error message.
+ * @param {unknown} error - Error.
+ * @returns {string} - Message.
+ */
+function errorMessage(error) {
+  if (error instanceof Error) return error.message
+
+  return String(error)
+}

--- a/src/sync/peer-mutation-bundle.js
+++ b/src/sync/peer-mutation-bundle.js
@@ -3,7 +3,7 @@
 import {createSignedMutation, mutationIdempotencyKey, verifySignedMutation} from "./device-identity.js"
 
 const PEER_MUTATION_BUNDLE_FORMAT = "velocious.sync.peer-mutation-bundle.v1"
-const EXPORTABLE_STATUSES = new Set(["pending", "applied-locally", "peer-applied", "conflict"])
+const EXPORTABLE_STATUSES = new Set(["pending", "applied-locally", "conflict"])
 
 /**
  * Peer mutation bundle exported by a device for offline/P2P transfer.
@@ -79,31 +79,51 @@ export async function importPeerMutationBundle({backendPublicKey, bundle, mutati
   const skipped = []
 
   for (const [index, entry] of normalizedBundle.mutations.entries()) {
-    try {
-      const mutation = await verifySignedMutation({backendPublicKey, now, signedMutation: entry.signedMutation})
-      const idempotencyKey = mutationIdempotencyKey(entry.signedMutation)
-      const duplicateRecord = existingByIdempotencyKey.get(idempotencyKey)
+    const mutation = await verifiedBundleMutation({backendPublicKey, entry, index, now, rejected})
 
-      if (duplicateRecord) {
-        skipped.push({
-          clientMutationId: mutation.clientMutationId,
-          idempotencyKey,
-          localRecordId: duplicateRecord.id,
-          reason: /** @type {"duplicate"} */ ("duplicate")
-        })
-        continue
-      }
+    if (!mutation) continue
 
-      const record = await mutationLog.append({mutation})
-      const updated = await mutationLog.updateStatus({id: record.id, status: "peer-applied"})
-      existingByIdempotencyKey.set(idempotencyKey, updated)
-      imported.push({clientMutationId: mutation.clientMutationId, idempotencyKey, localRecordId: updated.id})
-    } catch (error) {
-      rejected.push({errorMessage: errorMessage(error), index})
+    const idempotencyKey = mutationIdempotencyKey(entry.signedMutation)
+    const duplicateRecord = existingByIdempotencyKey.get(idempotencyKey)
+
+    if (duplicateRecord) {
+      skipped.push({
+        clientMutationId: mutation.clientMutationId,
+        idempotencyKey,
+        localRecordId: duplicateRecord.id,
+        reason: /** @type {"duplicate"} */ ("duplicate")
+      })
+      continue
     }
+
+    const record = await mutationLog.append({mutation})
+    const updated = await mutationLog.updateStatus({id: record.id, status: "peer-applied"})
+    existingByIdempotencyKey.set(idempotencyKey, updated)
+    imported.push({clientMutationId: mutation.clientMutationId, idempotencyKey, localRecordId: updated.id})
   }
 
   return {imported, rejected, skipped}
+}
+
+/**
+ * Verifies a bundle mutation and records normal per-entry verification rejections.
+ * Storage writes intentionally happen outside this helper so storage failures escape import.
+ * @param {object} args - Arguments.
+ * @param {import("./device-identity.js").SyncJsonWebKey} args.backendPublicKey - Backend public key.
+ * @param {PeerMutationBundleEntry} args.entry - Bundle entry.
+ * @param {number} args.index - Entry index.
+ * @param {Date} args.now - Verification time.
+ * @param {{errorMessage: string, index: number}[]} args.rejected - Rejection accumulator.
+ * @returns {Promise<import("./device-identity.js").SyncMutation | null>} - Verified mutation, or null when rejected.
+ */
+async function verifiedBundleMutation({backendPublicKey, entry, index, now, rejected}) {
+  try {
+    return await verifySignedMutation({backendPublicKey, now, signedMutation: entry.signedMutation})
+  } catch (error) {
+    rejected.push({errorMessage: errorMessage(error), index})
+
+    return null
+  }
 }
 
 /**

--- a/src/sync/peer-mutation-bundle.js
+++ b/src/sync/peer-mutation-bundle.js
@@ -71,8 +71,11 @@ export async function importPeerMutationBundle({backendPublicKey, bundle, mutati
   const normalizedBundle = normalizePeerMutationBundle(bundle)
   const existingRecords = await mutationLog.records()
   const existingByIdempotencyKey = new Map(existingRecords.map((record) => [mutationIdempotencyKey({mutation: record.mutation}), record]))
+  /** @type {{clientMutationId: string, idempotencyKey: string, localRecordId: string}[]} */
   const imported = []
+  /** @type {{errorMessage: string, index: number}[]} */
   const rejected = []
+  /** @type {{clientMutationId: string, idempotencyKey: string, localRecordId: string, reason: "duplicate"}[]} */
   const skipped = []
 
   for (const [index, entry] of normalizedBundle.mutations.entries()) {
@@ -86,7 +89,7 @@ export async function importPeerMutationBundle({backendPublicKey, bundle, mutati
           clientMutationId: mutation.clientMutationId,
           idempotencyKey,
           localRecordId: duplicateRecord.id,
-          reason: "duplicate"
+          reason: /** @type {"duplicate"} */ ("duplicate")
         })
         continue
       }


### PR DESCRIPTION
## Summary
- add peer mutation bundle export for signing local non-terminal mutations
- add peer mutation bundle import with signature verification, duplicate skipping, and peer-applied local status
- cover export/import/reject behavior with sync specs

## Test Plan
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/sync/peer-mutation-bundle-spec.js spec/sync/device-identity-spec.js spec/sync/local-mutation-log-spec.js

Task: #9998