### PR TITLE
Add generic sync API helpers

### DIFF
--- a/spec/sync/sync-api-controller-spec.js
+++ b/spec/sync/sync-api-controller-spec.js
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "../../src/testing/test.js"
+import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
+import SyncApiController from "../../src/sync/sync-api-controller.js"
+
+class TestSyncModel {}
+
+class TestSyncResource extends FrontendModelBaseResource {
+  static ModelClass = TestSyncModel
+}
+
+describe("sync api controller", () => {
+  it("passes ability context, locals, params, and request into sync resources", () => {
+    const request = {id: "request-1"}
+    const ability = {
+      getContext: () => ({currentDevice: {id: "device-1"}, currentUser: {id: "user-1"}, offlineGrant: {id: "grant-1"}}),
+      getLocals: () => ({traceId: "trace-1"})
+    }
+    const params = {authenticationToken: "token-1"}
+    const ControllerClass = SyncApiController.withSyncResourceClass(TestSyncResource)
+    const controller = Object.assign(Object.create(ControllerClass.prototype), {
+      currentAbility: () => ability,
+      params: () => params,
+      request: () => request
+    })
+
+    const resource = controller.syncResource(params)
+
+    expect(resource.currentUser()).toEqual({id: "user-1"})
+    expect(resource.currentDevice()).toEqual({id: "device-1"})
+    expect(resource.offlineGrant()).toEqual({id: "grant-1"})
+    expect(resource.request()).toEqual(request)
+    expect(resource.params()).toEqual(params)
+    expect(resource.getLocals()).toEqual({traceId: "trace-1"})
+  })
+})

--- a/spec/sync/sync-model-change-feed-service-spec.js
+++ b/spec/sync/sync-model-change-feed-service-spec.js
@@ -1,0 +1,24 @@
+import {describe, expect, it} from "../../src/testing/test.js"
+import SyncModelChangeFeedService from "../../src/sync/sync-model-change-feed-service.js"
+
+class TestSyncModel {}
+
+describe("sync model change-feed service", () => {
+  it("rejects sub-unit fractional limits instead of flooring them to zero", () => {
+    const service = new SyncModelChangeFeedService({modelClass: TestSyncModel, params: {limit: "0.5"}})
+
+    expect(() => service.normalizedLimit("0.5")).toThrow("Sync changes limit must be a positive integer.")
+  })
+
+  it("rejects positive fractional limits instead of silently flooring them", () => {
+    const service = new SyncModelChangeFeedService({modelClass: TestSyncModel, params: {limit: "1.5"}})
+
+    expect(() => service.normalizedLimit("1.5")).toThrow("Sync changes limit must be a positive integer.")
+  })
+
+  it("clamps valid integer limits to the configured maximum", () => {
+    const service = new SyncModelChangeFeedService({maxLimit: 2, modelClass: TestSyncModel, params: {limit: "10"}})
+
+    expect(service.normalizedLimit("10")).toEqual(2)
+  })
+})

--- a/spec/sync/sync-model-change-feed-service-spec.js
+++ b/spec/sync/sync-model-change-feed-service-spec.js
@@ -21,4 +21,16 @@ describe("sync model change-feed service", () => {
 
     expect(service.normalizedLimit("10")).toEqual(2)
   })
+
+  it("fails early when asked to read a value from an invalid sync row", () => {
+    const service = new SyncModelChangeFeedService({modelClass: TestSyncModel, params: {}})
+
+    expect(() => service.recordValue(null, "id")).toThrow("Sync changes row must be an object.")
+  })
+
+  it("fails early when a sync row is missing an expected field", () => {
+    const service = new SyncModelChangeFeedService({modelClass: TestSyncModel, params: {}})
+
+    expect(() => service.recordValue({}, "id")).toThrow("Sync changes row is missing id.")
+  })
 })

--- a/src/sync/sync-api-client-types.js
+++ b/src/sync/sync-api-client-types.js
@@ -1,0 +1,77 @@
+// @ts-check
+
+/**
+ * @module sync-api-client-types
+ */
+
+/** @typedef {{id: string | null, serverSequence: number | null, updatedAt: string} | null} SyncCursor */
+
+/**
+ * @typedef {object} SyncChangeEnvelope
+ * @property {() => unknown} data - Sync data payload.
+ * @property {() => unknown} id - Sync row identifier.
+ * @property {() => unknown} resourceId - Resource identifier.
+ * @property {() => string | null} resourceType - Resource type name.
+ * @property {() => string} syncType - Sync operation type.
+ */
+
+/**
+ * @typedef {object} SyncChangeApplyResult
+ * @property {boolean} changed - Whether the local store changed.
+ * @property {string | null} [resourceType] - Applied resource type override.
+ */
+
+/**
+ * @typedef {object} SyncResourceConfig
+ * @property {(args: {attributes: Record<string, unknown>, data: Record<string, unknown>, record: ?, sync: SyncChangeEnvelope}) => Promise<boolean | void> | boolean | void} [afterApply] - Optional post-save hook.
+ * @property {(args: {data: Record<string, unknown>, record: ?, sync: SyncChangeEnvelope}) => Promise<Record<string, unknown>> | Record<string, unknown>} attributes - Allowed attributes builder.
+ * @property {boolean} enabled - Whether this resource is sync-enabled.
+ * @property {(args: {data: Record<string, unknown>, resourceId: unknown, sync: SyncChangeEnvelope}) => Promise<?> | ?} [findRecord] - Optional upsert finder.
+ * @property {(args: {resourceId: unknown, sync: SyncChangeEnvelope}) => Promise<?> | ?} [findRecordForDelete] - Optional destroy finder.
+ * @property {?} modelClass - Velocious model class.
+ */
+
+/**
+ * @typedef {object} SyncChangesRequest
+ * @property {string} authenticationToken - Auth token.
+ * @property {string | null} [afterId] - Last seen row id.
+ * @property {number} [afterServerSequence] - Last seen server sequence.
+ * @property {string} [afterUpdatedAt] - Last seen timestamp.
+ * @property {number} limit - Page size.
+ * @property {string | null} [upToId] - Snapshot upper-bound row id.
+ * @property {number} [upToServerSequence] - Snapshot upper-bound server sequence.
+ * @property {string} [upToUpdatedAt] - Snapshot upper-bound timestamp.
+ */
+
+/**
+ * @typedef {object} SyncChangesResponse
+ * @property {string} [errorMessage] - Error message.
+ * @property {SyncCursor | Record<string, ?>} [nextCursor] - Next cursor.
+ * @property {string} [status] - Response status.
+ * @property {Array<unknown>} [syncs] - Sync rows.
+ * @property {SyncCursor | Record<string, ?>} [upToCursor] - Snapshot upper-bound cursor.
+ */
+
+/**
+ * @typedef {object} SyncChangesResult
+ * @property {boolean} changed - Whether any local record changed.
+ * @property {number} pages - Applied page count.
+ * @property {Record<string, boolean>} resourceChanged - Changed flags by resource type.
+ * @property {Record<string, number>} resourceCounts - Applied counts by resource type.
+ * @property {number} syncedCount - Applied row count.
+ */
+
+/**
+ * @typedef {object} SyncReplayItem
+ * @property {string | number} id - Sync id.
+ * @property {string} syncState - Replay state.
+ */
+
+/**
+ * @typedef {object} SyncReplayResponse
+ * @property {string} [errorMessage] - Error message.
+ * @property {string} [status] - Response status.
+ * @property {Array<SyncReplayItem>} [syncs] - Replay results.
+ */
+
+export {}

