### PR TITLE
Scheduled jobs: rename every option `first_in` to `firstIn` (drop snake_case alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2051,7 +2051,7 @@ export default new Configuration({
     jobs: {
       buildCleanup: {
         class: BuildCleanupJob,
-        every: ["1h", {first_in: "10s"}],
+        every: ["1h", {firstIn: "10s"}],
         options: {executionMode: "inline"}
       }
     }
@@ -2062,7 +2062,7 @@ export default new Configuration({
 Supported schedule syntax:
 
 - `every: "5m"`
-- `every: ["1h", {first_in: "30s"}]`
+- `every: ["1h", {firstIn: "30s"}]`
 - `every: ["1 day", {firstIn: "5 minutes"}]`
 
 Or a 5-field POSIX crontab expression via `cron`:

--- a/changelog.d/20260627120000-scheduled-job-first-in-camelcase.md
+++ b/changelog.d/20260627120000-scheduled-job-first-in-camelcase.md
@@ -1,0 +1,3 @@
+## Changed
+
+- Scheduled background jobs: the `every` first-run delay option is now `firstIn` only. The Sidekiq-style `first_in` snake_case alias has been removed so the option matches Velocious' camelCase config convention. The scheduled-job config types are exact, so an unknown key — including the now-removed `first_in` — is a TypeScript error at the call site rather than a silently-ignored option.

--- a/spec/background-jobs/basic-spec.js
+++ b/spec/background-jobs/basic-spec.js
@@ -56,7 +56,7 @@ describe("Background jobs", {databaseCleaning: {truncate: true}}, () => {
         scheduledTestJob: {
           args: ["scheduled", outputPath],
           class: TestJob,
-          every: ["1 hour", {first_in: "25ms"}],
+          every: ["1 hour", {firstIn: "25ms"}],
           options: {forked: false}
         }
       }
@@ -93,7 +93,7 @@ describe("Background jobs", {databaseCleaning: {truncate: true}}, () => {
       jobs: {
         validScheduledTestJob: {
           class: TestJob,
-          every: ["1 hour", {first_in: "25ms"}],
+          every: ["1 hour", {firstIn: "25ms"}],
           options: {forked: false}
         },
         invalidScheduledTestJob: {

--- a/spec/background-jobs/scheduler-spec.js
+++ b/spec/background-jobs/scheduler-spec.js
@@ -6,8 +6,8 @@ import TestJob from "../dummy/src/jobs/test-job.js"
 describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, () => {
   it("parses sidekiq-style duration strings", () => {
     expect(parseScheduledDuration("1m", "example.every")).toEqual(60000)
-    expect(parseScheduledDuration("5 seconds", "example.first_in")).toEqual(5000)
-    expect(parseScheduledDuration(250, "example.first_in")).toEqual(250)
+    expect(parseScheduledDuration("5 seconds", "example.firstIn")).toEqual(5000)
+    expect(parseScheduledDuration(250, "example.firstIn")).toEqual(250)
   })
 
   it("rejects string every intervals that round down below one millisecond", async () => {
@@ -72,7 +72,7 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
                 scheduledTestJob: {
                   args: ["hello", "/tmp/out.json"],
                   class: TestJob,
-                  every: ["1m", {first_in: "5s"}],
+                  every: ["1m", {firstIn: "5s"}],
                   options: {forked: false}
                 }
               }

--- a/src/background-jobs/scheduler.js
+++ b/src/background-jobs/scheduler.js
@@ -169,7 +169,7 @@ export default class BackgroundJobsScheduler {
     const everyConfig = /** @type {NonNullable<typeof jobConfiguration.every>} */ (jobConfiguration.every)
     const {everyValue, firstInValue} = this.normalizeEvery(everyConfig)
     const intervalMs = parseScheduledDuration(everyValue, `${jobKey}.every`)
-    const firstInMs = firstInValue !== undefined ? parseScheduledDuration(firstInValue, `${jobKey}.first_in`) : intervalMs
+    const firstInMs = firstInValue !== undefined ? parseScheduledDuration(firstInValue, `${jobKey}.firstIn`) : intervalMs
 
     if (intervalMs < 1) {
       throw new Error(`Scheduled background job ${jobKey}.every must be at least 1 millisecond.`)
@@ -262,7 +262,7 @@ export default class BackgroundJobsScheduler {
         return {everyValue}
       }
 
-      return {everyValue, firstInValue: everyOptions.firstIn ?? everyOptions.first_in}
+      return {everyValue, firstInValue: everyOptions.firstIn}
     }
 
     return {everyValue: every}

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -191,7 +191,6 @@
 /**
  * @typedef {object} ScheduledBackgroundJobEveryOptions
  * @property {number | string} [firstIn] - Delay before the first enqueue.
- * @property {number | string} [first_in] - Sidekiq-style alias for `firstIn`.
  */
 
 /**


### PR DESCRIPTION
## What

The scheduled-background-job `every` first-run delay option accepted both `firstIn` and the Sidekiq-style `first_in` snake_case alias. Velocious config uses camelCase everywhere else, so this drops the alias and keeps only `firstIn`.

```js
// before
every: ["1m", {first_in: "30s"}]   // or firstIn
// after
every: ["1m", {firstIn: "30s"}]
```

## Changes
- `src/configuration-types.js` — remove the `first_in` property from `ScheduledBackgroundJobEveryOptions`.
- `src/background-jobs/scheduler.js` — `normalizeEvery` reads `everyOptions.firstIn` only (dropped the `?? everyOptions.first_in` fallback); error-label uses `.firstIn`.
- Specs updated to `firstIn`.

## Type validation
The scheduled-job config typedefs (`ScheduledBackgroundJobConfiguration`, `ScheduledBackgroundJobEveryOptions`, `BackgroundJobOptions`) are exact object types with no index signature, so **any unknown key is a compile-time `TS2353` error at the call site** — including the now-removed `first_in`. Verified in a consumer:

```
error TS2353: Object literal may only specify known properties,
and 'first_in' does not exist in type 'ScheduledBackgroundJobEveryOptions'.
```

So a typo like `evry`, `frstIn`, or a stray `first_in` fails typecheck rather than being silently ignored at runtime.

## Verification
- `npm run typecheck` clean; `eslint` clean on changed files.
- Standalone check of `normalizeEvery`/`parseScheduledDuration`: `firstIn` is read; `first_in` is no longer read (returns `firstInValue: undefined`).
- Full `npm test` requires the DB services (run in CI).

## Note for consumers
This is a breaking change for anyone using `first_in`. Switch to `firstIn`. (TensorBuzz's usage is being updated alongside.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)