### PR TITLE
Add sync domain command replay

### DIFF
--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -11,7 +11,7 @@ import frontendModelCommandRouteHook from "../../src/routes/hooks/frontend-model
 import {createDeviceCertificate, createSignedMutation, generateSyncSigningKeyPair} from "../../src/sync/device-identity.js"
 import {createOfflineGrantFromBootstrap} from "../../src/sync/offline-grant.js"
 import {frontendModelSyncManifestForBackendProjects} from "../../src/frontend-models/resource-definition.js"
-import ServerChangeFeedStore from "../../src/sync/server-change-feed.js"
+import ServerChangeFeedStore, {serverChangeFeedStoreForConfiguration} from "../../src/sync/server-change-feed.js"
 
 /** @typedef {import("../../src/sync/device-identity.js").SignedSyncMutation} SignedSyncMutation */
 
@@ -271,6 +271,86 @@ describe("frontend-model sync replay", () => {
     expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
   })
 
+  it("replays custom sync commands through the resource command API and appends emitted changes", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        clientMutationId: "mutation-scan-attempt",
+        command: "scanAttempt",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "scanAttempt",
+        payload: {ticketId: "ticket-1", scannerId: "gate-a"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("success")
+    expect(payload.results[0].response).toEqual({scan: {scannerId: "gate-a", ticketId: "ticket-1"}, status: "success", syncChanges: [{attributes: {lastScannerId: "gate-a", scanned: true}, model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1"}]})
+    expect(payload.results[0].serverSequence).toEqual(1)
+
+    const store = serverChangeFeedStoreForConfiguration(configuration)
+    const changePage = await store.changesAfter({afterSequence: 0, limit: 10})
+
+    expect(changePage.changes).toEqual([{actorDeviceId: "scanner-1", actorUserId: "user-1", attributes: {lastScannerId: "gate-a", scanned: true}, createdAt: changePage.changes[0].createdAt, id: changePage.changes[0].id, idempotencyKey: "user-1:scanner-1:mutation-scan-attempt", model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1", response: {scan: {scannerId: "gate-a", ticketId: "ticket-1"}, status: "success", syncChanges: [{attributes: {lastScannerId: "gate-a", scanned: true}, model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1"}]}, scope: {eventId: "event-1"}, serverSequence: 1}])
+  })
+
+  it("rejects custom sync commands that are not registered on the resource", async () => {
+    const {backendKeys, configuration} = await syncReplayConfiguration()
+    const signedMutation = await signedReplayMutation({
+      backendKeys,
+      configuration,
+      mutation: {
+        actorDeviceId: "scanner-1",
+        actorUserId: "user-1",
+        clientMutationId: "mutation-unknown-command",
+        command: "closeGate",
+        model: "Ticket",
+        occurredAt: "2026-01-02T03:04:05.000Z",
+        offlineGrantId: "grant-1",
+        operation: "closeGate",
+        payload: {ticketId: "ticket-1"},
+        policyHash: syncPolicyHash(configuration, "Ticket")
+      }
+    })
+    const response = new Response({configuration})
+    const controller = new ReplayTestController({
+      action: "frontendSyncReplay",
+      configuration,
+      controller: "velocious/api",
+      params: {mutation: signedMutation},
+      request: requestFor(configuration),
+      response,
+      viewPath: "/tmp"
+    })
+
+    await controller.frontendSyncReplay()
+
+    const payload = JSON.parse(String(response.getBody()))
+
+    expect(payload.results[0].status).toEqual("error")
+    expect(payload.results[0].response.errorMessage).toEqual("Sync replay command is not registered for Ticket: closeGate")
+  })
+
   it("emits framework errors for unexpected replay command failures", async () => {
     const {backendKeys, configuration} = await syncReplayConfiguration()
     const frameworkErrors = []
@@ -466,11 +546,34 @@ async function appendTestChange(store, {clientMutationId, recordId, scope = {eve
 
 class TicketResource extends FrontendModelBaseResource {
   static attributes = ["id", "scanned"]
+  static collectionCommands = ["scanAttempt"]
   static sync = {
     metadata: {scope: "event"},
-    operations: ["find", "update"],
+    operations: ["find", "update", "scanAttempt", "closeGate"],
     policy: {grantScopeAttributes: ["eventId"]},
     policyVersion: "scanner-v1"
+  }
+
+  /**
+   * Applies a scanner domain command.
+   * @param {Record<string, ?>} args - Command arguments.
+   * @returns {Promise<Record<string, ?>>} - Command response with emitted sync changes.
+   */
+  async scanAttempt(args) {
+    const ticketId = String(args.ticketId)
+    const scannerId = String(args.scannerId)
+
+    return {
+      scan: {scannerId, ticketId},
+      status: "success",
+      syncChanges: [{
+        attributes: {lastScannerId: scannerId, scanned: true},
+        model: "Ticket",
+        operation: "update",
+        payload: {id: ticketId},
+        recordId: ticketId
+      }]
+    }
   }
 }
 

--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -6,6 +6,7 @@ import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
 import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
 import FrontendModelController from "../../src/frontend-model-controller.js"
 import Request from "../../src/http-server/client/request.js"
+import DatabaseRecord from "../../src/database/record/index.js"
 import Response from "../../src/http-server/client/response.js"
 import frontendModelCommandRouteHook from "../../src/routes/hooks/frontend-model-command-route-hook.js"
 import {createDeviceCertificate, createSignedMutation, generateSyncSigningKeyPair} from "../../src/sync/device-identity.js"
@@ -305,13 +306,13 @@ describe("frontend-model sync replay", () => {
     const payload = JSON.parse(String(response.getBody()))
 
     expect(payload.results[0].status).toEqual("success")
-    expect(payload.results[0].response).toEqual({scan: {scannerId: "gate-a", ticketId: "ticket-1"}, status: "success", syncChanges: [{attributes: {lastScannerId: "gate-a", scanned: true}, model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1"}]})
+    expect(payload.results[0].response).toEqual({modelName: "Ticket", scan: {scannerId: "gate-a", ticketId: "ticket-1"}, status: "success", syncChanges: [{attributes: {lastScannerId: "gate-a", scanned: true}, model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1"}]})
     expect(payload.results[0].serverSequence).toEqual(1)
 
     const store = serverChangeFeedStoreForConfiguration(configuration)
     const changePage = await store.changesAfter({afterSequence: 0, limit: 10})
 
-    expect(changePage.changes).toEqual([{actorDeviceId: "scanner-1", actorUserId: "user-1", attributes: {lastScannerId: "gate-a", scanned: true}, createdAt: changePage.changes[0].createdAt, id: changePage.changes[0].id, idempotencyKey: "user-1:scanner-1:mutation-scan-attempt", model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1", response: {scan: {scannerId: "gate-a", ticketId: "ticket-1"}, status: "success", syncChanges: [{attributes: {lastScannerId: "gate-a", scanned: true}, model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1"}]}, scope: {eventId: "event-1"}, serverSequence: 1}])
+    expect(changePage.changes).toEqual([{actorDeviceId: "scanner-1", actorUserId: "user-1", attributes: {lastScannerId: "gate-a", scanned: true}, createdAt: changePage.changes[0].createdAt, id: changePage.changes[0].id, idempotencyKey: "user-1:scanner-1:mutation-scan-attempt", model: "Ticket", operation: "update", payload: {id: "ticket-1"}, recordId: "ticket-1", response: payload.results[0].response, scope: {eventId: "event-1"}, serverSequence: 1}])
   })
 
   it("rejects custom sync commands that are not registered on the resource", async () => {
@@ -544,9 +545,14 @@ async function appendTestChange(store, {clientMutationId, recordId, scope = {eve
   })
 }
 
+class Ticket extends DatabaseRecord {
+  static modelName = "Ticket"
+}
+
 class TicketResource extends FrontendModelBaseResource {
   static attributes = ["id", "scanned"]
   static collectionCommands = ["scanAttempt"]
+  static ModelClass = Ticket
   static sync = {
     metadata: {scope: "event"},
     operations: ["find", "update", "scanAttempt", "closeGate"],
@@ -564,6 +570,7 @@ class TicketResource extends FrontendModelBaseResource {
     const scannerId = String(args.scannerId)
 
     return {
+      modelName: this.modelClass().getModelName(),
       scan: {scannerId, ticketId},
       status: "success",
       syncChanges: [{

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -3862,7 +3862,7 @@ export default class FrontendModelController extends Controller {
         request: this.request()
       },
       locals: this.currentAbility()?.getLocals() || {},
-      modelClass: undefined,
+      modelClass: this.frontendModelResourceModelClass(frontendModelResource),
       modelName: frontendModelResource.modelName,
       params: this.frontendModelParams(),
       resourceConfiguration: frontendModelResource.resourceConfiguration

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -3685,9 +3685,6 @@ export default class FrontendModelController extends Controller {
     if (syncResource.policyHash !== mutation.policyHash) {
       throw frontendSyncReplaySafeError(`Sync replay policy hash mismatch for ${mutation.model}`)
     }
-    if (!["create", "update", "destroy"].includes(mutation.operation)) {
-      throw frontendSyncReplaySafeError(`Sync replay operation is not supported yet: ${mutation.operation}`)
-    }
 
     const signedOfflineGrant = this.frontendSyncReplaySignedOfflineGrant(signedMutation)
     const offlineGrant = await this.frontendSyncReplayVerifiedOfflineGrant({
@@ -3698,19 +3695,24 @@ export default class FrontendModelController extends Controller {
     this.frontendSyncReplayValidateOfflineGrant({mutation, offlineGrant, syncResource})
 
     const commandParams = await this.frontendSyncReplayCommandParams(mutation)
+    const replayCommand = this.frontendSyncReplayCommandForMutation(mutation)
 
     let response
 
     try {
       response = await this.withFrontendModelParams(commandParams, async () => {
         return await this.withFrontendModelRequestContext(commandParams, this.response(), async () => {
-          return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
+          if (["create", "update", "destroy"].includes(mutation.operation)) {
+            return await this.frontendModelCommandPayload(/** @type {"create" | "update" | "destroy"} */ (mutation.operation)) || this.frontendModelErrorPayload("Action halted by beforeAction.")
+          }
+
+          return await this.frontendSyncReplayCustomCommandPayload({mutation, replayCommand}) || this.frontendModelErrorPayload("Action halted by beforeAction.")
         })
       })
     } catch (error) {
       const errorContext = this.frontendModelEndpointErrorContext({
         action: "frontendSyncReplay",
-        commandType: /** @type {"create" | "update" | "destroy"} */ (mutation.operation),
+        commandType: /** @type {?} */ (replayCommand.commandType),
         error,
         model: mutation.model
       })
@@ -3740,7 +3742,7 @@ export default class FrontendModelController extends Controller {
     } catch (error) {
       const errorContext = this.frontendModelEndpointErrorContext({
         action: "frontendSyncReplay",
-        commandType: /** @type {"create" | "update" | "destroy"} */ (mutation.operation),
+        commandType: /** @type {?} */ (replayCommand.commandType),
         error,
         model: mutation.model
       })
@@ -3834,6 +3836,60 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
+   * Replays a verified custom sync mutation through the resource command API.
+   * @param {object} args - Arguments.
+   * @param {import("./sync/device-identity.js").SyncMutation} args.mutation - Verified mutation.
+   * @param {{commandType: string, methodName?: string, scope?: "collection" | "member"}} args.replayCommand - Resolved replay command metadata.
+   * @returns {Promise<Record<string, ?>>} - Command response payload.
+   */
+  async frontendSyncReplayCustomCommandPayload({mutation, replayCommand}) {
+    if (typeof replayCommand.methodName !== "string" || replayCommand.methodName.length < 1) {
+      throw frontendSyncReplaySafeError(`Sync replay command is not registered for ${mutation.model}: ${mutation.operation}`)
+    }
+
+    const frontendModelResource = this.getConfiguration().getBackendProjects()
+      .map((backendProject) => this.frontendModelResourceConfigurationForBackendProjectModelName({backendProject, modelName: mutation.model}))
+      .find((resourceConfiguration) => resourceConfiguration)
+
+    if (!frontendModelResource) throw frontendSyncReplaySafeError(`Sync replay model is not enabled: ${mutation.model}`)
+
+    const resource = new frontendModelResource.resourceClass({
+      ability: this.currentAbility(),
+      controller: this,
+      context: {
+        ...(this.currentAbility()?.getContext() || {}),
+        params: this.frontendModelParams(),
+        request: this.request()
+      },
+      locals: this.currentAbility()?.getLocals() || {},
+      modelClass: undefined,
+      modelName: frontendModelResource.modelName,
+      params: this.frontendModelParams(),
+      resourceConfiguration: frontendModelResource.resourceConfiguration
+    })
+    const command = resource.resourceMethod(replayCommand.methodName)
+
+    if (!command) {
+      return this.frontendModelErrorPayload(`Missing frontend-model custom command '${replayCommand.methodName}'.`)
+    }
+
+    const commandArguments = /** @type {Record<string, ?>} */ (mutation.payload && typeof mutation.payload === "object" && !Array.isArray(mutation.payload) ? mutation.payload : {})
+    const responsePayload = await command.method.call(command.resource, commandArguments)
+
+    if (!responsePayload || typeof responsePayload !== "object") {
+      return {status: "success"}
+    }
+
+    return /** @type {Record<string, ?>} */ (
+      await this.autoSerializeFrontendModelsInPayload(
+        responsePayload,
+        /** @type {{serialize: (model: ?, action: string) => Promise<Record<string, ?>>}} */ (command.resource),
+        replayCommand.methodName
+      )
+    )
+  }
+
+  /**
    * Builds frontend-model command params for a verified replay mutation.
    * @param {import("./sync/device-identity.js").SyncMutation} mutation - Verified mutation.
    * @returns {Promise<Record<string, ?>>} - Frontend-model command params.
@@ -3847,7 +3903,24 @@ export default class FrontendModelController extends Controller {
       model: mutation.model
     })
 
-    if (mutation.operation !== "create") {
+    if (["create", "update", "destroy"].includes(mutation.operation)) {
+      if (mutation.operation !== "create") {
+        const id = commandParams.id || commandParams.recordId || primaryKeyValue
+
+        if (typeof id !== "string" && typeof id !== "number") throw frontendSyncReplaySafeError(`Sync replay ${mutation.operation} requires an id`)
+
+        commandParams.id = id
+      }
+
+      return commandParams
+    }
+
+    const replayCommand = this.frontendSyncReplayCommandForMutation(mutation)
+
+    commandParams.frontendModelCustomCommandMethodName = replayCommand.methodName
+    commandParams.frontendModelCustomCommandScope = replayCommand.scope
+
+    if (replayCommand.scope === "member") {
       const id = commandParams.id || commandParams.recordId || primaryKeyValue
 
       if (typeof id !== "string" && typeof id !== "number") throw frontendSyncReplaySafeError(`Sync replay ${mutation.operation} requires an id`)
@@ -3856,6 +3929,36 @@ export default class FrontendModelController extends Controller {
     }
 
     return commandParams
+  }
+
+  /**
+   * Resolves the frontend-model command used for a verified replay mutation.
+   * @param {import("./sync/device-identity.js").SyncMutation} mutation - Verified mutation.
+   * @returns {{commandType: string, methodName?: string, scope?: "collection" | "member"}} - Command metadata.
+   */
+  frontendSyncReplayCommandForMutation(mutation) {
+    if (["create", "update", "destroy"].includes(mutation.operation)) {
+      return {commandType: mutation.operation}
+    }
+
+    const frontendModelResource = this.getConfiguration().getBackendProjects()
+      .map((backendProject) => this.frontendModelResourceConfigurationForBackendProjectModelName({backendProject, modelName: mutation.model}))
+      .find((resourceConfiguration) => resourceConfiguration)
+
+    if (!frontendModelResource) throw frontendSyncReplaySafeError(`Sync replay model is not enabled: ${mutation.model}`)
+
+    const commandName = typeof mutation.command === "string" && mutation.command.length > 0 ? mutation.command : mutation.operation
+    const resourceConfiguration = frontendModelResource.resourceConfiguration
+
+    if (Object.prototype.hasOwnProperty.call(resourceConfiguration.collectionCommands, commandName)) {
+      return {commandType: commandName, methodName: commandName, scope: "collection"}
+    }
+
+    if (Object.prototype.hasOwnProperty.call(resourceConfiguration.memberCommands, commandName)) {
+      return {commandType: commandName, methodName: commandName, scope: "member"}
+    }
+
+    throw frontendSyncReplaySafeError(`Sync replay command is not registered for ${mutation.model}: ${commandName}`)
   }
 
   /**
@@ -3892,24 +3995,43 @@ export default class FrontendModelController extends Controller {
   async frontendSyncAppendServerChange({idempotencyKey, mutation, offlineGrant, response}) {
     if (response.status !== "success") return null
 
-    const payload = /** @type {Record<string, ?>} */ (mutation.payload && typeof mutation.payload === "object" && !Array.isArray(mutation.payload) ? mutation.payload : {})
-    const attributes = /** @type {Record<string, ?>} */ (mutation.attributes && typeof mutation.attributes === "object" && !Array.isArray(mutation.attributes) ? mutation.attributes : {})
-    const rawRecordId = payload.id || payload.recordId || attributes.id || null
-    const recordId = rawRecordId === null || rawRecordId === undefined ? null : String(rawRecordId)
-    const change = await serverChangeFeedStoreForConfiguration(this.getConfiguration()).append({
-      actorDeviceId: mutation.actorDeviceId,
-      actorUserId: mutation.actorUserId,
-      attributes,
-      idempotencyKey,
+    const store = serverChangeFeedStoreForConfiguration(this.getConfiguration())
+    const responseSyncChanges = Array.isArray(response.syncChanges) ? response.syncChanges : []
+    const syncChanges = responseSyncChanges.length > 0 ? responseSyncChanges : [{
+      attributes: mutation.attributes,
       model: mutation.model,
       operation: mutation.operation,
-      payload,
-      recordId,
-      response,
-      scope: offlineGrant.scopes
-    })
+      payload: mutation.payload
+    }]
+    let serverSequence = /** @type {number | null} */ (null)
 
-    return change.serverSequence
+    for (const syncChange of syncChanges) {
+      if (!syncChange || typeof syncChange !== "object" || Array.isArray(syncChange)) continue
+
+      const change = /** @type {Record<string, ?>} */ (syncChange)
+      const payload = /** @type {Record<string, ?>} */ (change.payload && typeof change.payload === "object" && !Array.isArray(change.payload) ? change.payload : {})
+      const attributes = /** @type {Record<string, ?>} */ (change.attributes && typeof change.attributes === "object" && !Array.isArray(change.attributes) ? change.attributes : {})
+      const model = typeof change.model === "string" && change.model.length > 0 ? change.model : mutation.model
+      const operation = typeof change.operation === "string" && change.operation.length > 0 ? change.operation : mutation.operation
+      const rawRecordId = change.recordId ?? payload.id ?? payload.recordId ?? attributes.id ?? null
+      const recordId = rawRecordId === null || rawRecordId === undefined ? null : String(rawRecordId)
+      const appendedChange = await store.append({
+        actorDeviceId: mutation.actorDeviceId,
+        actorUserId: mutation.actorUserId,
+        attributes,
+        idempotencyKey,
+        model,
+        operation,
+        payload,
+        recordId,
+        response,
+        scope: offlineGrant.scopes
+      })
+
+      serverSequence = appendedChange.serverSequence
+    }
+
+    return serverSequence
   }
 
   /**


### PR DESCRIPTION
## Summary
- replay non-CRUD sync operations through registered frontend-model resource commands
- append emitted command syncChanges to the server change feed
- cover successful command replay and unregistered command rejection in sync replay specs

## Verification
- VELOCIOUS_DISABLE_MSSQL=1 npm run test -- spec/controller/frontend-model-sync-replay-spec.js
- npm run typecheck
- npm run lint