--- a/src/sync/sync-api-client.js
+++ b/src/sync/sync-api-client.js
@@ -7,6 +7,258 @@
  */
 export default class SyncApiClient {
   /**
+   * Pulls backend sync changes in stable pages, applies them locally, and stores
+   * the acknowledged cursor. Apps provide only auth, persistence, transport, and
+   * resource policy hooks.
+   * @param {object} args - Pull args.
+   * @param {string} args.authenticationToken - Auth token to send with change requests.
+   * @param {number} [args.batchSize] - Max syncs per request. Defaults to 100.
+   * @param {() => Promise<SyncCursor | string | null | undefined>} args.loadCursor - Loads the persisted local cursor.
+   * @param {(cursor: SyncCursor) => Promise<void>} args.saveCursor - Persists the final acknowledged cursor.
+   * @param {(payload: SyncChangesRequest) => Promise<SyncChangesResponse>} args.postChanges - Posts one changes request.
+   * @param {(sync: SyncChangeEnvelope) => Promise<SyncChangeApplyResult>} args.applySync - Applies one normalized sync row locally.
+   * @param {(progress: {pages: number, syncedCount: number}) => void} [args.onProgress] - Progress callback.
+   * @returns {Promise<SyncChangesResult>} Pull result.
+   */
+  static async pullChanges(args) {
+    let afterCursor = this.syncCursorFromPayload(await args.loadCursor())
+    let upToCursor = null
+    let pages = 0
+    let syncedCount = 0
+    let changed = false
+    const resourceCounts = /** @type {Record<string, number>} */ ({})
+    const resourceChanged = /** @type {Record<string, boolean>} */ ({})
+    const batchSize = this.normalizedBatchSize(args.batchSize)
+
+    while (true) {
+      const changesResponse = await this.changesPage({...args, afterCursor, batchSize, upToCursor})
+      const syncs = changesResponse.syncs
+
+      if (!upToCursor) upToCursor = changesResponse.upToCursor
+      if (syncs.length === 0) break
+
+      pages += 1
+
+      for (const sync of syncs) {
+        const applyResult = await args.applySync(sync)
+        const resourceType = applyResult.resourceType ?? sync.resourceType()
+
+        changed ||= applyResult.changed === true
+        syncedCount += 1
+
+        if (resourceType) {
+          resourceCounts[resourceType] = (resourceCounts[resourceType] || 0) + 1
+          resourceChanged[resourceType] ||= applyResult.changed === true
+        }
+      }
+
+      afterCursor = changesResponse.nextCursor
+
+      if (args.onProgress) args.onProgress({pages, syncedCount})
+      if (syncs.length < batchSize) break
+    }
+
+    if (afterCursor) await args.saveCursor(afterCursor)
+
+    return {changed, pages, resourceChanged, resourceCounts, syncedCount}
+  }
+
+  /**
+   * Fetches and validates one backend sync changes page.
+   * @param {object} args - Page args.
+   * @param {SyncCursor} args.afterCursor - Last acknowledged cursor.
+   * @param {string} args.authenticationToken - Auth token.
+   * @param {number} args.batchSize - Page size.
+   * @param {(payload: SyncChangesRequest) => Promise<SyncChangesResponse>} args.postChanges - Changes poster.
+   * @param {SyncCursor} args.upToCursor - Snapshot upper-bound cursor.
+   * @returns {Promise<{nextCursor: SyncCursor, syncs: SyncChangeEnvelope[], upToCursor: SyncCursor}>} Normalized changes page.
+   */
+  static async changesPage({afterCursor, authenticationToken, batchSize, postChanges, upToCursor}) {
+    const response = await postChanges({
+      authenticationToken,
+      limit: batchSize,
+      ...this.cursorPayload("after", afterCursor),
+      ...this.cursorPayload("upTo", upToCursor)
+    })
+
+    this.ensureSuccessfulChangesResponse(response)
+
+    const syncs = /** @type {unknown[]} */ (response.syncs)
+
+    return {
+      nextCursor: this.syncCursorFromPayload(response.nextCursor ?? null),
+      syncs: syncs.map((syncPayload) => this.syncEnvelopeFromPayload(syncPayload)),
+      upToCursor: this.syncCursorFromPayload(response.upToCursor ?? null)
+    }
+  }
+
+  /**
+   * Checks API response status and shape for change-feed pulls.
+   * @param {SyncChangesResponse} response - Changes response.
+   * @returns {void}
+   */
+  static ensureSuccessfulChangesResponse(response) {
+    if (response.status === "error") throw new Error(response.errorMessage || "Sync changes failed")
+    if (!Array.isArray(response.syncs)) throw new Error("Sync changes response missing syncs")
+  }
+
+  /**
+   * Converts a cursor into request params with the given prefix.
+   * @param {"after" | "upTo"} prefix - Request field prefix.
+   * @param {SyncCursor} cursor - Cursor to serialize.
+   * @returns {Record<string, string | number | null>} Request params.
+   */
+  static cursorPayload(prefix, cursor) {
+    if (!cursor) return {}
+
+    return {
+      [`${prefix}Id`]: cursor.id,
+      ...(cursor.serverSequence ? {[`${prefix}ServerSequence`]: cursor.serverSequence} : {}),
+      [`${prefix}UpdatedAt`]: cursor.updatedAt
+    }
+  }
+
+  /**
+   * Parses a persisted or response cursor payload.
+   * @param {SyncCursor | string | Record<string, ?> | null | undefined} payload - Cursor payload.
+   * @returns {SyncCursor} Parsed cursor.
+   */
+  static syncCursorFromPayload(payload) {
+    if (!payload) return null
+
+    if (typeof payload === "string") {
+      try {
+        return this.syncCursorFromPayload(JSON.parse(payload))
+      } catch (_error) {
+        return {id: null, serverSequence: null, updatedAt: payload}
+      }
+    }
+
+    if (typeof payload !== "object" || Array.isArray(payload)) return null
+
+    const updatedAt = typeof payload.updatedAt === "string" ? payload.updatedAt : null
+
+    if (!updatedAt) return null
+
+    return {
+      id: payload.id === null || payload.id === undefined ? null : String(payload.id),
+      serverSequence: this.optionalInteger(payload.serverSequence),
+      updatedAt
+    }
+  }
+
+  /**
+   * Normalizes an optional integer-ish value.
+   * @param {?} value - Raw value.
+   * @returns {number | null} Parsed integer.
+   */
+  static optionalInteger(value) {
+    if (value === null || value === undefined || value === "") return null
+
+    const integer = Number(value)
+
+    if (!Number.isSafeInteger(integer)) throw new Error("Sync cursor serverSequence must be an integer")
+
+    return integer
+  }
+
+  /**
+   * Builds a normalized sync row adapter.
+   * @param {?} payload - Raw sync payload.
+   * @returns {SyncChangeEnvelope} Sync row adapter.
+   */
+  static syncEnvelopeFromPayload(payload) {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) throw new Error("Sync changes entry must be an object")
+
+    const syncPayload = /** @type {Record<string, ?>} */ (payload)
+
+    return {
+      data: () => syncPayload.data,
+      id: () => syncPayload.id,
+      resourceId: () => syncPayload.resourceId,
+      resourceType: () => syncPayload.resourceType === null || syncPayload.resourceType === undefined ? null : String(syncPayload.resourceType),
+      syncType: () => syncPayload.syncType === null || syncPayload.syncType === undefined ? "" : String(syncPayload.syncType)
+    }
+  }
+
+  /**
+   * Builds an app-configured resource applier for pulled sync rows. The sync
+   * mechanics stay here; apps only declare which models/attributes/hooks are
+   * allowed for each resource type.
+   * @param {Record<string, SyncResourceConfig>} resources - Resource policy map.
+   * @returns {(sync: SyncChangeEnvelope) => Promise<SyncChangeApplyResult>} Sync apply callback.
+   */
+  static resourceApplier(resources) {
+    return async (sync) => await this.applyResourceSync({resources, sync})
+  }
+
+  /**
+   * Applies one sync row using declarative resource policy.
+   * @param {{resources: Record<string, SyncResourceConfig>, sync: SyncChangeEnvelope}} args - Apply args.
+   * @returns {Promise<SyncChangeApplyResult>} Apply result.
+   */
+  static async applyResourceSync({resources, sync}) {
+    const resourceType = sync.resourceType()
+    const resource = resourceType ? resources[resourceType] : undefined
+
+    if (!resource || !resource.enabled) return {changed: false, resourceType}
+
+    if (sync.syncType() === "delete") {
+      return {changed: await this.destroySyncedResource({resource, sync}), resourceType}
+    }
+
+    const data = this.syncData(sync)
+    const record = resource.findRecord ? await resource.findRecord({data, resourceId: sync.resourceId(), sync}) : await resource.modelClass.findOrInitializeBy({id: data.id ?? sync.resourceId()})
+    const attributes = await resource.attributes({data, record, sync})
+    let changed = false
+
+    record.assign(attributes)
+
+    if (record.isChanged()) {
+      await record.save()
+      changed = true
+    }
+
+    if (resource.afterApply) {
+      const hookChanged = await resource.afterApply({attributes, data, record, sync})
+
+      changed ||= hookChanged === true
+    }
+
+    return {changed, resourceType}
+  }
+
+  /**
+   * Destroys a synced resource via its declared model policy.
+   * @param {{resource: SyncResourceConfig, sync: SyncChangeEnvelope}} args - Destroy args.
+   * @returns {Promise<boolean>} Whether a local row was destroyed.
+   */
+  static async destroySyncedResource({resource, sync}) {
+    const id = sync.resourceId()
+    const record = resource.findRecordForDelete ? await resource.findRecordForDelete({resourceId: id, sync}) : await resource.modelClass.findBy({id})
+
+    if (!record) return false
+
+    await record.destroy()
+    return true
+  }
+
+  /**
+   * Parses the embedded sync data JSON/object.
+   * @param {SyncChangeEnvelope} sync - Sync row.
+   * @returns {Record<string, unknown>} Sync data object.
+   */
+  static syncData(sync) {
+    const data = sync.data()
+
+    if (!data) throw new Error(`Sync ${sync.id()} is missing data`)
+    if (typeof data === "string") return /** @type {Record<string, unknown>} */ (JSON.parse(data))
+    if (typeof data === "object" && !Array.isArray(data)) return /** @type {Record<string, unknown>} */ (data)
+
+    throw new Error(`Sync ${sync.id()} has invalid data`)
+  }
+
+  /**
    * Drains pending sync records in stable order and marks acknowledged rows.
    * @param {object} args - Replay args.
    * @param {string} args.authenticationToken - Auth token to send with replay requests.
@@ -91,6 +343,63 @@ export default class SyncApiClient {
     return Math.floor(batchSize)
   }
 }
+
+/** @typedef {{id: string | null, serverSequence: number | null, updatedAt: string} | null} SyncCursor */
+
+/**
+ * @typedef {object} SyncChangeEnvelope
+ * @property {() => unknown} data - Sync data payload.
+ * @property {() => unknown} id - Sync row identifier.
+ * @property {() => unknown} resourceId - Resource identifier.
+ * @property {() => string | null} resourceType - Resource type name.
+ * @property {() => string} syncType - Sync operation type.
+ */
+
+/**
+ * @typedef {object} SyncChangeApplyResult
+ * @property {boolean} changed - Whether the local store changed.
+ * @property {string | null} [resourceType] - Applied resource type override.
+ */
+
+/**
+ * @typedef {object} SyncResourceConfig
+ * @property {(args: {attributes: Record<string, unknown>, data: Record<string, unknown>, record: ?, sync: SyncChangeEnvelope}) => Promise<boolean | void> | boolean | void} [afterApply] - Optional post-save hook.
+ * @property {(args: {data: Record<string, unknown>, record: ?, sync: SyncChangeEnvelope}) => Promise<Record<string, unknown>> | Record<string, unknown>} attributes - Allowed attributes builder.
+ * @property {boolean} enabled - Whether this resource is sync-enabled.
+ * @property {(args: {data: Record<string, unknown>, resourceId: unknown, sync: SyncChangeEnvelope}) => Promise<?> | ?} [findRecord] - Optional upsert finder.
+ * @property {(args: {resourceId: unknown, sync: SyncChangeEnvelope}) => Promise<?> | ?} [findRecordForDelete] - Optional destroy finder.
+ * @property {?} modelClass - Velocious model class.
+ */
+
+/**
+ * @typedef {object} SyncChangesRequest
+ * @property {string} authenticationToken - Auth token.
+ * @property {string | null} [afterId] - Last seen row id.
+ * @property {number} [afterServerSequence] - Last seen server sequence.
+ * @property {string} [afterUpdatedAt] - Last seen timestamp.
+ * @property {number} limit - Page size.
+ * @property {string | null} [upToId] - Snapshot upper-bound row id.
+ * @property {number} [upToServerSequence] - Snapshot upper-bound server sequence.
+ * @property {string} [upToUpdatedAt] - Snapshot upper-bound timestamp.
+ */
+
+/**
+ * @typedef {object} SyncChangesResponse
+ * @property {string} [errorMessage] - Error message.
+ * @property {SyncCursor | Record<string, ?>} [nextCursor] - Next cursor.
+ * @property {string} [status] - Response status.
+ * @property {Array<unknown>} [syncs] - Sync rows.
+ * @property {SyncCursor | Record<string, ?>} [upToCursor] - Snapshot upper-bound cursor.
+ */
+
+/**
+ * @typedef {object} SyncChangesResult
+ * @property {boolean} changed - Whether any local record changed.
+ * @property {number} pages - Applied page count.
+ * @property {Record<string, boolean>} resourceChanged - Changed flags by resource type.
+ * @property {Record<string, number>} resourceCounts - Applied counts by resource type.
+ * @property {number} syncedCount - Applied row count.
+ */
 
 /**
  * @typedef {object} SyncReplayItem

--- a/src/sync/sync-api-client.js
+++ b/src/sync/sync-api-client.js
@@ -1,0 +1,106 @@
+// @ts-check
+
+/**
+ * Generic client-side helper for replaying pending sync envelopes through the
+ * framework-owned `/velocious/sync/replay` endpoint. Apps provide only local
+ * persistence/auth hooks.
+ */
+export default class SyncApiClient {
+  /**
+   * Drains pending sync records in stable order and marks acknowledged rows.
+   * @param {object} args - Replay args.
+   * @param {string} args.authenticationToken - Auth token to send with replay requests.
+   * @param {number} [args.batchSize] - Max syncs per request. Defaults to 100.
+   * @param {() => Promise<Array<unknown>>} args.pendingSyncs - Loads pending local sync rows in replay order.
+   * @param {(sync: unknown) => string | number | null | undefined} args.syncId - Returns the local sync id.
+   * @param {(sync: unknown) => Record<string, ?>} args.syncPayload - Builds the API sync envelope.
+   * @param {(payload: {authenticationToken: string, syncs: Array<Record<string, ?>>}) => Promise<SyncReplayResponse>} args.postReplay - Posts one replay request.
+   * @param {(sync: unknown, response: SyncReplayItem) => Promise<void>} args.markSuccessful - Marks one sync as successful locally.
+   * @returns {Promise<void>} Resolves after all batches are replayed.
+   */
+  static async replayPending(args) {
+    const pendingSyncs = await args.pendingSyncs()
+    const batchSize = this.normalizedBatchSize(args.batchSize)
+
+    for (let offset = 0; offset < pendingSyncs.length; offset += batchSize) {
+      await this.replayBatch({...args, pendingSyncs: pendingSyncs.slice(offset, offset + batchSize)})
+    }
+  }
+
+  /**
+   * Replays one batch of syncs.
+   * @param {object} args - Replay args.
+   * @param {string} args.authenticationToken - Auth token.
+   * @param {Array<unknown>} args.pendingSyncs - Batch syncs.
+   * @param {(sync: unknown) => string | number | null | undefined} args.syncId - Sync id getter.
+   * @param {(sync: unknown) => Record<string, ?>} args.syncPayload - Payload builder.
+   * @param {(payload: {authenticationToken: string, syncs: Array<Record<string, ?>>}) => Promise<SyncReplayResponse>} args.postReplay - Replay poster.
+   * @param {(sync: unknown, response: SyncReplayItem) => Promise<void>} args.markSuccessful - Success hook.
+   * @returns {Promise<void>} Resolves after the batch is acknowledged.
+   */
+  static async replayBatch(args) {
+    const {authenticationToken, markSuccessful, pendingSyncs, postReplay, syncId, syncPayload} = args
+
+    if (pendingSyncs.length === 0) return
+
+    const syncsById = new Map()
+
+    for (const sync of pendingSyncs) {
+      const id = syncId(sync)
+
+      if (id !== undefined && id !== null) syncsById.set(String(id), sync)
+    }
+
+    const response = await postReplay({
+      authenticationToken,
+      syncs: pendingSyncs.map((sync) => syncPayload(sync))
+    })
+
+    this.ensureSuccessfulResponse(response)
+
+    for (const syncResponse of response.syncs || []) {
+      const sync = syncsById.get(String(syncResponse.id))
+
+      if (!sync) continue
+      if (syncResponse.syncState !== "successful") {
+        throw new Error(`Invalid sync state returned for sync ${String(syncResponse.id)}: ${String(syncResponse.syncState)}`)
+      }
+
+      await markSuccessful(sync, syncResponse)
+    }
+  }
+
+  /**
+   * Checks API response status and shape.
+   * @param {SyncReplayResponse} response - Replay response.
+   * @returns {void}
+   */
+  static ensureSuccessfulResponse(response) {
+    if (response.status === "error") throw new Error(response.errorMessage || "Sync failed")
+    if (!Array.isArray(response.syncs)) throw new Error("Sync response missing syncs")
+  }
+
+  /**
+   * Normalizes a positive batch size.
+   * @param {number | undefined} batchSize - Batch size.
+   * @returns {number} Positive batch size.
+   */
+  static normalizedBatchSize(batchSize) {
+    if (typeof batchSize !== "number" || !Number.isFinite(batchSize) || batchSize < 1) return 100
+
+    return Math.floor(batchSize)
+  }
+}
+
+/**
+ * @typedef {object} SyncReplayItem
+ * @property {string | number} id - Sync id.
+ * @property {string} syncState - Replay state.
+ */
+
+/**
+ * @typedef {object} SyncReplayResponse
+ * @property {string} [errorMessage] - Error message.
+ * @property {string} [status] - Response status.
+ * @property {Array<SyncReplayItem>} [syncs] - Replay results.
+ */

