### PR TITLE
Add SchemaCloner: clone table structure between databases + baseline ledger (V2)

### DIFF
--- a/spec/database/tenants/schema-cloner-spec.js
+++ b/spec/database/tenants/schema-cloner-spec.js
@@ -89,6 +89,25 @@ describe("SchemaCloner", () => {
     })
   })
 
+  it("clones an integer auto-increment primary key", async () => {
+    await withCloner(async ({cloner, sourceDb, targetDb}) => {
+      const counters = new TableData("counters")
+
+      counters.integer("id", {null: false, primaryKey: true})
+      counters.string("label", {maxLength: 64, null: true})
+
+      await sourceDb.createTable(counters)
+      sourceDb.clearSchemaCache()
+
+      await cloner.syncTables(["counters"])
+
+      const targetTable = await targetDb.getTableByNameOrFail("counters")
+      const idColumn = (await targetTable.getColumns()).find((column) => column.getName() === "id")
+
+      expect(idColumn?.getAutoIncrement()).toEqual(true)
+    })
+  })
+
   it("detects and heals ledger drift from the source", async () => {
     await withCloner(async ({cloner, sourceDb, targetDb}) => {
       await cloner.syncTables(["widgets"])

--- a/spec/database/tenants/schema-cloner-spec.js
+++ b/spec/database/tenants/schema-cloner-spec.js
@@ -1,0 +1,124 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../src/testing/test.js"
+import MigrationsLedger from "../../../src/database/migrations-ledger.js"
+import SchemaCloner from "../../../src/database/tenants/schema-cloner.js"
+import TableData from "../../../src/database/table-data/index.js"
+import TableIndex from "../../../src/database/table-data/table-index.js"
+import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.js"
+
+// The per-driver DDL/introspection the cloner orchestrates (createTable,
+// alterTableSQLs, createIndexSQLs, getColumns, getIndexes) is matrix-tested by the
+// existing migration browser specs, and the ledger integration by
+// migrations-ledger.browser-spec.js. The dummy app exposes a single database, so the
+// cross-database clone itself is covered here against SQLite's two-database harness.
+describe("SchemaCloner", () => {
+  /**
+   * @param {(args: {cloner: SchemaCloner, sourceDb: import("../../../src/database/drivers/base.js").default, targetDb: import("../../../src/database/drivers/base.js").default}) => Promise<void>} callback
+   * @returns {Promise<void>}
+   */
+  async function withCloner(callback) {
+    const {cleanup, configuration} = await createTenantTestConfiguration("schema-cloner")
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const sourceDb = dbs.default
+        const targetDb = dbs.analytics
+
+        await createWidgetsSourceTable(sourceDb)
+        await MigrationsLedger.markApplied(sourceDb, ["20260101000000", "20260102000000"])
+
+        await callback({cloner: new SchemaCloner({sourceDb, targetDb}), sourceDb, targetDb})
+      })
+    } finally {
+      await cleanup()
+    }
+  }
+
+  it("clones a missing table's columns and indexes into the target and baselines the ledger", async () => {
+    await withCloner(async ({cloner, targetDb}) => {
+      await cloner.syncTables(["widgets"])
+
+      expect(await targetDb.tableExists("widgets")).toEqual(true)
+
+      const targetTable = await targetDb.getTableByNameOrFail("widgets")
+      const columnNames = (await targetTable.getColumns()).map((column) => column.getName()).sort()
+
+      expect(columnNames).toEqual(["description", "id", "name"])
+
+      const indexColumns = (await targetTable.getIndexes())
+        .filter((index) => !index.isPrimaryKey())
+        .map((index) => index.getColumnNames().join(","))
+
+      expect(indexColumns).toContain("name")
+      expect((await MigrationsLedger.appliedVersions(targetDb)).sort()).toEqual(["20260101000000", "20260102000000"])
+    })
+  })
+
+  it("adds columns that appeared on the source to an already-cloned target", async () => {
+    await withCloner(async ({cloner, sourceDb, targetDb}) => {
+      await cloner.syncTables(["widgets"])
+
+      const addPrice = new TableData("widgets")
+
+      addPrice.integer("price", {null: true})
+
+      for (const sql of await sourceDb.alterTableSQLs(addPrice)) {
+        await sourceDb.query(sql)
+      }
+
+      sourceDb.clearSchemaCache()
+
+      await cloner.syncTables(["widgets"])
+
+      const targetTable = await targetDb.getTableByNameOrFail("widgets")
+      const columnNames = (await targetTable.getColumns()).map((column) => column.getName())
+
+      expect(columnNames.includes("price")).toEqual(true)
+    })
+  })
+
+  it("re-syncing an already-current table is an idempotent no-op", async () => {
+    await withCloner(async ({cloner, targetDb}) => {
+      await cloner.syncTables(["widgets"])
+      await cloner.syncTables(["widgets"])
+
+      const columnNames = (await (await targetDb.getTableByNameOrFail("widgets")).getColumns()).map((column) => column.getName()).sort()
+
+      expect(columnNames).toEqual(["description", "id", "name"])
+    })
+  })
+
+  it("detects and heals ledger drift from the source", async () => {
+    await withCloner(async ({cloner, sourceDb, targetDb}) => {
+      await cloner.syncTables(["widgets"])
+
+      expect(await cloner.ledgerDriftsFromSource()).toEqual(false)
+
+      await MigrationsLedger.markApplied(sourceDb, ["20260103000000"])
+
+      expect(await cloner.ledgerDriftsFromSource()).toEqual(true)
+
+      await cloner.reconcileLedger()
+
+      expect(await cloner.ledgerDriftsFromSource()).toEqual(false)
+      expect((await MigrationsLedger.appliedVersions(targetDb)).includes("20260103000000")).toEqual(true)
+    })
+  })
+})
+
+/**
+ * @param {import("../../../src/database/drivers/base.js").default} db
+ * @returns {Promise<void>}
+ */
+async function createWidgetsSourceTable(db) {
+  const widgets = new TableData("widgets")
+
+  widgets.bigint("id", {null: false, primaryKey: true})
+  widgets.string("name", {maxLength: 255, null: false})
+  widgets.text("description", {null: true})
+  widgets.addIndex(new TableIndex(["name"], {unique: true}))
+
+  await db.createTable(widgets)
+  db.clearSchemaCache()
+}

--- a/src/database/tenants/schema-cloner.js
+++ b/src/database/tenants/schema-cloner.js
@@ -236,13 +236,18 @@ export default class SchemaCloner {
    * @returns {TableIndex}
    */
   tableDataIndexFromSourceIndex(sourceIndex) {
-    if (this.targetDb.getType() === "sqlite") {
-      return new TableIndex(sourceIndex.getColumnNames(), {
-        unique: sourceIndex.isUnique()
-      })
+    /** @type {{name?: string, unique: boolean}} */
+    const args = {unique: sourceIndex.isUnique()}
+
+    // SQLite index names are unique per-database, not per-table, so let the driver
+    // generate one; other drivers preserve the source index name. Build the TableIndex
+    // directly (rather than via the driver's getTableDataIndex, which only MySQL and
+    // SQLite implement) so cloning a PostgreSQL or MS-SQL source table works too.
+    if (this.targetDb.getType() !== "sqlite") {
+      args.name = sourceIndex.getName()
     }
 
-    return sourceIndex.getTableDataIndex()
+    return new TableIndex(sourceIndex.getColumnNames(), args)
   }
 
   /**
@@ -347,7 +352,7 @@ export default class SchemaCloner {
    * @returns {Record<string, unknown>}
    */
   columnArgsFromSourceColumn(sourceColumn, {isNewColumn}) {
-    /** @type {{default?: unknown, isNewColumn: boolean, maxLength?: number, notes?: string, null: boolean, primaryKey?: boolean, type: string}} */
+    /** @type {{autoIncrement?: boolean, default?: unknown, isNewColumn: boolean, maxLength?: number, notes?: string, null: boolean, primaryKey?: boolean, type: string}} */
     const columnArgs = {
       isNewColumn,
       null: sourceColumn.getNull(),
@@ -361,7 +366,14 @@ export default class SchemaCloner {
       columnArgs.primaryKey = true
     }
 
-    if (maxLength !== undefined) {
+    if (sourceColumn.getAutoIncrement()) {
+      columnArgs.autoIncrement = true
+    }
+
+    // A maxLength of -1 is the MS-SQL "max" sentinel (NVARCHAR(MAX) / VARBINARY(MAX),
+    // backing Velocious text/json/blob columns); the column type drives the unbounded
+    // SQL, so don't forward -1 as an explicit length (it would emit NVARCHAR(-1)).
+    if (maxLength !== undefined && maxLength >= 0) {
       columnArgs.maxLength = maxLength
     }
 

--- a/src/database/tenants/schema-cloner.js
+++ b/src/database/tenants/schema-cloner.js
@@ -1,0 +1,378 @@
+// @ts-check
+
+import MigrationsLedger from "../migrations-ledger.js"
+import TableData from "../table-data/index.js"
+import TableIndex from "../table-data/table-index.js"
+
+const SIMPLE_DEFAULT_PATTERN = /^(?:-?\d+(?:\.\d+)?|[A-Za-z0-9 _.,:/@+-]*)$/
+
+/** @type {Record<string, number>} */
+const TEXT_TYPE_RANKS = {
+  tinytext: 1,
+  text: 2,
+  mediumtext: 3,
+  longtext: 4
+}
+
+/**
+ * Clones table structure (columns, text-type widening, indexes) from a source database
+ * into a target database for a given set of tables, then baselines the target's
+ * `schema_migrations` ledger to the source via {@link MigrationsLedger}. This is the
+ * mechanism multi-tenant apps use to provision a tenant database from a template/global
+ * database without re-running migrations: the structure is copied and the ledger is
+ * recorded as already-applied, so a later `db:tenants:migrate` does not re-run an
+ * `addColumn` whose column already exists.
+ *
+ * The cloner is intentionally policy-free — the caller decides which tables to sync and
+ * which databases are source/target. It is idempotent: missing tables are created,
+ * missing columns added, too-narrow text columns widened, and missing indexes created;
+ * an index whose definition diverges from the source is treated as drift and throws.
+ */
+export default class SchemaCloner {
+  /**
+   * Creates a cloner that copies table structure from `sourceDb` into `targetDb`.
+   * @param {{sourceDb: import("../drivers/base.js").default, targetDb: import("../drivers/base.js").default}} args
+   */
+  constructor({sourceDb, targetDb}) {
+    this.sourceDb = sourceDb
+    this.targetDb = targetDb
+  }
+
+  /**
+   * Clones every given table from the source into the target, then baselines the
+   * target's ledger so the cloned schema is recorded as already-migrated.
+   * @param {string[]} tableNames
+   * @returns {Promise<void>}
+   */
+  async syncTables(tableNames) {
+    for (const tableName of tableNames) {
+      await this.syncTable(tableName)
+    }
+
+    await this.reconcileLedger()
+  }
+
+  /**
+   * Clones a single table from the source into the target, creating it or adding and
+   * widening columns and indexes as needed.
+   * @param {string} tableName
+   * @returns {Promise<void>}
+   */
+  async syncTable(tableName) {
+    const sourceTable = await this.sourceDb.getTableByName(tableName)
+
+    if (!sourceTable) {
+      throw new Error(`Expected source table to exist: ${tableName}`)
+    }
+
+    if (!await this.targetDb.tableExists(tableName)) {
+      await this.createTargetTable({sourceTable, tableName})
+      return
+    }
+
+    const changedColumns = await this.ensureTargetColumns({sourceTable, tableName})
+
+    if (changedColumns) {
+      this.targetDb.clearSchemaCache()
+    }
+
+    await this.ensureTargetIndexes({sourceTable, tableName})
+  }
+
+  /**
+   * Creates the table in the target from the source table's columns and its
+   * non-primary-key indexes.
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
+   * @returns {Promise<void>}
+   */
+  async createTargetTable({sourceTable, tableName}) {
+    const tableData = new TableData(tableName)
+
+    for (const sourceColumn of await sourceTable.getColumns()) {
+      tableData.addColumn(sourceColumn.getName(), this.columnArgsFromSourceColumn(sourceColumn, {isNewColumn: false}))
+    }
+
+    for (const sourceIndex of await sourceTable.getIndexes()) {
+      if (!sourceIndex.isPrimaryKey()) {
+        tableData.addIndex(this.tableDataIndexFromSourceIndex(sourceIndex))
+      }
+    }
+
+    await this.targetDb.createTable(tableData)
+    this.targetDb.clearSchemaCache()
+  }
+
+  /**
+   * Adds columns present on the source but missing from the target, and widens
+   * too-narrow target text columns.
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
+   * @returns {Promise<boolean>} Whether any column was added or widened.
+   */
+  async ensureTargetColumns({sourceTable, tableName}) {
+    const sourceColumns = await sourceTable.getColumns()
+    const targetTable = await this.targetDb.getTableByNameOrFail(tableName)
+    const targetColumnsByName = new Map()
+    const missingColumns = []
+    const columnsNeedingWidening = []
+
+    for (const targetColumn of await targetTable.getColumns()) {
+      targetColumnsByName.set(targetColumn.getName(), targetColumn)
+    }
+
+    for (const sourceColumn of sourceColumns) {
+      const targetColumn = targetColumnsByName.get(sourceColumn.getName())
+
+      if (!targetColumn) {
+        missingColumns.push(sourceColumn)
+      } else if (this.columnNeedsWidening(sourceColumn, targetColumn)) {
+        columnsNeedingWidening.push(sourceColumn)
+      }
+    }
+
+    if (missingColumns.length <= 0 && columnsNeedingWidening.length <= 0) {
+      return false
+    }
+
+    const tableData = new TableData(tableName)
+
+    for (const sourceColumn of missingColumns) {
+      tableData.addColumn(sourceColumn.getName(), this.columnArgsFromSourceColumn(sourceColumn, {isNewColumn: true}))
+    }
+
+    for (const sourceColumn of columnsNeedingWidening) {
+      tableData.addColumn(sourceColumn.getName(), this.columnArgsFromSourceColumn(sourceColumn, {isNewColumn: false}))
+    }
+
+    for (const alterSql of await this.targetDb.alterTableSQLs(tableData)) {
+      await this.targetDb.query(alterSql)
+    }
+
+    return true
+  }
+
+  /**
+   * Creates non-primary-key indexes present on the source but missing from the target,
+   * and throws if an existing target index diverges from the source.
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
+   * @returns {Promise<void>}
+   */
+  async ensureTargetIndexes({sourceTable, tableName}) {
+    const targetTable = await this.targetDb.getTableByNameOrFail(tableName)
+    /** @type {Map<string, import("../drivers/base-columns-index.js").default>} */
+    const targetIndexesByName = new Map()
+    const targetIndexSignatures = new Set()
+    let createdIndex = false
+
+    for (const targetIndex of await targetTable.getIndexes()) {
+      targetIndexesByName.set(targetIndex.getName(), targetIndex)
+      targetIndexSignatures.add(this.indexSignature(targetIndex))
+    }
+
+    for (const sourceIndex of await sourceTable.getIndexes()) {
+      if (sourceIndex.isPrimaryKey()) {
+        continue
+      }
+
+      const sourceIndexSignature = this.indexSignature(sourceIndex)
+
+      // SQLite index names are unique per-database, not per-table, so match cloned
+      // indexes by their column/uniqueness signature rather than their name.
+      if (this.targetDb.getType() === "sqlite" && targetIndexSignatures.has(sourceIndexSignature)) {
+        continue
+      }
+
+      const targetIndex = this.targetDb.getType() === "sqlite" ? undefined : targetIndexesByName.get(sourceIndex.getName())
+
+      if (!targetIndex) {
+        const createIndexSqls = await this.targetDb.createIndexSQLs(this.createIndexArgsFromSourceIndex({sourceIndex, tableName}))
+
+        for (const createIndexSql of createIndexSqls) {
+          await this.targetDb.query(createIndexSql)
+        }
+
+        createdIndex = true
+        targetIndexSignatures.add(sourceIndexSignature)
+        continue
+      }
+
+      if (!this.indexesMatch(sourceIndex, targetIndex)) {
+        throw new Error(`Schema clone index drift for ${tableName}.${sourceIndex.getName()}`)
+      }
+    }
+
+    if (createdIndex) {
+      this.targetDb.clearSchemaCache()
+    }
+  }
+
+  /**
+   * Baselines the target ledger so the cloned schema is recorded as already-applied.
+   * @returns {Promise<string[]>} The versions newly recorded on the target.
+   */
+  async reconcileLedger() {
+    return await MigrationsLedger.baselineFromDatabase({sourceDb: this.sourceDb, targetDb: this.targetDb})
+  }
+
+  /**
+   * Whether the target ledger is missing any version applied on the source — i.e. the
+   * target schema may have been advanced out of band without recording it.
+   * @returns {Promise<boolean>}
+   */
+  async ledgerDriftsFromSource() {
+    if (!await MigrationsLedger.tableExists(this.targetDb)) {
+      return true
+    }
+
+    const sourceVersions = await MigrationsLedger.appliedVersions(this.sourceDb)
+    const targetVersionSet = new Set(await MigrationsLedger.appliedVersions(this.targetDb))
+
+    return sourceVersions.some((version) => !targetVersionSet.has(version))
+  }
+
+  /**
+   * Maps a source index into a TableData index for table creation (SQLite omits the
+   * index name so the driver can generate a unique one).
+   * @param {import("../drivers/base-columns-index.js").default} sourceIndex
+   * @returns {TableIndex}
+   */
+  tableDataIndexFromSourceIndex(sourceIndex) {
+    if (this.targetDb.getType() === "sqlite") {
+      return new TableIndex(sourceIndex.getColumnNames(), {
+        unique: sourceIndex.isUnique()
+      })
+    }
+
+    return sourceIndex.getTableDataIndex()
+  }
+
+  /**
+   * Builds driver create-index args from a source index (the index name is omitted on
+   * SQLite, where index names are unique per-database rather than per-table).
+   * @param {{sourceIndex: import("../drivers/base-columns-index.js").default, tableName: string}} args
+   * @returns {{columns: string[], name?: string, tableName: string, unique: boolean}}
+   */
+  createIndexArgsFromSourceIndex({sourceIndex, tableName}) {
+    /** @type {{columns: string[], name?: string, tableName: string, unique: boolean}} */
+    const createIndexArgs = {
+      columns: sourceIndex.getColumnNames(),
+      tableName,
+      unique: sourceIndex.isUnique()
+    }
+
+    if (this.targetDb.getType() !== "sqlite") {
+      createIndexArgs.name = sourceIndex.getName()
+    }
+
+    return createIndexArgs
+  }
+
+  /**
+   * Whether two indexes have the same uniqueness and ordered column list.
+   * @param {import("../drivers/base-columns-index.js").default} sourceIndex
+   * @param {import("../drivers/base-columns-index.js").default} targetIndex
+   * @returns {boolean}
+   */
+  indexesMatch(sourceIndex, targetIndex) {
+    const sourceColumnNames = sourceIndex.getColumnNames()
+    const targetColumnNames = targetIndex.getColumnNames()
+
+    if (sourceIndex.isUnique() !== targetIndex.isUnique()) {
+      return false
+    }
+
+    if (sourceColumnNames.length !== targetColumnNames.length) {
+      return false
+    }
+
+    for (let columnIndex = 0; columnIndex < sourceColumnNames.length; columnIndex++) {
+      if (sourceColumnNames[columnIndex] !== targetColumnNames[columnIndex]) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * A stable signature for an index, used to match cloned indexes by shape.
+   * @param {import("../drivers/base-columns-index.js").default} index
+   * @returns {string}
+   */
+  indexSignature(index) {
+    return `${index.isUnique() ? "unique" : "index"}:${index.getColumnNames().join(",")}`
+  }
+
+  /**
+   * Normalizes a column type to its canonical lowercase form (`int` becomes `integer`).
+   * @param {string} columnType
+   * @returns {string}
+   */
+  normalizedColumnType(columnType) {
+    const normalizedType = columnType.toLowerCase()
+
+    if (normalizedType === "int") {
+      return "integer"
+    }
+
+    return normalizedType
+  }
+
+  /**
+   * The widening rank of a text column type (0 when not a text type).
+   * @param {string} columnType
+   * @returns {number}
+   */
+  textTypeRank(columnType) {
+    return TEXT_TYPE_RANKS[this.normalizedColumnType(columnType)] || 0
+  }
+
+  /**
+   * Whether the target's text column is narrower than the source's and must be widened.
+   * @param {import("../drivers/base-column.js").default} sourceColumn
+   * @param {import("../drivers/base-column.js").default} targetColumn
+   * @returns {boolean}
+   */
+  columnNeedsWidening(sourceColumn, targetColumn) {
+    const sourceRank = this.textTypeRank(sourceColumn.getType())
+    const targetRank = this.textTypeRank(targetColumn.getType())
+
+    return sourceRank > 0 && targetRank > 0 && sourceRank > targetRank
+  }
+
+  /**
+   * Builds TableData column args from a source column, copying type, nullability,
+   * length, notes, simple defaults and (for full clones) primary-key flag.
+   * @param {import("../drivers/base-column.js").default} sourceColumn
+   * @param {{isNewColumn: boolean}} args
+   * @returns {Record<string, unknown>}
+   */
+  columnArgsFromSourceColumn(sourceColumn, {isNewColumn}) {
+    /** @type {{default?: unknown, isNewColumn: boolean, maxLength?: number, notes?: string, null: boolean, primaryKey?: boolean, type: string}} */
+    const columnArgs = {
+      isNewColumn,
+      null: sourceColumn.getNull(),
+      type: this.normalizedColumnType(sourceColumn.getType())
+    }
+    const defaultValue = sourceColumn.getDefault()
+    const maxLength = sourceColumn.getMaxLength()
+    const notes = sourceColumn.getNotes()
+
+    if (!isNewColumn && sourceColumn.getPrimaryKey()) {
+      columnArgs.primaryKey = true
+    }
+
+    if (maxLength !== undefined) {
+      columnArgs.maxLength = maxLength
+    }
+
+    if (notes) {
+      columnArgs.notes = notes
+    }
+
+    if (defaultValue !== null && defaultValue !== undefined && SIMPLE_DEFAULT_PATTERN.test(String(defaultValue))) {
+      columnArgs.default = defaultValue
+    }
+
+    return columnArgs
+  }
+}


### PR DESCRIPTION
## Why

Second phase of moving the generic multi-tenant machinery into Velocious. Apps that provision a tenant database by cloning table structure from a template/global database need a reusable, policy-free cloner. This logic currently lives (app-specific) in TensorBuzz's `ProjectTenantSchemaService`; this PR extracts the generic half into the framework, on top of the `MigrationsLedger` baseline primitive (#820).

## What

New `src/database/tenants/schema-cloner.js` — `SchemaCloner`:

- `new SchemaCloner({sourceDb, targetDb}).syncTables(tableNames)` — for each table: create it from the source (columns + non-PK indexes) if missing, else add missing columns, widen too-narrow text columns, and create missing indexes (matching by signature on SQLite, by name elsewhere; an index whose definition diverges from the source throws). Then baselines the target's `schema_migrations` ledger to the source.
- `reconcileLedger()` / `ledgerDriftsFromSource()` — baseline the target ledger / detect when the target's schema was advanced out of band without recording it.

Policy-free: the caller chooses the table list and which databases are source/target.

## Tests & matrix coverage

`spec/database/tenants/schema-cloner-spec.js` (SQLite two-DB harness): clone-missing-table (columns + indexes + ledger baseline), add-columns-to-existing-target, idempotent re-sync, and drift detect+heal.

The cloner is orchestration over driver primitives that are already exercised against the full MariaDB/PostgreSQL/MS-SQL/SQLite matrix by the existing `spec/database/migration/*.browser-spec.js` tests (createTable, addColumn, addIndex, column/index introspection) and, for the ledger, by `migrations-ledger.browser-spec.js`. The cross-database clone itself can't run on the dummy app (it exposes a single database), so it's covered on SQLite's two-database test harness. If a dedicated matrix clone test is wanted, I can add a second dummy-app database identifier in a follow-up.

`eslint` + `tsc` clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
