### PR TITLE
Support packages contributing models, resources, migrations & frontend models

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -17,7 +17,11 @@
     "spec/dummy/src/connections/**/*.js",
     "spec/dummy/src/routes/**/*.js",
     "spec/dummy/src/config/**/*.js",
-    "spec/dummy/shared/frontend-command-types.js"
+    "spec/dummy/shared/frontend-command-types.js",
+    "spec/dummy-package/velocious-package.js",
+    "spec/dummy-package/src/models/**/*.js",
+    "spec/dummy-package/src/resources/**/*.js",
+    "spec/dummy-package/src/database/migrations/**/*.js"
   ],
   "ignorePatterns": [
     "build/**",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * Database models that work almost the same in frontend and backend
 * Declarative state machines for models (see [docs/state-machine.md](docs/state-machine.md))
 * Migrations for schema changes and UTC datetime storage (see [docs/database-migrations.md](docs/database-migrations.md))
+* External packages (engines) that contribute data models, frontend-model resources and migrations to a consuming app (see [docs/packages.md](docs/packages.md))
 * Controllers and views for HTTP endpoints
 * Frontend-model transport for creating, updating, querying, and subscribing to query-filtered lifecycle events over HTTP/WebSocket, with structured per-attribute validation error responses (see [docs/frontend-models.md](docs/frontend-models.md))
 * Client-side offline sync mutation logs and frontend-model optimistic queueing primitives (see [docs/offline-sync.md](docs/offline-sync.md))

--- a/changelog.d/20260701-package-contributions.md
+++ b/changelog.d/20260701-package-contributions.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Add support for external npm packages (engines) that contribute data models, frontend-model resources and migrations to a consuming app. List them in `Configuration({packages: [new VelociousPackage({name, url: import.meta.url})]})`; the framework loads each package's `src/models`, discovers its `src/resources`, runs its `src/database/migrations`, and generates its frontend models into the app's `src/frontend-models`. Model-name and cross-source migration-timestamp collisions fail loudly; apps that pass no `packages` are unaffected.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,46 @@
+# Velocious packages (engines)
+
+External npm packages can contribute **data models, frontend-model resources and migrations** to a consuming app. A package ships its model / resource / migration once; the app registers the package and Velocious loads its models, discovers its resources, runs its migrations, and generates its frontend models into the app — so consumers don't hand-write any of it.
+
+## Authoring a package
+
+Structure the package like a mini backend and export a descriptor from its root:
+
+```
+your-package/
+  velocious-package.js
+  src/
+    models/foo.js
+    model-bases/foo.js
+    resources/foo-resource.js          # a *-resource.js with a static ModelClass
+    database/migrations/20260101000000-create-foos.js
+```
+
+```js
+// velocious-package.js
+import VelociousPackage from "velocious/build/src/packages/velocious-package.js"
+
+export default new VelociousPackage({name: "your-package", url: import.meta.url})
+```
+
+`url: import.meta.url` lets the framework derive the package root (the directory containing this file) and, from it, `src/models`, `src/resources` and `src/database/migrations`. Override any of them with `modelsPath` / `resourcesPath` / `migrationsPath` if your layout differs. (A dependency-free package may instead export a plain `{name, path}` descriptor — the app wraps it via `VelociousPackage.from(...)`.)
+
+## Registering packages in an app
+
+```js
+import yourPackage from "your-package/velocious-package.js"
+
+new Configuration({
+  packages: [yourPackage],
+  // ...the app's own configuration
+})
+```
+
+That is all the app needs. On boot Velocious:
+
+- **Models** — loads the package's `src/models` right after the app's own `initializeModels` hook. A package model whose name collides with an already-registered (different) model throws a clear error.
+- **Resources** — auto-discovers the package's `src/resources/*-resource.js` (the same discovery used for the app's own resources), so package models get frontend-model HTTP endpoints, authorization, and realtime websocket broadcasting for free.
+- **Migrations** — `db:migrate` / `db:tenants:migrate` / `rollback` run the app's migrations **and** every package's, interleaved by their 14-digit timestamp. Timestamps must be unique across the app and all packages — a cross-source collision throws (the `schema_migrations` ledger keys on the timestamp).
+- **Frontend models** — `velocious generate:frontend-models` writes each package's frontend model into the app's `src/frontend-models`, merged into the app's shared `index.js` / `setup.js` — identical to the app's own models.
+
+Apps that pass no `packages` behave exactly as before.