--- a/src/sync/sync-api-client.js
+++ b/src/sync/sync-api-client.js
@@ -2,6 +2,16 @@
 
 import {optionalInteger} from "typanic"
 
+/** @typedef {import("./sync-api-client-types.js").SyncChangeApplyResult} SyncChangeApplyResult */
+/** @typedef {import("./sync-api-client-types.js").SyncChangeEnvelope} SyncChangeEnvelope */
+/** @typedef {import("./sync-api-client-types.js").SyncChangesRequest} SyncChangesRequest */
+/** @typedef {import("./sync-api-client-types.js").SyncChangesResponse} SyncChangesResponse */
+/** @typedef {import("./sync-api-client-types.js").SyncChangesResult} SyncChangesResult */
+/** @typedef {import("./sync-api-client-types.js").SyncCursor} SyncCursor */
+/** @typedef {import("./sync-api-client-types.js").SyncReplayItem} SyncReplayItem */
+/** @typedef {import("./sync-api-client-types.js").SyncReplayResponse} SyncReplayResponse */
+/** @typedef {import("./sync-api-client-types.js").SyncResourceConfig} SyncResourceConfig */
+
 /**
  * Generic client-side helper for replaying pending sync envelopes through the
  * framework-owned `/velocious/sync/replay` endpoint. Apps provide only local
@@ -330,73 +340,3 @@ export default class SyncApiClient {
     return Math.floor(batchSize)
   }
 }
-
-/** @typedef {{id: string | null, serverSequence: number | null, updatedAt: string} | null} SyncCursor */
-
-/**
- * @typedef {object} SyncChangeEnvelope
- * @property {() => unknown} data - Sync data payload.
- * @property {() => unknown} id - Sync row identifier.
- * @property {() => unknown} resourceId - Resource identifier.
- * @property {() => string | null} resourceType - Resource type name.
- * @property {() => string} syncType - Sync operation type.
- */
-
-/**
- * @typedef {object} SyncChangeApplyResult
- * @property {boolean} changed - Whether the local store changed.
- * @property {string | null} [resourceType] - Applied resource type override.
- */
-
-/**
- * @typedef {object} SyncResourceConfig
- * @property {(args: {attributes: Record<string, unknown>, data: Record<string, unknown>, record: ?, sync: SyncChangeEnvelope}) => Promise<boolean | void> | boolean | void} [afterApply] - Optional post-save hook.
- * @property {(args: {data: Record<string, unknown>, record: ?, sync: SyncChangeEnvelope}) => Promise<Record<string, unknown>> | Record<string, unknown>} attributes - Allowed attributes builder.
- * @property {boolean} enabled - Whether this resource is sync-enabled.
- * @property {(args: {data: Record<string, unknown>, resourceId: unknown, sync: SyncChangeEnvelope}) => Promise<?> | ?} [findRecord] - Optional upsert finder.
- * @property {(args: {resourceId: unknown, sync: SyncChangeEnvelope}) => Promise<?> | ?} [findRecordForDelete] - Optional destroy finder.
- * @property {?} modelClass - Velocious model class.
- */
-
-/**
- * @typedef {object} SyncChangesRequest
- * @property {string} authenticationToken - Auth token.
- * @property {string | null} [afterId] - Last seen row id.
- * @property {number} [afterServerSequence] - Last seen server sequence.
- * @property {string} [afterUpdatedAt] - Last seen timestamp.
- * @property {number} limit - Page size.
- * @property {string | null} [upToId] - Snapshot upper-bound row id.
- * @property {number} [upToServerSequence] - Snapshot upper-bound server sequence.
- * @property {string} [upToUpdatedAt] - Snapshot upper-bound timestamp.
- */
-
-/**
- * @typedef {object} SyncChangesResponse
- * @property {string} [errorMessage] - Error message.
- * @property {SyncCursor | Record<string, ?>} [nextCursor] - Next cursor.
- * @property {string} [status] - Response status.
- * @property {Array<unknown>} [syncs] - Sync rows.
- * @property {SyncCursor | Record<string, ?>} [upToCursor] - Snapshot upper-bound cursor.
- */
-
-/**
- * @typedef {object} SyncChangesResult
- * @property {boolean} changed - Whether any local record changed.
- * @property {number} pages - Applied page count.
- * @property {Record<string, boolean>} resourceChanged - Changed flags by resource type.
- * @property {Record<string, number>} resourceCounts - Applied counts by resource type.
- * @property {number} syncedCount - Applied row count.
- */
-
-/**
- * @typedef {object} SyncReplayItem
- * @property {string | number} id - Sync id.
- * @property {string} syncState - Replay state.
- */
-
-/**
- * @typedef {object} SyncReplayResponse
- * @property {string} [errorMessage] - Error message.
- * @property {string} [status] - Response status.
- * @property {Array<SyncReplayItem>} [syncs] - Replay results.
- */

