### PR TITLE
Add apartment-style Tenant facade + db:tenants:drop (V4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2242,4 +2242,6 @@ npx velocious db:tenants:migrate projectTenant --parallel 20
 
 `afterMigrateTenant` hooks run inside the active default and tenant database connection scope for the tenant being migrated.
 
+At runtime, the apartment-style `Tenant` façade (`velocious/build/src/tenants/tenant.js`) is the single entry point: `Tenant.with(tenant, callback)` / `Tenant.current()` to switch into and read a tenant context, `Tenant.each({identifier, callback, parallel?, filter?})` to run a callback within every provider-listed tenant, and `Tenant.drop({identifier, tenant})` (plus the `db:tenants:drop` CLI command) to drop a tenant's database through the provider's `dropDatabase` hook.
+
 See [docs/tenant-databases.md](docs/tenant-databases.md) for the full configuration and migration pattern.

--- a/changelog.d/20260628190000-tenant-facade-and-drop.md
+++ b/changelog.d/20260628190000-tenant-facade-and-drop.md
@@ -1,0 +1,5 @@
+## Added
+
+- Added the apartment-style `Tenant` runtime façade (`src/tenants/tenant.js`): `Tenant.with(tenant, callback)` / `Tenant.current()` for switching into and reading a tenant context, `Tenant.each({identifier, callback, parallel?, filter?})` for running a callback within every provider-listed tenant, and `Tenant.drop({identifier, tenant})` for dropping one tenant's database through the provider's `dropDatabase` hook (with an active-database guard so an unresolved tenant can never drop the base/template database).
+- Added the `db:tenants:drop` CLI command, wiring the previously-unused `dropDatabase` tenant database provider hook.
+- Extracted the shared `TenantIterator` so the `db:tenants:*` commands and the `Tenant` façade run per-tenant work through one implementation.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -83,7 +83,10 @@ Run tenant lifecycle commands by database identifier:
 npx velocious db:tenants:create projectTenant
 npx velocious db:tenants:check projectTenant
 npx velocious db:tenants:migrate projectTenant
+npx velocious db:tenants:drop projectTenant
 ```
+
+`db:tenants:drop` drops every listed tenant's database through the provider's `dropDatabase` hook (define it alongside `createDatabase`). Like the other lifecycle commands it honors `--parallel`.
 
 Tenant lifecycle commands run one tenant at a time by default. Add `--parallel` to process up to 20 tenants at once, or pass a positive integer to choose a different concurrency:
 
@@ -113,6 +116,36 @@ export default CreateBuilds
 ```
 
 Normal `db:migrate` continues to migrate non-tenant databases only. Use `db:tenants:migrate <identifier>` when you want to run migrations for every tenant returned by the provider.
+
+## Runtime tenant façade
+
+At runtime, the apartment-style `Tenant` façade is the single entry point for working with tenants. It composes the existing primitives (`Current.withTenant`/`runWithTenant`, the tenant database provider, and the connection pools), so it does not introduce any separate tenant bookkeeping:
+
+```js
+import Tenant from "velocious/build/src/tenants/tenant.js"
+
+// Switch into a tenant's context (a "tenant" is whatever descriptor your
+// tenantDatabaseResolver understands) and read the current one back.
+await Tenant.with({slug: "alpha"}, async () => {
+  Tenant.current() // => {slug: "alpha"}
+})
+
+// Run a callback within every tenant the provider lists, optionally filtered
+// and a few at a time. Returns how many tenants the callback ran for.
+await Tenant.each({
+  identifier: "projectTenant",
+  parallel: 8,
+  filter: (tenant) => tenant.migrated,
+  callback: async ({tenant}) => { /* runs inside this tenant's context */ }
+})
+
+// Drop one tenant's database through the provider's dropDatabase hook.
+await Tenant.drop({identifier: "projectTenant", tenant: {slug: "alpha"}})
+```
+
+`Tenant.with` / `Tenant.current` delegate to `Current` (which owns the async-context tenant state); `Tenant.each` is the runtime counterpart of the `db:tenants:*` per-tenant iteration and shares its engine; `Tenant.drop` refuses to run for a tenant that does not resolve to an active tenant database, so an unresolved descriptor can never drop the base/template database. `each` and `drop` default to the current configuration but accept an explicit `configuration` for non-global use.
+
+Provisioning a tenant database from the default/template database is mechanism the framework also provides: `SchemaCloner` clones table structure and baselines the `schema_migrations` ledger, and `DataCopier` copies a tenant's owned rows following a `TenantTablePlan`. Call these from your provider's `createDatabase`/migration hooks to materialize a new tenant.
 
 Because `listTenants` runs every time, tenant databases are dynamic:
 

--- a/spec/cli/commands/db/tenants/drop-spec.js
+++ b/spec/cli/commands/db/tenants/drop-spec.js
@@ -1,0 +1,150 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../src/testing/test.js"
+import AsyncTrackedMultiConnection from "../../../../../src/database/pool/async-tracked-multi-connection.js"
+import Cli from "../../../../../src/cli/index.js"
+import Configuration from "../../../../../src/configuration.js"
+import EnvironmentHandlerNode from "../../../../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import SqliteDriver from "../../../../../src/database/drivers/sqlite/index.js"
+
+describe("Cli - Commands - db:tenants:drop", () => {
+  it("drops every listed tenant through the provider's dropDatabase hook", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-drop-"))
+    /** @type {Array<{name: string, slug: string}>} */
+    const droppedTenants = []
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-drop-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-drop-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          dropDatabase: async ({databaseConfiguration, tenant}) => {
+            const tenantObject = /** @type {{slug: string}} */ (tenant)
+
+            droppedTenants.push({name: databaseConfiguration.name, slug: tenantObject.slug})
+          },
+          listTenants: async () => [{slug: "alpha"}, {slug: "beta"}]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-drop-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:tenants:drop", "projectTenant"],
+      testing: true
+    })
+
+    try {
+      const result = await cli.execute()
+
+      expect(result).toEqual({identifier: "projectTenant", tenantCount: 2})
+      expect(droppedTenants.sort((first, second) => first.slug.localeCompare(second.slug))).toEqual([
+        {name: "velocious-cli-tenants-drop-project-alpha", slug: "alpha"},
+        {name: "velocious-cli-tenants-drop-project-beta", slug: "beta"}
+      ])
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("throws when the provider does not define dropDatabase", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-drop-missing-"))
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenants-drop-missing-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenants-drop-missing-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          listTenants: async () => [{slug: "alpha"}]
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenants-drop-missing-project-${tenantObject.slug}`}
+      }
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:tenants:drop", "projectTenant"],
+      testing: true
+    })
+
+    try {
+      let caughtError = null
+
+      try {
+        await cli.execute()
+      } catch (error) {
+        caughtError = error
+      }
+
+      expect(caughtError instanceof Error && caughtError.message.includes("must define dropDatabase")).toEqual(true)
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+})

--- a/spec/tenants/tenant-spec.js
+++ b/spec/tenants/tenant-spec.js
@@ -1,0 +1,115 @@
+// @ts-check
+
+import Current from "../../src/current.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import Tenant from "../../src/tenants/tenant.js"
+import {createTenantTestConfiguration} from "../helpers/tenant-test-helpers.js"
+
+describe("Tenant", () => {
+  /**
+   * @param {{listTenants: () => Promise<Array<?>> | Array<?>, dropDatabase?: (args: ?) => Promise<void> | void}} provider
+   * @param {(args: {configuration: import("../../src/configuration.js").default}) => Promise<void>} callback
+   * @returns {Promise<void>}
+   */
+  async function withConfiguration(provider, callback) {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-tenant-facade")
+    let previousConfiguration
+
+    configuration.setTenantDatabaseProviders({projectTenant: provider})
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+
+      await callback({configuration})
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  }
+
+  it("runs a callback within a tenant context and reads it back via current()", async () => {
+    await withConfiguration({listTenants: () => []}, async () => {
+      expect(Tenant.current()).toBeUndefined()
+
+      const insideTenant = await Tenant.with({slug: "alpha"}, async () => Tenant.current())
+
+      expect(insideTenant).toEqual({slug: "alpha"})
+      expect(Tenant.current()).toBeUndefined()
+    })
+  })
+
+  it("iterates every tenant the provider lists, running the callback in each tenant context", async () => {
+    await withConfiguration({listTenants: () => [{slug: "alpha"}, {slug: "beta"}]}, async ({configuration}) => {
+      /** @type {string[]} */
+      const seenSlugs = []
+      const tenantCount = await Tenant.each({
+        callback: async ({tenant}) => {
+          const currentTenant = /** @type {{slug: string}} */ (Current.tenant())
+
+          seenSlugs.push(currentTenant.slug)
+          expect(tenant).toEqual(currentTenant)
+        },
+        configuration,
+        identifier: "projectTenant"
+      })
+
+      expect(tenantCount).toEqual(2)
+      expect(seenSlugs.sort()).toEqual(["alpha", "beta"])
+    })
+  })
+
+  it("only iterates the tenants that pass the filter", async () => {
+    await withConfiguration({listTenants: () => [{migrated: true, slug: "alpha"}, {migrated: false, slug: "beta"}]}, async ({configuration}) => {
+      /** @type {string[]} */
+      const seenSlugs = []
+      const tenantCount = await Tenant.each({
+        callback: async ({tenant}) => {
+          seenSlugs.push(/** @type {{slug: string}} */ (tenant).slug)
+        },
+        configuration,
+        filter: (tenant) => Boolean(/** @type {{migrated: boolean}} */ (tenant).migrated),
+        identifier: "projectTenant"
+      })
+
+      expect(tenantCount).toEqual(1)
+      expect(seenSlugs).toEqual(["alpha"])
+    })
+  })
+
+  it("drops a tenant through the provider's dropDatabase hook", async () => {
+    /** @type {Array<{name: string, slug: string}>} */
+    const dropped = []
+    const provider = {
+      dropDatabase: async (/** @type {{databaseConfiguration: {name: string}, tenant: {slug: string}}} */ {databaseConfiguration, tenant}) => {
+        dropped.push({name: databaseConfiguration.name, slug: tenant.slug})
+      },
+      listTenants: () => []
+    }
+
+    await withConfiguration(provider, async ({configuration}) => {
+      await Tenant.drop({configuration, identifier: "projectTenant", tenant: {slug: "alpha"}})
+
+      expect(dropped).toEqual([{name: "velocious-tenant-facade-projectTenant-alpha", slug: "alpha"}])
+    })
+  })
+
+  it("throws when dropping a tenant whose provider has no dropDatabase hook", async () => {
+    await withConfiguration({listTenants: () => []}, async ({configuration}) => {
+      let caughtError = null
+
+      try {
+        await Tenant.drop({configuration, identifier: "projectTenant", tenant: {slug: "alpha"}})
+      } catch (error) {
+        caughtError = error
+      }
+
+      expect(caughtError instanceof Error && caughtError.message.includes("must define dropDatabase")).toEqual(true)
+    })
+  })
+})

--- a/spec/tenants/tenant-spec.js
+++ b/spec/tenants/tenant-spec.js
@@ -99,6 +99,31 @@ describe("Tenant", () => {
     })
   })
 
+  it("refuses to drop an unresolved tenant instead of dropping the template database", async () => {
+    /** @type {string[]} */
+    const dropped = []
+    const provider = {
+      dropDatabase: async (/** @type {{databaseConfiguration: {name: string}}} */ {databaseConfiguration}) => {
+        dropped.push(databaseConfiguration.name)
+      },
+      listTenants: () => []
+    }
+
+    await withConfiguration(provider, async ({configuration}) => {
+      let caughtError = null
+
+      // A blank slug does not resolve to a tenant database for the tenantOnly identifier.
+      try {
+        await Tenant.drop({configuration, identifier: "projectTenant", tenant: {slug: ""}})
+      } catch (error) {
+        caughtError = error
+      }
+
+      expect(caughtError instanceof Error && caughtError.message.includes("is inactive for tenant")).toEqual(true)
+      expect(dropped).toEqual([])
+    })
+  })
+
   it("throws when dropping a tenant whose provider has no dropDatabase hook", async () => {
     await withConfiguration({listTenants: () => []}, async ({configuration}) => {
       let caughtError = null

--- a/src/cli/commands/db/tenants/drop.js
+++ b/src/cli/commands/db/tenants/drop.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import BaseCommand from "../../../base-command.js"
+import TenantDatabaseCommandHelper from "../../../tenant-database-command-helper.js"
+
+export default class DbTenantsDrop extends BaseCommand {
+  /**
+   * Drops the tenant database/schema for every listed tenant through the provider's
+   * `dropDatabase` hook.
+   * @returns {Promise<{identifier: string, tenantCount: number} | void>} - Result in test mode.
+   */
+  async execute() {
+    const helper = new TenantDatabaseCommandHelper({
+      command: this,
+      identifier: this.processArgs?.[1]
+    })
+    const provider = helper.provider
+
+    if (typeof provider.dropDatabase !== "function") {
+      throw new Error(`Tenant database provider for ${helper.identifier} must define dropDatabase to use db:tenants:drop`)
+    }
+
+    const tenantCount = await helper.eachTenant(async ({databaseConfiguration, tenant}) => {
+      await provider.dropDatabase?.({
+        configuration: this.getConfiguration(),
+        databaseConfiguration,
+        identifier: helper.identifier,
+        tenant
+      })
+    })
+
+    if (this.args.testing) return {identifier: helper.identifier, tenantCount}
+  }
+}

--- a/src/cli/tenant-database-command-helper.js
+++ b/src/cli/tenant-database-command-helper.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import TenantIterator from "../tenants/tenant-iterator.js"
+
 export default class TenantDatabaseCommandHelper {
   /**
    * Runs constructor.
@@ -76,55 +78,13 @@ export default class TenantDatabaseCommandHelper {
    */
   async eachTenant(callback) {
     const tenants = await this.listTenants()
-    const parallelCount = this.parallelCount()
+    const iterator = new TenantIterator({
+      configuration: this.configuration,
+      identifier: this.identifier,
+      parallelCount: this.parallelCount()
+    })
 
-    if (parallelCount <= 1) {
-      for (const tenant of tenants) {
-        await this.runTenantCallback({callback, tenant})
-      }
-
-      return tenants.length
-    }
-
-    /**
-     * Failures.
-     * @type {Array<{error: Error, tenant: ?}>} */
-    const failures = []
-    const workers = []
-    let tenantIndex = 0
-    const workerCount = Math.min(parallelCount, tenants.length)
-
-    for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
-      workers.push((async () => {
-        while (tenantIndex < tenants.length) {
-          const tenant = tenants[tenantIndex]
-
-          tenantIndex++
-
-          try {
-            await this.runTenantCallback({callback, tenant})
-          } catch (error) {
-            failures.push({
-              error: error instanceof Error ? error : new Error(String(error)),
-              tenant
-            })
-          }
-        }
-      })())
-    }
-
-    await Promise.all(workers)
-
-    if (failures.length > 0) {
-      const failedTenantLabels = failures.map((failure) => this.tenantLabel(failure.tenant)).join(", ")
-
-      throw new AggregateError(
-        failures.map((failure) => failure.error),
-        `Failed tenant database command for tenant(s): ${failedTenantLabels}`
-      )
-    }
-
-    return tenants.length
+    return await iterator.run(tenants, callback)
   }
 
   /**
@@ -155,42 +115,5 @@ export default class TenantDatabaseCommandHelper {
     }
 
     return parallelCount
-  }
-
-  /**
-   * Runs run tenant callback.
-   * @param {object} args - Tenant callback args.
-   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>} args.callback - Callback.
-   * @param {?} args.tenant - Tenant.
-   * @returns {Promise<void>}
-   */
-  async runTenantCallback({callback, tenant}) {
-    await this.configuration.runWithTenant(tenant, async () => {
-      if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
-        throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${this.tenantLabel(tenant)}`)
-      }
-
-      await callback({
-        databaseConfiguration: this.configuration.resolveDatabaseConfiguration(this.identifier),
-        tenant
-      })
-    })
-  }
-
-  /**
-   * Runs tenant label.
-   * @param {?} tenant - Tenant.
-   * @returns {string} - Human readable tenant label.
-   */
-  tenantLabel(tenant) {
-    if (tenant && typeof tenant === "object") {
-      const tenantObject = /** @type {{id?: ?, name?: ?, slug?: ?}} */ (tenant)
-
-      if (tenantObject.slug) return String(tenantObject.slug)
-      if (tenantObject.name) return String(tenantObject.name)
-      if (tenantObject.id) return String(tenantObject.id)
-    }
-
-    return JSON.stringify(tenant)
   }
 }

