### PR TITLE
Check dependent restricts across tenant databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2231,7 +2231,7 @@ Use `configuration.runWithTenant(tenant, callback)` or `Current.tenant()` when c
 
 Tenant-switched model classes fail closed by default: if `switchesTenantDatabase(...)` cannot resolve a tenant database identifier for the current tenant, Velocious raises `TenantDatabaseScopeError` instead of running the query against the configured fallback database. Set `enforceTenantDatabaseScopes: false` only for legacy apps that still need the old fallback behavior during migration.
 
-For Apartment-style project/account databases, mark the logical per-tenant identifier with `tenantOnly: true`, provide `tenantDatabaseProviders`, and run tenant lifecycle commands explicitly. One logical identifier can resolve to any number of physical tenant databases at runtime; provider `listTenants` is queried for every command run so added/removed tenants do not require configuration changes or redeploys.
+For Apartment-style project/account databases, mark the logical per-tenant identifier with `tenantOnly: true`, provide `tenantDatabaseProviders`, and run tenant lifecycle commands explicitly. One logical identifier can resolve to any number of physical tenant databases at runtime; provider `listTenants` is queried for every command run so added/removed tenants do not require configuration changes or redeploys. Cross-tenant `dependent: "restrict"` checks use the matching provider's optional `listRestrictTenants` when present, otherwise `listTenants`, and fail closed when the target tenant identifier has no configured provider.
 
 ```sh
 npx velocious db:tenants:create projectTenant

--- a/changelog.d/20260628063000-tenant-dependent-restrict.md
+++ b/changelog.d/20260628063000-tenant-dependent-restrict.md
@@ -1,0 +1,1 @@
+`dependent: "restrict"` now checks tenant-switched child relationships across every tenant returned by the configured tenant database provider before allowing a non-tenant parent destroy.

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -72,6 +72,8 @@ Project.hasMany("tasks", {dependent: "restrict"})
 
 The restrict error message follows the pattern `"Cannot delete record because dependent <relationship> exist"`.
 
+When a non-tenant parent declares `dependent: "restrict"` against a tenant-switched child model, Velocious checks every tenant returned by the matching `tenantDatabaseProviders[identifier].listRestrictTenants` provider, falling back to `listTenants` when no restrict-specific list exists. It runs the relationship count inside each tenant context and stops after the first dependent row. If a tenant-switched child cannot be enumerated because no provider exists, destroy raises an error instead of falling through to the database delete.
+
 ## Counter cache
 
 The `counterCache` option on `belongsTo` automatically syncs a count column on the parent model when child records are created, destroyed, or reparented:

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -55,6 +55,11 @@ export default new Configuration({
         // Adding/removing projects changes the next command run immediately.
         return await Project.all().select(["id", "databaseName"]).toArray()
       },
+      listRestrictTenants: async ({configuration}) => {
+        // Optional: return only existing/readable tenant databases for
+        // cross-tenant dependent: "restrict" checks.
+        return await Project.where({tenantState: "migrated"}).select(["id", "databaseName"]).toArray()
+      },
       createDatabase: async ({databaseConfiguration, tenant}) => {
         // App-specific database creation, grants, and structure loading.
       },
@@ -114,5 +119,9 @@ Because `listTenants` runs every time, tenant databases are dynamic:
 - newly created tenants are included in the next `db:tenants:create/check/migrate` run;
 - removed tenants disappear from the next provider result and are no longer migrated;
 - the app can still serve any one tenant immediately by resolving its tenant object through `tenantDatabaseResolver`.
+
+The same provider list is used when a non-tenant model destroys with `dependent: "restrict"` relationships pointing at tenant-switched child models. Velocious counts the relationship inside each tenant context and blocks the parent destroy if any tenant has dependent rows. This keeps application code from duplicating tenant scans just to avoid foreign-key failures at delete time.
+
+If lifecycle commands need to include tenants whose databases are not readable yet, add `listRestrictTenants`. Dependent restrict checks use `listRestrictTenants` when present and otherwise fall back to `listTenants`.
 
 If the targeted identifier is disabled with `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS`, tenant lifecycle commands fail fast instead of silently skipping the tenant connection.

--- a/spec/database/record/tenant-database-spec.js
+++ b/spec/database/record/tenant-database-spec.js
@@ -24,6 +24,19 @@ StaticProjectTenantRecord.switchesTenantDatabase("projectTenant")
 
 class GlobalRecord extends DatabaseRecord {}
 
+class TenantRestrictParent extends DatabaseRecord {}
+TenantRestrictParent.setTableName("tenant_restrict_parents")
+
+class TenantRestrictChild extends DatabaseRecord {}
+TenantRestrictChild.setTableName("tenant_restrict_children")
+TenantRestrictChild.switchesTenantDatabase("projectTenant")
+
+TenantRestrictParent.hasMany("tenantRestrictChildren", {
+  dependent: "restrict",
+  foreignKey: "parentId",
+  klass: TenantRestrictChild
+})
+
 async function createTenantAnalyticsRecordTable(configuration, tenant) {
   await configuration.runWithTenant(tenant, async () => {
     await configuration.ensureConnections(async (dbs) => {
@@ -39,6 +52,24 @@ async function initializeTenantAnalyticsRecord(configuration) {
 
     await TenantAnalyticsRecord.initializeRecord({configuration})
   })
+}
+
+async function createTenantRestrictTables(configuration, tenants) {
+  await configuration.ensureConnections(async (dbs) => {
+    await dbs.default.query("CREATE TABLE IF NOT EXISTS tenant_restrict_parents(id integer PRIMARY KEY AUTOINCREMENT, name varchar(255))")
+
+    await TenantRestrictParent.initializeRecord({configuration})
+  })
+
+  for (const tenant of tenants) {
+    await configuration.runWithTenant(tenant, async () => {
+      await configuration.ensureConnections(async (dbs) => {
+        await dbs.projectTenant.query("CREATE TABLE IF NOT EXISTS tenant_restrict_children(id integer PRIMARY KEY AUTOINCREMENT, parent_id integer NOT NULL, name varchar(255))")
+
+        await TenantRestrictChild.initializeRecord({configuration})
+      })
+    })
+  }
 }
 
 describe("DatabaseRecord tenant database switching", {databaseCleaning: {transaction: true}}, () => {
@@ -192,6 +223,138 @@ describe("DatabaseRecord tenant database switching", {databaseCleaning: {transac
       await configuration.runWithTenant({}, async () => {
         await expect(async () => StaticProjectTenantRecord.getDatabaseIdentifier()).toThrow(TenantDatabaseScopeError)
       })
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("checks dependent restrict relationships in every listed tenant database", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-dependent-restrict")
+    const tenants = [{slug: "alpha"}, {slug: "beta"}]
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      configuration.setTenantDatabaseProviders({
+        projectTenant: {
+          listTenants: async () => tenants
+        }
+      })
+      await createTenantRestrictTables(configuration, tenants)
+
+      const parent = await TenantRestrictParent.create({name: "Restricted parent"})
+
+      await configuration.runWithTenant({slug: "beta"}, async () => {
+        await configuration.ensureConnections(async () => {
+          await TenantRestrictChild.create({
+            name: "Blocking child",
+            parentId: parent.id()
+          })
+        })
+      })
+
+      await expect(async () => parent.destroy()).toThrowError("Cannot delete record because dependent tenantRestrictChildren exist")
+
+      const foundParent = await configuration.ensureConnections(async () => {
+        return await TenantRestrictParent.findBy({id: parent.id()})
+      })
+
+      expect(foundParent).toBeDefined()
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("uses restrict tenant lists instead of lifecycle tenant lists for dependent restrict checks", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-dependent-restrict-list")
+    const tenants = [{slug: "alpha"}, {slug: "beta"}]
+    let lifecycleTenantCalls = 0
+    let restrictTenantCalls = 0
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      configuration.setTenantDatabaseProviders({
+        projectTenant: {
+          listRestrictTenants: async () => {
+            restrictTenantCalls += 1
+
+            return tenants
+          },
+          listTenants: async () => {
+            lifecycleTenantCalls += 1
+
+            return [{slug: "pending"}]
+          }
+        }
+      })
+      await createTenantRestrictTables(configuration, tenants)
+
+      const parent = await TenantRestrictParent.create({name: "Restricted parent"})
+
+      await configuration.runWithTenant({slug: "beta"}, async () => {
+        await configuration.ensureConnections(async () => {
+          await TenantRestrictChild.create({
+            name: "Blocking child",
+            parentId: parent.id()
+          })
+        })
+      })
+
+      await expect(async () => parent.destroy()).toThrowError("Cannot delete record because dependent tenantRestrictChildren exist")
+      expect(lifecycleTenantCalls).toEqual(0)
+      expect(restrictTenantCalls).toEqual(1)
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
+  it("allows dependent restrict destroys when listed tenant databases have no dependents", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-dependent-restrict-empty")
+    const tenants = [{slug: "alpha"}, {slug: "beta"}]
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      configuration.setTenantDatabaseProviders({
+        projectTenant: {
+          listTenants: async () => tenants
+        }
+      })
+      await createTenantRestrictTables(configuration, tenants)
+
+      const parent = await TenantRestrictParent.create({name: "Unrestricted parent"})
+
+      await configuration.ensureConnections(async () => {
+        await parent.destroy()
+      })
+
+      const foundParent = await configuration.ensureConnections(async () => {
+        return await TenantRestrictParent.findBy({id: parent.id()})
+      })
+
+      expect(foundParent).toEqual(undefined)
     } finally {
       previousConfiguration?.setCurrent()
       await cleanup()

--- a/spec/database/record/tenant-database-spec.js
+++ b/spec/database/record/tenant-database-spec.js
@@ -324,6 +324,34 @@ describe("DatabaseRecord tenant database switching", {databaseCleaning: {transac
     }
   })
 
+  it("fails closed when the target tenant provider is not configured", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-dependent-restrict-missing-provider")
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+      configuration.setTenantDatabaseProviders({
+        analytics: {
+          listTenants: async () => [{slug: "alpha"}]
+        }
+      })
+      await createTenantRestrictTables(configuration, [])
+
+      const parent = await TenantRestrictParent.create({name: "Restricted parent"})
+
+      await expect(async () => parent.destroy()).toThrowError("Cannot check dependent tenantRestrictChildren because TenantRestrictChild switches tenant database projectTenant but no tenant database provider is configured for projectTenant")
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+
   it("allows dependent restrict destroys when listed tenant databases have no dependents", async () => {
     const {cleanup, configuration} = await createTenantTestConfiguration("velocious-record-tenant-dependent-restrict-empty")
     const tenants = [{slug: "alpha"}, {slug: "beta"}]

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -475,6 +475,7 @@
 /**
  * @typedef {object} TenantDatabaseProviderType
  * @property {function({configuration: import("./configuration.js").default, identifier: string}) : Array<?> | Promise<Array<?>>} listTenants - Lists tenants that should be created, checked, or migrated for this database identifier.
+ * @property {function({configuration: import("./configuration.js").default, identifier: string}) : Array<?> | Promise<Array<?>>} [listRestrictTenants] - Lists existing tenants that should be checked for dependent restrict destroys. Defaults to listTenants.
  * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: ?}) : void | Promise<void>} [createDatabase] - Creates the tenant database/schema for one tenant.
  * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: ?}) : void | Promise<void>} [dropDatabase] - Drops the tenant database/schema for one tenant.
  * @property {function({configuration: import("./configuration.js").default, databaseConfiguration: DatabaseConfigurationType, identifier: string, tenant: ?}) : void | Promise<void>} [checkTenant] - Checks one tenant database before generic connection validation.

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -22,6 +22,8 @@
  * @typedef {import("./instance-relationships/base.js").default & {query: () => ModelClassQuery<typeof VelociousDatabaseRecord>}} RestrictInstanceRelationship
  */
 
+/** @typedef {import("../../configuration-types.js").TenantDatabaseProviderType} TenantDatabaseProviderType */
+
 import timeout from "awaitery/build/timeout.js"
 import BelongsToInstanceRelationship from "./instance-relationships/belongs-to.js"
 import BelongsToRelationship from "./relationships/belongs-to.js"
@@ -3401,38 +3403,33 @@ class VelociousDatabaseRecord {
     const configuration = this.getModelClass()._getConfiguration()
     const tenantDatabaseProviders = configuration.getTenantDatabaseProviders()
     const providerEntries = Object.entries(tenantDatabaseProviders)
+    const targetIdentifier = TargetModelClass.getTenantDatabaseIdentifier(null)
 
     if (providerEntries.length == 0) {
       throw new Error(`Cannot check dependent ${instanceRelationship.getRelationship().getRelationshipName()} because ${TargetModelClass.getModelName()} switches tenant databases but no tenant database providers are configured`)
     }
 
+    if (targetIdentifier) {
+      const provider = tenantDatabaseProviders[targetIdentifier]
+
+      if (!provider) {
+        throw new Error(`Cannot check dependent ${instanceRelationship.getRelationship().getRelationshipName()} because ${TargetModelClass.getModelName()} switches tenant database ${targetIdentifier} but no tenant database provider is configured for ${targetIdentifier}`)
+      }
+
+      return await this._dependentRestrictProviderCount(instanceRelationship, TargetModelClass, targetIdentifier, provider)
+    }
+
+    let matchingProviderSeen = false
+
     for (const [identifier, provider] of providerEntries) {
-      const listTenants = typeof provider.listRestrictTenants == "function"
-        ? provider.listRestrictTenants
-        : provider.listTenants
-      const listTenantsMethodName = typeof provider.listRestrictTenants == "function"
-        ? "listRestrictTenants"
-        : "listTenants"
-
-      if (typeof listTenants != "function") {
-        throw new Error(`Tenant database provider for ${identifier} must define listTenants or listRestrictTenants before dependent restrict can check ${instanceRelationship.getRelationship().getRelationshipName()}`)
-      }
-
-      const tenants = await configuration.ensureConnections({name: `Dependent restrict tenants: ${TargetModelClass.getModelName()}`}, async () => {
-        return await listTenants({
-          configuration,
-          identifier
-        })
-      })
-
-      if (!Array.isArray(tenants)) {
-        throw new Error(`Tenant database provider for ${identifier} must return an array from ${listTenantsMethodName}`)
-      }
+      const tenants = await this._dependentRestrictProviderTenants(instanceRelationship, TargetModelClass, identifier, provider)
 
       for (const tenant of tenants) {
         if (TargetModelClass.getTenantDatabaseIdentifier(tenant) != identifier) {
           continue
         }
+
+        matchingProviderSeen = true
 
         const count = await configuration.runWithTenant(tenant, async () => {
           if (!configuration.isDatabaseIdentifierActive(identifier)) {
@@ -3448,7 +3445,75 @@ class VelociousDatabaseRecord {
       }
     }
 
+    if (!matchingProviderSeen) {
+      throw new Error(`Cannot check dependent ${instanceRelationship.getRelationship().getRelationshipName()} because no tenant database provider matched ${TargetModelClass.getModelName()}`)
+    }
+
     return 0
+  }
+
+  /**
+   * Counts tenant-scoped dependent records for one configured tenant provider.
+   * @param {RestrictInstanceRelationship} instanceRelationship - Relationship instance to count.
+   * @param {typeof VelociousDatabaseRecord} TargetModelClass - Related model class.
+   * @param {string} identifier - Tenant database identifier.
+   * @param {TenantDatabaseProviderType} provider - Tenant database provider.
+   * @returns {Promise<number>} - Dependent row count.
+   */
+  async _dependentRestrictProviderCount(instanceRelationship, TargetModelClass, identifier, provider) {
+    const configuration = this.getModelClass()._getConfiguration()
+    const tenants = await this._dependentRestrictProviderTenants(instanceRelationship, TargetModelClass, identifier, provider)
+
+    for (const tenant of tenants) {
+      const count = await configuration.runWithTenant(tenant, async () => {
+        if (!configuration.isDatabaseIdentifierActive(identifier)) {
+          throw new Error(`Tenant database identifier ${identifier} is inactive while checking dependent ${instanceRelationship.getRelationship().getRelationshipName()}`)
+        }
+
+        return await configuration.ensureConnections({name: `Dependent restrict count: ${TargetModelClass.getModelName()}`}, async () => {
+          return await instanceRelationship.query().count()
+        })
+      })
+
+      if (count > 0) return count
+    }
+
+    return 0
+  }
+
+  /**
+   * Lists restrict-check tenants for one configured tenant provider.
+   * @param {RestrictInstanceRelationship} instanceRelationship - Relationship instance to count.
+   * @param {typeof VelociousDatabaseRecord} TargetModelClass - Related model class.
+   * @param {string} identifier - Tenant database identifier.
+   * @param {TenantDatabaseProviderType} provider - Tenant database provider.
+   * @returns {Promise<Array<?>>} - Listed tenant objects.
+   */
+  async _dependentRestrictProviderTenants(instanceRelationship, TargetModelClass, identifier, provider) {
+    const configuration = this.getModelClass()._getConfiguration()
+    const listTenants = typeof provider.listRestrictTenants == "function"
+      ? provider.listRestrictTenants
+      : provider.listTenants
+    const listTenantsMethodName = typeof provider.listRestrictTenants == "function"
+      ? "listRestrictTenants"
+      : "listTenants"
+
+    if (typeof listTenants != "function") {
+      throw new Error(`Tenant database provider for ${identifier} must define listTenants or listRestrictTenants before dependent restrict can check ${instanceRelationship.getRelationship().getRelationshipName()}`)
+    }
+
+    const tenants = await configuration.ensureConnections({name: `Dependent restrict tenants: ${TargetModelClass.getModelName()}`}, async () => {
+      return await listTenants({
+        configuration,
+        identifier
+      })
+    })
+
+    if (!Array.isArray(tenants)) {
+      throw new Error(`Tenant database provider for ${identifier} must return an array from ${listTenantsMethodName}`)
+    }
+
+    return tenants
   }
 
   /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -17,6 +17,11 @@
  * @typedef {{new (changes?: Record<string, unknown>): T}} ModelConstructor
  */
 
+/**
+ * RestrictInstanceRelationship type.
+ * @typedef {import("./instance-relationships/base.js").default & {query: () => ModelClassQuery<typeof VelociousDatabaseRecord>}} RestrictInstanceRelationship
+ */
+
 import timeout from "awaitery/build/timeout.js"
 import BelongsToInstanceRelationship from "./instance-relationships/belongs-to.js"
 import BelongsToRelationship from "./relationships/belongs-to.js"
@@ -1626,6 +1631,14 @@ class VelociousDatabaseRecord {
    */
   static switchesTenantDatabase(databaseIdentifierOrResolver) {
     this._tenantDatabaseIdentifierResolver = databaseIdentifierOrResolver
+  }
+
+  /**
+   * Runs has tenant database identifier resolver.
+   * @returns {boolean} - Whether this model resolves its database from the current tenant.
+   */
+  static hasTenantDatabaseIdentifierResolver() {
+    return Boolean(this._tenantDatabaseIdentifierResolver)
   }
 
   /**
@@ -3360,6 +3373,85 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * Counts dependent records for a `dependent: "restrict"` relationship.
+   * @param {RestrictInstanceRelationship} instanceRelationship - Relationship instance to count.
+   * @returns {Promise<number>} - Dependent row count.
+   */
+  async _dependentRestrictCount(instanceRelationship) {
+    const TargetModelClass = instanceRelationship.getTargetModelClass()
+
+    if (!TargetModelClass || !TargetModelClass.hasTenantDatabaseIdentifierResolver()) {
+      return await instanceRelationship.query().count()
+    }
+
+    if (this.getModelClass().hasTenantDatabaseIdentifierResolver()) {
+      return await instanceRelationship.query().count()
+    }
+
+    return await this._dependentRestrictTenantCount(instanceRelationship, TargetModelClass)
+  }
+
+  /**
+   * Counts tenant-scoped dependent records across all provider-listed tenants.
+   * @param {RestrictInstanceRelationship} instanceRelationship - Relationship instance to count.
+   * @param {typeof VelociousDatabaseRecord} TargetModelClass - Related model class.
+   * @returns {Promise<number>} - Dependent row count.
+   */
+  async _dependentRestrictTenantCount(instanceRelationship, TargetModelClass) {
+    const configuration = this.getModelClass()._getConfiguration()
+    const tenantDatabaseProviders = configuration.getTenantDatabaseProviders()
+    const providerEntries = Object.entries(tenantDatabaseProviders)
+
+    if (providerEntries.length == 0) {
+      throw new Error(`Cannot check dependent ${instanceRelationship.getRelationship().getRelationshipName()} because ${TargetModelClass.getModelName()} switches tenant databases but no tenant database providers are configured`)
+    }
+
+    for (const [identifier, provider] of providerEntries) {
+      const listTenants = typeof provider.listRestrictTenants == "function"
+        ? provider.listRestrictTenants
+        : provider.listTenants
+      const listTenantsMethodName = typeof provider.listRestrictTenants == "function"
+        ? "listRestrictTenants"
+        : "listTenants"
+
+      if (typeof listTenants != "function") {
+        throw new Error(`Tenant database provider for ${identifier} must define listTenants or listRestrictTenants before dependent restrict can check ${instanceRelationship.getRelationship().getRelationshipName()}`)
+      }
+
+      const tenants = await configuration.ensureConnections({name: `Dependent restrict tenants: ${TargetModelClass.getModelName()}`}, async () => {
+        return await listTenants({
+          configuration,
+          identifier
+        })
+      })
+
+      if (!Array.isArray(tenants)) {
+        throw new Error(`Tenant database provider for ${identifier} must return an array from ${listTenantsMethodName}`)
+      }
+
+      for (const tenant of tenants) {
+        if (TargetModelClass.getTenantDatabaseIdentifier(tenant) != identifier) {
+          continue
+        }
+
+        const count = await configuration.runWithTenant(tenant, async () => {
+          if (!configuration.isDatabaseIdentifierActive(identifier)) {
+            throw new Error(`Tenant database identifier ${identifier} is inactive while checking dependent ${instanceRelationship.getRelationship().getRelationshipName()}`)
+          }
+
+          return await configuration.ensureConnections({name: `Dependent restrict count: ${TargetModelClass.getModelName()}`}, async () => {
+            return await instanceRelationship.query().count()
+          })
+        })
+
+        if (count > 0) return count
+      }
+    }
+
+    return 0
+  }
+
+  /**
    * Destroys the record in the database and all of its dependent records.
    * @returns {Promise<void>} - Resolves when complete.
    */
@@ -3368,8 +3460,8 @@ class VelociousDatabaseRecord {
 
     for (const relationship of this.getModelClass().getRelationships()) {
       if (relationship.getDependent() == "restrict") {
-        const instanceRelationship = /** @type {?} */ (this.getRelationshipByName(relationship.getRelationshipName()))
-        const count = await instanceRelationship.query().count()
+        const instanceRelationship = /** @type {RestrictInstanceRelationship} */ (this.getRelationshipByName(relationship.getRelationshipName()))
+        const count = await this._dependentRestrictCount(instanceRelationship)
 
         if (count > 0) {
           throw new Error(`Cannot delete record because dependent ${relationship.getRelationshipName()} exist`)


### PR DESCRIPTION
## Summary
- make dependent restrict checks enumerate tenant databases when a non-tenant parent is referenced by tenant-scoped records
- add optional listRestrictTenants provider hook so restrictive checks can use the migrated tenant set instead of lifecycle queues
- document cross-tenant restrict behavior and add focused tenant database specs

## Verification
- VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npm run test -- spec/database/record/tenant-database-spec.js
- npm run build
- npm run lint
- npm run typecheck
- npm run fallow