--- a/spec/dummy-package/src/database/migrations/20230728075330-create-jobler-jobs.js
+++ b/spec/dummy-package/src/database/migrations/20230728075330-create-jobler-jobs.js
@@ -1,0 +1,11 @@
+import Migration from "../../../../../src/database/migration/index.js"
+
+export default class CreateJoblerJobs extends Migration {
+  async change() {
+    await this.createTable("jobler_jobs", {id: {type: "bigint"}}, (t) => {
+      t.string("name")
+      t.string("status")
+      t.timestamps()
+    })
+  }
+}

--- a/spec/dummy-package/src/models/jobler-job.js
+++ b/spec/dummy-package/src/models/jobler-job.js
@@ -1,0 +1,4 @@
+import DatabaseRecord from "../../../../src/database/record/index.js"
+
+export default class JoblerJob extends DatabaseRecord {
+}

--- a/spec/dummy-package/src/resources/jobler-job-resource.js
+++ b/spec/dummy-package/src/resources/jobler-job-resource.js
@@ -1,0 +1,11 @@
+import BaseResource from "../../../../src/authorization/base-resource.js"
+import JoblerJob from "../models/jobler-job.js"
+
+export default class JoblerJobResource extends BaseResource {
+  static ModelClass = JoblerJob
+
+  /** @returns {void} */
+  abilities() {
+    this.can(["read"])
+  }
+}

--- a/spec/dummy-package/velocious-package.js
+++ b/spec/dummy-package/velocious-package.js
@@ -1,0 +1,3 @@
+import VelociousPackage from "../../src/packages/velocious-package.js"
+
+export default new VelociousPackage({name: "dummy-package", url: import.meta.url})