--- a/src/tenants/tenant-iterator.js
+++ b/src/tenants/tenant-iterator.js
@@ -63,7 +63,7 @@ export default class TenantIterator {
     await Promise.all(workers)
 
     if (failures.length > 0) {
-      const failedTenantLabels = failures.map((failure) => this.tenantLabel(failure.tenant)).join(", ")
+      const failedTenantLabels = failures.map((failure) => TenantIterator.tenantLabel(failure.tenant)).join(", ")
 
       throw new AggregateError(
         failures.map((failure) => failure.error),
@@ -82,7 +82,7 @@ export default class TenantIterator {
   async runTenantCallback({callback, tenant}) {
     await this.configuration.runWithTenant(tenant, async () => {
       if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
-        throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${this.tenantLabel(tenant)}`)
+        throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${TenantIterator.tenantLabel(tenant)}`)
       }
 
       await callback({
@@ -97,7 +97,7 @@ export default class TenantIterator {
    * @param {?} tenant
    * @returns {string}
    */
-  tenantLabel(tenant) {
+  static tenantLabel(tenant) {
     if (tenant && typeof tenant === "object") {
       const tenantObject = /** @type {{id?: ?, name?: ?, slug?: ?}} */ (tenant)
 

--- a/src/tenants/tenant-iterator.js
+++ b/src/tenants/tenant-iterator.js
@@ -1,0 +1,111 @@
+// @ts-check
+
+/**
+ * Runs a callback once within each tenant's context for a tenant database identifier,
+ * optionally several tenants at a time. Each tenant is entered with `runWithTenant`, and a
+ * tenant whose database identifier is inactive throws rather than running the callback
+ * against the wrong connection. When iterating in parallel the per-tenant failures are
+ * collected and rethrown together as an `AggregateError` so one bad tenant does not hide the
+ * others. This is the iteration engine shared by the `db:tenants:*` CLI commands and the
+ * runtime {@link Tenant} façade; the caller is responsible for producing the tenant list.
+ */
+export default class TenantIterator {
+  /**
+   * Creates an iterator bound to a configuration and tenant database identifier.
+   * @param {{configuration: import("../configuration.js").default, identifier: string, parallelCount?: number}} args
+   */
+  constructor({configuration, identifier, parallelCount = 1}) {
+    this.configuration = configuration
+    this.identifier = identifier
+    this.parallelCount = parallelCount
+  }
+
+  /**
+   * Runs `callback` within each tenant's context and returns how many tenants were processed.
+   * @param {Array<?>} tenants
+   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>} callback
+   * @returns {Promise<number>}
+   */
+  async run(tenants, callback) {
+    if (this.parallelCount <= 1) {
+      for (const tenant of tenants) {
+        await this.runTenantCallback({callback, tenant})
+      }
+
+      return tenants.length
+    }
+
+    /** @type {Array<{error: Error, tenant: ?}>} */
+    const failures = []
+    const workers = []
+    let tenantIndex = 0
+    const workerCount = Math.min(this.parallelCount, tenants.length)
+
+    for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+      workers.push((async () => {
+        while (tenantIndex < tenants.length) {
+          const tenant = tenants[tenantIndex]
+
+          tenantIndex++
+
+          try {
+            await this.runTenantCallback({callback, tenant})
+          } catch (error) {
+            failures.push({
+              error: error instanceof Error ? error : new Error(String(error)),
+              tenant
+            })
+          }
+        }
+      })())
+    }
+
+    await Promise.all(workers)
+
+    if (failures.length > 0) {
+      const failedTenantLabels = failures.map((failure) => this.tenantLabel(failure.tenant)).join(", ")
+
+      throw new AggregateError(
+        failures.map((failure) => failure.error),
+        `Failed tenant database command for tenant(s): ${failedTenantLabels}`
+      )
+    }
+
+    return tenants.length
+  }
+
+  /**
+   * Enters one tenant's context and runs the callback, asserting the database is active first.
+   * @param {{callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, tenant: ?}} args
+   * @returns {Promise<void>}
+   */
+  async runTenantCallback({callback, tenant}) {
+    await this.configuration.runWithTenant(tenant, async () => {
+      if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
+        throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${this.tenantLabel(tenant)}`)
+      }
+
+      await callback({
+        databaseConfiguration: this.configuration.resolveDatabaseConfiguration(this.identifier),
+        tenant
+      })
+    })
+  }
+
+  /**
+   * Builds a human-readable label for a tenant for use in error messages.
+   * @param {?} tenant
+   * @returns {string}
+   */
+  tenantLabel(tenant) {
+    if (tenant && typeof tenant === "object") {
+      const tenantObject = /** @type {{id?: ?, name?: ?, slug?: ?}} */ (tenant)
+
+      if (tenantObject.slug) return String(tenantObject.slug)
+      if (tenantObject.name) return String(tenantObject.name)
+      if (tenantObject.id) return String(tenantObject.id)
+    }
+
+    return JSON.stringify(tenant)
+  }
+}

--- a/src/tenants/tenant.js
+++ b/src/tenants/tenant.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+import Current from "../current.js"
+import TenantIterator from "./tenant-iterator.js"
+
+/**
+ * Apartment-style runtime façade for multi-tenant apps. A "tenant" is whatever descriptor
+ * object the app's `tenantDatabaseResolver` understands (an account, a project, …); this
+ * class is the single discoverable home for switching into a tenant's context, reading the
+ * current one, iterating every tenant of a database identifier, and dropping a tenant's
+ * database. Switching/reading delegate to {@link Current} (which owns the async-context
+ * tenant state), so they compose with the existing connection pools and request lifecycle;
+ * iteration and drop drive the app's tenant database provider hooks.
+ */
+export default class Tenant {
+  /**
+   * Runs `callback` with `tenant` as the current tenant, restoring the previous tenant after.
+   * @param {object} tenant Descriptor understood by the app's tenantDatabaseResolver.
+   * @param {() => Promise<?>} callback
+   * @returns {Promise<?>}
+   */
+  static async with(tenant, callback) {
+    return await Current.withTenant(tenant, callback)
+  }
+
+  /**
+   * The current tenant descriptor, or undefined when running outside any tenant context.
+   * @returns {Record<string, unknown> | undefined}
+   */
+  static current() {
+    return Current.tenant()
+  }
+
+  /**
+   * Lists the tenants for a database identifier through the provider and runs `callback`
+   * within each tenant's context, optionally filtered and several at a time. Returns how
+   * many tenants the callback ran for (after filtering).
+   * @param {{identifier: string, callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, parallel?: number, filter?: (tenant: ?) => boolean, configuration?: import("../configuration.js").default}} args
+   * @returns {Promise<number>}
+   */
+  static async each({identifier, callback, parallel = 1, filter, configuration = Current.configuration()}) {
+    const provider = configuration.getTenantDatabaseProvider(identifier)
+    const listedTenants = await configuration.ensureConnections({name: `Tenant.each: ${identifier}`}, async () => {
+      return await provider.listTenants({configuration, identifier})
+    })
+
+    if (!Array.isArray(listedTenants)) {
+      throw new Error(`Tenant database provider for ${identifier} must return an array from listTenants`)
+    }
+
+    const tenants = filter ? listedTenants.filter(filter) : listedTenants
+    const iterator = new TenantIterator({configuration, identifier, parallelCount: parallel})
+
+    return await iterator.run(tenants, callback)
+  }
+
+  /**
+   * Drops one tenant's database/schema through the provider's `dropDatabase` hook.
+   * @param {{identifier: string, tenant: object, configuration?: import("../configuration.js").default}} args
+   * @returns {Promise<void>}
+   */
+  static async drop({identifier, tenant, configuration = Current.configuration()}) {
+    const provider = configuration.getTenantDatabaseProvider(identifier)
+
+    if (typeof provider.dropDatabase !== "function") {
+      throw new Error(`Tenant database provider for ${identifier} must define dropDatabase to drop a tenant`)
+    }
+
+    await configuration.runWithTenant(tenant, async () => {
+      await provider.dropDatabase?.({
+        configuration,
+        databaseConfiguration: configuration.resolveDatabaseConfiguration(identifier),
+        identifier,
+        tenant
+      })
+    })
+  }
+}

--- a/src/tenants/tenant.js
+++ b/src/tenants/tenant.js
@@ -67,6 +67,14 @@ export default class Tenant {
     }
 
     await configuration.runWithTenant(tenant, async () => {
+      // Guard against an unresolved tenant. resolveDatabaseConfiguration falls back to the
+      // base (template/default) tenant database when the resolver returns nothing for this
+      // descriptor, so without this check a provider that drops by databaseConfiguration.name
+      // would drop the template database instead of rejecting the bad tenant.
+      if (!configuration.isDatabaseIdentifierActive(identifier)) {
+        throw new Error(`Tenant database identifier ${identifier} is inactive for tenant: ${TenantIterator.tenantLabel(tenant)}`)
+      }
+
       await provider.dropDatabase?.({
         configuration,
         databaseConfiguration: configuration.resolveDatabaseConfiguration(identifier),


### PR DESCRIPTION
## What

Adds the runtime **`Tenant`** façade and wires the tenant **drop** lifecycle, completing the apartment-style multi-tenant surface in Velocious. Until now Velocious had tenant switching (`Current.withTenant`/`runWithTenant`), per-identifier resolution, and the `db:tenants:create|check|migrate` CLI — but no cohesive runtime entry point for apps, and no way to drop a tenant (`provider.dropDatabase` was typed but unwired, and tenant iteration lived only inside the CLI helper).

## New / changed

- **`src/tenants/tenant-iterator.js`** — `TenantIterator`, the iteration engine **extracted** from `TenantDatabaseCommandHelper.eachTenant`: enters each tenant with `runWithTenant`, asserts the database identifier is active, and aggregates per-tenant failures when running in parallel. `TenantDatabaseCommandHelper` now **delegates** to it (its inline loop, `runTenantCallback`, and `tenantLabel` are removed), so the CLI commands and the façade share one implementation.
- **`src/tenants/tenant.js`** — the `Tenant` façade:
  - `with(tenant, callback)` / `current()` delegate to `Current` (which owns the async-context tenant state).
  - `each({identifier, callback, parallel?, filter?, configuration?})` lists the provider's tenants and runs a callback within each tenant's context, with an optional `filter` (e.g. migrated-only) — the runtime counterpart of the CLI's per-tenant iteration.
  - `drop({identifier, tenant, configuration?})` drops one tenant via the provider's `dropDatabase` hook.
- **`src/cli/commands/db/tenants/drop.js`** — `db:tenants:drop`, auto-discovered like the other `db:tenants:*` commands, dropping every listed tenant through `provider.dropDatabase`.

## Tests

- `spec/tenants/tenant-spec.js` (5): `with`/`current`, `each`, filtered `each`, `drop`, and the missing-hook throw.
- `spec/cli/commands/db/tenants/drop-spec.js` (2): drops every listed tenant; throws when the provider has no `dropDatabase`.
- The existing `db:tenants:migrate` spec (8 tests, including bounded parallelism and after-migrate hooks) stays green, confirming the `eachTenant` extraction is behavior-preserving. `eslint` 0 errors, `tsc --noEmit` clean.

## Plan context

Final Velocious phase of extracting TensorBuzz's bespoke multi-tenancy into the framework. V1 `MigrationsLedger` (1.0.481), V2 `SchemaCloner` (1.0.482), V3 `DataCopier` (#822, in review). With this façade, TensorBuzz's `ApartmentElevator` (~190 call sites) can be replaced by `Tenant.with` / `Tenant.each` / `Tenant.current` in **T4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)