--- a/src/sync/sync-api-client.js
+++ b/src/sync/sync-api-client.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import {optionalInteger} from "typanic"
+
 /**
  * Generic client-side helper for replaying pending sync envelopes through the
  * framework-owned `/velocious/sync/replay` endpoint. Apps provide only local
@@ -142,24 +144,9 @@ export default class SyncApiClient {
 
     return {
       id: payload.id === null || payload.id === undefined ? null : String(payload.id),
-      serverSequence: this.optionalInteger(payload.serverSequence),
+      serverSequence: optionalInteger(payload.serverSequence === "" ? null : payload.serverSequence),
       updatedAt
     }
-  }
-
-  /**
-   * Normalizes an optional integer-ish value.
-   * @param {?} value - Raw value.
-   * @returns {number | null} Parsed integer.
-   */
-  static optionalInteger(value) {
-    if (value === null || value === undefined || value === "") return null
-
-    const integer = Number(value)
-
-    if (!Number.isSafeInteger(integer)) throw new Error("Sync cursor serverSequence must be an integer")
-
-    return integer
   }
 
   /**

--- a/src/sync/sync-api-controller.js
+++ b/src/sync/sync-api-controller.js
@@ -1,0 +1,154 @@
+// @ts-check
+
+import Controller from "../controller.js"
+import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
+
+/**
+ * Generic `/velocious/sync` transport controller.
+ *
+ * Apps provide a sync resource class; Velocious owns endpoint shape and
+ * rendering. The app resource owns auth, scoping, and domain-specific
+ * replay/change hooks.
+ */
+export default class SyncApiController extends Controller {
+  /**
+   * Renders a replay response from the configured sync resource.
+   * @returns {Promise<void>}
+   */
+  async replay() {
+    const resource = /** @type {FrontendModelBaseResource & {replay: () => Promise<unknown>}} */ (this.syncResource(this.params()))
+
+    await this.render({json: /** @type {object} */ (await resource.replay())})
+  }
+
+  /**
+   * Renders a change-feed response from the configured sync resource.
+   * @returns {Promise<void>}
+   */
+  async changes() {
+    const resource = /** @type {FrontendModelBaseResource & {changes: () => Promise<unknown>}} */ (this.syncResource(this.params()))
+
+    await this.render({json: /** @type {object} */ (await resource.changes())})
+  }
+
+  /**
+   * Builds the sync resource that backs the transport endpoint.
+   * @param {Record<string, unknown>} params - Request params/body.
+   * @returns {FrontendModelBaseResource} Sync resource instance.
+   */
+  syncResource(params) {
+    const ResourceClass = this.syncResourceClass()
+
+    return new ResourceClass({
+      ability: this.currentAbility(),
+      controller: /** @type {import("../frontend-model-resource/base-resource.js").FrontendModelResourceController} */ (/** @type {unknown} */ (this)),
+      modelClass: this.syncModelClass(),
+      modelName: this.syncModelName(),
+      params: /** @type {import("../configuration-types.js").VelociousParams} */ (/** @type {unknown} */ (params)),
+      resourceConfiguration: this.syncResourceConfiguration(ResourceClass)
+    })
+  }
+
+  /**
+   * Returns the app-provided sync resource class.
+   * @returns {import("../configuration-types.js").FrontendModelResourceClassType} Sync resource class.
+   */
+  syncResourceClass() {
+    return this.missingSyncResourceClass()
+  }
+
+  /**
+   * Builds a sync API controller class bound to the given resource.
+   * @param {import("../configuration-types.js").FrontendModelResourceClassType} ResourceClass - Sync resource class.
+   * @returns {typeof SyncApiController} Controller class for the resource.
+   */
+  static withSyncResourceClass(ResourceClass) {
+    return class ConfiguredSyncApiController extends this {
+      /**
+       * Returns the configured sync resource class.
+       * @returns {import("../configuration-types.js").FrontendModelResourceClassType} Sync resource class.
+       */
+      syncResourceClass() {
+        return ResourceClass
+      }
+    }
+  }
+
+  /**
+   * Mounts the standard Velocious sync endpoints into a route configuration.
+   * @param {{configuration?: import("../configuration.js").default, at?: string, syncResourceClass?: import("../configuration-types.js").FrontendModelResourceClassType}} args - Mount args.
+   * @returns {void}
+   */
+  static mountInto(args) {
+    const {configuration, syncResourceClass} = args
+    const ControllerClass = syncResourceClass ? this.withSyncResourceClass(syncResourceClass) : this
+    const at = this.normalizedMountPath(args.at || "/velocious/sync")
+
+    if (!configuration) throw new Error("SyncApiController.mountInto requires configuration")
+
+    configuration.routes((routes) => {
+      routes.post(`${at}/changes`, {to: [ControllerClass, "changes"]})
+      routes.post(`${at}/replay`, {to: [ControllerClass, "replay"]})
+    })
+  }
+
+  /**
+   * Normalizes a sync mount path.
+   * @param {string} at - Mount path.
+   * @returns {string} Normalized mount path without trailing slash.
+   */
+  static normalizedMountPath(at) {
+    if (typeof at !== "string" || !at.startsWith("/")) {
+      throw new Error(`SyncApiController mount path must start with '/', got: ${String(at)}`)
+    }
+
+    return at.replace(/\/+$/u, "") || "/"
+  }
+
+  /**
+   * Raises a configuration error for subclasses that do not provide a resource.
+   * @returns {import("../configuration-types.js").FrontendModelResourceClassType} Sync resource class.
+   */
+  missingSyncResourceClass() {
+    return /** @type {typeof FrontendModelBaseResource} */ (/** @type {unknown} */ (this.raiseMissingSyncResourceClass()))
+  }
+
+  /** Raises a configuration error for subclasses that do not provide a resource. */
+  raiseMissingSyncResourceClass() {
+    throw new Error("SyncApiController.syncResourceClass must be implemented")
+  }
+
+  /**
+   * Returns the model class exposed by the sync resource.
+   * @returns {typeof import("../database/record/index.js").default} Sync model class.
+   */
+  syncModelClass() {
+    const ResourceClass = this.syncResourceClass()
+    const modelClass = ResourceClass.ModelClass
+
+    if (!modelClass) throw new Error("Sync resource class must define static ModelClass")
+
+    return modelClass
+  }
+
+  /**
+   * Returns the model name used to initialize the resource.
+   * @returns {string} Sync model name.
+   */
+  syncModelName() {
+    return this.syncModelClass().name
+  }
+
+  /**
+   * Builds the minimal resource configuration needed by the sync resource.
+   * @param {import("../configuration-types.js").FrontendModelResourceClassType} ResourceClass - Sync resource class.
+   * @returns {import("../configuration-types.js").FrontendModelResourceConfiguration} Resource configuration.
+   */
+  syncResourceConfiguration(ResourceClass) {
+    return /** @type {import("../configuration-types.js").FrontendModelResourceConfiguration} */ ({
+      attributes: ResourceClass.attributes || {},
+      sync: {enabled: true}
+    })
+  }
+}
+