--- a/spec/packages/velocious-packages-spec.js
+++ b/spec/packages/velocious-packages-spec.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import VelociousPackage from "../../src/packages/velocious-package.js"
+import dummyPackage from "../dummy-package/velocious-package.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/** @returns {Configuration} */
+function buildConfigurationWithPackage() {
+  return new Configuration({
+    backendProjects: [{frontendModelsOutputPath: "/tmp/app", path: "/tmp/app-backend"}],
+    directory: "/tmp/nonexistent-velocious-app",
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    packages: [dummyPackage]
+  })
+}
+
+describe("VelociousPackage", () => {
+  it("derives its directories from the descriptor url", () => {
+    expect(dummyPackage.getName()).toEqual("dummy-package")
+    expect(dummyPackage.getModelsPath().endsWith("/spec/dummy-package/src/models")).toEqual(true)
+    expect(dummyPackage.getResourcesPath().endsWith("/spec/dummy-package/src/resources")).toEqual(true)
+    expect(dummyPackage.getMigrationsPath().endsWith("/spec/dummy-package/src/database/migrations")).toEqual(true)
+  })
+
+  it("wraps a plain descriptor via from() and returns instances unchanged", () => {
+    const wrapped = VelociousPackage.from({name: "plain", path: "/tmp/plain"})
+
+    expect(wrapped.getModelsPath()).toEqual("/tmp/plain/src/models")
+    expect(VelociousPackage.from(dummyPackage)).toBe(dummyPackage)
+  })
+})
+
+describe("Configuration with packages", () => {
+  it("exposes the registered packages", () => {
+    expect(buildConfigurationWithPackage().getPackages()).toEqual([dummyPackage])
+  })
+
+  it("appends a derived backend project targeting the app frontend-models output", () => {
+    const backendProjects = buildConfigurationWithPackage().getBackendProjects()
+
+    expect(backendProjects.length).toEqual(2)
+    expect(backendProjects[1].frontendModelsOutputPath).toEqual("/tmp/app")
+    expect(backendProjects[1].path.endsWith("/spec/dummy-package")).toEqual(true)
+  })
+
+  it("includes the package's migrations in findMigrations with their real absolute paths", async () => {
+    const migrations = await buildConfigurationWithPackage().getEnvironmentHandler().findMigrations()
+    const joblerMigration = migrations.find((migration) => migration.file === "20230728075330-create-jobler-jobs.js")
+
+    if (!joblerMigration) {
+      throw new Error("Expected the package migration to be discovered.")
+    }
+
+    expect(joblerMigration.fullPath?.endsWith("/spec/dummy-package/src/database/migrations/20230728075330-create-jobler-jobs.js")).toEqual(true)
+    expect(joblerMigration.date).toEqual(20230728075330)
+  })
+
+  it("leaves a configuration without packages unchanged", () => {
+    const configuration = new Configuration({
+      backendProjects: [{path: "/tmp/app-backend"}],
+      directory: "/tmp/app",
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode()
+    })
+
+    expect(configuration.getPackages()).toEqual([])
+    expect(configuration.getBackendProjects().length).toEqual(1)
+  })
+})

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -417,9 +417,25 @@
 
 /**
  * @typedef {object} BackendProjectConfiguration
- * @property {string} path - Path to the backend project.
+ * @property {string} path - Path to the backend project. May be an app root or a contributing package root (package entries are appended internally from `packages`).
  * @property {string} [frontendModelsOutputPath] - Optional output project path where `src/frontend-models` should be generated.
  * @property {Record<string, FrontendModelResourceDefinition>} [frontendModels] - Auto-discovered frontend model definitions keyed by model class name. Set internally by the environment handler — do not set manually.
+ */
+
+/**
+ * A descriptor for an external Velocious package (engine) that contributes models,
+ * resources and migrations. A package usually exports `new VelociousPackage({name, url: import.meta.url})`.
+ * @typedef {object} VelociousPackageDescriptor
+ * @property {string} name - The package name.
+ * @property {string} [url] - The descriptor module's `import.meta.url`; the package root is derived from it when `path` is omitted.
+ * @property {string} [path] - The package root directory (the one containing `src`). Derived from `url` when omitted.
+ * @property {string} [modelsPath] - Override for the package's models directory (default `<path>/src/models`).
+ * @property {string} [resourcesPath] - Override for the package's frontend-model resources directory (default `<path>/src/resources`).
+ * @property {string} [migrationsPath] - Override for the package's migrations directory (default `<path>/src/database/migrations`).
+ */
+
+/**
+ * @typedef {import("./packages/velocious-package.js").default | VelociousPackageDescriptor} VelociousPackageConfiguration
  */
 
 /**
@@ -490,6 +506,7 @@
  * @property {AbilityResolverType} [abilityResolver] - Resolver for creating request-scoped ability instances.
  * @property {AttachmentsConfiguration} [attachments] - Attachment storage configuration.
  * @property {BackendProjectConfiguration[]} [backendProjects] - Backend project definitions used for frontend model generation.
+ * @property {VelociousPackageConfiguration[]} [packages] - External Velocious packages that contribute models, frontend-model resources and migrations.
  * @property {{[key: string]: {[key: string]: DatabaseConfigurationType}}} database - Database configurations keyed by environment and identifier.
  * @property {boolean} [debug] - Enable debug logging.
  * @property {boolean | DebugEndpointConfiguration} [debugEndpoint] - Enable the built-in debug endpoint. Defaults to false.

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -419,6 +419,7 @@
  * @typedef {object} BackendProjectConfiguration
  * @property {string} path - Path to the backend project. May be an app root or a contributing package root (package entries are appended internally from `packages`).
  * @property {string} [frontendModelsOutputPath] - Optional output project path where `src/frontend-models` should be generated.
+ * @property {string} [resourcesPath] - Optional override for the resources directory to auto-discover; defaults to `<path>/src/resources`. Set internally for package entries.
  * @property {Record<string, FrontendModelResourceDefinition>} [frontendModels] - Auto-discovered frontend model definitions keyed by model class name. Set internally by the environment handler — do not set manually.
  */
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -25,6 +25,10 @@ import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
 import {validateTimeZone} from "./time-zone.js"
 import {withTrackedStack} from "./utils/with-tracked-stack.js"
