### PR TITLE
Bump snapreq to ^0.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,8 @@ unsubscribe()
 await client.close()
 ```
 
+For long-lived Node clients, the constructor also accepts opt-in liveness options (all default off, so browser/Expo usage is unchanged): `webSocketImplementation` (inject Node's `ws`, since the global/undici WebSocket exposes neither protocol ping nor an unref-able socket), `heartbeatIntervalMs` (a ping heartbeat that drops a socket whose peer stops ponging, so a client notices a vanished server), and `unref` (unref the underlying socket so an idle connection can't keep the process alive on its own). See [docs/websocket-channels.md](docs/websocket-channels.md).
+
 ## Subscribe to events
 
 ```js

--- a/changelog.d/20260702085013-bump-snapreq-0.0.9.md
+++ b/changelog.d/20260702085013-bump-snapreq-0.0.9.md
@@ -1,0 +1,9 @@
+Bump the `snapreq` dependency to `^0.0.9`, which exposes new opt-in WebSocket
+liveness options through `VelociousWebsocketClient` (its constructor forwards
+args straight through to `SnapReqWebSocketClient`). Long-lived Node consumers can
+now pass `webSocketImplementation` (inject Node's `ws`, since the browser/undici
+global exposes neither protocol ping nor an unref-able socket), `heartbeatIntervalMs`
+(a protocol ping heartbeat that drops a socket whose peer stops ponging, so a
+client notices a vanished server), and `unref` (unref the underlying socket so an
+idle connection can't keep the Node event loop alive on its own). All three
+default off, so browser/Expo usage is unchanged. See `docs/websocket-channels.md`.

--- a/docs/websocket-channels.md
+++ b/docs/websocket-channels.md
@@ -110,6 +110,10 @@ Client behavior:
 - Queued subscriptions preserve `lastEventId`, so replay checkpoints survive delayed initial connects as well as later reconnects.
 - `connect()` is the normal public entrypoint. By default it enables auto-reconnect, and when a `networkMonitor` is configured it waits for the monitor to report online before opening or re-opening the socket.
 - Callers that need lower-level behavior can still override `connect({autoReconnect: false})` or `connect({waitForOnline: false})`, but those are opt-outs rather than the normal app path.
+- **Connection liveness (opt-in, Node long-lived clients).** The constructor forwards snapreq 0.0.9's liveness options straight through, so a long-lived server-side consumer can keep a socket from silently leaking. All three default off, so browser/Expo usage is unchanged:
+  - `webSocketImplementation` — a `WebSocket` constructor to use instead of the global one. Inject Node's `ws` here to get real protocol ping/pong and an unref-able socket; the browser/undici global exposes neither, so the two options below are no-ops without it.
+  - `heartbeatIntervalMs` — when `> 0` (and the implementation supports `.ping()`), send a protocol ping every interval and drop the socket if the peer did not pong since the previous ping, so a client notices a vanished server within ~2× the interval (the ping timer is `unref`'d and never keeps the process alive on its own).
+  - `unref` — unref the underlying socket so an idle connection can never pin the Node event loop by itself.
 
 ## Lifecycle guarantees (Phase 1B)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "pure-uuid": "^2.0.0",
         "require-context": "^1.1.0",
         "set-state-compare": "^1.0.61",
-        "snapreq": "^0.0.8",
+        "snapreq": "^0.0.9",
         "sql-escape-string": "^1.1.0",
         "sql.js": "^1.12.0",
         "strftime": "^0.10.2",
@@ -15350,9 +15350,9 @@
       }
     },
     "node_modules/snapreq": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.8.tgz",
-      "integrity": "sha512-S7ecgyOBPI4bkiJ8TrMPsbfA0aN8brWvBZo+Hsoy1bVSJUp3kNi4EzZtoZPUXdHe+Ej1IvbydhKP7lNFnP+yfg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.9.tgz",
+      "integrity": "sha512-KRqZ9TxIUJPfwr9ecO5o0iMKKx5JvzeenjqsWjwJbFNMxI3QRuk0u4AuyhLWb3ahsv4LmVW1TKeqcZSBAYUiMg==",
       "license": "ISC"
     },
     "node_modules/socks": {
@@ -27704,9 +27704,9 @@
       }
     },
     "snapreq": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.8.tgz",
-      "integrity": "sha512-S7ecgyOBPI4bkiJ8TrMPsbfA0aN8brWvBZo+Hsoy1bVSJUp3kNi4EzZtoZPUXdHe+Ej1IvbydhKP7lNFnP+yfg=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.9.tgz",
+      "integrity": "sha512-KRqZ9TxIUJPfwr9ecO5o0iMKKx5JvzeenjqsWjwJbFNMxI3QRuk0u4AuyhLWb3ahsv4LmVW1TKeqcZSBAYUiMg=="
     },
     "socks": {
       "version": "2.8.7",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "pure-uuid": "^2.0.0",
     "require-context": "^1.1.0",
     "set-state-compare": "^1.0.61",
-    "snapreq": "^0.0.8",
+    "snapreq": "^0.0.9",
     "sql-escape-string": "^1.1.0",
     "sql.js": "^1.12.0",
     "strftime": "^0.10.2",


### PR DESCRIPTION
Bumps `snapreq` `^0.0.8` → `^0.0.9` to pick up snapreq's opt-in WebSocket **ping heartbeat**, socket **unref**, and **injectable WebSocket implementation** (kaspernj/snapreq#21).

`VelociousWebsocketClient` already forwards constructor options straight through to `SnapReqWebSocketClient`, so consumers can enable these (e.g. the TensorBuzz file-streaming client injecting Node `ws` + a heartbeat + unref, so a build-log websocket can never pin a worker fork's event loop) with **no velocious code change** — just the dependency bump. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)