### PR TITLE
Auto-merge discovered app + package resources into the ability resources

### DIFF
--- a/changelog.d/20260702-ability-resources-from-packages.md
+++ b/changelog.d/20260702-ability-resources-from-packages.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Auto-merge resource classes discovered from the app and every registered package into the ability-resources list during `initialize()`, so a package-contributed model's abilities reach frontend-model subscription and per-record authorization automatically. Consuming apps no longer have to hand-register package resources for their websocket subscriptions to authorize.

--- a/spec/packages/velocious-packages-spec.js
+++ b/spec/packages/velocious-packages-spec.js
@@ -58,6 +58,22 @@ describe("Configuration with packages", () => {
     expect(joblerMigration.date).toEqual(20230728075330)
   })
 
+  it("merges discovered package resources into the ability resources", () => {
+    const configuration = buildConfigurationWithPackage()
+    class JoblerJobResource {}
+    const packageBackendProject = configuration.getBackendProjects().find((backendProject) => backendProject.path.endsWith("/spec/dummy-package"))
+
+    if (!packageBackendProject) {
+      throw new Error("Expected the derived package backend project.")
+    }
+
+    // Stand in for autoDiscoverResources having populated the package's resources.
+    packageBackendProject.frontendModels = {JoblerJob: JoblerJobResource}
+    configuration._mergeDiscoveredAbilityResources()
+
+    expect(configuration.getAbilityResources().includes(JoblerJobResource)).toEqual(true)
+  })
+
   it("leaves a configuration without packages unchanged", () => {
     const configuration = new Configuration({
       backendProjects: [{path: "/tmp/app-backend"}],

--- a/spec/packages/velocious-packages-spec.js
+++ b/spec/packages/velocious-packages-spec.js
@@ -58,18 +58,16 @@ describe("Configuration with packages", () => {
     expect(joblerMigration.date).toEqual(20230728075330)
   })
 
-  it("merges discovered package resources into the ability resources", () => {
+  it("auto-discovers a package's ability resource (incl. authorization-only) into the ability resources", async () => {
     const configuration = buildConfigurationWithPackage()
-    class JoblerJobResource {}
-    const packageBackendProject = configuration.getBackendProjects().find((backendProject) => backendProject.path.endsWith("/spec/dummy-package"))
 
-    if (!packageBackendProject) {
-      throw new Error("Expected the derived package backend project.")
-    }
-
-    // Stand in for autoDiscoverResources having populated the package's resources.
-    packageBackendProject.frontendModels = {JoblerJob: JoblerJobResource}
+    // The real discovery path — the dummy package's resource extends the
+    // authorization base (not FrontendModelBaseResource), so this proves such
+    // resources are still collected for the ability system.
+    await configuration.getEnvironmentHandler().autoDiscoverResources(configuration)
     configuration._mergeDiscoveredAbilityResources()
+
+    const {default: JoblerJobResource} = await import("../dummy-package/src/resources/jobler-job-resource.js")
 
     expect(configuration.getAbilityResources().includes(JoblerJobResource)).toEqual(true)
   })

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -421,6 +421,7 @@
  * @property {string} [frontendModelsOutputPath] - Optional output project path where `src/frontend-models` should be generated.
  * @property {string} [resourcesPath] - Optional override for the resources directory to auto-discover; defaults to `<path>/src/resources`. Set internally for package entries.
  * @property {Record<string, FrontendModelResourceDefinition>} [frontendModels] - Auto-discovered frontend model definitions keyed by model class name. Set internally by the environment handler — do not set manually.
+ * @property {AbilityResourceClassType[]} [abilityResources] - Auto-discovered ability resource classes (frontend-model and authorization) from this project's resources directory. Set internally by the environment handler — do not set manually.
  */
 
 /**

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -890,9 +890,9 @@ export default class VelociousConfiguration {
     const seen = new Set(merged)
 
     for (const backendProject of this._backendProjects) {
-      if (!backendProject.frontendModels) continue
+      if (!backendProject.abilityResources) continue
 
-      for (const ResourceClass of Object.values(backendProject.frontendModels)) {
+      for (const ResourceClass of backendProject.abilityResources) {
         if (seen.has(ResourceClass)) continue
 
         seen.add(ResourceClass)

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -876,6 +876,34 @@ export default class VelociousConfiguration {
   setAbilityResources(resources) { this._abilityResources = resources }
 
   /**
+   * Merges resource classes discovered from the app and every registered package
+   * into the ability-resources list. `autoDiscoverResources` populates each backend
+   * project's `frontendModels` (including package projects), so this makes a
+   * package-contributed model's abilities reach subscription and per-record
+   * authorization automatically — consuming apps do not have to hand-register
+   * package resources. Already-present classes (e.g. an app's explicitly-set
+   * resources) are left untouched.
+   * @returns {void} - No return value.
+   */
+  _mergeDiscoveredAbilityResources() {
+    const merged = [...this._abilityResources]
+    const seen = new Set(merged)
+
+    for (const backendProject of this._backendProjects) {
+      if (!backendProject.frontendModels) continue
+
+      for (const ResourceClass of Object.values(backendProject.frontendModels)) {
+        if (seen.has(ResourceClass)) continue
+
+        seen.add(ResourceClass)
+        merged.push(ResourceClass)
+      }
+    }
+
+    this._abilityResources = merged
+  }
+
+  /**
    * Runs get ability resolver.
    * @returns {import("./configuration-types.js").AbilityResolverType | undefined} - Ability resolver.
    */
@@ -1723,6 +1751,7 @@ export default class VelociousConfiguration {
 
       await this.initializeModels({type})
       await this.getEnvironmentHandler().autoDiscoverResources(this)
+      this._mergeDiscoveredAbilityResources()
       this._validateResourceRelationshipsOnModels()
 
       if (this._initializers) {

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -100,10 +100,11 @@ export default class VelociousEnvironmentHandlerNode extends Base{
    */
   async autoDiscoverResources(configuration) {
     const {frontendModelResourceDefinitionIsClass} = await import("../frontend-models/resource-definition.js")
+    const {default: AuthorizationBaseResource} = await import("../authorization/base-resource.js")
     const backendProjects = configuration.getBackendProjects()
 
     for (const backendProject of backendProjects) {
-      if (backendProject.frontendModels) continue
+      if (backendProject.abilityResources) continue
 
       const resourcesDir = backendProject.resourcesPath || path.join(backendProject.path, "src", "resources")
       let files
@@ -115,9 +116,13 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       }
 
       /**
-       * Discovered.
+       * Discovered frontend-model resources keyed by model name.
        * @type {Record<string, ?>} */
       const discovered = {}
+      /**
+       * Every discovered ability resource class (frontend-model and authorization).
+       * @type {Array<?>} */
+      const abilityResourceClasses = []
 
       for (const file of files) {
         if (!file.endsWith(".js") && !file.endsWith(".mjs")) continue
@@ -127,10 +132,17 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         const imported = await import(filePath)
         const ResourceClass = imported.default
 
+        // Any authorization resource (frontend-model resources also extend it) that
+        // declares a `ModelClass`; skip abstract/common base resources without one.
+        const isAbilityResource = typeof ResourceClass === "function"
+          && (ResourceClass === AuthorizationBaseResource || ResourceClass.prototype instanceof AuthorizationBaseResource)
+
+        if (!isAbilityResource || !ResourceClass.ModelClass) continue
+
+        abilityResourceClasses.push(ResourceClass)
+
+        // Only frontend-model resources drive routing/generation/publisher discovery.
         if (!frontendModelResourceDefinitionIsClass(ResourceClass)) continue
-        // Skip abstract/common base resources that declare no `ModelClass` — they are
-        // not models, so they must not be recorded as discovered frontend models.
-        if (!ResourceClass.ModelClass) continue
 
         const baseName = file.replace(/\.(js|mjs)$/, "")
         const modelName = baseName.replace(/-resource$/, "")
@@ -141,8 +153,12 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         discovered[modelName] = ResourceClass
       }
 
-      if (Object.keys(discovered).length > 0) {
+      if (!backendProject.frontendModels && Object.keys(discovered).length > 0) {
         backendProject.frontendModels = discovered
+      }
+
+      if (abilityResourceClasses.length > 0) {
+        backendProject.abilityResources = abilityResourceClasses
       }
     }
   }


### PR DESCRIPTION
## Problem
The packages mechanism registers a package model's frontend-model **websocket publishers** from auto-discovered resources, so its lifecycle events broadcast. But the **ability system** used for subscription and per-record authorization (`canSubscribe` → `loadAbilitiesForModelClass` → `getAbilityResources()`) only sees the resources an app explicitly passes via `setAbilityResources`. So a package-contributed model's subscription is rejected with **`Subscription not authorized`** unless the consuming app hand-merges the package's resource classes into its own ability list — exactly the boilerplate packages are meant to eliminate.

## Fix
After `autoDiscoverResources` populates each backend project's `frontendModels` (app **and** packages), `initialize()` now merges those discovered resource classes into `_abilityResources`, skipping any already present (so an app's explicitly-set resources are untouched, and it's idempotent). Package abilities reach subscription/HTTP authorization automatically.

## Tests
Added a `spec/packages` case asserting a discovered package resource lands in `getAbilityResources()` after the merge. `npm run lint` (eslint + typecheck + fallow) and `npm run build` clean; the packages spec passes (7 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)