### PR TITLE
Add MigrationsLedger: single-owner schema_migrations ledger + baseline primitive

### DIFF
--- a/spec/database/migrations-ledger-spec.js
+++ b/spec/database/migrations-ledger-spec.js
@@ -1,0 +1,99 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import MigrationsLedger from "../../src/database/migrations-ledger.js"
+import {createTenantTestConfiguration} from "../helpers/tenant-test-helpers.js"
+
+describe("MigrationsLedger", () => {
+  it("creates the ledger table and records versions as applied without running migrations", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("migrations-ledger")
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const db = dbs.default
+
+        expect(await MigrationsLedger.tableExists(db)).toEqual(false)
+
+        const recorded = await MigrationsLedger.markApplied(db, ["20260101000000", "20260102000000"])
+
+        expect(recorded.sort()).toEqual(["20260101000000", "20260102000000"])
+        expect(await MigrationsLedger.tableExists(db)).toEqual(true)
+        expect((await MigrationsLedger.appliedVersions(db)).sort()).toEqual(["20260101000000", "20260102000000"])
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("is idempotent — re-marking already-applied versions records only the new ones", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("migrations-ledger")
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const db = dbs.default
+
+        await MigrationsLedger.markApplied(db, ["20260101000000", "20260102000000"])
+
+        const recorded = await MigrationsLedger.markApplied(db, ["20260101000000", "20260103000000"])
+
+        expect(recorded).toEqual(["20260103000000"])
+        expect((await MigrationsLedger.appliedVersions(db)).sort()).toEqual([
+          "20260101000000",
+          "20260102000000",
+          "20260103000000"
+        ])
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("records and removes a single version idempotently", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("migrations-ledger")
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const db = dbs.default
+
+        await MigrationsLedger.ensureTable(db)
+        await MigrationsLedger.recordVersion(db, "20260101000000")
+        await MigrationsLedger.recordVersion(db, "20260101000000")
+
+        expect(await MigrationsLedger.hasVersion(db, "20260101000000")).toEqual(true)
+        expect(await MigrationsLedger.appliedVersions(db)).toEqual(["20260101000000"])
+
+        await MigrationsLedger.removeVersion(db, "20260101000000")
+
+        expect(await MigrationsLedger.hasVersion(db, "20260101000000")).toEqual(false)
+        expect(await MigrationsLedger.appliedVersions(db)).toEqual([])
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("baselines a target database from a source database's applied versions", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("migrations-ledger")
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const sourceDb = dbs.default
+        const targetDb = dbs.analytics
+
+        await MigrationsLedger.markApplied(sourceDb, ["20260101000000", "20260102000000", "20260103000000"])
+        await MigrationsLedger.markApplied(targetDb, ["20260101000000"])
+
+        const recorded = await MigrationsLedger.baselineFromDatabase({sourceDb, targetDb})
+
+        expect(recorded.sort()).toEqual(["20260102000000", "20260103000000"])
+        expect((await MigrationsLedger.appliedVersions(targetDb)).sort()).toEqual([
+          "20260101000000",
+          "20260102000000",
+          "20260103000000"
+        ])
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/spec/database/migrations-ledger-spec.js
+++ b/spec/database/migrations-ledger-spec.js
@@ -4,6 +4,11 @@ import {describe, expect, it} from "../../src/testing/test.js"
 import MigrationsLedger from "../../src/database/migrations-ledger.js"
 import {createTenantTestConfiguration} from "../helpers/tenant-test-helpers.js"
 
+// Unit coverage for the cases the dummy-app browser matrix can't exercise: creating
+// the ledger table from scratch and the cross-database `baselineFromDatabase`
+// orchestration (the dummy app exposes only a single `default` database). The
+// per-driver DDL/CRUD primitives are covered against the real matrix in
+// migrations-ledger.browser-spec.js.
 describe("MigrationsLedger", () => {
   it("creates the ledger table and records versions as applied without running migrations", async () => {
     const {cleanup, configuration} = await createTenantTestConfiguration("migrations-ledger")

--- a/spec/database/migrations-ledger.browser-spec.js
+++ b/spec/database/migrations-ledger.browser-spec.js
@@ -1,0 +1,58 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import MigrationsLedger from "../../src/database/migrations-ledger.js"
+
+// Runs against the real database driver matrix (MariaDB / PostgreSQL / MS-SQL /
+// SQLite) via the dummy app, so driver-specific implementations of the ledger's
+// DDL, introspection and CRUD are exercised. `schema_migrations` already exists in
+// the dummy app (migrations prepared it through MigrationsLedger.ensureTable /
+// recordVersion on every matrix DB), so these cases add their own throwaway versions
+// and clean them up, leaving the real ledger untouched. The cross-database
+// `baselineFromDatabase` orchestration and the from-scratch table creation are
+// covered in the SQLite unit spec, which can spin up a second/empty database.
+describe("MigrationsLedger - browser DB matrix", {tags: ["dummy"]}, () => {
+  it("records, queries and removes versions against the real database driver", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const v1 = "ledger-browser-spec-0001"
+      const v2 = "ledger-browser-spec-0002"
+      const v3 = "ledger-browser-spec-0003"
+
+      expect(await MigrationsLedger.tableExists(db)).toEqual(true)
+      await MigrationsLedger.ensureTable(db)
+
+      const originalCount = (await MigrationsLedger.appliedVersions(db)).length
+
+      try {
+        const recorded = await MigrationsLedger.markApplied(db, [v1, v2])
+
+        expect(recorded.sort()).toEqual([v1, v2])
+        expect(await MigrationsLedger.hasVersion(db, v1)).toEqual(true)
+        expect(await MigrationsLedger.hasVersion(db, v2)).toEqual(true)
+
+        // Idempotent: re-marking v1 records nothing, only v3 is new.
+        const recordedAgain = await MigrationsLedger.markApplied(db, [v1, v3])
+
+        expect(recordedAgain).toEqual([v3])
+
+        const versions = await MigrationsLedger.appliedVersions(db)
+
+        expect(versions.length).toEqual(originalCount + 3)
+        expect(versions.includes(v1)).toEqual(true)
+
+        // recordVersion is idempotent for a single version.
+        await MigrationsLedger.recordVersion(db, v1)
+
+        expect((await MigrationsLedger.appliedVersions(db)).length).toEqual(originalCount + 3)
+      } finally {
+        for (const version of [v1, v2, v3]) {
+          await MigrationsLedger.removeVersion(db, version)
+        }
+      }
+
+      expect(await MigrationsLedger.hasVersion(db, v1)).toEqual(false)
+      expect((await MigrationsLedger.appliedVersions(db)).length).toEqual(originalCount)
+    })
+  })
+})

--- a/src/database/migrations-ledger.js
+++ b/src/database/migrations-ledger.js
@@ -1,0 +1,147 @@
+// @ts-check
+
+import {digg} from "diggerize"
+import TableData from "./table-data/index.js"
+
+const TABLE_NAME = "schema_migrations"
+
+/**
+ * Single owner of the `schema_migrations` ledger shape and the only place that reads
+ * or writes applied migration versions for a database connection. The migrator uses
+ * it to record versions as it runs migrations; provisioning / schema-clone paths use
+ * `markApplied` / `baselineFromDatabase` to record versions as applied WITHOUT
+ * re-running them (the Rails `schema:load` / Flyway `baseline` idea). That keeps the
+ * ledger honest when a database's schema was advanced out of band — e.g. by cloning
+ * table structure between databases — so the migrator does not later re-run a
+ * migration whose schema object already exists.
+ */
+export default class MigrationsLedger {
+  /**
+   * The ledger table name.
+   * @returns {string}
+   */
+  static tableName() {
+    return TABLE_NAME
+  }
+
+  /**
+   * Whether the ledger table exists on the given database.
+   * @param {import("./drivers/base.js").default} db
+   * @returns {Promise<boolean>}
+   */
+  static async tableExists(db) {
+    const table = await db.getTableByName(TABLE_NAME, {throwError: false})
+
+    return Boolean(table)
+  }
+
+  /**
+   * Creates the ledger table if it does not exist. This is the single definition of
+   * the `schema_migrations` table shape.
+   * @param {import("./drivers/base.js").default} db
+   * @returns {Promise<void>}
+   */
+  static async ensureTable(db) {
+    if (await MigrationsLedger.tableExists(db)) return
+
+    const tableData = new TableData(TABLE_NAME, {ifNotExists: true})
+
+    tableData.string("version", {null: false, primaryKey: true})
+
+    for (const sql of await db.createTableSql(tableData)) {
+      await db.query(sql)
+    }
+
+    db.clearSchemaCache()
+  }
+
+  /**
+   * Every applied migration version recorded in the ledger.
+   * @param {import("./drivers/base.js").default} db
+   * @returns {Promise<string[]>}
+   */
+  static async appliedVersions(db) {
+    const rows = await db.select(TABLE_NAME)
+
+    return rows.map((row) => `${digg(row, "version")}`)
+  }
+
+  /**
+   * Whether the given version is recorded as applied.
+   * @param {import("./drivers/base.js").default} db
+   * @param {string} version
+   * @returns {Promise<boolean>}
+   */
+  static async hasVersion(db, version) {
+    const rows = await db.newQuery()
+      .from(TABLE_NAME)
+      .where({version})
+      .results()
+
+    return rows.length > 0
+  }
+
+  /**
+   * Records a single version as applied. The targeted existence check keeps the
+   * migrator's per-migration hot path cheap (no full-table load per migration).
+   * @param {import("./drivers/base.js").default} db
+   * @param {string} version
+   * @returns {Promise<void>}
+   */
+  static async recordVersion(db, version) {
+    if (await MigrationsLedger.hasVersion(db, version)) return
+
+    await db.insert({tableName: TABLE_NAME, data: {version}})
+  }
+
+  /**
+   * Removes a version from the ledger (used when migrating down).
+   * @param {import("./drivers/base.js").default} db
+   * @param {string} version
+   * @returns {Promise<void>}
+   */
+  static async removeVersion(db, version) {
+    await db.delete({tableName: TABLE_NAME, conditions: {version}})
+  }
+
+  /**
+   * Baselines a database's ledger: records each version as applied without running
+   * its migration. Idempotent — already-recorded versions are skipped. Ensures the
+   * ledger table exists first, then loads the existing set once for the whole batch.
+   * @param {import("./drivers/base.js").default} db
+   * @param {string[]} versions
+   * @returns {Promise<string[]>} The versions that were newly recorded.
+   */
+  static async markApplied(db, versions) {
+    await MigrationsLedger.ensureTable(db)
+
+    const existing = new Set(await MigrationsLedger.appliedVersions(db))
+    const recorded = []
+
+    for (const version of versions) {
+      const normalizedVersion = `${version}`
+
+      if (existing.has(normalizedVersion)) continue
+
+      await db.insert({tableName: TABLE_NAME, data: {version: normalizedVersion}})
+      existing.add(normalizedVersion)
+      recorded.push(normalizedVersion)
+    }
+
+    return recorded
+  }
+
+  /**
+   * Baselines `targetDb` to match the applied versions of `sourceDb`. Use when a
+   * provisioning path advanced `targetDb`'s schema to match `sourceDb` out of band
+   * (e.g. cloning table structure between databases): the migrations are, by
+   * construction, already applied on the target, so record them without re-running.
+   * @param {{sourceDb: import("./drivers/base.js").default, targetDb: import("./drivers/base.js").default}} args
+   * @returns {Promise<string[]>} The versions that were newly recorded on the target.
+   */
+  static async baselineFromDatabase({sourceDb, targetDb}) {
+    const sourceVersions = await MigrationsLedger.appliedVersions(sourceDb)
+
+    return await MigrationsLedger.markApplied(targetDb, sourceVersions)
+  }
+}

--- a/src/database/migrator.js
+++ b/src/database/migrator.js
@@ -3,9 +3,9 @@
 import {digg} from "diggerize"
 import * as inflection from "inflection"
 import Logger from "../logger.js"
+import MigrationsLedger from "./migrations-ledger.js"
 import {NotImplementedError} from "./migration/index.js"
 import restArgsError from "../utils/rest-args-error.js"
-import TableData from "./table-data/index.js"
 
 export default class VelociousDatabaseMigrator {
   /**
@@ -79,22 +79,11 @@ export default class VelociousDatabaseMigrator {
       return
     }
 
-    const exists = await this.migrationsTableExist(db)
-
-    if (exists) {
+    if (await this.migrationsTableExist(db)) {
       this.logger.debug(`${dbIdentifier} migrations table already exists - skipping`)
     } else {
-      this.logger.debug("New TableData for schema_migrations")
-      const schemaMigrationsTable = new TableData("schema_migrations", {ifNotExists: true})
-
-      schemaMigrationsTable.string("version", {null: false, primaryKey: true})
-
-      const createSchemaMigrationsTableSqls = await db.createTableSql(schemaMigrationsTable)
-
-      for (const createSchemaMigrationsTableSql of createSchemaMigrationsTableSqls) {
-        this.logger.debug(`Creating migrations table with SQL`, createSchemaMigrationsTableSql)
-        await db.query(createSchemaMigrationsTableSql)
-      }
+      this.logger.debug("Creating schema_migrations table via MigrationsLedger")
+      await MigrationsLedger.ensureTable(db)
     }
   }
 
@@ -255,13 +244,11 @@ export default class VelociousDatabaseMigrator {
       return
     }
 
-    const rows = await db.select("schema_migrations")
+    const versions = await MigrationsLedger.appliedVersions(db)
 
     this.migrationsVersions[dbIdentifier] = {}
 
-    for (const row of rows) {
-      const version = digg(row, "version")
-
+    for (const version of versions) {
       this.migrationsVersions[dbIdentifier][version] = true
     }
   }
@@ -272,11 +259,7 @@ export default class VelociousDatabaseMigrator {
    * @returns {Promise<boolean>} - Resolves with Whether migrations table exist.
    */
   async migrationsTableExist(db) {
-    const schemaTable = await db.getTableByName("schema_migrations", {throwError: false})
-
-    if (!schemaTable) return false
-
-    return true
+    return await MigrationsLedger.tableExists(db)
   }
 
   /**
@@ -525,14 +508,7 @@ export default class VelociousDatabaseMigrator {
           }
         }
 
-        const existingSchemaMigrations = await db.newQuery()
-          .from("schema_migrations")
-          .where({version: dateString})
-          .results()
-
-        if (existingSchemaMigrations.length == 0) {
-          await db.insert({tableName: "schema_migrations", data: {version: dateString}})
-        }
+        await MigrationsLedger.recordVersion(db, dateString)
       } else if (direction == "down") {
         try {
           await migrationInstance.down()
@@ -544,7 +520,7 @@ export default class VelociousDatabaseMigrator {
           }
         }
 
-        await db.delete({tableName: "schema_migrations", conditions: {version: dateString}})
+        await MigrationsLedger.removeVersion(db, dateString)
       } else {
         throw new Error(`Unknown direction: ${direction}`)
       }


### PR DESCRIPTION
## Why

Multi-tenant apps that provision a tenant database by **cloning table structure from another database** (e.g. copying the default DB's tables into a per-tenant DB) advance that tenant's *schema* out of band. Nothing records the corresponding migration versions in the tenant's `schema_migrations`, so `db:tenants:migrate` later re-runs an `addColumn` whose column already exists and fails with `ER_DUP_FIELDNAME`. The fix is to **baseline** the ledger — record versions as applied without re-running the migrations (the Rails `schema:load` / Flyway `baseline` idea) — but Velocious had no primitive for that, and the `schema_migrations` table shape was open-coded inside the migrator.

This is the first phase of moving a generic, apartment-style multi-tenant module into Velocious.

## What

New `src/database/migrations-ledger.js` — `MigrationsLedger`, the single owner of the `schema_migrations` shape and the only place that reads/writes applied versions:

- `ensureTable` / `tableExists` / `appliedVersions` / `hasVersion`
- `recordVersion` / `removeVersion` — the migrator's per-migration hot path
- `markApplied(db, versions)` — idempotent baseline of a version set (creates the table, skips already-recorded versions)
- `baselineFromDatabase({sourceDb, targetDb})` — baseline a target DB to a source DB's applied set

The migrator now **delegates** table creation, version loading, and per-migration ledger writes to `MigrationsLedger` (net code reduction), so the DDL/shape has one owner. Behavior is unchanged — the per-migration write keeps a targeted existence check, so no extra full-table loads on the hot path.

## Tests

`spec/database/migrations-ledger-spec.js`: ensure-table + record-without-running, idempotent re-mark, record/remove single version, and `baselineFromDatabase` across two DBs. Existing `db:migrate` and `db:tenants:migrate` specs (and the broader migration/db command suite, 51 tests) stay green. `npm run eslint` + `tsc` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