--- a/src/sync/sync-api-controller.js
+++ b/src/sync/sync-api-controller.js
@@ -38,10 +38,17 @@ export default class SyncApiController extends Controller {
    */
   syncResource(params) {
     const ResourceClass = this.syncResourceClass()
+    const ability = this.currentAbility()
 
     return new ResourceClass({
-      ability: this.currentAbility(),
+      ability,
       controller: /** @type {import("../frontend-model-resource/base-resource.js").FrontendModelResourceController} */ (/** @type {unknown} */ (this)),
+      context: {
+        ...(ability?.getContext() || {}),
+        params: this.params(),
+        request: this.request()
+      },
+      locals: ability?.getLocals() || {},
       modelClass: this.syncModelClass(),
       modelName: this.syncModelName(),
       params: /** @type {import("../configuration-types.js").VelociousParams} */ (/** @type {unknown} */ (params)),

--- a/src/sync/sync-model-change-feed-service.js
+++ b/src/sync/sync-model-change-feed-service.js
@@ -61,11 +61,11 @@ export default class SyncModelChangeFeedService {
 
     const limit = Number(value)
 
-    if (!Number.isFinite(limit) || limit <= 0) {
-      throw VelociousError.safe("Sync changes limit must be a positive number.", {code: "sync-invalid-changes-limit"})
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw VelociousError.safe("Sync changes limit must be a positive integer.", {code: "sync-invalid-changes-limit"})
     }
 
-    return Math.min(Math.floor(limit), this.maxLimit)
+    return Math.min(limit, this.maxLimit)
   }
 
   /**

--- a/src/sync/sync-model-change-feed-service.js
+++ b/src/sync/sync-model-change-feed-service.js
@@ -212,7 +212,7 @@ export default class SyncModelChangeFeedService {
    */
   recordValue(record, name) {
     if (!record || typeof record !== "object") {
-      throw VelociousError.safe("Sync changes row must be an object.", {code: "sync-invalid-changes-row"})
+      throw new Error("Sync changes row must be an object.")
     }
 
     const recordObject = /** @type {Record<string, ?>} */ (record)
@@ -220,7 +220,7 @@ export default class SyncModelChangeFeedService {
     const value = typeof method === "function" ? method.call(record) : method
 
     if (value === undefined) {
-      throw VelociousError.safe(`Sync changes row is missing ${name}.`, {code: "sync-invalid-changes-row"})
+      throw new Error(`Sync changes row is missing ${name}.`)
     }
 
     return value

--- a/src/sync/sync-model-change-feed-service.js
+++ b/src/sync/sync-model-change-feed-service.js
@@ -211,14 +211,19 @@ export default class SyncModelChangeFeedService {
    * @returns {unknown} Record value.
    */
   recordValue(record, name) {
-    if (!record || typeof record !== "object") return undefined
+    if (!record || typeof record !== "object") {
+      throw VelociousError.safe("Sync changes row must be an object.", {code: "sync-invalid-changes-row"})
+    }
 
     const recordObject = /** @type {Record<string, ?>} */ (record)
     const method = recordObject[name]
+    const value = typeof method === "function" ? method.call(record) : method
 
-    if (typeof method === "function") return method.call(record)
+    if (value === undefined) {
+      throw VelociousError.safe(`Sync changes row is missing ${name}.`, {code: "sync-invalid-changes-row"})
+    }
 
-    return method
+    return value
   }
 
   /**

--- a/src/sync/sync-model-change-feed-service.js
+++ b/src/sync/sync-model-change-feed-service.js
@@ -1,0 +1,239 @@
+// @ts-check
+
+import VelociousError from "../velocious-error.js"
+
+/**
+ * Generic cursor-paginated change feed over an app-owned sync/change model.
+ *
+ * Apps provide the model and optional scoping/serialization hooks. Velocious owns
+ * cursor parsing, snapshot high-water resolution, stable ordering, page limits,
+ * and response shape for `/velocious/sync/changes` style endpoints.
+ */
+export default class SyncModelChangeFeedService {
+  /**
+   * Creates a generic sync-model change-feed service.
+   * @param {object} args - Service arguments.
+   * @param {typeof import("../database/record/index.js").default} args.modelClass - Sync/change model class.
+   * @param {Record<string, unknown>} args.params - Request params.
+   * @param {number} [args.defaultLimit] - Default page size.
+   * @param {number} [args.maxLimit] - Maximum page size.
+   * @param {(record: ?) => Record<string, unknown>} [args.serializeRecord] - Record serializer.
+   * @param {function({query: import("../database/query/model-class-query.js").default}): void} [args.scopeQuery] - Applies app-owned visibility scope.
+   */
+  constructor({defaultLimit = 1000, maxLimit = 1000, modelClass, params, scopeQuery, serializeRecord}) {
+    this.defaultLimit = defaultLimit
+    this.maxLimit = maxLimit
+    this.modelClass = modelClass
+    this.params = params
+    this.scopeQuery = scopeQuery || null
+    this.serializeRecord = serializeRecord || ((record) => this.defaultSerializeRecord(record))
+  }
+
+  /**
+   * Builds a stable change-feed page.
+   * @returns {Promise<{status: string, nextCursor: {id: string, serverSequence: number, updatedAt: string} | null, syncs: Array<Record<string, unknown>>, upToCursor: {id: string, serverSequence: number, updatedAt: string} | null}>} Change-feed page result.
+   */
+  async changes() {
+    const limit = this.normalizedLimit(this.params.limit)
+    const upToCursor = await this.resolveUpToCursor()
+
+    if (!upToCursor) return {status: "success", nextCursor: null, syncs: [], upToCursor: null}
+
+    const query = this.pageQuery({limit, upToCursor})
+    const records = await query.toArray()
+    const nextCursor = records.length > 0 ? this.cursorForRecord(records[records.length - 1]) : upToCursor
+
+    return {
+      status: "success",
+      nextCursor,
+      syncs: records.map((record) => this.serializeRecord(record)),
+      upToCursor
+    }
+  }
+
+  /**
+   * Normalizes the requested page limit.
+   * @param {unknown} value - Raw limit param.
+   * @returns {number} Normalized page limit.
+   */
+  normalizedLimit(value) {
+    if (value === undefined || value === null || value === "") return this.defaultLimit
+
+    const limit = Number(value)
+
+    if (!Number.isFinite(limit) || limit <= 0) {
+      throw VelociousError.safe("Sync changes limit must be a positive number.", {code: "sync-invalid-changes-limit"})
+    }
+
+    return Math.min(Math.floor(limit), this.maxLimit)
+  }
+
+  /**
+   * Parses an optional positive integer cursor field.
+   * @param {unknown} value - Raw integer param.
+   * @param {string} name - Param name for error messages.
+   * @returns {number | null} Positive integer value, or null when omitted.
+   */
+  optionalPositiveIntegerParam(value, name) {
+    if (value === undefined || value === null || value === "") return null
+
+    const integer = Number(value)
+
+    if (!Number.isSafeInteger(integer) || integer <= 0) {
+      throw VelociousError.safe(`${name} must be a positive integer.`, {code: "sync-invalid-changes-cursor"})
+    }
+
+    return integer
+  }
+
+  /**
+   * Resolves the high-water cursor that bounds the current feed page.
+   * @returns {Promise<{id: string, serverSequence: number, updatedAt: string} | null>} Snapshot upper-bound cursor.
+   */
+  async resolveUpToCursor() {
+    const upToServerSequence = this.optionalPositiveIntegerParam(this.params.upToServerSequence, "upToServerSequence")
+
+    if (upToServerSequence !== null && typeof this.params.upToUpdatedAt === "string" && typeof this.params.upToId === "string") {
+      return {id: this.params.upToId, serverSequence: upToServerSequence, updatedAt: this.params.upToUpdatedAt}
+    }
+
+    if (typeof this.params.upToUpdatedAt === "string" && typeof this.params.upToId === "string") {
+      const upToRecord = await this.modelClass.findBy({id: this.params.upToId})
+
+      if (upToRecord) return this.cursorForRecord(upToRecord)
+    }
+
+    const query = this.scopedQuery()
+    const table = query.driver.quoteTable(this.modelClass.tableName())
+    const serverSequenceColumn = query.driver.quoteColumn("server_sequence")
+    const latestRecords = await query
+      .order(`${table}.${serverSequenceColumn} DESC`)
+      .limit(1)
+      .toArray()
+
+    if (latestRecords.length === 0) return null
+
+    return this.cursorForRecord(latestRecords[0])
+  }
+
+  /**
+   * Builds the ordered and cursor-filtered page query.
+   * @param {{limit: number, upToCursor: {id: string, serverSequence: number, updatedAt: string}}} args - Page query args.
+   * @returns {import("../database/query/model-class-query.js").default} Page query.
+   */
+  pageQuery({limit, upToCursor}) {
+    const query = this.scopedQuery()
+    const driver = query.driver
+    const table = driver.quoteTable(this.modelClass.tableName())
+    const serverSequenceColumn = `${table}.${driver.quoteColumn("server_sequence")}`
+    const updatedAtColumn = `${table}.${driver.quoteColumn("updated_at")}`
+    const idColumn = `${table}.${driver.quoteColumn("id")}`
+
+    query
+      .where(`${serverSequenceColumn} <= ${driver.quote(upToCursor.serverSequence)}`)
+      .order(`${serverSequenceColumn} ASC`)
+      .limit(limit)
+
+    const afterServerSequence = this.optionalPositiveIntegerParam(this.params.afterServerSequence, "afterServerSequence")
+
+    if (afterServerSequence !== null) {
+      query.where(`${serverSequenceColumn} > ${driver.quote(afterServerSequence)}`)
+    } else if (typeof this.params.afterUpdatedAt === "string" && this.params.afterUpdatedAt !== "") {
+      const isPagingExistingSnapshot = typeof this.params.upToUpdatedAt === "string" && this.params.upToUpdatedAt !== "" && typeof this.params.upToId === "string" && this.params.upToId !== ""
+
+      if (isPagingExistingSnapshot && typeof this.params.afterId === "string" && this.params.afterId !== "") {
+        query.where(`(${updatedAtColumn} > ${driver.quote(this.params.afterUpdatedAt)} OR (${updatedAtColumn} = ${driver.quote(this.params.afterUpdatedAt)} AND ${idColumn} > ${driver.quote(this.params.afterId)}))`)
+      } else {
+        query.where(`${updatedAtColumn} >= ${driver.quote(this.params.afterUpdatedAt)}`)
+      }
+    }
+
+    return query
+  }
+
+  /**
+   * Builds a base query with app-owned scope applied.
+   * @returns {import("../database/query/model-class-query.js").default} Scoped base query.
+   */
+  scopedQuery() {
+    const query = this.modelClass.where({})
+
+    if (this.scopeQuery) this.scopeQuery({query})
+
+    return query
+  }
+
+  /**
+   * Serializes a record into a transport cursor.
+   * @param {?} record - Sync/change record.
+   * @returns {{id: string, serverSequence: number, updatedAt: string}} Cursor for row.
+   */
+  cursorForRecord(record) {
+    return {id: String(this.recordValue(record, "id")), serverSequence: Number(this.recordValue(record, "serverSequence")), updatedAt: this.isoDate(this.recordValue(record, "updatedAt"))}
+  }
+
+  /**
+   * Serializes a record using the standard sync envelope shape.
+   * @param {?} record - Sync/change record.
+   * @returns {Record<string, unknown>} Default serialized row.
+   */
+  defaultSerializeRecord(record) {
+    return {
+      data: this.recordData(record),
+      eventId: this.recordValue(record, "eventId"),
+      id: this.recordValue(record, "id"),
+      resourceId: this.recordValue(record, "resourceId"),
+      resourceType: this.recordValue(record, "resourceType"),
+      serverSequence: this.recordValue(record, "serverSequence"),
+      syncType: this.recordValue(record, "syncType"),
+      updatedAt: this.isoDate(this.recordValue(record, "updatedAt"))
+    }
+  }
+
+  /**
+   * Reads and parses the record data payload.
+   * @param {?} record - Sync/change record.
+   * @returns {unknown} Parsed data value.
+   */
+  recordData(record) {
+    const data = this.recordValue(record, "data")
+
+    if (data === "" || data === null || data === undefined) return null
+    if (typeof data !== "string") return data
+
+    return JSON.parse(data)
+  }
+
+  /**
+   * Reads a value from either a record accessor method or plain property.
+   * @param {?} record - Sync/change record.
+   * @param {string} name - Camel-cased value/method name.
+   * @returns {unknown} Record value.
+   */
+  recordValue(record, name) {
+    if (!record || typeof record !== "object") return undefined
+
+    const recordObject = /** @type {Record<string, ?>} */ (record)
+    const method = recordObject[name]
+
+    if (typeof method === "function") return method.call(record)
+
+    return method
+  }
+
+  /**
+   * Converts a date-like value to an ISO string.
+   * @param {Date | string | null | undefined | unknown} value - Date value.
+   * @returns {string} ISO date.
+   */
+  isoDate(value) {
+    const date = value instanceof Date ? value : new Date(typeof value === "string" || typeof value === "number" ? value : 0)
+
+    if (Number.isNaN(date.getTime())) {
+      throw VelociousError.safe("Sync changes row has an invalid updated_at value.", {code: "sync-invalid-changes-row"})
+    }
+
+    return date.toISOString()
+  }
+}
+


### PR DESCRIPTION
Adds framework-owned helpers for the generic /velocious/sync transport and cursor-paginated sync-model change feeds so apps only provide resource/domain hooks.