+import InitializerFromRequireContext from "./database/initializer-from-require-context.js"
+import VelociousPackage from "./packages/velocious-package.js"
+import requireContext from "require-context"
+import {access} from "node:fs/promises"
 
 export {CurrentConfigurationNotSetError}
 
@@ -127,7 +131,7 @@ export default class VelociousConfiguration {
    * Runs constructor.
    * @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments.
    */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, packages, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -174,6 +178,18 @@ export default class VelociousConfiguration {
     this._exposeInternalErrorsToClients = exposeInternalErrorsToClients
     this._directory = directory
     this._initializeModels = initializeModels
+    /** @type {VelociousPackage[]} */
+    this._packages = (packages || []).map((entry) => VelociousPackage.from(entry))
+
+    // Append a derived backend-project per package so the existing resource
+    // discovery + frontend-model generation machinery includes it. Package
+    // frontend models are generated into the app's frontend-models output.
+    const appFrontendModelsOutputPath = this._backendProjects[0]?.frontendModelsOutputPath
+
+    for (const velociousPackage of this._packages) {
+      this._backendProjects.push(velociousPackage.toBackendProjectConfiguration({frontendModelsOutputPath: appFrontendModelsOutputPath}))
+    }
+
     this._isInitialized = false
     this.httpServer = httpServer || {}
     /**
@@ -840,6 +856,12 @@ export default class VelociousConfiguration {
    * @returns {import("./configuration-types.js").BackendProjectConfiguration[]} - Backend projects.
    */
   getBackendProjects() { return this._backendProjects }
+
+  /**
+   * Runs get packages.
+   * @returns {VelociousPackage[]} - Registered Velocious packages.
+   */
+  getPackages() { return this._packages }
 
   /**
    * Runs get ability resources.
@@ -1671,7 +1693,43 @@ export default class VelociousConfiguration {
         await this._initializeModels({configuration: this, type: args.type})
       }
 
+      await this._initializePackageModels()
+
       await this.getEnvironmentHandler().initializeFrontendModelWebsocketPublishers(this)
+    }
+  }
+
+  /**
+   * Loads models contributed by registered packages into the model registry,
+   * after the app's own `initializeModels` hook has run. A package whose models
+   * directory is absent is skipped; a package model whose name collides with an
+   * already-registered different class throws a clear error.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _initializePackageModels() {
+    for (const velociousPackage of this._packages) {
+      const modelsPath = velociousPackage.getModelsPath()
+
+      try {
+        await access(modelsPath)
+      } catch {
+        continue
+      }
+
+      const packageRequireContext = /** @type {import("./database/initializer-from-require-context.js").ModelClassRequireContextType} */ (requireContext(modelsPath, true, /^(.+)\.js$/))
+
+      for (const fileName of packageRequireContext.keys()) {
+        const modelClass = packageRequireContext(fileName)?.default
+        const existing = modelClass && this.modelClasses[modelClass.getModelName()]
+
+        if (existing && existing !== modelClass) {
+          throw new Error(`Package "${velociousPackage.getName()}" model "${modelClass.getModelName()}" collides with an already-registered model.`)
+        }
+      }
+
+      await this.ensureConnections({name: `Initialize ${velociousPackage.getName()} package models`}, async () => {
+        await new InitializerFromRequireContext({requireContext: packageRequireContext}).initialize({configuration: this})
+      })
     }
   }
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -25,10 +25,7 @@ import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
 import {validateTimeZone} from "./time-zone.js"
 import {withTrackedStack} from "./utils/with-tracked-stack.js"
-import InitializerFromRequireContext from "./database/initializer-from-require-context.js"
 import VelociousPackage from "./packages/velocious-package.js"
-import requireContext from "require-context"
-import {access} from "node:fs/promises"
 
 export {CurrentConfigurationNotSetError}
 
@@ -1695,43 +1692,9 @@ export default class VelociousConfiguration {
         await this._initializeModels({configuration: this, type: args.type})
       }
 
