### PR TITLE
Add generic tenant DataCopier + TenantTablePlan (V3)

### DIFF
--- a/spec/database/tenants/data-copier-spec.js
+++ b/spec/database/tenants/data-copier-spec.js
@@ -100,6 +100,48 @@ describe("DataCopier", () => {
     })
   })
 
+  it("removes target rows that no longer exist in the source on re-copy", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-a")
+
+      // A child that was copied before is later removed from the source snapshot.
+      await sourceDb.query("DELETE FROM gizmo_parts WHERE id = 'p2'")
+
+      await copier.copy("acct-a")
+
+      const gizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(gizmoParts.map((row) => row.id)).toEqual(["p1"])
+    })
+  })
+
+  it("throws when a parent-scoped entry appears before its parent in the plan", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      /** @type {import("../../../src/database/tenants/tenant-table-plan.js").TenantTablePlanEntry[]} */
+      const misorderedPlan = [
+        {parentColumn: "gizmo_id", parentTableName: "gizmos", tableName: "gizmo_parts"},
+        {keyColumn: "account_id", tableName: "gizmos"}
+      ]
+      const copier = new DataCopier({sourceDb, tablePlan: misorderedPlan, targetDb})
+
+      let caughtError = null
+
+      try {
+        await copier.copy("acct-a")
+      } catch (error) {
+        caughtError = error
+      }
+
+      expect(caughtError instanceof Error && caughtError.message.includes("has not been loaded")).toEqual(true)
+    })
+  })
+
   it("refreshes stale target rows with the current source values", async () => {
     await withDatabases(async ({sourceDb, targetDb}) => {
       await seedSource(sourceDb)

--- a/spec/database/tenants/data-copier-spec.js
+++ b/spec/database/tenants/data-copier-spec.js
@@ -1,0 +1,177 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../src/testing/test.js"
+import DataCopier from "../../../src/database/tenants/data-copier.js"
+import TableData from "../../../src/database/table-data/index.js"
+import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.js"
+
+/** @type {import("../../../src/database/tenants/tenant-table-plan.js").TenantTablePlanEntry[]} */
+const TABLE_PLAN = [
+  {tableName: "gizmos", keyColumn: "account_id"},
+  {parentColumn: "gizmo_id", parentTableName: "gizmos", tableName: "gizmo_parts"}
+]
+
+// The per-driver row CRUD the copier orchestrates (select/insert/delete, transactions and
+// withDisabledForeignKeys) is matrix-tested elsewhere; the dummy app exposes a single
+// database, so the cross-database copy itself is covered here against SQLite's two-database
+// harness (default = source, analytics = target).
+describe("DataCopier", () => {
+  /**
+   * @param {(args: {sourceDb: import("../../../src/database/drivers/base.js").default, targetDb: import("../../../src/database/drivers/base.js").default}) => Promise<void>} callback
+   * @returns {Promise<void>}
+   */
+  async function withDatabases(callback) {
+    const {cleanup, configuration} = await createTenantTestConfiguration("data-copier")
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const sourceDb = dbs.default
+        const targetDb = dbs.analytics
+
+        await createGizmoTables(sourceDb)
+        await createGizmoTables(targetDb)
+
+        await callback({sourceDb, targetDb})
+      })
+    } finally {
+      await cleanup()
+    }
+  }
+
+  /**
+   * @param {import("../../../src/database/drivers/base.js").default} db
+   * @returns {Promise<void>}
+   */
+  async function seedSource(db) {
+    await db.query(db.insertSql({
+      columns: ["id", "account_id", "name"],
+      tableName: "gizmos",
+      rows: [["g1", "acct-a", "Alpha"], ["g2", "acct-b", "Beta"]]
+    }))
+    await db.query(db.insertSql({
+      columns: ["id", "gizmo_id", "label"],
+      tableName: "gizmo_parts",
+      rows: [["p1", "g1", "A-part"], ["p2", "g1", "A-part-2"], ["p3", "g2", "B-part"]]
+    }))
+  }
+
+  it("copies only the keyed tenant's rows and the children that hang off them", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-a")
+
+      const gizmos = await targetDb.query("SELECT id FROM gizmos ORDER BY id")
+      const gizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(gizmos.map((row) => row.id)).toEqual(["g1"])
+      expect(gizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+    })
+  })
+
+  it("returns the loaded rows keyed by table name", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+      const rowsByTableName = await copier.copy("acct-a")
+
+      expect(rowsByTableName.get("gizmos")?.map((row) => row.id)).toEqual(["g1"])
+      expect((rowsByTableName.get("gizmo_parts") || []).map((row) => row.id).sort()).toEqual(["p1", "p2"])
+    })
+  })
+
+  it("is idempotent — re-copying replaces the target rows instead of duplicating them", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-a")
+      await copier.copy("acct-a")
+
+      const gizmos = await targetDb.query("SELECT id FROM gizmos ORDER BY id")
+      const gizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(gizmos.map((row) => row.id)).toEqual(["g1"])
+      expect(gizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+    })
+  })
+
+  it("refreshes stale target rows with the current source values", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      // A stale copy of g1 already lives in the target with an outdated name.
+      await targetDb.query(targetDb.insertSql({
+        columns: ["id", "account_id", "name"],
+        tableName: "gizmos",
+        rows: [["g1", "acct-a", "Outdated"]]
+      }))
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-a")
+
+      const gizmos = await targetDb.query("SELECT name FROM gizmos WHERE id = 'g1'")
+
+      expect(gizmos.map((row) => row.name)).toEqual(["Alpha"])
+    })
+  })
+
+  it("copies nothing for a tenant key with no rows", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-unknown")
+
+      const gizmos = await targetDb.query("SELECT id FROM gizmos")
+      const gizmoParts = await targetDb.query("SELECT id FROM gizmo_parts")
+
+      expect(gizmos).toEqual([])
+      expect(gizmoParts).toEqual([])
+    })
+  })
+
+  it("reports progress for the tables it touches", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      /** @type {string[]} */
+      const progress = []
+      const copier = new DataCopier({onProgress: (message) => progress.push(message), sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-a")
+
+      expect(progress.some((message) => message.includes("gizmos: loaded 1 row(s)"))).toEqual(true)
+      expect(progress.some((message) => message.includes("gizmo_parts: inserting 2 row(s)"))).toEqual(true)
+    })
+  })
+})
+
+/**
+ * @param {import("../../../src/database/drivers/base.js").default} db
+ * @returns {Promise<void>}
+ */
+async function createGizmoTables(db) {
+  const gizmos = new TableData("gizmos")
+
+  gizmos.string("id", {maxLength: 64, null: false, primaryKey: true})
+  gizmos.string("account_id", {maxLength: 64, null: false})
+  gizmos.string("name", {maxLength: 255, null: true})
+
+  await db.createTable(gizmos)
+
+  const gizmoParts = new TableData("gizmo_parts")
+
+  gizmoParts.string("id", {maxLength: 64, null: false, primaryKey: true})
+  gizmoParts.string("gizmo_id", {maxLength: 64, null: false})
+  gizmoParts.string("label", {maxLength: 255, null: true})
+
+  await db.createTable(gizmoParts)
+  db.clearSchemaCache()
+}

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -36,11 +36,13 @@ function uniqueStrings(values) {
  * apps that keep each tenant's data in its own database use it to (re)materialise the
  * tenant's rows from a global/template database.
  *
- * The copy is delete-then-reinsert and therefore idempotent: for every table touched by
- * the plan the matching target rows are deleted (children first) and the freshly loaded
- * source rows inserted (parents first), all inside one target transaction with foreign-key
- * enforcement disabled so the ordering never trips a constraint. Reads, deletes and inserts
- * are chunked to bound statement size.
+ * The copy is delete-then-reinsert and therefore idempotent, and it mirrors the source
+ * snapshot: the rows to delete are the tenant's *current* rows in the target (selected with
+ * the same plan traversal run against the target), so a row that was removed from the source
+ * since the last copy is dropped from the target too rather than lingering. The deletes run
+ * children first and the source inserts parents first, all inside one target transaction with
+ * foreign-key enforcement disabled so the ordering never trips a constraint. Reads, deletes
+ * and inserts are chunked to bound statement size.
  *
  * The copier is policy-free: the caller supplies the plan, the source/target databases and
  * the tenant key, and {@link DataCopier#copy} returns the loaded rows keyed by table name so
@@ -72,31 +74,35 @@ export default class DataCopier {
 
   /**
    * Copies every plan table's rows for `keyValue` from the source into the target and
-   * returns the loaded rows keyed by table name. Deletes (children first) and inserts
-   * (parents first) run in a single target transaction with foreign keys disabled.
+   * returns the copied source rows keyed by table name. The target's current tenant rows
+   * are deleted (children first) and the source rows inserted (parents first) in a single
+   * target transaction with foreign keys disabled.
    * @param {string} keyValue
    * @returns {Promise<Map<string, Record<string, unknown>[]>>}
    */
   async copy(keyValue) {
-    const rowsByTableName = await this.loadRows(keyValue)
+    const sourceRowsByTableName = await this.loadRows(this.sourceDb, keyValue)
+    const targetRowsByTableName = await this.loadRows(this.targetDb, keyValue)
 
     await this.targetDb.withDisabledForeignKeys(async () => {
       await this.targetDb.transaction(async () => {
-        await this.deleteTargetRows(rowsByTableName)
-        await this.insertTargetRows(rowsByTableName)
+        await this.deleteTargetRows(targetRowsByTableName)
+        await this.insertTargetRows(sourceRowsByTableName)
       })
     })
 
-    return rowsByTableName
+    return sourceRowsByTableName
   }
 
   /**
-   * Loads the source rows for `keyValue` for every table in the plan, resolving
-   * parent-scoped tables from the ids already selected for their parent table.
+   * Loads the rows for `keyValue` for every table in the plan from `db`, resolving
+   * parent-scoped tables from the ids already selected for their parent table. Used for
+   * both the source rows to copy and the target's current tenant rows to delete.
+   * @param {import("../drivers/base.js").default} db
    * @param {string} keyValue
    * @returns {Promise<Map<string, Record<string, unknown>[]>>}
    */
-  async loadRows(keyValue) {
+  async loadRows(db, keyValue) {
     /** @type {Map<string, string[]>} */
     const idsByTableName = new Map()
     /** @type {Map<string, Record<string, unknown>[]>} */
@@ -108,6 +114,7 @@ export default class DataCopier {
       if (tableConfig.keyColumn) {
         rows = await this.queryRowsByColumn({
           columnName: tableConfig.keyColumn,
+          db,
           tableName: tableConfig.tableName,
           values: [keyValue]
         })
@@ -116,12 +123,15 @@ export default class DataCopier {
           throw new Error(`Expected keyColumn or parentTableName+parentColumn for table ${tableConfig.tableName} in the tenant table plan.`)
         }
 
-        const parentIds = idsByTableName.get(tableConfig.parentTableName) || []
+        if (!idsByTableName.has(tableConfig.parentTableName)) {
+          throw new Error(`Tenant table plan entry ${tableConfig.tableName} references parent table ${tableConfig.parentTableName}, which has not been loaded; parent tables must appear before their children in the plan.`)
+        }
 
         rows = await this.queryRowsByColumn({
           columnName: tableConfig.parentColumn,
+          db,
           tableName: tableConfig.tableName,
-          values: parentIds
+          values: idsByTableName.get(tableConfig.parentTableName) || []
         })
       }
 
@@ -137,11 +147,11 @@ export default class DataCopier {
   }
 
   /**
-   * Selects all source rows of `tableName` whose `columnName` is in `values`, chunked.
-   * @param {{columnName: string, tableName: string, values: string[]}} args
+   * Selects all rows of `tableName` in `db` whose `columnName` is in `values`, chunked.
+   * @param {{columnName: string, db: import("../drivers/base.js").default, tableName: string, values: string[]}} args
    * @returns {Promise<Record<string, unknown>[]>}
    */
-  async queryRowsByColumn({columnName, tableName, values}) {
+  async queryRowsByColumn({columnName, db, tableName, values}) {
     const normalizedValues = uniqueStrings(values)
 
     if (normalizedValues.length <= 0) {
@@ -149,13 +159,13 @@ export default class DataCopier {
     }
 
     const rows = []
-    const quotedTable = this.sourceDb.quoteTable(tableName)
-    const quotedColumn = this.sourceDb.quoteColumn(columnName)
+    const quotedTable = db.quoteTable(tableName)
+    const quotedColumn = db.quoteColumn(columnName)
 
     for (const valuesChunk of chunks(normalizedValues, this.queryChunkSize)) {
-      const sql = `SELECT ${quotedTable}.* FROM ${quotedTable} WHERE ${quotedColumn} IN (${this.quotedValuesSql(this.sourceDb, valuesChunk)})`
+      const sql = `SELECT ${quotedTable}.* FROM ${quotedTable} WHERE ${quotedColumn} IN (${this.quotedValuesSql(db, valuesChunk)})`
 
-      rows.push(...await this.executeQuietQuery(this.sourceDb, sql))
+      rows.push(...await this.executeQuietQuery(db, sql))
     }
 
     return rows

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -1,0 +1,259 @@
+// @ts-check
+
+const DEFAULT_INSERT_CHUNK_SIZE = 100
+const DEFAULT_QUERY_CHUNK_SIZE = 500
+
+/**
+ * Splits an array into chunks of at most `chunkSize` items.
+ * @template T
+ * @param {T[]} values
+ * @param {number} chunkSize
+ * @returns {T[][]}
+ */
+function chunks(values, chunkSize) {
+  const chunkedValues = []
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunkedValues.push(values.slice(index, index + chunkSize))
+  }
+
+  return chunkedValues
+}
+
+/**
+ * Stringifies values and returns the distinct, non-blank ones, preserving first-seen order.
+ * @param {unknown[]} values
+ * @returns {string[]}
+ */
+function uniqueStrings(values) {
+  return Array.from(new Set(values.map((value) => String(value)).filter((value) => value.trim())))
+}
+
+/**
+ * Copies a single tenant's rows from a source database into a target database, following a
+ * table plan that partitions each table either by a direct tenant key column or by
+ * parent-id traversal. This is the row-level counterpart to schema cloning: multi-tenant
+ * apps that keep each tenant's data in its own database use it to (re)materialise the
+ * tenant's rows from a global/template database.
+ *
+ * The copy is delete-then-reinsert and therefore idempotent: for every table touched by
+ * the plan the matching target rows are deleted (children first) and the freshly loaded
+ * source rows inserted (parents first), all inside one target transaction with foreign-key
+ * enforcement disabled so the ordering never trips a constraint. Reads, deletes and inserts
+ * are chunked to bound statement size.
+ *
+ * The copier is policy-free: the caller supplies the plan, the source/target databases and
+ * the tenant key, and {@link DataCopier#copy} returns the loaded rows keyed by table name so
+ * the caller can perform any app-specific post-copy work (for example registering record
+ * locations) without that policy leaking into the framework.
+ */
+export default class DataCopier {
+  /**
+   * Creates a copier that moves tenant-owned rows from `sourceDb` into `targetDb`.
+   * @param {{
+   *   sourceDb: import("../drivers/base.js").default,
+   *   targetDb: import("../drivers/base.js").default,
+   *   tablePlan: import("./tenant-table-plan.js").TenantTablePlanEntry[],
+   *   idColumn?: string,
+   *   insertChunkSize?: number,
+   *   queryChunkSize?: number,
+   *   onProgress?: (message: string) => void
+   * }} args
+   */
+  constructor({sourceDb, targetDb, tablePlan, idColumn = "id", insertChunkSize = DEFAULT_INSERT_CHUNK_SIZE, queryChunkSize = DEFAULT_QUERY_CHUNK_SIZE, onProgress}) {
+    this.sourceDb = sourceDb
+    this.targetDb = targetDb
+    this.tablePlan = tablePlan
+    this.idColumn = idColumn
+    this.insertChunkSize = insertChunkSize
+    this.queryChunkSize = queryChunkSize
+    this.onProgress = onProgress
+  }
+
+  /**
+   * Copies every plan table's rows for `keyValue` from the source into the target and
+   * returns the loaded rows keyed by table name. Deletes (children first) and inserts
+   * (parents first) run in a single target transaction with foreign keys disabled.
+   * @param {string} keyValue
+   * @returns {Promise<Map<string, Record<string, unknown>[]>>}
+   */
+  async copy(keyValue) {
+    const rowsByTableName = await this.loadRows(keyValue)
+
+    await this.targetDb.withDisabledForeignKeys(async () => {
+      await this.targetDb.transaction(async () => {
+        await this.deleteTargetRows(rowsByTableName)
+        await this.insertTargetRows(rowsByTableName)
+      })
+    })
+
+    return rowsByTableName
+  }
+
+  /**
+   * Loads the source rows for `keyValue` for every table in the plan, resolving
+   * parent-scoped tables from the ids already selected for their parent table.
+   * @param {string} keyValue
+   * @returns {Promise<Map<string, Record<string, unknown>[]>>}
+   */
+  async loadRows(keyValue) {
+    /** @type {Map<string, string[]>} */
+    const idsByTableName = new Map()
+    /** @type {Map<string, Record<string, unknown>[]>} */
+    const rowsByTableName = new Map()
+
+    for (const tableConfig of this.tablePlan) {
+      let rows
+
+      if (tableConfig.keyColumn) {
+        rows = await this.queryRowsByColumn({
+          columnName: tableConfig.keyColumn,
+          tableName: tableConfig.tableName,
+          values: [keyValue]
+        })
+      } else {
+        if (!tableConfig.parentColumn || !tableConfig.parentTableName) {
+          throw new Error(`Expected keyColumn or parentTableName+parentColumn for table ${tableConfig.tableName} in the tenant table plan.`)
+        }
+
+        const parentIds = idsByTableName.get(tableConfig.parentTableName) || []
+
+        rows = await this.queryRowsByColumn({
+          columnName: tableConfig.parentColumn,
+          tableName: tableConfig.tableName,
+          values: parentIds
+        })
+      }
+
+      if (rows.length > 0) {
+        this.reportProgress(`${tableConfig.tableName}: loaded ${rows.length} row(s)`)
+      }
+
+      idsByTableName.set(tableConfig.tableName, uniqueStrings(rows.map((row) => row[this.idColumn])))
+      rowsByTableName.set(tableConfig.tableName, rows)
+    }
+
+    return rowsByTableName
+  }
+
+  /**
+   * Selects all source rows of `tableName` whose `columnName` is in `values`, chunked.
+   * @param {{columnName: string, tableName: string, values: string[]}} args
+   * @returns {Promise<Record<string, unknown>[]>}
+   */
+  async queryRowsByColumn({columnName, tableName, values}) {
+    const normalizedValues = uniqueStrings(values)
+
+    if (normalizedValues.length <= 0) {
+      return []
+    }
+
+    const rows = []
+    const quotedTable = this.sourceDb.quoteTable(tableName)
+    const quotedColumn = this.sourceDb.quoteColumn(columnName)
+
+    for (const valuesChunk of chunks(normalizedValues, this.queryChunkSize)) {
+      const sql = `SELECT ${quotedTable}.* FROM ${quotedTable} WHERE ${quotedColumn} IN (${this.quotedValuesSql(this.sourceDb, valuesChunk)})`
+
+      rows.push(...await this.executeQuietQuery(this.sourceDb, sql))
+    }
+
+    return rows
+  }
+
+  /**
+   * Deletes the matching target rows for every plan table, children before parents, so the
+   * reinsert that follows starts from a clean slate without violating foreign keys.
+   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName
+   * @returns {Promise<void>}
+   */
+  async deleteTargetRows(rowsByTableName) {
+    for (const tableConfig of [...this.tablePlan].reverse()) {
+      const rowIds = uniqueStrings((rowsByTableName.get(tableConfig.tableName) || []).map((row) => row[this.idColumn]))
+
+      if (rowIds.length <= 0) {
+        continue
+      }
+
+      const quotedTable = this.targetDb.quoteTable(tableConfig.tableName)
+      const quotedIdColumn = this.targetDb.quoteColumn(this.idColumn)
+
+      for (const rowIdsChunk of chunks(rowIds, this.queryChunkSize)) {
+        await this.executeQuietQuery(
+          this.targetDb,
+          `DELETE FROM ${quotedTable} WHERE ${quotedIdColumn} IN (${this.quotedValuesSql(this.targetDb, rowIdsChunk)})`
+        )
+      }
+    }
+  }
+
+  /**
+   * Inserts the loaded source rows into the target for every plan table, parents before
+   * children, chunked to bound statement size.
+   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName
+   * @returns {Promise<void>}
+   */
+  async insertTargetRows(rowsByTableName) {
+    for (const tableConfig of this.tablePlan) {
+      const rows = rowsByTableName.get(tableConfig.tableName) || []
+
+      if (rows.length <= 0) {
+        continue
+      }
+
+      const columns = Object.keys(rows[0])
+      const insertChunks = chunks(rows, this.insertChunkSize)
+
+      this.reportProgress(`${tableConfig.tableName}: inserting ${rows.length} row(s) in ${insertChunks.length} chunk(s)`)
+
+      for (const rowsChunk of insertChunks) {
+        await this.insertRowsQuietly({
+          columns,
+          db: this.targetDb,
+          rows: rowsChunk.map((row) => columns.map((column) => row[column])),
+          tableName: tableConfig.tableName
+        })
+      }
+    }
+  }
+
+  /**
+   * Quotes and comma-joins values for an SQL `IN (...)` list against the given database.
+   * @param {import("../drivers/base.js").default} db
+   * @param {string[]} values
+   * @returns {string}
+   */
+  quotedValuesSql(db, values) {
+    return values.map((value) => db.quote(value)).join(", ")
+  }
+
+  /**
+   * Runs a query without per-query logging, used for the high-volume copy statements.
+   * @param {import("../drivers/base.js").default} db
+   * @param {string} sql
+   * @returns {Promise<Record<string, unknown>[]>}
+   */
+  async executeQuietQuery(db, sql) {
+    return await db.query(sql, {logQuery: false})
+  }
+
+  /**
+   * Inserts column-aligned row tuples into a table without per-query logging.
+   * @param {{columns: string[], db: import("../drivers/base.js").default, rows: Array<Array<unknown>>, tableName: string}} args
+   * @returns {Promise<void>}
+   */
+  async insertRowsQuietly({columns, db, rows, tableName}) {
+    await this.executeQuietQuery(db, db.insertSql({columns, tableName, rows}))
+  }
+
+  /**
+   * Forwards a progress message to the optional `onProgress` callback when one was given.
+   * @param {string} message
+   * @returns {void}
+   */
+  reportProgress(message) {
+    if (this.onProgress) {
+      this.onProgress(message)
+    }
+  }
+}

--- a/src/database/tenants/tenant-table-plan.js
+++ b/src/database/tenants/tenant-table-plan.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+/**
+ * Describes how one table's rows are partitioned between tenants so a DataCopier can select
+ * the subset that belongs to a given tenant key.
+ *
+ * A row belongs to the tenant when its `keyColumn` equals the tenant key value, or — for
+ * tables that have no direct tenant column — when its `parentColumn` references a row of
+ * `parentTableName` that was itself already selected as belonging to the tenant. Exactly
+ * one of `keyColumn` or the (`parentTableName` + `parentColumn`) pair must be set; a
+ * parent-scoped entry must appear after its parent in the plan so the parent ids are known
+ * by the time the child is loaded.
+ * @typedef {object} TenantTablePlanEntry
+ * @property {string} tableName Name of the table whose rows are partitioned by tenant.
+ * @property {string} [keyColumn] Column matched directly against the tenant key value.
+ * @property {string} [parentTableName] Earlier-in-plan table whose selected rows scope this one.
+ * @property {string} [parentColumn] Column on this table referencing the parent table's primary key.
+ */
+
+export {}


### PR DESCRIPTION
## What

Adds a generic, policy-free **row-copy** mechanism for multi-tenant apps that keep each tenant's data in its own database, alongside the existing `SchemaCloner` (which clones table structure and baselines the `schema_migrations` ledger). Together they let an app provision a tenant database from a global/template database. This is the framework home for logic apps were hand-rolling.

## New

- **`src/database/tenants/tenant-table-plan.js`** — the `TenantTablePlanEntry` typedef. Each table is partitioned either by `keyColumn` (matched directly against the tenant key value) or by `parentTableName` + `parentColumn` (scoped to the parent table's already-selected rows). A parent-scoped entry must appear after its parent in the plan.
- **`src/database/tenants/data-copier.js`** — `DataCopier({sourceDb, targetDb, tablePlan, idColumn?, insertChunkSize?, queryChunkSize?, onProgress?})`:
  - `copy(keyValue)` loads each plan table's rows for the tenant (direct key or parent-id traversal), then **deletes children-first and reinserts parents-first** into the target inside a single transaction with **foreign keys disabled**, all **chunked** to bound statement size.
  - Returns the loaded rows keyed by table name so the caller can perform app-specific post-copy work (e.g. registering record locations) **without that policy leaking into the framework** — preferred over an injected per-table hook because the typical post-copy step is a single cross-table operation.
  - Optional `onProgress(message)` reports per-table load/insert counts.

## Tests

The cross-database copy is unit-tested against SQLite's two-database harness (the dummy app exposes a single database, so — as with `SchemaCloner` — the per-driver row CRUD it orchestrates is covered by the existing matrix specs). `spec/database/tenants/data-copier-spec.js` (6 tests): copies only the keyed tenant's rows + the children hanging off them; returns the loaded rows; is idempotent (re-copy replaces, refreshes stale target rows); copies nothing for an unknown key; reports progress. `eslint` 0 errors, `tsc --noEmit` clean.

## Plan context

Part of extracting TensorBuzz's bespoke multi-tenant machinery into Velocious so any app can declare "a tenant is a Project / Account / whatever". V1 added `MigrationsLedger` (1.0.481), V2 added `SchemaCloner` (1.0.482). This V3 adds the data copier; V4 will add the runtime `Tenant` façade + `db:tenants:drop`. TensorBuzz's `ProjectTenantDataMigratorService` will then delegate its row-copy to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)