### PR TITLE
Reap silent WebSocket sessions to stop frontend-model save fan-out leak

### DIFF
--- a/spec/http-server/websocket-session-heartbeat-spec.js
+++ b/spec/http-server/websocket-session-heartbeat-spec.js
@@ -61,6 +61,21 @@ describe("WebsocketSession heartbeat", () => {
     session.destroy()
   })
 
+  it("stays alive while a large frame is still being uploaded across ticks", () => {
+    const {session} = buildSession()
+
+    session._heartbeatTick()
+    // Incomplete binary frame: header declares a 4096-byte payload but
+    // no payload bytes have arrived yet, so _processBuffer returns early.
+    session.onData(Buffer.from([0x82, 0x7E, 0x10, 0x00]))
+    session._heartbeatTick()
+
+    expect(session.isPaused()).toEqual(false)
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(true)
+
+    session.destroy()
+  })
+
   it("reaps a silent resumable session whose ping went unanswered and removes it on grace expiry", async () => {
     const {session} = buildSession()
     const subscription = new ResumableChannel({params: {}, session, subscriptionId: "s1"})

--- a/spec/http-server/websocket-session-heartbeat-spec.js
+++ b/spec/http-server/websocket-session-heartbeat-spec.js
@@ -1,0 +1,102 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import EventEmitter from "../../src/utils/event-emitter.js"
+import WebsocketChannel from "../../src/http-server/websocket-channel.js"
+import WebsocketRequest from "../../src/http-server/client/websocket-request.js"
+import WebsocketSession from "../../src/http-server/client/websocket-session.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import waitFor from "../helpers/wait-for.js"
+
+const WEBSOCKET_PING_FRAME_FIRST_BYTE = 0x89
+
+class ResumableChannel extends WebsocketChannel {
+  /** @returns {boolean} */
+  canSubscribe() { return true }
+}
+
+/**
+ * Builds a websocket session backed by a fake client whose emitted
+ * output frames are captured for assertions.
+ * @returns {{output: Buffer[], session: WebsocketSession}}
+ */
+function buildSession() {
+  const clientEvents = new EventEmitter()
+  /** @type {Buffer[]} */
+  const output = []
+
+  clientEvents.on("output", (buffer) => output.push(buffer))
+
+  const session = new WebsocketSession({
+    client: /** @type {any} */ ({events: clientEvents, remoteAddress: "127.0.0.1"}),
+    configuration: dummyConfiguration,
+    upgradeRequest: new WebsocketRequest({method: "GET", path: "/websocket", remoteAddress: "127.0.0.1"})
+  })
+
+  return {output, session}
+}
+
+describe("WebsocketSession heartbeat", () => {
+  it("pings the client on a heartbeat tick", () => {
+    const {output, session} = buildSession()
+
+    session._heartbeatTick()
+
+    expect(output.length).toEqual(1)
+    expect(output[0][0]).toEqual(WEBSOCKET_PING_FRAME_FIRST_BYTE)
+
+    session.destroy()
+  })
+
+  it("stays alive when the client answers with a pong frame", () => {
+    const {session} = buildSession()
+
+    session._heartbeatTick()
+    session.onData(Buffer.from([0x8A, 0x00]))
+    session._heartbeatTick()
+
+    expect(session.isPaused()).toEqual(false)
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(true)
+
+    session.destroy()
+  })
+
+  it("reaps a silent resumable session whose ping went unanswered and removes it on grace expiry", async () => {
+    const {session} = buildSession()
+    const subscription = new ResumableChannel({params: {}, session, subscriptionId: "s1"})
+
+    session._channelSubscriptions.set("s1", {channelType: "frontend-models", subscription})
+    dummyConfiguration._registerWebsocketChannelSubscription("frontend-models", subscription)
+
+    session._heartbeatTick()
+    session._heartbeatTick()
+
+    expect(session.isPaused()).toEqual(true)
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(true)
+
+    dummyConfiguration._expireWebsocketSession(session.sessionId)
+
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(false)
+    await waitFor(() => !dummyConfiguration._websocketChannelSubscriptions.has("frontend-models"))
+  })
+
+  it("fully tears down a silent session that has no resumable state", () => {
+    const {session} = buildSession()
+
+    session._heartbeatTick()
+    session._heartbeatTick()
+
+    expect(session.isPaused()).toEqual(false)
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(false)
+  })
+
+  it("removes the session from the configuration registry on grace expiry", () => {
+    const {session} = buildSession()
+
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(true)
+
+    session._finalizeGraceExpiry()
+
+    expect(dummyConfiguration._websocketSessions.has(session)).toEqual(false)
+  })
+})

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -232,6 +232,9 @@ export default class VelociousConfiguration {
     /** Grace period for paused WebSocket sessions before permanent teardown. */
     this._websocketSessionGraceSeconds = 300
 
+    /** Interval (seconds) between server→client heartbeat pings; 0 disables reaping of silent sockets. */
+    this._websocketSessionHeartbeatSeconds = 30
+
     /**
      * Optional wrapper called around every WebSocket-borne request /
      * connection message / channel dispatch. Apps register it here
@@ -2043,6 +2046,12 @@ export default class VelociousConfiguration {
   getWebsocketSessionGraceSeconds() { return this._websocketSessionGraceSeconds }
 
   /**
+   * Runs get websocket session heartbeat seconds.
+   * @returns {number} - Interval (seconds) between server→client heartbeat pings; 0 disables reaping.
+   */
+  getWebsocketSessionHeartbeatSeconds() { return this._websocketSessionHeartbeatSeconds }
+
+  /**
    * Registers a wrapper invoked around every WS-borne request /
    * connection message / channel dispatch. The wrapper receives the
    * session and a `next` callback; it must call `next()` to run the
@@ -2117,6 +2126,16 @@ export default class VelociousConfiguration {
   setWebsocketSessionGraceSeconds(seconds) {
     if (!Number.isFinite(seconds) || seconds < 0) throw new Error(`Invalid grace seconds: ${seconds}`)
     this._websocketSessionGraceSeconds = seconds
+  }
+
+  /**
+   * Runs set websocket session heartbeat seconds.
+   * @param {number} seconds
+   * @returns {void}
+   */
+  setWebsocketSessionHeartbeatSeconds(seconds) {
+    if (!Number.isFinite(seconds) || seconds < 0) throw new Error(`Invalid heartbeat seconds: ${seconds}`)
+    this._websocketSessionHeartbeatSeconds = seconds
   }
 
   /**

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -296,6 +296,11 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @returns {void} - No return value.
    */
   onData(data) {
+    // Any inbound bytes — a data frame, the auto-pong answering our
+    // heartbeat, or a partial frame still being uploaded — prove the
+    // socket is alive. Mark it here, before `_processBuffer` may return
+    // early waiting for the rest of an incomplete frame.
+    this._heartbeatAlive = true
     this.buffer = Buffer.concat([this.buffer, data])
     this._processBuffer()
   }
@@ -618,10 +623,6 @@ export default class VelociousHttpServerClientWebsocketSession {
 
       this.buffer = this.buffer.slice(offset + maskLength + payloadLength)
 
-      // Any complete inbound frame — data, ping, or the auto-pong sent
-      // in response to our heartbeat — proves the socket is alive.
-      this._heartbeatAlive = true
-
       // Control frames (opcode >= 0x8) must not be fragmented per
       // RFC 6455 and can arrive interleaved with a fragmented data
       // message. Handle them first without touching the fragment
@@ -638,7 +639,7 @@ export default class VelociousHttpServerClientWebsocketSession {
       }
 
       if (opcode === WEBSOCKET_OPCODE_PONG) {
-        // Answer to a heartbeat ping; liveness already recorded above.
+        // Answer to a heartbeat ping; liveness is recorded in onData.
         continue
       }
 
@@ -796,7 +797,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @returns {void}
    */
   _startHeartbeat() {
-    const intervalSeconds = this.configuration.getWebsocketSessionHeartbeatSeconds?.() ?? 0
+    const intervalSeconds = this.configuration.getWebsocketSessionHeartbeatSeconds()
 
     if (!intervalSeconds || intervalSeconds <= 0) return
 

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -210,12 +210,13 @@ export default class VelociousHttpServerClientWebsocketSession {
     this._heartbeatAlive = true
 
     /**
-     * Per-session heartbeat interval handle.
+     * Per-session heartbeat interval handle. Started from
+     * `sendSessionEstablished` once the socket is live, not at
+     * construction, so directly-constructed sessions in tests don't
+     * spin up a background timer.
      * @type {ReturnType<typeof setInterval> | null}
      */
     this._heartbeatTimer = null
-
-    this._startHeartbeat()
   }
 
   /**
@@ -229,6 +230,9 @@ export default class VelociousHttpServerClientWebsocketSession {
       sessionId: this.sessionId,
       graceSeconds: this.configuration.getWebsocketSessionGraceSeconds?.() || 300
     })
+
+    // The socket is live now, so begin reaping it if it goes silent.
+    this._startHeartbeat()
   }
 
   /**

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -199,6 +199,23 @@ export default class VelociousHttpServerClientWebsocketSession {
     this._fragmentedBytes = 0
 
     this.configuration._websocketSessions.add(this)
+
+    /**
+     * Heartbeat liveness flag. Set true on every inbound frame
+     * (including the client's auto-pong) and cleared each time a ping
+     * is sent; a still-false flag at the next tick means the socket
+     * has gone silent.
+     * @type {boolean}
+     */
+    this._heartbeatAlive = true
+
+    /**
+     * Per-session heartbeat interval handle.
+     * @type {ReturnType<typeof setInterval> | null}
+     */
+    this._heartbeatTimer = null
+
+    this._startHeartbeat()
   }
 
   /**
@@ -251,6 +268,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   }
 
   destroy() {
+    this._stopHeartbeat()
     this.configuration._websocketSessions.delete(this)
     this._paused = false
     void this._teardownChannel()
@@ -596,6 +614,10 @@ export default class VelociousHttpServerClientWebsocketSession {
 
       this.buffer = this.buffer.slice(offset + maskLength + payloadLength)
 
+      // Any complete inbound frame — data, ping, or the auto-pong sent
+      // in response to our heartbeat — proves the socket is alive.
+      this._heartbeatAlive = true
+
       // Control frames (opcode >= 0x8) must not be fragmented per
       // RFC 6455 and can arrive interleaved with a fragmented data
       // message. Handle them first without touching the fragment
@@ -608,6 +630,11 @@ export default class VelociousHttpServerClientWebsocketSession {
       if (opcode === WEBSOCKET_OPCODE_CLOSE) {
         this.sendGoodbye(this.client)
         this._handleClose()
+        continue
+      }
+
+      if (opcode === WEBSOCKET_OPCODE_PONG) {
+        // Answer to a heartbeat ping; liveness already recorded above.
         continue
       }
 
@@ -757,6 +784,60 @@ export default class VelociousHttpServerClientWebsocketSession {
   }
 
   /**
+   * Starts the per-session heartbeat. Each tick pings the client and
+   * reaps the session if the previous ping went unanswered, so a
+   * half-open socket (client gone without a TCP FIN / close frame)
+   * cannot linger forever holding channel subscriptions. Disabled when
+   * the configured interval is 0.
+   * @returns {void}
+   */
+  _startHeartbeat() {
+    const intervalSeconds = this.configuration.getWebsocketSessionHeartbeatSeconds?.() ?? 0
+
+    if (!intervalSeconds || intervalSeconds <= 0) return
+
+    this._heartbeatTimer = setInterval(() => this._heartbeatTick(), intervalSeconds * 1000)
+
+    // Don't let the heartbeat timer keep the process alive.
+    if (typeof this._heartbeatTimer.unref === "function") this._heartbeatTimer.unref()
+  }
+
+  /**
+   * One heartbeat cycle. Reaps the session via the normal close path
+   * when the previous ping was not answered; otherwise marks it
+   * pending and pings again. Browsers and React Native sockets answer
+   * server pings with an automatic pong, which lands in `_processBuffer`
+   * and re-marks the session alive.
+   * @returns {void}
+   */
+  _heartbeatTick() {
+    if (this._paused || !this.client?.events) return
+
+    if (!this._heartbeatAlive) {
+      // No frame arrived since the last ping — the socket is dead.
+      // Route through `_handleClose` so resumable state still pauses
+      // for the grace window and everything else is torn down.
+      this._stopHeartbeat()
+      this._handleClose()
+      return
+    }
+
+    this._heartbeatAlive = false
+    this._sendControlFrame(WEBSOCKET_OPCODE_PING, Buffer.alloc(0))
+  }
+
+  /**
+   * Stops the per-session heartbeat timer, if any.
+   * @returns {void}
+   */
+  _stopHeartbeat() {
+    if (this._heartbeatTimer) {
+      clearInterval(this._heartbeatTimer)
+      this._heartbeatTimer = null
+    }
+  }
+
+  /**
    * Runs send control frame.
    * @param {number} opcode - Opcode.
    * @param {Buffer} payload - Payload data.
@@ -891,6 +972,9 @@ export default class VelociousHttpServerClientWebsocketSession {
     const hasResumableState = this._connections.size > 0 || this._channelSubscriptions.size > 0
 
     if (hasResumableState && !this._paused) {
+      // Paused sessions have no live socket to ping; the grace timer
+      // owns their eventual teardown from here.
+      this._stopHeartbeat()
       this._paused = true
       this.socket = null
       // Kick off auth-identity capture for resume verification. Runs
@@ -905,6 +989,8 @@ export default class VelociousHttpServerClientWebsocketSession {
       return
     }
 
+    this._stopHeartbeat()
+    this.configuration._websocketSessions.delete(this)
     void this._runMessageHandlerClose()
     void this._teardownChannel()
     void this._teardownConnections("session_destroyed")
@@ -919,6 +1005,8 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @returns {void}
    */
   _finalizeGraceExpiry() {
+    this._stopHeartbeat()
+    this.configuration._websocketSessions.delete(this)
     void this._runMessageHandlerClose()
     void this._teardownChannel()
     void this._teardownConnections("grace_expired")


### PR DESCRIPTION
## Problem

Production (Awesome Tasks) developed severe save-lag. Live diagnostics via the `/velocious/debug` endpoint showed the DB pool fully idle/healthy, but **2803 registered WebSocket sessions, every one with `connectionCount: 0`** (no live socket) — ~2300 still holding `frontend-models` channel subscriptions to `Task`/`TaskBoard`/`BoardColumn`. The debug payload was 1.5 MB of these ghosts.

Every model save calls `broadcastFrontendModelEvent` → `_broadcastToChannelLocal`, which loops over **all** subscriptions in `_websocketChannelSubscriptions`. With thousands of dead subscriptions, each save fanned out across the zombies. The set only grew between deploys, so saves got progressively slower — matching the user's "it didn't get fixed" report.

## Root causes & fixes

1. **No reaping of half-open sockets.** A client gone without a TCP FIN / close frame never triggered `_handleClose`, so the session stayed "live" forever with its subscriptions registered. The server answered client pings but never pinged the client.
   - Add a **per-session server heartbeat**: ping each live session; if a ping goes unanswered by the next tick, reap it through the normal `_handleClose` path (so resumable state still pauses for the grace window). Any inbound frame — including the browser/React-Native **auto-pong** — re-marks the session alive. Driven by `websocketSessionHeartbeatSeconds` (default **30s**, `0` disables). PONG frames are now handled explicitly instead of logged as "unsupported control opcode".

2. **`_websocketSessions` never pruned on terminal paths.** `_finalizeGraceExpiry` and the non-resumable `_handleClose` teardown tore down subscriptions but never removed the session object from `configuration._websocketSessions` (only `destroy()`, on successful resume, did) — leaking the session object and bloating the debug payload.
   - Remove the session from the registry on every terminal path.

## Tests

`spec/http-server/websocket-session-heartbeat-spec.js` covers: ping emission, pong-keeps-alive, reaping a silent resumable session (→ pause → grace removal), reaping a silent non-resumable session (full teardown), and registry removal on grace expiry. Existing close/resume specs still pass; `npm run lint` is green.