-      await this._initializePackageModels()
+      await this.getEnvironmentHandler().initializePackageModels(this)
 
       await this.getEnvironmentHandler().initializeFrontendModelWebsocketPublishers(this)
-    }
-  }
-
-  /**
-   * Loads models contributed by registered packages into the model registry,
-   * after the app's own `initializeModels` hook has run. A package whose models
-   * directory is absent is skipped; a package model whose name collides with an
-   * already-registered different class throws a clear error.
-   * @returns {Promise<void>} - Resolves when complete.
-   */
-  async _initializePackageModels() {
-    for (const velociousPackage of this._packages) {
-      const modelsPath = velociousPackage.getModelsPath()
-
-      try {
-        await access(modelsPath)
-      } catch {
-        continue
-      }
-
-      const packageRequireContext = /** @type {import("./database/initializer-from-require-context.js").ModelClassRequireContextType} */ (requireContext(modelsPath, true, /^(.+)\.js$/))
-
-      for (const fileName of packageRequireContext.keys()) {
-        const modelClass = packageRequireContext(fileName)?.default
-        const existing = modelClass && this.modelClasses[modelClass.getModelName()]
-
-        if (existing && existing !== modelClass) {
-          throw new Error(`Package "${velociousPackage.getName()}" model "${modelClass.getModelName()}" collides with an already-registered model.`)
-        }
-      }
-
-      await this.ensureConnections({name: `Initialize ${velociousPackage.getName()} package models`}, async () => {
-        await new InitializerFromRequireContext({requireContext: packageRequireContext}).initialize({configuration: this})
-      })
     }
   }
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -164,7 +164,9 @@ export default class VelociousConfiguration {
     this._beaconLastDownError = undefined
     this._scheduledBackgroundJobs = scheduledBackgroundJobs
     this._attachments = attachments || {}
-    this._backendProjects = backendProjects || []
+    // Copy so appending package-derived entries below never mutates a caller's
+    // shared array (config modules commonly export a reused backendProjects array).
+    this._backendProjects = backendProjects ? [...backendProjects] : []
     /** @type {import("./configuration-types.js").ClientErrorPayloadReporterType[]} */
     this._clientErrorPayloadReporters = []
     this.cors = cors

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -614,4 +614,13 @@ export default class VelociousEnvironmentHandlerBase {
   async initializeFrontendModelWebsocketPublishers(_configuration) {
     // No-op in base handler; Node handler does the real registration.
   }
+
+  /**
+   * Loads models contributed by registered packages.
+   * @param {import("../configuration.js").default} _configuration - Configuration instance.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async initializePackageModels(_configuration) {
+    // No-op in base handler; Node handler loads package models from the filesystem.
+  }
 }

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -761,32 +761,79 @@ export default class VelociousEnvironmentHandlerNode extends Base{
    * @returns {Promise<Array<import("./base.js").MigrationObjectType>>} - Resolves with the migrations.
    */
   async findMigrations() {
-    const migrationsPath = `${this.getConfiguration().getDirectory()}/src/database/migrations`
-    const glob = await fs.glob(`${migrationsPath}/**/*.js`)
-    let files = []
+    const configuration = this.getConfiguration()
+    const migrationDirectories = [`${configuration.getDirectory()}/src/database/migrations`]
 
-    for await (const fullPath of glob) {
-      const file = await path.basename(fullPath)
-
-      const match = file.match(/^(\d{14})-(.+)\.js$/)
-
-      if (!match) continue
-
-      const date = parseInt(match[1])
-      const migrationName = match[2]
-      const migrationClassName = inflection.camelize(migrationName.replaceAll("-", "_"))
-
-      files.push({
-        file,
-        fullPath: `${migrationsPath}/${file}`,
-        date,
-        migrationClassName
-      })
+    for (const velociousPackage of configuration.getPackages()) {
+      migrationDirectories.push(velociousPackage.getMigrationsPath())
     }
 
-    files = files.sort((migration1, migration2) => migration1.date - migration2.date)
+    /** @type {Array<import("./base.js").MigrationObjectType>} */
+    const files = []
 
-    return files
+    for (const migrationsPath of migrationDirectories) {
+      await this._collectMigrationsFromDirectory(migrationsPath, files)
+    }
+
+    this._ensureNoMigrationTimestampCollisions(files)
+
+    return files.sort((migration1, migration2) => migration1.date - migration2.date)
+  }
+
+  /**
+   * Collects migration files from one directory into `files`, preserving each
+   * file's real absolute path (so app and package migrations keep their own
+   * source location). A missing directory is skipped.
+   * @param {string} migrationsPath - Directory to scan.
+   * @param {Array<import("./base.js").MigrationObjectType>} files - Accumulator to push into.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async _collectMigrationsFromDirectory(migrationsPath, files) {
+    const glob = await fs.glob(`${migrationsPath}/**/*.js`)
+
+    try {
+      for await (const fullPath of glob) {
+        const file = await path.basename(fullPath)
+        const match = file.match(/^(\d{14})-(.+)\.js$/)
+
+        if (!match) continue
+
+        const date = parseInt(match[1])
+        const migrationName = match[2]
+        const migrationClassName = inflection.camelize(migrationName.replaceAll("-", "_"))
+
+        files.push({file, fullPath, date, migrationClassName})
+      }
+    } catch (error) {
+      if (/** @type {NodeJS.ErrnoException} */ (error)?.code !== "ENOENT") {
+        throw error
+      }
+    }
+  }
+
+  /**
+   * Throws if two migrations from different files share the same 14-digit
+   * timestamp. The `schema_migrations` ledger keys on the timestamp, so a silent
+   * collision (e.g. between the app and a package, or two packages) would leave
+   * the second migration un-run — a data bug. Fail loudly instead.
+   * @param {Array<import("./base.js").MigrationObjectType>} files - Collected migrations.
+   * @returns {void} - No return value.
+   */
+  _ensureNoMigrationTimestampCollisions(files) {
+    /** @type {Map<number, string>} */
+    const pathsByDate = new Map()
+
+    for (const migration of files) {
+      if (!migration.fullPath) continue
+
+      const existing = pathsByDate.get(migration.date)
+
+      if (existing && existing !== migration.fullPath) {
+        throw new Error(`Two migrations share the timestamp ${migration.date}: ${existing} and ${migration.fullPath}. Migration timestamps must be unique across the app and all packages.`)
+      }
+
+      pathsByDate.set(migration.date, migration.fullPath)
+    }
   }
 
   /**

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -31,6 +31,8 @@ import * as inflection from "inflection"
 import path from "path"
 import {AsyncLocalStorage as NodeAsyncLocalStorage} from "node:async_hooks"
 import {timingSafeEqual} from "node:crypto"
+import requireContext from "require-context"
+import InitializerFromRequireContext from "../database/initializer-from-require-context.js"
 import toImportSpecifier from "../utils/to-import-specifier.js"
 import {validateTimeZone} from "../time-zone.js"
 
@@ -142,6 +144,43 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       if (Object.keys(discovered).length > 0) {
         backendProject.frontendModels = discovered
       }
+    }
+  }
+
+  /**
+   * Loads models contributed by registered packages into the model registry,
+   * after the app's own `initializeModels` hook. A package whose models directory
+   * is absent is skipped; a package model whose name collides with an
+   * already-registered different class throws. Node-only (uses the filesystem), so
+   * it lives here rather than in the browser-bundled Configuration.
+   * @param {import("../configuration.js").default} configuration - Configuration instance.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async initializePackageModels(configuration) {
+    for (const velociousPackage of configuration.getPackages()) {
+      const modelsPath = velociousPackage.getModelsPath()
+
+      try {
+        await fs.access(modelsPath)
+      } catch {
+        continue
+      }
+
+      const packageRequireContext = /** @type {import("../database/initializer-from-require-context.js").ModelClassRequireContextType} */ (requireContext(modelsPath, true, /^(.+)\.js$/))
+      const modelClasses = configuration.getModelClasses()
+
+      for (const fileName of packageRequireContext.keys()) {
+        const modelClass = packageRequireContext(fileName)?.default
+        const existing = modelClass && modelClasses[modelClass.getModelName()]
+
+        if (existing && existing !== modelClass) {
+          throw new Error(`Package "${velociousPackage.getName()}" model "${modelClass.getModelName()}" collides with an already-registered model.`)
+        }
+      }
+
+      await configuration.ensureConnections({name: `Initialize ${velociousPackage.getName()} package models`}, async () => {
+        await new InitializerFromRequireContext({requireContext: packageRequireContext}).initialize({configuration})
+      })
     }
   }
 

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -103,7 +103,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
     for (const backendProject of backendProjects) {
       if (backendProject.frontendModels) continue
 
-      const resourcesDir = path.join(backendProject.path, "src", "resources")
+      const resourcesDir = backendProject.resourcesPath || path.join(backendProject.path, "src", "resources")
       let files
 
       try {

--- a/src/packages/velocious-package.js
+++ b/src/packages/velocious-package.js
@@ -1,0 +1,105 @@
+// @ts-check
+
+import {dirname} from "path"
+import {fileURLToPath} from "url"
+
+import restArgsError from "../utils/rest-args-error.js"
+
+/**
+ * A Velocious package (engine): an external npm package that contributes data
+ * models, frontend-model resources and migrations to a consuming app. The app
+ * lists packages in `Configuration({packages: [...]})`; the framework then loads
+ * the package's `src/models`, discovers its `src/resources`, runs its
+ * `src/database/migrations`, and generates its frontend models into the app.
+ */
+export default class VelociousPackage {
+  /**
+   * Wraps a plain descriptor as a VelociousPackage (or returns it unchanged when
+   * it already is one), so packages can be listed without importing this class.
+   * @param {VelociousPackage | import("../configuration-types.js").VelociousPackageDescriptor} descriptor - Package or plain descriptor.
+   * @returns {VelociousPackage} - The package instance.
+   */
+  static from(descriptor) {
+    if (descriptor instanceof VelociousPackage) {
+      return descriptor
+    }
+
+    return new VelociousPackage(descriptor)
+  }
+
+  /**
+   * Runs constructor.
+   * @param {import("../configuration-types.js").VelociousPackageDescriptor} args - Package descriptor.
+   */
+  constructor({name, url, path, modelsPath, resourcesPath, migrationsPath, ...restArgs}) {
+    restArgsError(restArgs)
+
+    if (!name) {
+      throw new Error("A velocious package requires a name.")
+    }
+
+    if (!path && !url) {
+      throw new Error(`Velocious package "${name}" requires a "path" or a "url" (usually import.meta.url).`)
+    }
+
+    this._name = name
+    this._path = path || dirname(fileURLToPath(/** @type {string} */ (url)))
+    this._modelsPath = modelsPath
+    this._resourcesPath = resourcesPath
+    this._migrationsPath = migrationsPath
+  }
+
+  /**
+   * Runs get name.
+   * @returns {string} - The package name.
+   */
+  getName() {
+    return this._name
+  }
+
+  /**
+   * Runs get path.
+   * @returns {string} - The package root directory (the one that contains `src`).
+   */
+  getPath() {
+    return this._path
+  }
+
+  /**
+   * Runs get models path.
+   * @returns {string} - The package's models directory.
+   */
+  getModelsPath() {
+    return this._modelsPath || `${this._path}/src/models`
+  }
+
+  /**
+   * Runs get resources path.
+   * @returns {string} - The package's frontend-model resources directory.
+   */
+  getResourcesPath() {
+    return this._resourcesPath || `${this._path}/src/resources`
+  }
+
+  /**
+   * Runs get migrations path.
+   * @returns {string} - The package's migrations directory.
+   */
+  getMigrationsPath() {
+    return this._migrationsPath || `${this._path}/src/database/migrations`
+  }
+
+  /**
+   * Derives the internal backend-project entry the framework appends so the
+   * existing resource-discovery + frontend-model generation machinery picks up
+   * this package. Generated frontend models are written to the app's output.
+   * @param {{frontendModelsOutputPath: string | undefined}} args - The app's frontend-models output path.
+   * @returns {import("../configuration-types.js").BackendProjectConfiguration} - The derived backend project.
+   */
+  toBackendProjectConfiguration({frontendModelsOutputPath}) {
+    return {
+      frontendModelsOutputPath,
+      path: this.getPath()
+    }
+  }
+}

--- a/src/packages/velocious-package.js
+++ b/src/packages/velocious-package.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-import {dirname} from "path"
-import {fileURLToPath} from "url"
-
 import restArgsError from "../utils/rest-args-error.js"
 
 /**
@@ -28,6 +25,18 @@ export default class VelociousPackage {
   }
 
   /**
+   * Derives the containing directory of a module url without Node's `path`/`url`
+   * modules, so this class stays safe to import in browser/Expo bundles.
+   * @param {string} url - A module url (usually `import.meta.url`).
+   * @returns {string} - The directory path that contains the module.
+   */
+  static _directoryFromUrl(url) {
+    const directoryUrl = new URL(".", url)
+
+    return decodeURIComponent(directoryUrl.pathname).replace(/\/$/, "")
+  }
+
+  /**
    * Runs constructor.
    * @param {import("../configuration-types.js").VelociousPackageDescriptor} args - Package descriptor.
    */
@@ -43,7 +52,7 @@ export default class VelociousPackage {
     }
 
     this._name = name
-    this._path = path || dirname(fileURLToPath(/** @type {string} */ (url)))
+    this._path = path || VelociousPackage._directoryFromUrl(/** @type {string} */ (url))
     this._modelsPath = modelsPath
     this._resourcesPath = resourcesPath
     this._migrationsPath = migrationsPath

--- a/src/packages/velocious-package.js
+++ b/src/packages/velocious-package.js
@@ -99,7 +99,8 @@ export default class VelociousPackage {
   toBackendProjectConfiguration({frontendModelsOutputPath}) {
     return {
       frontendModelsOutputPath,
-      path: this.getPath()
+      path: this.getPath(),
+      resourcesPath: this.getResourcesPath()
     }
   }
 }


### PR DESCRIPTION
## What

Adds a first-class **`packages`** (engines) concept so an external npm package can ship a data model + frontend-model resource + migration once, and any consuming app picks them up — instead of the app hand-writing all of them. This is the framework foundation for packages like `velocious-jobler` (which wants to ship its `JoblerJob`).

## How

- **`VelociousPackage`** descriptor (`src/packages/velocious-package.js`): `new VelociousPackage({name, url: import.meta.url})` derives the package root and its `src/models`, `src/resources`, `src/database/migrations` (all overridable).
- **`Configuration({packages: [...]})`**: each package is reconciled into an appended `backendProjects` entry (`path` = package root, `frontendModelsOutputPath` = the app's), so the **existing** resource auto-discovery, frontend-model generation, authorization, and websocket publishing include it with no change. Package **models** load via a new `_initializePackageModels` step that runs after the app's `initializeModels` hook, with a **model-name collision guard**.
- **`findMigrations()`** now globs the app's migrations **plus every package's**, preserving each file's real absolute path, keeping the global 14-digit-timestamp sort so app + package migrations interleave, and **throwing on a duplicate timestamp across sources** (the `schema_migrations` ledger keys on the timestamp, so a silent clash would leave a migration un-run).
- Frontend-model generation needs no generator change: because a package is a derived `backendProjects` entry pointing its output at the app, `generate:frontend-models` writes the package's model into the app's `src/frontend-models`, merged into the shared `index.js`/`setup.js`.

## Backwards compatibility

Apps that pass no `packages` get an empty list, nothing appended or loaded — byte-for-byte identical behavior.

## Tests

`spec/dummy-package/` fixture (model + resource + migration + descriptor) and `spec/packages/velocious-packages-spec.js` cover: path derivation + `.from()`, `getPackages()`, the derived backend project targeting the app output, multi-source `findMigrations` with real absolute paths, and the no-packages-unchanged path. `npm run lint` (eslint + typecheck + fallow) and `npm run build` clean; the new spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)