### PR TITLE
Add built-in record auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * Database framework with familiar MVC concepts
 * Database models with migrations and validations
 * Database models that work almost the same in frontend and backend
+* Built-in record auditing for model lifecycle changes (see [docs/auditing.md](docs/auditing.md))
 * Declarative state machines for models (see [docs/state-machine.md](docs/state-machine.md))
 * Migrations for schema changes and UTC datetime storage (see [docs/database-migrations.md](docs/database-migrations.md))
 * Controllers and views for HTTP endpoints

--- a/changelog.d/20260629153000-built-in-auditing.md
+++ b/changelog.d/20260629153000-built-in-auditing.md
@@ -1,0 +1,1 @@
+Added built-in record auditing with automatic create/update/destroy audit rows, manual `createAudit(...)`, audit callbacks, and `withoutAudit(...)` query scopes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This folder contains implementation learnings and practical guidance discovered 
 
 ## Index
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
+- `docs/auditing.md`: Built-in lifecycle audit rows, manual audit events, and audit-missing scopes.
 - `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
 - `docs/database-migrations.md`: Migration helpers, UTC datetime storage, implicit primary keys, and reference column defaults.
 - `docs/http-server.md`: HTTP server worker configuration and socket distribution behavior.

--- a/docs/auditing.md
+++ b/docs/auditing.md
@@ -1,0 +1,109 @@
+# Record Auditing
+
+Velocious can write Rails-style audit rows for model lifecycle changes.
+Declare auditing on the model class after relationships and validations are
+registered:
+
+```js
+import TaskBase from "../model-bases/task.js"
+
+class Task extends TaskBase {}
+
+Task.belongsTo("project")
+Task.validates("name", {presence: true})
+Task.audited()
+
+export default Task
+```
+
+## Schema
+
+Applications must create the shared audit tables in their own migrations. Match
+the `auditable` reference type to the primary-key type used by the audited
+models:
+
+```js
+import Migration from "velocious/build/src/database/migration/index.js"
+
+export default class CreateAuditTables extends Migration {
+  async up() {
+    await this.createTable("audit_actions", {id: {type: "bigint"}}, (table) => {
+      table.string("action", {index: {unique: true}, null: false})
+      table.timestamps()
+    })
+
+    await this.createTable("audit_auditable_types", {id: {type: "bigint"}}, (table) => {
+      table.string("name", {index: {unique: true}, null: false})
+      table.timestamps()
+    })
+
+    await this.createTable("audits", {id: {type: "bigint"}}, (table) => {
+      table.references("audit_action", {foreignKey: true, null: false, type: "bigint"})
+      table.references("audit_auditable_type", {foreignKey: true, null: false, type: "bigint"})
+      table.references("auditable", {null: false, polymorphic: true, type: "bigint"})
+      table.json("audited_changes")
+      table.json("params")
+      table.timestamps()
+    })
+  }
+}
+```
+
+The shared lookup tables keep repeated action names and audited model types out
+of the `audits` rows while still storing `auditable_type` directly for simple
+polymorphic queries.
+
+## Automatic Audits
+
+`Model.audited()` registers lifecycle callbacks that create audit rows for:
+
+- `create`: stores the new values assigned before insert.
+- `update`: stores the new values for changed attributes.
+- `destroy`: stores the record attributes as they were before deletion.
+
+Audit change keys use model attribute names such as `projectId`, not database
+column names such as `project_id`.
+
+## Manual Audits
+
+Call `record.createAudit(...)` when application code needs to record a custom
+action:
+
+```js
+await task.createAudit({
+  action: "publish",
+  params: {
+    source: "admin"
+  }
+})
+```
+
+`params` is optional JSON metadata. Velocious does not attach a current user or
+request automatically in this first built-in auditing slice; pass that context
+explicitly in `params` when an app needs it.
+
+## Querying Missing Audits
+
+Use `Model.withoutAudit(action)` to find records that have not yet received an
+audit row for an action:
+
+```js
+const unreviewedTasks = await Task.withoutAudit("reviewed")
+  .where({projectId: project.id()})
+  .order({column: "name", direction: "ASC"})
+  .toArray()
+```
+
+## Audit Events
+
+Register callbacks with `Model.onAudit(action, callback)`:
+
+```js
+const unsubscribe = Task.onAudit("create", async ({auditId, record}) => {
+  await notifyAuditCreated({auditId, taskId: record.id()})
+})
+```
+
+The callback runs after the audit row is inserted. If the callback throws during
+a lifecycle audit, the surrounding save/destroy operation fails with that error,
+so use it for required follow-up work rather than best-effort logging.

--- a/docs/auditing.md
+++ b/docs/auditing.md
@@ -18,29 +18,30 @@ export default Task
 
 ## Schema
 
-Applications must create the shared audit tables in their own migrations. Match
-the `auditable` reference type to the primary-key type used by the audited
-models:
+Applications must create the shared audit tables in their own migrations. The
+audit tables use the database default UUID primary key. Match the `auditable`
+reference type to the primary-key type used by the audited models only when an
+audited model uses a non-default primary-key type:
 
 ```js
 import Migration from "velocious/build/src/database/migration/index.js"
 
 export default class CreateAuditTables extends Migration {
   async up() {
-    await this.createTable("audit_actions", {id: {type: "bigint"}}, (table) => {
+    await this.createTable("audit_actions", (table) => {
       table.string("action", {index: {unique: true}, null: false})
       table.timestamps()
     })
 
-    await this.createTable("audit_auditable_types", {id: {type: "bigint"}}, (table) => {
+    await this.createTable("audit_auditable_types", (table) => {
       table.string("name", {index: {unique: true}, null: false})
       table.timestamps()
     })
 
-    await this.createTable("audits", {id: {type: "bigint"}}, (table) => {
-      table.references("audit_action", {foreignKey: true, null: false, type: "bigint"})
-      table.references("audit_auditable_type", {foreignKey: true, null: false, type: "bigint"})
-      table.references("auditable", {null: false, polymorphic: true, type: "bigint"})
+    await this.createTable("audits", (table) => {
+      table.references("audit_action", {foreignKey: true, null: false})
+      table.references("audit_auditable_type", {foreignKey: true, null: false})
+      table.references("auditable", {null: false, polymorphic: true})
       table.json("audited_changes")
       table.json("params")
       table.timestamps()

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -38,6 +38,10 @@ await this.createTable("legacy_events", {id: {type: "bigint"}}, (table) => {
 
 SQLite stores auto-increment primary keys through its special `INTEGER PRIMARY KEY` form even when a migration asks for `bigint`, while non-primary reference columns keep the configured `bigint` type. PostgreSQL emits `BIGSERIAL` for auto-increment `bigint` primary keys.
 
+Features that need framework-owned tables, such as record auditing, should
+still be declared through normal application migrations. See
+[record auditing](auditing.md#schema) for the shared `audits` table layout.
+
 `removeIndex(tableName, nameOrColumns, args)` drops an index by explicit name, or by deriving the same database-specific default name that `addIndex(...)` uses when passed columns:
 
 ```js

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -120,7 +120,7 @@ describe("Cli - Commands - db:migrate", () => {
 
       if (defaultDatabaseType == "mysql") {
         expect(indexesNames).toEqual(["index_on_token","user_id"])
-      } else if (defaultDatabaseType == "sqlite") {
+      } else if (defaultDatabaseType == "sqlite" || defaultDatabaseType == "pgsql") {
         expect(indexesNames).toEqual(["index_on_authentication_tokens_token", "index_on_authentication_tokens_user_id"])
       } else {
         expect(indexesNames).toEqual(["index_on_token", "index_on_user_id"])
@@ -129,7 +129,7 @@ describe("Cli - Commands - db:migrate", () => {
       // It creates unique indexes
       let tokenIndexName
 
-      if (defaultDatabaseType == "sqlite") {
+      if (defaultDatabaseType == "sqlite" || defaultDatabaseType == "pgsql") {
         tokenIndexName = "index_on_authentication_tokens_token"
       } else {
         tokenIndexName = "index_on_token"

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -58,6 +58,9 @@ describe("Cli - Commands - db:migrate", () => {
       const tableNames = [
         "accounts",
         "acts_as_list_items",
+        "audit_actions",
+        "audit_auditable_types",
+        "audits",
         "authentication_tokens",
         "autoindex_test",
         "comments",
@@ -178,6 +181,9 @@ describe("Cli - Commands - db:migrate", () => {
         [
           "accounts",
           "acts_as_list_items",
+          "audit_actions",
+          "audit_auditable_types",
+          "audits",
           "authentication_tokens",
           "comments",
           "interactions",
@@ -211,13 +217,17 @@ describe("Cli - Commands - db:migrate", () => {
         "20251228090000",
         "20251228090010",
         "20260418090000",
-        "20260601052206"
+        "20260601052206",
+        "20260629160000"
       ])
     } else {
       expect(filteredTables.sort()).toEqual(
         [
           "accounts",
           "acts_as_list_items",
+          "audit_actions",
+          "audit_auditable_types",
+          "audits",
           "authentication_tokens",
           "comments",
           "interactions",
@@ -252,7 +262,8 @@ describe("Cli - Commands - db:migrate", () => {
         "20251228090000",
         "20251228090010",
         "20260418090000",
-        "20260601052206"
+        "20260601052206",
+        "20260629160000"
       ])
     }
   })

--- a/spec/cli/commands/db/rollback-spec.js
+++ b/spec/cli/commands/db/rollback-spec.js
@@ -106,6 +106,7 @@ describe("Cli - Commands - db:rollback", () => {
     const filteredTables = tablesResult.filter((tableName) => !internalTables.has(tableName))
     const expectedRolledBackTables = [
       ...(databaseIdentifiers.includes("mssql") ? ["accounts"] : []),
+      "acts_as_list_items",
       "authentication_tokens",
       "comments",
       "interactions",
@@ -136,7 +137,8 @@ describe("Cli - Commands - db:rollback", () => {
       "20251225230806",
       "20251228090000",
       "20251228090010",
-      "20260418090000"
+      "20260418090000",
+      "20260601052206"
     ]
 
     expect(uniqunize(filteredTables.sort())).toEqual(expectedRolledBackTables)
@@ -147,8 +149,8 @@ describe("Cli - Commands - db:rollback", () => {
 
     const {defaultSchemaMigrations: newDefaultSchemaMigrations, tablesResult: newTablesResult} = await getTestData()
     const filteredNewTablesResult = newTablesResult.filter((tableName) => !internalTables.has(tableName))
-    const expectedMigratedTables = [...expectedRolledBackTables, "acts_as_list_items"].sort()
-    const expectedMigratedMigrations = [...expectedRolledBackMigrations, "20260601052206"].sort()
+    const expectedMigratedTables = [...expectedRolledBackTables, "audit_actions", "audit_auditable_types", "audits"].sort()
+    const expectedMigratedMigrations = [...expectedRolledBackMigrations, "20260629160000"].sort()
 
     expect(uniqunize(filteredNewTablesResult.sort())).toEqual(expectedMigratedTables)
 

--- a/spec/database/drivers/create-sql/create-index-sql.browser-spec.js
+++ b/spec/database/drivers/create-sql/create-index-sql.browser-spec.js
@@ -15,7 +15,7 @@ describe("database - create sql - create index sql", {tags: ["dummy"]}, () => {
       } else if (dbs.default.getType() == "mssql") {
         expect(createIndexSQLs).toEqual("CREATE INDEX [index_on_id_and_created_at] ON [projects] ([id], [created_at])")
       } else if (dbs.default.getType() == "pgsql") {
-        expect(createIndexSQLs).toEqual(`CREATE INDEX "index_on_id_and_created_at" ON "projects" ("id", "created_at")`)
+        expect(createIndexSQLs).toEqual(`CREATE INDEX "index_on_projects_id_and_created_at" ON "projects" ("id", "created_at")`)
       } else {
         expect(createIndexSQLs).toEqual("CREATE INDEX `index_on_id_and_created_at` ON `projects` (`id`, `created_at`)")
       }

--- a/spec/database/query/create-table-foreign-key-sql-spec.js
+++ b/spec/database/query/create-table-foreign-key-sql-spec.js
@@ -93,4 +93,16 @@ describe("database - query - create-table foreign-key SQL", {databaseCleaning: {
 
     expect(sqls[0]).toContain("`id` BIGSERIAL PRIMARY KEY NOT NULL")
   })
+
+  it("uses table-qualified default index names for PostgreSQL column indexes", async () => {
+    const tableData = new TableData("velocious_attachments")
+
+    tableData.addColumn("name", {index: true, null: false, type: "string"})
+
+    const inlineSqls = await new CreateTableBase({driver: buildDriver("pgsql"), tableData}).toSql()
+    const sqls = await new CreateTableBase({driver: buildDriver("pgsql"), indexInCreateTable: false, tableData}).toSql()
+
+    expect(inlineSqls[0]).toContain("INDEX `index_on_velocious_attachments_name` (`name`)")
+    expect(sqls[1]).toEqual("CREATE INDEX `index_on_velocious_attachments_name` ON `velocious_attachments` (`name`)")
+  })
 })

--- a/spec/database/record/auditing.browser-spec.js
+++ b/spec/database/record/auditing.browser-spec.js
@@ -10,6 +10,17 @@ import Task from "../../dummy/src/models/task.js"
  */
 
 /**
+ * AuditRow type.
+ * @typedef {object} AuditRow
+ * @property {string} action
+ * @property {AuditJson | null} auditedChanges
+ * @property {number} auditableId
+ * @property {string} auditableType
+ * @property {AuditJson | null} params
+ * @property {string} typeName
+ */
+
+/**
  * @param {string | AuditJson | null} value - JSON value from the database.
  * @returns {AuditJson | null} Parsed JSON.
  */
@@ -21,7 +32,21 @@ function parsedJson(value) {
   return value
 }
 
-/** @returns {Promise<Array<{action: string, auditedChanges: AuditJson | null, auditableId: number, auditableType: string, params: AuditJson | null, typeName: string}>>} */
+/**
+ * @param {AuditRow[]} rows - Audit rows.
+ * @param {string} action - Audit action.
+ * @param {number} auditableId - Audited record id.
+ * @returns {AuditRow} Matching audit row.
+ */
+function auditRowFor(rows, action, auditableId) {
+  const row = rows.find((auditRow) => auditRow.action === action && auditRow.auditableId === auditableId)
+
+  expect(row).toBeDefined()
+
+  return /** @type {AuditRow} */ (row)
+}
+
+/** @returns {Promise<AuditRow[]>} */
 async function auditRows() {
   return await Configuration.current().ensureConnections(async (dbs) => {
     const db = dbs.default
@@ -36,7 +61,6 @@ async function auditRows() {
       FROM ${db.quoteTable("audits")}
       INNER JOIN ${db.quoteTable("audit_actions")} ON ${db.quoteTable("audit_actions")}.${db.quoteColumn("id")} = ${db.quoteTable("audits")}.${db.quoteColumn("audit_action_id")}
       INNER JOIN ${db.quoteTable("audit_auditable_types")} ON ${db.quoteTable("audit_auditable_types")}.${db.quoteColumn("id")} = ${db.quoteTable("audits")}.${db.quoteColumn("audit_auditable_type_id")}
-      ORDER BY ${db.quoteTable("audits")}.${db.quoteColumn("id")} ASC
     `))
 
     return rows.map((row) => ({
@@ -70,26 +94,32 @@ describe("Record - auditing", {tags: ["dummy"]}, () => {
       await taskWithCustomAudit.destroy()
 
       const rows = await auditRows()
+      const rowSummaries = rows.map((row) => [row.action, row.auditableType, row.auditableId, row.typeName])
+      const taskWithCustomAuditCreateRow = auditRowFor(rows, "create", taskWithCustomAudit.id())
+      const taskWithCustomAuditUpdateRow = auditRowFor(rows, "update", taskWithCustomAudit.id())
+      const taskWithCustomAuditCustomRow = auditRowFor(rows, "custom", taskWithCustomAudit.id())
+      const taskWithCustomAuditDestroyRow = auditRowFor(rows, "destroy", taskWithCustomAudit.id())
 
-      expect(rows.map((row) => [row.action, row.auditableType, row.auditableId, row.typeName])).toEqual([
-        ["create", "Task", taskWithCustomAudit.id(), "Task"],
-        ["update", "Task", taskWithCustomAudit.id(), "Task"],
-        ["custom", "Task", taskWithCustomAudit.id(), "Task"],
-        ["create", "Task", taskWithoutCustomAudit.id(), "Task"],
-        ["destroy", "Task", taskWithCustomAudit.id(), "Task"]
-      ])
-      expect(rows[0].auditedChanges).toEqual({
+      expect(rowSummaries).toHaveLength(5)
+      expect(rowSummaries).toContainEqual(["create", "Task", taskWithCustomAudit.id(), "Task"])
+      expect(rowSummaries).toContainEqual(["update", "Task", taskWithCustomAudit.id(), "Task"])
+      expect(rowSummaries).toContainEqual(["custom", "Task", taskWithCustomAudit.id(), "Task"])
+      expect(rowSummaries).toContainEqual(["create", "Task", taskWithoutCustomAudit.id(), "Task"])
+      expect(rowSummaries).toContainEqual(["destroy", "Task", taskWithCustomAudit.id(), "Task"])
+      expect(taskWithCustomAuditCreateRow.auditedChanges).toEqual({
         description: "Initial description",
         name: "Audited task",
         projectId: project.id()
       })
-      expect(rows[1].auditedChanges).toEqual({
+      expect(taskWithCustomAuditUpdateRow.auditedChanges).toEqual({
         description: "Updated description",
         name: "Updated audited task"
       })
-      expect(rows[2].params).toEqual({source: "spec"})
-      expect(rows[4].auditedChanges?.id).toEqual(taskWithCustomAudit.id())
-      expect(rows[4].auditedChanges?.name).toEqual("Updated audited task")
+      expect(taskWithCustomAuditCustomRow.params).toEqual({source: "spec"})
+      expect(taskWithCustomAuditDestroyRow.auditedChanges).toMatchObject({
+        id: taskWithCustomAudit.id(),
+        name: "Updated audited task"
+      })
       expect(events).toEqual([{action: "create", recordId: taskWithCustomAudit.id()}, {action: "create", recordId: taskWithoutCustomAudit.id()}])
 
       const withoutCustomAudit = await Task.withoutAudit("custom")

--- a/spec/database/record/auditing.browser-spec.js
+++ b/spec/database/record/auditing.browser-spec.js
@@ -25,14 +25,14 @@ function parsedJson(value) {
 async function auditRows() {
   return await Configuration.current().ensureConnections(async (dbs) => {
     const db = dbs.default
-    const rows = /** @type {Array<{action: string, auditedChanges: string | AuditJson | null, auditableId: number, auditableType: string, params: string | AuditJson | null, typeName: string}>>} */ (await db.query(`
+    const rows = /** @type {Array<{action: string, audited_changes: string | AuditJson | null, auditable_id: number, auditable_type: string, params: string | AuditJson | null, type_name: string}>>} */ (await db.query(`
       SELECT
         audit_actions.action AS action,
-        audits.audited_changes AS auditedChanges,
-        audits.auditable_id AS auditableId,
-        audits.auditable_type AS auditableType,
+        audits.audited_changes AS audited_changes,
+        audits.auditable_id AS auditable_id,
+        audits.auditable_type AS auditable_type,
         audits.params AS params,
-        audit_auditable_types.name AS typeName
+        audit_auditable_types.name AS type_name
       FROM ${db.quoteTable("audits")}
       INNER JOIN ${db.quoteTable("audit_actions")} ON ${db.quoteTable("audit_actions")}.${db.quoteColumn("id")} = ${db.quoteTable("audits")}.${db.quoteColumn("audit_action_id")}
       INNER JOIN ${db.quoteTable("audit_auditable_types")} ON ${db.quoteTable("audit_auditable_types")}.${db.quoteColumn("id")} = ${db.quoteTable("audits")}.${db.quoteColumn("audit_auditable_type_id")}
@@ -40,9 +40,12 @@ async function auditRows() {
     `))
 
     return rows.map((row) => ({
-      ...row,
-      auditedChanges: parsedJson(row.auditedChanges),
-      params: parsedJson(row.params)
+      action: row.action,
+      auditedChanges: parsedJson(row.audited_changes),
+      auditableId: row.auditable_id,
+      auditableType: row.auditable_type,
+      params: parsedJson(row.params),
+      typeName: row.type_name
     }))
   })
 }

--- a/spec/database/record/auditing.browser-spec.js
+++ b/spec/database/record/auditing.browser-spec.js
@@ -1,0 +1,102 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import Project from "../../dummy/src/models/project.js"
+import Task from "../../dummy/src/models/task.js"
+
+/**
+ * AuditJson type.
+ * @typedef {Record<string, string | number | boolean | null>} AuditJson
+ */
+
+/**
+ * @param {string | AuditJson | null} value - JSON value from the database.
+ * @returns {AuditJson | null} Parsed JSON.
+ */
+function parsedJson(value) {
+  if (typeof value === "string") {
+    return /** @type {AuditJson} */ (JSON.parse(value))
+  }
+
+  return value
+}
+
+/** @returns {Promise<Array<{action: string, auditedChanges: AuditJson | null, auditableId: number, auditableType: string, params: AuditJson | null, typeName: string}>>} */
+async function auditRows() {
+  return await Configuration.current().ensureConnections(async (dbs) => {
+    const db = dbs.default
+    const rows = /** @type {Array<{action: string, auditedChanges: string | AuditJson | null, auditableId: number, auditableType: string, params: string | AuditJson | null, typeName: string}>>} */ (await db.query(`
+      SELECT
+        audit_actions.action AS action,
+        audits.audited_changes AS auditedChanges,
+        audits.auditable_id AS auditableId,
+        audits.auditable_type AS auditableType,
+        audits.params AS params,
+        audit_auditable_types.name AS typeName
+      FROM ${db.quoteTable("audits")}
+      INNER JOIN ${db.quoteTable("audit_actions")} ON ${db.quoteTable("audit_actions")}.${db.quoteColumn("id")} = ${db.quoteTable("audits")}.${db.quoteColumn("audit_action_id")}
+      INNER JOIN ${db.quoteTable("audit_auditable_types")} ON ${db.quoteTable("audit_auditable_types")}.${db.quoteColumn("id")} = ${db.quoteTable("audits")}.${db.quoteColumn("audit_auditable_type_id")}
+      ORDER BY ${db.quoteTable("audits")}.${db.quoteColumn("id")} ASC
+    `))
+
+    return rows.map((row) => ({
+      ...row,
+      auditedChanges: parsedJson(row.auditedChanges),
+      params: parsedJson(row.params)
+    }))
+  })
+}
+
+describe("Record - auditing", {tags: ["dummy"]}, () => {
+  it("records automatic and manual audits for audited models", async () => {
+    /** @type {Array<{action: string, recordId: number}>} */
+    const events = []
+    const unsubscribe = Task.onAudit("create", ({action, record}) => {
+      events.push({action, recordId: record.id()})
+    })
+
+    try {
+      const project = await Project.create({name: "Audit project"})
+      const taskWithCustomAudit = await Task.create({description: "Initial description", name: "Audited task", project})
+
+      await taskWithCustomAudit.update({description: "Updated description", name: "Updated audited task"})
+      await taskWithCustomAudit.createAudit({action: "custom", params: {source: "spec"}})
+
+      const taskWithoutCustomAudit = await Task.create({name: "Task without custom audit", project})
+
+      await taskWithCustomAudit.destroy()
+
+      const rows = await auditRows()
+
+      expect(rows.map((row) => [row.action, row.auditableType, row.auditableId, row.typeName])).toEqual([
+        ["create", "Task", taskWithCustomAudit.id(), "Task"],
+        ["update", "Task", taskWithCustomAudit.id(), "Task"],
+        ["custom", "Task", taskWithCustomAudit.id(), "Task"],
+        ["create", "Task", taskWithoutCustomAudit.id(), "Task"],
+        ["destroy", "Task", taskWithCustomAudit.id(), "Task"]
+      ])
+      expect(rows[0].auditedChanges).toEqual({
+        description: "Initial description",
+        name: "Audited task",
+        projectId: project.id()
+      })
+      expect(rows[1].auditedChanges).toEqual({
+        description: "Updated description",
+        name: "Updated audited task"
+      })
+      expect(rows[2].params).toEqual({source: "spec"})
+      expect(rows[4].auditedChanges?.id).toEqual(taskWithCustomAudit.id())
+      expect(rows[4].auditedChanges?.name).toEqual("Updated audited task")
+      expect(events).toEqual([{action: "create", recordId: taskWithCustomAudit.id()}, {action: "create", recordId: taskWithoutCustomAudit.id()}])
+
+      const withoutCustomAudit = await Task.withoutAudit("custom")
+        .where({projectId: project.id()})
+        .order({column: "name", direction: "ASC"})
+        .toArray()
+
+      expect(withoutCustomAudit.map((task) => task.id())).toEqual([taskWithoutCustomAudit.id()])
+    } finally {
+      unsubscribe()
+    }
+  })
+})

--- a/spec/dummy/db/structure-default.sql
+++ b/spec/dummy/db/structure-default.sql
@@ -1,10 +1,10 @@
 CREATE TABLE `acts_as_list_items` (`id` INTEGER PRIMARY KEY NOT NULL, `project_id` BIGINT NOT NULL, `position` INTEGER, `name` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
 
-CREATE TABLE `audit_actions` (`id` INTEGER PRIMARY KEY NOT NULL, `action` VARCHAR(255) NOT NULL, `created_at` DATETIME, `updated_at` DATETIME);
+CREATE TABLE `audit_actions` (`id` UUID PRIMARY KEY NOT NULL, `action` VARCHAR(255) NOT NULL, `created_at` DATETIME, `updated_at` DATETIME);
 
-CREATE TABLE `audit_auditable_types` (`id` INTEGER PRIMARY KEY NOT NULL, `name` VARCHAR(255) NOT NULL, `created_at` DATETIME, `updated_at` DATETIME);
+CREATE TABLE `audit_auditable_types` (`id` UUID PRIMARY KEY NOT NULL, `name` VARCHAR(255) NOT NULL, `created_at` DATETIME, `updated_at` DATETIME);
 
-CREATE TABLE `audits` (`id` INTEGER PRIMARY KEY NOT NULL, `audit_action_id` BIGINT NOT NULL REFERENCES `audit_actions`(`id`), `audit_auditable_type_id` BIGINT NOT NULL REFERENCES `audit_auditable_types`(`id`), `auditable_id` BIGINT NOT NULL, `auditable_type` VARCHAR(255), `audited_changes` JSON, `params` JSON, `created_at` DATETIME, `updated_at` DATETIME);
+CREATE TABLE `audits` (`id` UUID PRIMARY KEY NOT NULL, `audit_action_id` UUID NOT NULL REFERENCES `audit_actions`(`id`), `audit_auditable_type_id` UUID NOT NULL REFERENCES `audit_auditable_types`(`id`), `auditable_id` BIGINT NOT NULL, `auditable_type` VARCHAR(255), `audited_changes` JSON, `params` JSON, `created_at` DATETIME, `updated_at` DATETIME);
 
 CREATE TABLE "authentication_tokens" (`id` INTEGER PRIMARY KEY NOT NULL, `user_token` VARCHAR(255) DEFAULT '''UUID()''', `user_id` BIGINT, `created_at` DATETIME, `updated_at` DATETIME, CONSTRAINT `authentication_tokens_user_id_0` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`));
 

--- a/spec/dummy/db/structure-default.sql
+++ b/spec/dummy/db/structure-default.sql
@@ -1,0 +1,75 @@
+CREATE TABLE `acts_as_list_items` (`id` INTEGER PRIMARY KEY NOT NULL, `project_id` BIGINT NOT NULL, `position` INTEGER, `name` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `audit_actions` (`id` INTEGER PRIMARY KEY NOT NULL, `action` VARCHAR(255) NOT NULL, `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `audit_auditable_types` (`id` INTEGER PRIMARY KEY NOT NULL, `name` VARCHAR(255) NOT NULL, `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `audits` (`id` INTEGER PRIMARY KEY NOT NULL, `audit_action_id` BIGINT NOT NULL REFERENCES `audit_actions`(`id`), `audit_auditable_type_id` BIGINT NOT NULL REFERENCES `audit_auditable_types`(`id`), `auditable_id` BIGINT NOT NULL, `auditable_type` VARCHAR(255), `audited_changes` JSON, `params` JSON, `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE "authentication_tokens" (`id` INTEGER PRIMARY KEY NOT NULL, `user_token` VARCHAR(255) DEFAULT '''UUID()''', `user_id` BIGINT, `created_at` DATETIME, `updated_at` DATETIME, CONSTRAINT `authentication_tokens_user_id_0` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`));
+
+CREATE TABLE `comments` (`id` INTEGER PRIMARY KEY NOT NULL, `task_id` BIGINT NOT NULL REFERENCES `tasks`(`id`), `body` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `interactions` (`id` INTEGER PRIMARY KEY NOT NULL, `subject_id` BIGINT NOT NULL, `subject_type` VARCHAR(255), `kind` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE "project_details" (`id` INTEGER PRIMARY KEY NOT NULL, `project_id` BIGINT NOT NULL, `note` TEXT, `created_at` DATETIME, `updated_at` DATETIME, `is_active` BOOLEAN, CONSTRAINT `project_details_project_id_0` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`));
+
+CREATE TABLE `project_translations` (`id` INTEGER PRIMARY KEY NOT NULL, `project_id` BIGINT NOT NULL REFERENCES `projects`(`id`), `locale` VARCHAR(255) NOT NULL, `name` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE "projects" (`id` INTEGER PRIMARY KEY NOT NULL, `creating_user_reference` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME, `tasks_count` INTEGER DEFAULT 0 NOT NULL);
+
+CREATE TABLE `schema_migrations` (`version` VARCHAR(255) PRIMARY KEY NOT NULL);
+
+CREATE TABLE `string_subject_interactions` (`id` INTEGER PRIMARY KEY NOT NULL, `subject_id` VARCHAR(255) NOT NULL, `subject_type` VARCHAR(255), `kind` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `string_subjects` (`id` VARCHAR(255) PRIMARY KEY NOT NULL, `name` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE "tasks" (`id` INTEGER PRIMARY KEY NOT NULL, `project_id` BIGINT NOT NULL, `name` VARCHAR(255), `description` TEXT, `created_at` DATETIME, `updated_at` DATETIME, `is_done` BOOLEAN, CONSTRAINT `tasks_project_id_0` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`));
+
+CREATE TABLE `users` (`id` INTEGER PRIMARY KEY NOT NULL, `email` VARCHAR(255) NOT NULL, `encrypted_password` VARCHAR(255) NOT NULL, `reference` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `uuid_interactions` (`id` INTEGER PRIMARY KEY NOT NULL, `subject_id` UUID NOT NULL, `subject_type` VARCHAR(255), `kind` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `uuid_items` (`id` UUID PRIMARY KEY NOT NULL, `title` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
+
+CREATE TABLE `velocious_attachments` (`id` VARCHAR(255) PRIMARY KEY NOT NULL, `record_type` VARCHAR(255) NOT NULL, `record_id` VARCHAR(255) NOT NULL, `name` VARCHAR(255) NOT NULL, `position` INTEGER NOT NULL, `filename` VARCHAR(255) NOT NULL, `content_type` VARCHAR(255), `byte_size` BIGINT NOT NULL, `driver` VARCHAR(255), `storage_key` VARCHAR(255), `content_base64` TEXT, `created_at_ms` BIGINT NOT NULL, `updated_at_ms` BIGINT NOT NULL);
+
+CREATE INDEX `index_on_acts_as_list_items_project_id` ON `acts_as_list_items` (`project_id`);
+
+CREATE UNIQUE INDEX `index_on_acts_as_list_items_project_id_and_position` ON `acts_as_list_items` (`project_id`, `position`);
+
+CREATE UNIQUE INDEX `index_on_audit_actions_action` ON `audit_actions` (`action`);
+
+CREATE UNIQUE INDEX `index_on_audit_auditable_types_name` ON `audit_auditable_types` (`name`);
+
+CREATE INDEX `index_on_audits_audit_action_id` ON `audits` (`audit_action_id`);
+
+CREATE INDEX `index_on_audits_audit_auditable_type_id` ON `audits` (`audit_auditable_type_id`);
+
+CREATE INDEX `index_on_audits_auditable_id` ON `audits` (`auditable_id`);
+
+CREATE UNIQUE INDEX `index_on_authentication_tokens_token` ON `authentication_tokens` (`user_token`);
+
+CREATE INDEX `index_on_authentication_tokens_user_id` ON `authentication_tokens` (`user_id`);
+
+CREATE INDEX `index_on_comments_task_id` ON `comments` (`task_id`);
+
+CREATE INDEX `index_on_interactions_subject_id` ON `interactions` (`subject_id`);
+
+CREATE INDEX `index_on_project_details_project_id` ON `project_details` (`project_id`);
+
+CREATE INDEX `index_on_project_translations_project_id` ON `project_translations` (`project_id`);
+
+CREATE INDEX `index_on_string_subject_interactions_subject_id` ON `string_subject_interactions` (`subject_id`);
+
+CREATE INDEX `index_on_tasks_project_id` ON `tasks` (`project_id`);
+
+CREATE UNIQUE INDEX `index_on_users_email` ON `users` (`email`);
+
+CREATE INDEX `index_on_uuid_interactions_subject_id` ON `uuid_interactions` (`subject_id`);
+
+CREATE INDEX `index_on_velocious_attachments_name` ON `velocious_attachments` (`name`);
+
+CREATE INDEX `index_on_velocious_attachments_record_id` ON `velocious_attachments` (`record_id`);
+
+CREATE INDEX `index_on_velocious_attachments_record_type` ON `velocious_attachments` (`record_type`);

--- a/spec/dummy/src/database/migrations/20260629160000-create-audit-tables.js
+++ b/spec/dummy/src/database/migrations/20260629160000-create-audit-tables.js
@@ -1,0 +1,30 @@
+import Migration from "../../../../../src/database/migration/index.js"
+
+export default class CreateAuditTables extends Migration {
+  async up() {
+    await this.createTable("audit_actions", {id: {type: "bigint"}}, (table) => {
+      table.string("action", {index: {unique: true}, null: false})
+      table.timestamps()
+    })
+
+    await this.createTable("audit_auditable_types", {id: {type: "bigint"}}, (table) => {
+      table.string("name", {index: {unique: true}, null: false})
+      table.timestamps()
+    })
+
+    await this.createTable("audits", {id: {type: "bigint"}}, (table) => {
+      table.references("audit_action", {foreignKey: true, null: false, type: "bigint"})
+      table.references("audit_auditable_type", {foreignKey: true, null: false, type: "bigint"})
+      table.references("auditable", {null: false, polymorphic: true, type: "bigint"})
+      table.json("audited_changes")
+      table.json("params")
+      table.timestamps()
+    })
+  }
+
+  async down() {
+    await this.dropTable("audits")
+    await this.dropTable("audit_auditable_types")
+    await this.dropTable("audit_actions")
+  }
+}

--- a/spec/dummy/src/database/migrations/20260629160000-create-audit-tables.js
+++ b/spec/dummy/src/database/migrations/20260629160000-create-audit-tables.js
@@ -2,19 +2,19 @@ import Migration from "../../../../../src/database/migration/index.js"
 
 export default class CreateAuditTables extends Migration {
   async up() {
-    await this.createTable("audit_actions", {id: {type: "bigint"}}, (table) => {
+    await this.createTable("audit_actions", (table) => {
       table.string("action", {index: {unique: true}, null: false})
       table.timestamps()
     })
 
-    await this.createTable("audit_auditable_types", {id: {type: "bigint"}}, (table) => {
+    await this.createTable("audit_auditable_types", (table) => {
       table.string("name", {index: {unique: true}, null: false})
       table.timestamps()
     })
 
-    await this.createTable("audits", {id: {type: "bigint"}}, (table) => {
-      table.references("audit_action", {foreignKey: true, null: false, type: "bigint"})
-      table.references("audit_auditable_type", {foreignKey: true, null: false, type: "bigint"})
+    await this.createTable("audits", (table) => {
+      table.references("audit_action", {foreignKey: true, null: false})
+      table.references("audit_auditable_type", {foreignKey: true, null: false})
       table.references("auditable", {null: false, polymorphic: true, type: "bigint"})
       table.json("audited_changes")
       table.json("params")

--- a/spec/dummy/src/models/task.js
+++ b/spec/dummy/src/models/task.js
@@ -31,5 +31,6 @@ Task.hasOneAttachment("descriptionFile")
 Task.acceptsNestedAttributesFor("comments", {allowDestroy: true})
 Task.acceptsNestedAttributesFor("project")
 Task.validates("name", {presence: true, uniqueness: {scope: "projectId"}})
+Task.audited()
 
 export default Task

--- a/src/database/query/create-index-base.js
+++ b/src/database/query/create-index-base.js
@@ -32,7 +32,7 @@ export default class VelociousDatabaseQueryCreateIndexBase extends QueryBase {
     let indexName = `index_on_`
     let columnCount = 0
 
-    if (databaseType == "sqlite") indexName += `${this.tableName}_`
+    if (databaseType == "sqlite" || databaseType == "pgsql") indexName += `${this.tableName}_`
 
     for (const column of this.columns) {
       columnCount++

--- a/src/database/query/create-table-base.js
+++ b/src/database/query/create-table-base.js
@@ -111,7 +111,7 @@ export default class VelociousDatabaseQueryCreateTableBase extends QueryBase {
 
         let indexName = `index_on_`
 
-        if (databaseType == "sqlite") sql += `${tableData.getName()}_`
+        if (databaseType == "sqlite" || databaseType == "pgsql") indexName += `${tableData.getName()}_`
 
         indexName += column.getName()
 
@@ -181,7 +181,7 @@ export default class VelociousDatabaseQueryCreateTableBase extends QueryBase {
 
         let indexName = `index_on_`
 
-        if (databaseType == "sqlite") indexName += `${tableData.getName()}_`
+        if (databaseType == "sqlite" || databaseType == "pgsql") indexName += `${tableData.getName()}_`
 
         indexName += column.getName()
 

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import UUID from "pure-uuid"
+
 /**
  * AuditChanges type.
  * @typedef {Record<string, ?>} AuditChanges
@@ -151,11 +153,13 @@ async function createAuditWithCurrentConnection(record, args, modelClass) {
     value: modelClass.getModelName(),
     currentDate
   })
+  const auditId = new UUID(4).format()
 
   const insertResult = await db.query(db.insertSql({
     returnLastInsertedColumnNames: ["id"],
     tableName: "audits",
     data: {
+      id: auditId,
       audit_action_id: auditActionId,
       audit_auditable_type_id: auditAuditableTypeId,
       auditable_id: record.id(),
@@ -166,17 +170,17 @@ async function createAuditWithCurrentConnection(record, args, modelClass) {
       updated_at: currentDate
     }
   }))
-  const auditId = auditIdFromInsertResult(insertResult) ?? await db.lastInsertID()
+  const insertedAuditId = auditIdFromInsertResult(insertResult) ?? auditId
 
   await emitAuditEvent(modelClass, action, {
     action,
-    auditId,
+    auditId: insertedAuditId,
     auditedChanges,
     params,
     record
   })
 
-  return auditId
+  return insertedAuditId
 }
 
 /**
@@ -310,6 +314,7 @@ async function findOrCreateLookupId({columnName, currentDate, db, tableName, val
     conflictColumns: [columnName],
     updateColumns: [columnName],
     data: {
+      id: new UUID(4).format(),
       [columnName]: value,
       created_at: currentDate,
       updated_at: currentDate

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -1,0 +1,383 @@
+// @ts-check
+
+/**
+ * AuditChanges type.
+ * @typedef {Record<string, ?>} AuditChanges
+ */
+
+/**
+ * AuditEventPayload type.
+ * @typedef {object} AuditEventPayload
+ * @property {string} action - Audit action name.
+ * @property {number | string} auditId - Created audit row id.
+ * @property {AuditChanges | null} auditedChanges - Changes captured for the audit.
+ * @property {Record<string, ?> | null} params - Optional caller-supplied audit params.
+ * @property {import("./index.js").default} record - Audited record.
+ */
+
+/**
+ * AuditCallback type.
+ * @typedef {(payload: AuditEventPayload) => void | Promise<void>} AuditCallback
+ */
+
+/**
+ * CreateAuditArgs type.
+ * @typedef {object} CreateAuditArgs
+ * @property {string} action - Audit action name.
+ * @property {AuditChanges | null} [auditedChanges] - Explicit changes to persist.
+ * @property {Record<string, ?> | null} [params] - Optional metadata to store with the audit.
+ */
+
+/**
+ * AuditedModelClass type.
+ * @typedef {typeof import("./index.js").default & {
+ *   _auditCallbacks?: Record<string, AuditCallback[]>,
+ *   _auditLifecycleCallbacksRegistered?: boolean
+ * }} AuditedModelClass
+ */
+
+/**
+ * Adds automatic create/update/destroy auditing callbacks to a model class.
+ * @param {AuditedModelClass} modelClass - Model class to audit.
+ * @returns {void}
+ */
+function registerAuditing(modelClass) {
+  if (Object.prototype.hasOwnProperty.call(modelClass, "_auditLifecycleCallbacksRegistered") && modelClass._auditLifecycleCallbacksRegistered) {
+    return
+  }
+
+  modelClass._auditLifecycleCallbacksRegistered = true
+  modelClass.beforeCreate("captureCreateAuditChanges")
+  modelClass.afterCreate("createCreateAudit")
+  modelClass.beforeUpdate("captureUpdateAuditChanges")
+  modelClass.afterUpdate("createUpdateAudit")
+  modelClass.afterDestroy("createDestroyAudit")
+}
+
+/**
+ * Registers an audit event callback for a model/action pair.
+ * @param {AuditedModelClass} modelClass - Model class to observe.
+ * @param {string} action - Audit action name.
+ * @param {AuditCallback} callback - Callback invoked after matching audit rows are created.
+ * @returns {() => void} Unsubscribe function.
+ */
+function registerAuditCallback(modelClass, action, callback) {
+  const normalizedAction = normalizeAction(action)
+  const callbacks = auditCallbacksForModelClass(modelClass)
+
+  if (!callbacks[normalizedAction]) {
+    callbacks[normalizedAction] = []
+  }
+
+  callbacks[normalizedAction].push(callback)
+
+  return () => {
+    const actionCallbacks = callbacks[normalizedAction]
+    const index = actionCallbacks.indexOf(callback)
+
+    if (index >= 0) {
+      actionCallbacks.splice(index, 1)
+    }
+  }
+}
+
+/**
+ * Captures the new values for fields changed on a record.
+ * @param {import("./index.js").default} record - Record whose pending changes should be captured.
+ * @returns {AuditChanges} New values keyed by attribute name.
+ */
+function auditChangesForCurrentChanges(record) {
+  const changes = record.changes()
+  /** @type {AuditChanges} */
+  const auditedChanges = {}
+  const columnNameToAttributeName = record.getModelClass().getColumnNameToAttributeNameMap()
+
+  for (const [attributeName, change] of Object.entries(changes)) {
+    auditedChanges[columnNameToAttributeName[attributeName] || attributeName] = change[1]
+  }
+
+  return auditedChanges
+}
+
+/**
+ * Captures the current attributes for a destroy audit.
+ * @param {import("./index.js").default} record - Record being destroyed.
+ * @returns {AuditChanges} Current attributes keyed by attribute name.
+ */
+function auditChangesForDestroy(record) {
+  return {...record.attributes()}
+}
+
+/**
+ * Creates an audit row for a record.
+ * @param {import("./index.js").default} record - Record to audit.
+ * @param {CreateAuditArgs} args - Audit row options.
+ * @returns {Promise<number | string>} Created audit row id.
+ */
+async function createAudit(record, args) {
+  const modelClass = /** @type {AuditedModelClass} */ (record.getModelClass())
+
+  return await modelClass._getConfiguration().ensureConnections({name: `${modelClass.getModelName()} audit`}, async () => {
+    return await createAuditWithCurrentConnection(record, args, modelClass)
+  })
+}
+
+/**
+ * Creates an audit row using the current model database connection.
+ * @param {import("./index.js").default} record - Record to audit.
+ * @param {CreateAuditArgs} args - Audit row options.
+ * @param {AuditedModelClass} modelClass - Audited model class.
+ * @returns {Promise<number | string>} Created audit row id.
+ */
+async function createAuditWithCurrentConnection(record, args, modelClass) {
+  if (!record.isPersisted()) throw new Error(`Cannot audit unpersisted ${modelClass.getModelName()} record`)
+
+  const action = normalizeAction(args.action)
+  const auditedChanges = args.auditedChanges === undefined ? null : args.auditedChanges
+  const params = args.params === undefined ? null : args.params
+  const db = modelClass.connection()
+  const currentDate = new Date()
+  const auditActionId = await findOrCreateLookupId({
+    columnName: "action",
+    db,
+    tableName: "audit_actions",
+    value: action,
+    currentDate
+  })
+  const auditAuditableTypeId = await findOrCreateLookupId({
+    columnName: "name",
+    db,
+    tableName: "audit_auditable_types",
+    value: modelClass.getModelName(),
+    currentDate
+  })
+
+  await db.insert({
+    tableName: "audits",
+    data: {
+      audit_action_id: auditActionId,
+      audit_auditable_type_id: auditAuditableTypeId,
+      auditable_id: record.id(),
+      auditable_type: modelClass.getModelName(),
+      audited_changes: auditedChanges,
+      params,
+      created_at: currentDate,
+      updated_at: currentDate
+    }
+  })
+
+  const auditId = await db.lastInsertID()
+
+  await emitAuditEvent(modelClass, action, {
+    action,
+    auditId,
+    auditedChanges,
+    params,
+    record
+  })
+
+  return auditId
+}
+
+/**
+ * Captures create changes on a model instance.
+ * @param {import("./index.js").default & {_pendingCreateAuditChanges?: AuditChanges}} record - Record to capture.
+ * @returns {void}
+ */
+function captureCreateAuditChanges(record) {
+  record._pendingCreateAuditChanges = auditChangesForCurrentChanges(record)
+}
+
+/**
+ * Creates the create audit row for a model instance.
+ * @param {import("./index.js").default & {_pendingCreateAuditChanges?: AuditChanges}} record - Record to audit.
+ * @returns {Promise<void>}
+ */
+async function createCreateAudit(record) {
+  await createAudit(record, {
+    action: "create",
+    auditedChanges: record._pendingCreateAuditChanges || null
+  })
+
+  record._pendingCreateAuditChanges = undefined
+}
+
+/**
+ * Captures update changes on a model instance.
+ * @param {import("./index.js").default & {_pendingUpdateAuditChanges?: AuditChanges}} record - Record to capture.
+ * @returns {void}
+ */
+function captureUpdateAuditChanges(record) {
+  record._pendingUpdateAuditChanges = auditChangesForCurrentChanges(record)
+}
+
+/**
+ * Creates the update audit row for a model instance.
+ * @param {import("./index.js").default & {_pendingUpdateAuditChanges?: AuditChanges}} record - Record to audit.
+ * @returns {Promise<void>}
+ */
+async function createUpdateAudit(record) {
+  const auditedChanges = record._pendingUpdateAuditChanges || null
+
+  record._pendingUpdateAuditChanges = undefined
+
+  if (!auditedChanges || Object.keys(auditedChanges).length <= 0) return
+
+  await createAudit(record, {
+    action: "update",
+    auditedChanges
+  })
+}
+
+/**
+ * Creates the destroy audit row for a model instance.
+ * @param {import("./index.js").default} record - Record to audit.
+ * @returns {Promise<void>}
+ */
+async function createDestroyAudit(record) {
+  await createAudit(record, {
+    action: "destroy",
+    auditedChanges: auditChangesForDestroy(record)
+  })
+}
+
+/**
+ * Returns records without an audit row for the given action.
+ * @template {AuditedModelClass} MC
+ * @param {MC} modelClass - Model class to scope.
+ * @param {string} action - Audit action to exclude.
+ * @returns {import("../query/model-class-query.js").default<MC>} Query scoped to records without that audit action.
+ */
+function withoutAudit(modelClass, action) {
+  const db = modelClass.connection()
+  const modelTableSql = db.quoteTable(modelClass.tableName())
+  const auditsTableSql = db.quoteTable("audits")
+  const auditActionsTableSql = db.quoteTable("audit_actions")
+  const modelPrimaryKeySql = `${modelTableSql}.${db.quoteColumn(modelClass.primaryKey())}`
+  const auditAuditableIdSql = `${auditsTableSql}.${db.quoteColumn("auditable_id")}`
+  const auditAuditableTypeSql = `${auditsTableSql}.${db.quoteColumn("auditable_type")}`
+  const auditActionIdSql = `${auditsTableSql}.${db.quoteColumn("audit_action_id")}`
+  const auditActionsIdSql = `${auditActionsTableSql}.${db.quoteColumn("id")}`
+  const auditActionsActionSql = `${auditActionsTableSql}.${db.quoteColumn("action")}`
+
+  return modelClass
+    .all()
+    .where(`
+      NOT EXISTS (
+        SELECT 1
+        FROM ${auditsTableSql}
+        INNER JOIN ${auditActionsTableSql}
+          ON ${auditActionsIdSql} = ${auditActionIdSql}
+        WHERE ${auditAuditableTypeSql} = ${db.quote(modelClass.getModelName())}
+          AND ${auditAuditableIdSql} = ${modelPrimaryKeySql}
+          AND ${auditActionsActionSql} = ${db.quote(normalizeAction(action))}
+      )
+    `)
+}
+
+/**
+ * Finds or creates a lookup row and returns its id.
+ * @param {object} args - Options object.
+ * @param {string} args.columnName - Lookup value column.
+ * @param {Date} args.currentDate - Timestamp to write when inserting.
+ * @param {import("../drivers/base.js").default} args.db - Database driver.
+ * @param {string} args.tableName - Lookup table.
+ * @param {string} args.value - Lookup value.
+ * @returns {Promise<number | string>} Lookup row id.
+ */
+async function findOrCreateLookupId({columnName, currentDate, db, tableName, value}) {
+  await db.upsert({
+    tableName,
+    conflictColumns: [columnName],
+    updateColumns: [columnName],
+    data: {
+      [columnName]: value,
+      created_at: currentDate,
+      updated_at: currentDate
+    }
+  })
+
+  const id = await findLookupId({columnName, db, tableName, value})
+
+  if (id === null) throw new Error(`Couldn't find ${tableName}.${columnName} after upsert`)
+
+  return id
+}
+
+/**
+ * Finds a lookup id by value.
+ * @param {object} args - Options object.
+ * @param {string} args.columnName - Lookup value column.
+ * @param {import("../drivers/base.js").default} args.db - Database driver.
+ * @param {string} args.tableName - Lookup table.
+ * @param {string} args.value - Lookup value.
+ * @returns {Promise<number | string | null>} Lookup row id or null.
+ */
+async function findLookupId({columnName, db, tableName, value}) {
+  const rows = /** @type {Array<{id: number | string}>} */ (await db.query(`
+    SELECT ${db.quoteColumn("id")} AS id
+    FROM ${db.quoteTable(tableName)}
+    WHERE ${db.quoteColumn(columnName)} = ${db.quote(value)}
+  `))
+
+  if (rows[0]) return rows[0].id
+
+  return null
+}
+
+/**
+ * Normalizes an audit action.
+ * @param {string} action - Action name.
+ * @returns {string} Normalized action.
+ */
+function normalizeAction(action) {
+  const normalizedAction = action.trim()
+
+  if (!normalizedAction) throw new Error("Audit action must be present")
+
+  return normalizedAction
+}
+
+/**
+ * Returns the callback map owned by a model class.
+ * @param {AuditedModelClass} modelClass - Model class.
+ * @returns {Record<string, AuditCallback[]>} Callback map.
+ */
+function auditCallbacksForModelClass(modelClass) {
+  if (!Object.prototype.hasOwnProperty.call(modelClass, "_auditCallbacks")) {
+    modelClass._auditCallbacks = {}
+  }
+
+  const callbacks = modelClass._auditCallbacks
+
+  if (!callbacks) throw new Error(`Audit callbacks weren't initialized for ${modelClass.getModelName()}`)
+
+  return callbacks
+}
+
+/**
+ * Emits audit callbacks for a model/action pair.
+ * @param {AuditedModelClass} modelClass - Model class.
+ * @param {string} action - Audit action.
+ * @param {AuditEventPayload} payload - Event payload.
+ * @returns {Promise<void>}
+ */
+async function emitAuditEvent(modelClass, action, payload) {
+  const callbacks = auditCallbacksForModelClass(modelClass)[action] || []
+
+  for (const callback of [...callbacks]) {
+    await callback(payload)
+  }
+}
+
+export {
+  captureCreateAuditChanges,
+  captureUpdateAuditChanges,
+  createAudit,
+  createCreateAudit,
+  createDestroyAudit,
+  createUpdateAudit,
+  registerAuditCallback,
+  registerAuditing,
+  withoutAudit
+}

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -152,7 +152,8 @@ async function createAuditWithCurrentConnection(record, args, modelClass) {
     currentDate
   })
 
-  await db.insert({
+  const insertResult = await db.query(db.insertSql({
+    returnLastInsertedColumnNames: ["id"],
     tableName: "audits",
     data: {
       audit_action_id: auditActionId,
@@ -164,9 +165,8 @@ async function createAuditWithCurrentConnection(record, args, modelClass) {
       created_at: currentDate,
       updated_at: currentDate
     }
-  })
-
-  const auditId = await db.lastInsertID()
+  }))
+  const auditId = auditIdFromInsertResult(insertResult) ?? await db.lastInsertID()
 
   await emitAuditEvent(modelClass, action, {
     action,
@@ -177,6 +177,25 @@ async function createAuditWithCurrentConnection(record, args, modelClass) {
   })
 
   return auditId
+}
+
+/**
+ * Reads an audit id returned by INSERT ... RETURNING / OUTPUT.
+ * @param {Array<Record<string, ?>> | null | undefined} insertResult - Insert query result.
+ * @returns {number | string | null} Created audit id when the driver returned it.
+ */
+function auditIdFromInsertResult(insertResult) {
+  if (!Array.isArray(insertResult)) return null
+
+  const row = insertResult[0]
+
+  if (!row) return null
+
+  const id = row.id
+
+  if (typeof id == "number" || typeof id == "string") return id
+
+  return null
 }
 
 /**

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -46,6 +46,7 @@ import singularizeModelName from "../../utils/singularize-model-name.js"
 import {defineModelScope} from "../../utils/model-scope.js"
 import { normalizeDateStringForWrite, normalizeDateValueForRead, normalizeDateValueForWrite } from "../datetime-storage.js"
 import {formatValue} from "../../utils/format-value.js"
+import {captureCreateAuditChanges, captureUpdateAuditChanges, createAudit, createCreateAudit, createDestroyAudit, createUpdateAudit, registerAuditCallback, registerAuditing, withoutAudit} from "./auditing.js"
 import ValidatorsFormat from "./validators/format.js"
 import ValidatorsPresence from "./validators/presence.js"
 import ValidatorsUniqueness from "./validators/uniqueness.js"
@@ -248,6 +249,16 @@ class VelociousDatabaseRecord {
   static _eagerLoadRecordMetadata
 
   /**
+   * Narrows the runtime value to the documented type.
+   * @type {Record<string, import("./auditing.js").AuditCallback[]> | undefined} */
+  static _auditCallbacks
+
+  /**
+   * Narrows the runtime value to the documented type.
+   * @type {boolean | undefined} */
+  static _auditLifecycleCallbacksRegistered
+
+  /**
    * Returns the model name, preferring an explicit `static modelName` declaration
    * over the JavaScript class `.name` property. This allows minified builds to
    * preserve correct model names without relying on `keep_classnames`.
@@ -445,6 +456,16 @@ class VelociousDatabaseRecord {
   _changes = {}
 
   /**
+   * Changes captured before a create audit is written.
+   * @type {import("./auditing.js").AuditChanges | undefined} */
+  _pendingCreateAuditChanges = undefined
+
+  /**
+   * Changes captured before an update audit is written.
+   * @type {import("./auditing.js").AuditChanges | undefined} */
+  _pendingUpdateAuditChanges = undefined
+
+  /**
    * Attribute names explicitly assigned in the current update call.
    * @type {Set<string> | undefined}
    */
@@ -611,6 +632,37 @@ class VelociousDatabaseRecord {
    */
   static afterDestroy(callback) {
     VelociousDatabaseRecord.registerLifecycleCallback.call(this, "afterDestroy", /** @type {LifecycleCallbackType} */ (callback))
+  }
+
+  /**
+   * Enables automatic create/update/destroy auditing for this model.
+   * @returns {void}
+   */
+  static audited() {
+    registerAuditing(this)
+  }
+
+  /**
+   * Registers a callback invoked after this model writes an audit row for the action.
+   * @template {typeof VelociousDatabaseRecord} MC
+   * @this {MC}
+   * @param {string} action - Audit action name.
+   * @param {import("./auditing.js").AuditCallback} callback - Callback to run after audit creation.
+   * @returns {() => void} Unsubscribe function.
+   */
+  static onAudit(action, callback) {
+    return registerAuditCallback(this, action, callback)
+  }
+
+  /**
+   * Returns records that do not have an audit row for the given action.
+   * @template {typeof VelociousDatabaseRecord} MC
+   * @this {MC}
+   * @param {string} action - Audit action name.
+   * @returns {ModelClassQuery<MC>} Query scoped to records without that audit action.
+   */
+  static withoutAudit(action) {
+    return withoutAudit(this, action)
   }
 
   /**
@@ -3595,6 +3647,55 @@ class VelociousDatabaseRecord {
 
     await this._connection().query(sql, {logName: `${this.getModelClass().name} Destroy`})
     await this._runLifecycleCallbacks("afterDestroy")
+  }
+
+  /**
+   * Stores an audit row for this record.
+   * @param {import("./auditing.js").CreateAuditArgs} args - Audit row options.
+   * @returns {Promise<number | string>} Created audit row id.
+   */
+  async createAudit(args) {
+    return await createAudit(this, args)
+  }
+
+  /**
+   * Captures create changes before persistence clears the change set.
+   * @returns {void}
+   */
+  captureCreateAuditChanges() {
+    captureCreateAuditChanges(this)
+  }
+
+  /**
+   * Writes the create audit row.
+   * @returns {Promise<void>}
+   */
+  async createCreateAudit() {
+    await createCreateAudit(this)
+  }
+
+  /**
+   * Captures update changes before persistence clears the change set.
+   * @returns {void}
+   */
+  captureUpdateAuditChanges() {
+    captureUpdateAuditChanges(this)
+  }
+
+  /**
+   * Writes the update audit row.
+   * @returns {Promise<void>}
+   */
+  async createUpdateAudit() {
+    await createUpdateAudit(this)
+  }
+
+  /**
+   * Writes the destroy audit row.
+   * @returns {Promise<void>}
+   */
+  async createDestroyAudit() {
+    await createDestroyAudit(this)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add Velocious record auditing APIs: `Model.audited()`, `record.createAudit(...)`, `Model.onAudit(...)`, and `Model.withoutAudit(...)`
- Add dummy-app audit tables, generated default schema dump, docs, and changelog
- Cover automatic create/update/destroy audits, manual audits, audit callbacks, and audit-missing scopes

## Tests
- `VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/database/record/auditing.browser-spec.js`
- `VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/database/record/create.browser-spec.js spec/database/record/update.browser-spec.js spec/database/record/destroy.browser-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- restored `spec/dummy/src/config/configuration.js` after verification