### PR TITLE
Add SyncResourceBase, model-backed replay defaults and sync route auto-mount

### DIFF
--- a/changelog.d/20260702190000-sync-resource-base-auto-mount.md
+++ b/changelog.d/20260702190000-sync-resource-base-auto-mount.md
@@ -1,0 +1,5 @@
+# Changelog
+
+- Add `SyncResourceBase` (`src/sync/sync-resource-base.js`): a server sync resource base owning changes/replay orchestration — optional client scope parsing (`{resourceType, conditions}`), change-feed construction, and replay delegation/response shaping — so apps only implement `authorizeChanges`, `scopeChangesQuery`, and `replayServiceClass`.
+- Add model-backed default hooks to `SyncEnvelopeReplayService`: passing `syncModel` (and optionally `actorForeignKeyColumn`) to the constructor enables default `findExistingReplaySync` (actor + resource identity lookup) and `persistReplayMutation` (stale-guarded upsert with server re-sequencing), removing per-app duplication.
+- Auto-mount the Velocious sync endpoints from configuration: `sync.api = {resourceClass, mountPath?}` registers `POST <mountPath>/changes` and `POST <mountPath>/replay` during `initialize()` (default mount path `/velocious/sync`). The manual `route.mount(SyncApiController, ...)` path keeps working.

--- a/spec/sync/sync-configuration-mount-spec.js
+++ b/spec/sync/sync-configuration-mount-spec.js
@@ -3,6 +3,7 @@
 import {describe, expect, it} from "../../src/testing/test.js"
 import Configuration from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import SyncApiController from "../../src/sync/sync-api-controller.js"
 import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
 
 class TestSyncModel {}
@@ -51,7 +52,7 @@ describe("sync configuration mount", () => {
   it("auto-mounts sync changes and replay routes when sync.api is configured", async () => {
     const configuration = buildConfiguration({api: {resourceClass: TestSyncResource}})
 
-    await configuration.mountConfiguredSyncApi()
+    SyncApiController.mountFromConfiguration(configuration)
 
     const changesRoute = await resolveRoute(configuration, "/velocious/sync/changes")
     const replayRoute = await resolveRoute(configuration, "/velocious/sync/replay")
@@ -63,7 +64,7 @@ describe("sync configuration mount", () => {
   it("mounts sync routes at a configured mount path", async () => {
     const configuration = buildConfiguration({api: {mountPath: "/api/sync", resourceClass: TestSyncResource}})
 
-    await configuration.mountConfiguredSyncApi()
+    SyncApiController.mountFromConfiguration(configuration)
 
     expect((await resolveRoute(configuration, "/api/sync/changes"))?.action).toEqual("changes")
     expect(await resolveRoute(configuration, "/velocious/sync/changes")).toEqual(null)
@@ -72,7 +73,7 @@ describe("sync configuration mount", () => {
   it("does not mount sync routes when sync.api is absent", async () => {
     const configuration = buildConfiguration()
 
-    await configuration.mountConfiguredSyncApi()
+    SyncApiController.mountFromConfiguration(configuration)
 
     expect(await resolveRoute(configuration, "/velocious/sync/changes")).toEqual(null)
   })
@@ -80,11 +81,11 @@ describe("sync configuration mount", () => {
   it("only mounts the sync routes once across repeated initializations", async () => {
     const configuration = buildConfiguration({api: {resourceClass: TestSyncResource}})
 
-    await configuration.mountConfiguredSyncApi()
+    SyncApiController.mountFromConfiguration(configuration)
 
     const hookCountAfterFirstMount = configuration.getRouteResolverHooks().length
 
-    await configuration.mountConfiguredSyncApi()
+    SyncApiController.mountFromConfiguration(configuration)
 
     expect(configuration.getRouteResolverHooks().length).toEqual(hookCountAfterFirstMount)
   })

--- a/spec/sync/sync-configuration-mount-spec.js
+++ b/spec/sync/sync-configuration-mount-spec.js
@@ -1,0 +1,100 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
+
+class TestSyncModel {}
+
+class TestSyncResource extends FrontendModelBaseResource {
+  static ModelClass = /** @type {?} */ (TestSyncModel)
+}
+
+/**
+ * Builds a minimal configuration for sync mount tests.
+ * @param {Record<string, ?>} [sync] - Sync configuration.
+ * @returns {Configuration} Configuration instance.
+ */
+function buildConfiguration(sync) {
+  return new Configuration({
+    database: {test: {}},
+    directory: "/tmp/velocious-sync-mount-spec",
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    locales: ["en"],
+    sync
+  })
+}
+
+/**
+ * Resolves a route hook match for a request path.
+ * @param {Configuration} configuration - Configuration with route hooks.
+ * @param {string} currentPath - Request path.
+ * @returns {Promise<Record<string, ?> | null>} Matched route or null.
+ */
+async function resolveRoute(configuration, currentPath) {
+  const request = {httpMethod: () => "POST"}
+
+  for (const hook of configuration.getRouteResolverHooks()) {
+    const match = await hook({configuration, currentPath, request: /** @type {?} */ (request)})
+
+    if (match) return match
+  }
+
+  return null
+}
+
+describe("sync configuration mount", () => {
+  it("auto-mounts sync changes and replay routes when sync.api is configured", async () => {
+    const configuration = buildConfiguration({api: {resourceClass: TestSyncResource}})
+
+    await configuration.mountConfiguredSyncApi()
+
+    const changesRoute = await resolveRoute(configuration, "/velocious/sync/changes")
+    const replayRoute = await resolveRoute(configuration, "/velocious/sync/replay")
+
+    expect(changesRoute?.action).toEqual("changes")
+    expect(replayRoute?.action).toEqual("replay")
+  })
+
+  it("mounts sync routes at a configured mount path", async () => {
+    const configuration = buildConfiguration({api: {mountPath: "/api/sync", resourceClass: TestSyncResource}})
+
+    await configuration.mountConfiguredSyncApi()
+
+    expect((await resolveRoute(configuration, "/api/sync/changes"))?.action).toEqual("changes")
+    expect(await resolveRoute(configuration, "/velocious/sync/changes")).toEqual(null)
+  })
+
+  it("does not mount sync routes when sync.api is absent", async () => {
+    const configuration = buildConfiguration()
+
+    await configuration.mountConfiguredSyncApi()
+
+    expect(await resolveRoute(configuration, "/velocious/sync/changes")).toEqual(null)
+  })
+
+  it("only mounts the sync routes once across repeated initializations", async () => {
+    const configuration = buildConfiguration({api: {resourceClass: TestSyncResource}})
+
+    await configuration.mountConfiguredSyncApi()
+
+    const hookCountAfterFirstMount = configuration.getRouteResolverHooks().length
+
+    await configuration.mountConfiguredSyncApi()
+
+    expect(configuration.getRouteResolverHooks().length).toEqual(hookCountAfterFirstMount)
+  })
+
+  it("rejects an invalid sync.api.resourceClass at configuration time", async () => {
+    await expect(() => buildConfiguration({api: {resourceClass: "SyncResource"}})).toThrow(/sync\.api\.resourceClass must be a resource class/u)
+    await expect(() => buildConfiguration({api: {resourceClass: class {}}})).toThrow(/must define static ModelClass/u)
+  })
+
+  it("rejects an invalid sync.api.mountPath at configuration time", async () => {
+    await expect(() => buildConfiguration({api: {mountPath: "velocious/sync", resourceClass: TestSyncResource}})).toThrow(/sync\.api\.mountPath must start with '\/'/u)
+  })
+})

--- a/spec/sync/sync-envelope-replay-service-spec.js
+++ b/spec/sync/sync-envelope-replay-service-spec.js
@@ -159,7 +159,168 @@ describe("sync envelope replay service", () => {
 
     expect(result).toEqual({syncs: [{id: 7, reason: "mandant-mismatch", syncState: "failed"}]})
   })
+
+  it("finds existing sync rows through the configured sync model", async () => {
+    const syncModel = buildFakeSyncModel()
+    const service = new ModelBackedReplayService({syncModel})
+    const result = await service.replay({
+      authenticationToken: "token-1",
+      syncs: [{
+        clientUpdatedAt: "2026-06-25T11:00:00.000Z",
+        data: {name: "Changed"},
+        id: 12,
+        resourceId: 34,
+        resourceType: "Task",
+        syncType: "update"
+      }]
+    })
+
+    expect(result).toEqual({syncs: [{id: 12, syncState: "successful"}]})
+    expect(syncModel.findByCalls).toEqual([{
+      authentication_token_id: "actor-1",
+      resource_id: "34",
+      resource_type: "Task"
+    }])
+  })
+
+  it("creates a sync row through the configured sync model when none exists", async () => {
+    const syncModel = buildFakeSyncModel()
+    const service = new ModelBackedReplayService({syncModel})
+
+    await service.replay({
+      authenticationToken: "token-1",
+      syncs: [{
+        clientUpdatedAt: "2026-06-25T11:00:00.000Z",
+        data: {name: "Changed"},
+        id: 12,
+        resourceId: 34,
+        resourceType: "Task",
+        syncType: "update"
+      }]
+    })
+
+    const {client_updated_at: clientUpdatedAt, ...createdAttributes} = syncModel.createCalls[0]
+
+    expect(clientUpdatedAt.toISOString()).toEqual("2026-06-25T11:00:00.000Z")
+    expect(createdAttributes).toEqual({
+      authentication_token_id: "actor-1",
+      data: JSON.stringify({name: "Changed"}),
+      resource_id: "34",
+      resource_type: "Task",
+      sync_type: "update"
+    })
+  })
+
+  it("updates and re-sequences an existing sync row for newer client mutations", async () => {
+    const existingSync = buildFakeSyncRecord({clientUpdatedAt: new Date("2026-06-25T10:00:00.000Z")})
+    const syncModel = buildFakeSyncModel({existingSync})
+    const service = new ModelBackedReplayService({syncModel})
+
+    await service.replay({
+      authenticationToken: "token-1",
+      syncs: [{
+        clientUpdatedAt: "2026-06-25T11:00:00.000Z",
+        data: {name: "Changed"},
+        id: 12,
+        resourceId: 34,
+        resourceType: "Task",
+        syncType: "update"
+      }]
+    })
+
+    expect(syncModel.createCalls).toEqual([])
+    expect(existingSync.calls).toEqual(["assign", "advanceServerSequence", "save"])
+    expect(existingSync.assignedAttributes.sync_type).toEqual("update")
+  })
+
+  it("does not persist stale mutations over a newer existing sync row", async () => {
+    const existingSync = buildFakeSyncRecord({clientUpdatedAt: new Date("2026-06-25T12:00:00.000Z")})
+    const syncModel = buildFakeSyncModel({existingSync})
+    const service = new ModelBackedReplayService({syncModel})
+    const result = await service.replay({
+      authenticationToken: "token-1",
+      syncs: [{
+        clientUpdatedAt: "2026-06-25T11:00:00.000Z",
+        data: {name: "Changed"},
+        id: 12,
+        resourceId: 34,
+        resourceType: "Task",
+        syncType: "update"
+      }]
+    })
+
+    expect(result).toEqual({syncs: [{id: 12, syncState: "successful"}]})
+    expect(syncModel.createCalls).toEqual([])
+    expect(existingSync.calls).toEqual([])
+  })
+
+  it("fails loudly when model-backed defaults get an actor without an id", async () => {
+    const syncModel = buildFakeSyncModel()
+    const service = new ModelBackedReplayService({actor: {}, syncModel})
+
+    await expect(async () => await service.replay({
+      authenticationToken: "token-1",
+      syncs: [{clientUpdatedAt: "2026-06-25T11:00:00.000Z", id: 1, resourceId: "1", resourceType: "Task", syncType: "update"}]
+    })).toThrow(/actor with an id/u)
+  })
 })
+
+/**
+ * Builds a fake sync record for model-backed replay tests.
+ * @param {{clientUpdatedAt: Date}} args - Existing record state.
+ * @returns {{assign: Function, advanceServerSequence: Function, save: Function, clientUpdatedAt: Function, calls: Array<string>, assignedAttributes: Record<string, ?>}} Fake sync record.
+ */
+function buildFakeSyncRecord({clientUpdatedAt}) {
+  const record = {
+    assignedAttributes: {},
+    calls: [],
+    assign(attributes) {
+      record.calls.push("assign")
+      record.assignedAttributes = attributes
+    },
+    async advanceServerSequence() {
+      record.calls.push("advanceServerSequence")
+    },
+    clientUpdatedAt: () => clientUpdatedAt,
+    async save() {
+      record.calls.push("save")
+    }
+  }
+
+  return record
+}
+
+/**
+ * Builds a fake sync model class for model-backed replay tests.
+ * @param {{existingSync?: ?}} [args] - Existing record returned from findBy.
+ * @returns {{findBy: Function, create: Function, findByCalls: Array<Record<string, ?>>, createCalls: Array<Record<string, ?>>}} Fake sync model.
+ */
+function buildFakeSyncModel({existingSync = null} = {}) {
+  const model = {
+    createCalls: [],
+    findByCalls: [],
+    async create(attributes) {
+      model.createCalls.push(attributes)
+    },
+    async findBy(conditions) {
+      model.findByCalls.push(conditions)
+      return existingSync
+    }
+  }
+
+  return model
+}
+
+class ModelBackedReplayService extends SyncEnvelopeReplayService {
+  constructor({actor = {id: () => "actor-1"}, syncModel}) {
+    super({logger: {warn: () => {}}, syncModel})
+    this.actor = actor
+  }
+
+  async authenticateReplay() {
+    return {actor: this.actor, authenticated: true}
+  }
+}
 
 class TestSyncEnvelopeReplayService extends SyncEnvelopeReplayService {
   constructor(callbacks) {

--- a/spec/sync/sync-resource-base-spec.js
+++ b/spec/sync/sync-resource-base-spec.js
@@ -1,0 +1,185 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import SyncEnvelopeReplayService from "../../src/sync/sync-envelope-replay-service.js"
+import SyncModelChangeFeedService from "../../src/sync/sync-model-change-feed-service.js"
+import SyncResourceBase from "../../src/sync/sync-resource-base.js"
+
+class TestSyncModel {}
+
+/**
+ * Builds a sync resource instance without the frontend-model pipeline.
+ * @param {typeof SyncResourceBase} ResourceClass - Resource class to instantiate.
+ * @param {Record<string, ?>} params - Request params.
+ * @returns {SyncResourceBase} Resource instance.
+ */
+function buildResource(ResourceClass, params) {
+  return /** @type {SyncResourceBase} */ (Object.assign(Object.create(ResourceClass.prototype), {
+    params: () => params
+  }))
+}
+
+describe("sync resource base", () => {
+  it("parses an optional scope param into a serialized scope", () => {
+    const resource = buildResource(SyncResourceBase, {})
+
+    expect(resource.changesScope({})).toEqual(null)
+    expect(resource.changesScope({scope: {conditions: {partnerId: 5}, resourceType: "Event"}}))
+      .toEqual({conditions: {partnerId: 5}, resourceType: "Event"})
+  })
+
+  it("fails loudly on malformed scope params", async () => {
+    const resource = buildResource(SyncResourceBase, {})
+
+    await expect(() => resource.changesScope({scope: "Event"})).toThrow(/scope must be an object/u)
+    await expect(() => resource.changesScope({scope: {conditions: {a: 1}}})).toThrow(/resourceType/u)
+    await expect(() => resource.changesScope({scope: {conditions: [], resourceType: "Event"}})).toThrow(/conditions must be an object/u)
+  })
+
+  it("calls authorizeChanges with the parsed scope before serving changes", async () => {
+    /** @type {Array<string>} */
+    const calls = []
+
+    class TestResource extends SyncResourceBase {
+      static ModelClass = TestSyncModel
+
+      /** @param {{params: Record<string, ?>, scope: import("../../src/sync/sync-resource-base.js").SerializedChangesScope | null}} args @returns {Promise<void>} */
+      async authorizeChanges({scope}) {
+        calls.push(`authorize:${scope?.resourceType}`)
+      }
+
+      /** @param {{params: Record<string, ?>, scope: import("../../src/sync/sync-resource-base.js").SerializedChangesScope | null}} args @returns {{changes: () => Promise<Record<string, ?>>}} */
+      changeFeedService(args) {
+        calls.push(`feed:${args.scope?.resourceType}`)
+        return {changes: async () => ({status: "success", syncs: []})}
+      }
+    }
+
+    const resource = buildResource(TestResource, {scope: {conditions: {partnerId: 5}, resourceType: "Event"}})
+    const result = await resource.changes()
+
+    expect(calls).toEqual(["authorize:Event", "feed:Event"])
+    expect(result).toEqual({status: "success", syncs: []})
+  })
+
+  it("propagates authorizeChanges rejections without serving changes", async () => {
+    /** @type {Array<string>} */
+    const calls = []
+
+    class TestResource extends SyncResourceBase {
+      static ModelClass = TestSyncModel
+
+      /** @returns {Promise<void>} */
+      async authorizeChanges() {
+        throw new Error("Not allowed to read sync changes")
+      }
+
+      /** @returns {{changes: () => Promise<Record<string, ?>>}} */
+      changeFeedService() {
+        calls.push("feed")
+        return {changes: async () => ({})}
+      }
+    }
+
+    const resource = buildResource(TestResource, {})
+
+    await expect(async () => await resource.changes()).toThrow("Not allowed to read sync changes")
+    expect(calls).toEqual([])
+  })
+
+  it("builds a change feed service that scopes through scopeChangesQuery", () => {
+    /** @type {Array<Record<string, ?>>} */
+    const scopeCalls = []
+
+    class TestResource extends SyncResourceBase {
+      static ModelClass = TestSyncModel
+
+      /** @param {{params: Record<string, ?>, query: ?, scope: import("../../src/sync/sync-resource-base.js").SerializedChangesScope | null}} args @returns {void} */
+      scopeChangesQuery({query, scope}) {
+        scopeCalls.push({query, scope})
+      }
+    }
+
+    const params = {scope: {conditions: {partnerId: 5}, resourceType: "Event"}}
+    const resource = buildResource(TestResource, params)
+    const scope = resource.changesScope(params)
+    const service = resource.changeFeedService({params, scope})
+
+    expect(service instanceof SyncModelChangeFeedService).toEqual(true)
+
+    const fakeQuery = {id: "query-1"}
+
+    service.scopeQuery({query: fakeQuery})
+
+    expect(scopeCalls).toEqual([{query: fakeQuery, scope: {conditions: {partnerId: 5}, resourceType: "Event"}}])
+  })
+
+  it("delegates replay to the app replay service and reshapes successful results", async () => {
+    /** @type {Array<Record<string, ?>>} */
+    const replayCalls = []
+
+    class TestReplayService extends SyncEnvelopeReplayService {
+      /** @param {Record<string, ?>} params @returns {Promise<{syncs: Array<Record<string, ?>>}>} */
+      async replay(params) {
+        replayCalls.push(params)
+        return {syncs: [{id: 1, syncState: "successful"}]}
+      }
+    }
+
+    class TestResource extends SyncResourceBase {
+      static ModelClass = TestSyncModel
+
+      /** @returns {typeof SyncEnvelopeReplayService} */
+      replayServiceClass() {
+        return TestReplayService
+      }
+    }
+
+    const params = {authenticationToken: "token-1", syncs: [{id: 1}]}
+    const resource = buildResource(TestResource, params)
+    const result = await resource.replay()
+
+    expect(replayCalls).toEqual([params])
+    expect(result).toEqual({status: "success", syncs: [{id: 1, syncState: "successful"}]})
+  })
+
+  it("passes replay error results through unchanged", async () => {
+    class TestReplayService extends SyncEnvelopeReplayService {
+      /** @returns {Promise<{syncs: Array<Record<string, ?>>, status: string, errorCode: string, errorMessage: string}>} */
+      async replay() {
+        return {errorCode: "invalid-token", errorMessage: "Invalid token", status: "error", syncs: []}
+      }
+    }
+
+    class TestResource extends SyncResourceBase {
+      static ModelClass = TestSyncModel
+
+      /** @returns {typeof SyncEnvelopeReplayService} */
+      replayServiceClass() {
+        return TestReplayService
+      }
+    }
+
+    const resource = buildResource(TestResource, {})
+    const result = await resource.replay()
+
+    expect(result).toEqual({errorCode: "invalid-token", errorMessage: "Invalid token", status: "error", syncs: []})
+  })
+
+  it("throws configuration errors when hooks are not implemented", async () => {
+    class TestResource extends SyncResourceBase {
+      static ModelClass = TestSyncModel
+
+      /** @returns {Promise<void>} */
+      async authorizeChanges() {}
+    }
+
+    const bareResource = buildResource(SyncResourceBase, {})
+    const scopedResource = buildResource(TestResource, {})
+    const service = scopedResource.changeFeedService({params: {}, scope: null})
+
+    await expect(async () => await bareResource.changes()).toThrow("SyncResourceBase#authorizeChanges must be implemented")
+    await expect(() => service.scopeQuery({query: {}})).toThrow("SyncResourceBase#scopeChangesQuery must be implemented")
+    await expect(async () => await scopedResource.replay()).toThrow("SyncResourceBase#replayServiceClass must be implemented")
+  })
+})

--- a/src/application.js
+++ b/src/application.js
@@ -4,6 +4,7 @@ import AppRoutes from "./routes/app-routes.js"
 import Logger from "./logger.js"
 import HttpServer from "./http-server/index.js"
 import HttpServerLock from "./http-server/server-lock.js"
+import SyncApiController from "./sync/sync-api-controller.js"
 import websocketEventsHost from "./http-server/websocket-events-host.js"
 import restArgsError from "./utils/rest-args-error.js"
 
@@ -53,6 +54,8 @@ export default class VelociousApplication {
     const routes = await AppRoutes.getRoutes(this.configuration)
 
     await this.configuration.initialize({type: this.getType()})
+
+    SyncApiController.mountFromConfiguration(this.configuration)
 
     this.configuration.setRoutes(routes)
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -356,8 +356,16 @@
  */
 
 /**
+ * Velocious sync API endpoint configuration.
+ * @typedef {object} VelociousSyncApiConfiguration
+ * @property {string} [mountPath] - Mount path for the sync endpoints. Defaults to "/velocious/sync".
+ * @property {FrontendModelResourceClassType} resourceClass - App sync resource class served by the auto-mounted sync endpoints.
+ */
+
+/**
  * Velocious sync configuration.
  * @typedef {object} VelociousSyncConfiguration
+ * @property {VelociousSyncApiConfiguration} [api] - Auto-mounts the Velocious sync changes/replay endpoints for this resource class.
  * @property {import("./sync/device-identity.js").SyncJsonWebKey | null} [deviceCertificateBackendPublicKey] - Public backend key used to verify offline device certificates for sync replay.
  * @property {number} [changeFeedRetentionSize] - Number of accepted server changes retained before clients must refresh from snapshot.
  * @property {Array<import("./sync/offline-grant.js").OfflineGrantSigningKey>} offlineGrantSigningKeys - Signing keys used to issue and verify offline grants. Secrets must never be exposed to clients.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -424,6 +424,7 @@ export default class VelociousConfiguration {
    * @returns {import("./configuration-types.js").VelociousSyncConfiguration} - Normalized sync configuration.
    */
   _normalizeSyncConfiguration(sync) {
+    const api = sync?.api
     const deviceCertificateBackendPublicKey = sync?.deviceCertificateBackendPublicKey || null
     const changeFeedRetentionSize = sync?.changeFeedRetentionSize
     const offlineGrantSigningKeys = sync?.offlineGrantSigningKeys || []
@@ -441,11 +442,56 @@ export default class VelociousConfiguration {
     }
 
     return {
+      api: this._normalizeSyncApiConfiguration(api),
       changeFeedRetentionSize: changeFeedRetentionSize || 10000,
       deviceCertificateBackendPublicKey,
       offlineGrantSigningKeys: offlineGrantSigningKeys.map((key) => normalizeOfflineGrantSigningKey(key)),
       offlineGrantTtlMs: offlineGrantTtlMs || 24 * 60 * 60 * 1000
     }
+  }
+
+  /**
+   * Normalizes sync API endpoint configuration.
+   * @param {import("./configuration-types.js").VelociousSyncApiConfiguration | undefined} api - Sync API configuration.
+   * @returns {import("./configuration-types.js").VelociousSyncApiConfiguration | undefined} - Normalized sync API configuration.
+   */
+  _normalizeSyncApiConfiguration(api) {
+    if (api === undefined || api === null) return undefined
+
+    if (typeof api !== "object" || Array.isArray(api)) {
+      throw new Error("sync.api must be an object with a resourceClass")
+    }
+
+    const {mountPath, resourceClass} = api
+
+    if (typeof resourceClass !== "function") {
+      throw new Error(`sync.api.resourceClass must be a resource class, got: ${String(resourceClass)}`)
+    }
+    if (!resourceClass.ModelClass) {
+      throw new Error(`sync.api.resourceClass ${resourceClass.name} must define static ModelClass`)
+    }
+    if (mountPath !== undefined && (typeof mountPath !== "string" || !mountPath.startsWith("/"))) {
+      throw new Error(`sync.api.mountPath must start with '/', got: ${String(mountPath)}`)
+    }
+
+    return {mountPath, resourceClass}
+  }
+
+  /**
+   * Auto-mounts the Velocious sync changes/replay endpoints when sync.api is configured.
+   * Guarded so repeated initializations don't register the routes more than once.
+   * @returns {Promise<void>} - Resolves when the configured sync API is mounted.
+   */
+  async mountConfiguredSyncApi() {
+    const api = this.getSyncConfiguration().api
+
+    if (!api || this._mountedSyncApi) return
+
+    this._mountedSyncApi = true
+
+    const SyncApiController = (await import("./sync/sync-api-controller.js")).default
+
+    SyncApiController.mountInto({at: api.mountPath, configuration: this, syncResourceClass: api.resourceClass})
   }
 
   /**
@@ -1753,6 +1799,7 @@ export default class VelociousConfiguration {
       await this.getEnvironmentHandler().autoDiscoverResources(this)
       this._mergeDiscoveredAbilityResources()
       this._validateResourceRelationshipsOnModels()
+      await this.mountConfiguredSyncApi()
 
       if (this._initializers) {
         const initializers = await this._initializers({configuration: this})

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -478,23 +478,6 @@ export default class VelociousConfiguration {
   }
 
   /**
-   * Auto-mounts the Velocious sync changes/replay endpoints when sync.api is configured.
-   * Guarded so repeated initializations don't register the routes more than once.
-   * @returns {Promise<void>} - Resolves when the configured sync API is mounted.
-   */
-  async mountConfiguredSyncApi() {
-    const api = this.getSyncConfiguration().api
-
-    if (!api || this._mountedSyncApi) return
-
-    this._mountedSyncApi = true
-
-    const SyncApiController = (await import("./sync/sync-api-controller.js")).default
-
-    SyncApiController.mountInto({at: api.mountPath, configuration: this, syncResourceClass: api.resourceClass})
-  }
-
-  /**
    * Runs get database configuration.
    * @returns {Record<string, import("./configuration-types.js").DatabaseConfigurationType>} - The database configuration.
    */
@@ -1799,7 +1782,6 @@ export default class VelociousConfiguration {
       await this.getEnvironmentHandler().autoDiscoverResources(this)
       this._mergeDiscoveredAbilityResources()
       this._validateResourceRelationshipsOnModels()
-      await this.mountConfiguredSyncApi()
 
       if (this._initializers) {
         const initializers = await this._initializers({configuration: this})

--- a/src/sync/sync-api-controller.js
+++ b/src/sync/sync-api-controller.js
@@ -3,6 +3,9 @@
 import Controller from "../controller.js"
 import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
 
+/** Configurations whose sync.api routes have already been mounted. */
+const mountedConfigurations = new WeakSet()
+
 /**
  * Generic `/velocious/sync` transport controller.
  *
@@ -97,6 +100,23 @@ export default class SyncApiController extends Controller {
       routes.post(`${at}/changes`, {to: [ControllerClass, "changes"]})
       routes.post(`${at}/replay`, {to: [ControllerClass, "replay"]})
     })
+  }
+
+  /**
+   * Auto-mounts the sync endpoints configured through `sync.api` on a configuration.
+   * No-op when `sync.api` is absent; guarded so repeated server boots with the
+   * same configuration register the routes only once.
+   * @param {import("../configuration.js").default} configuration - Configuration instance.
+   * @returns {void}
+   */
+  static mountFromConfiguration(configuration) {
+    const api = configuration.getSyncConfiguration().api
+
+    if (!api || mountedConfigurations.has(configuration)) return
+
+    mountedConfigurations.add(configuration)
+
+    this.mountInto({at: api.mountPath, configuration, syncResourceClass: api.resourceClass})
   }
 
   /**

--- a/src/sync/sync-envelope-replay-service.js
+++ b/src/sync/sync-envelope-replay-service.js
@@ -12,11 +12,26 @@
 export default class SyncEnvelopeReplayService {
   /**
    * Creates a sync envelope replay service.
+   *
+   * When a sync model is given, `findExistingReplaySync` and
+   * `persistReplayMutation` get model-backed default implementations. The sync
+   * model must expose `findBy`/`create` statics plus instance
+   * `assign`/`save`/`clientUpdatedAt` and `advanceServerSequence` (the
+   * change-feed sequence contract), and the actor returned from
+   * `authenticateReplay` must expose an `id()` method.
    * @param {object} [args] - Constructor arguments.
    * @param {{debug?: (...args: Array<unknown>) => void, warn?: (...args: Array<unknown>) => void}} [args.logger] - Logger used for normalization warnings.
+   * @param {?} [args.syncModel] - Sync/change model enabling model-backed default hooks.
+   * @param {string} [args.actorForeignKeyColumn] - Sync model column linking rows to the replay actor.
    */
   constructor(args = {}) {
     this.logger = args.logger || console
+    this.syncModel = args.syncModel || null
+    this.actorForeignKeyColumn = args.actorForeignKeyColumn || "authentication_token_id"
+
+    if (args.actorForeignKeyColumn !== undefined && (typeof args.actorForeignKeyColumn !== "string" || args.actorForeignKeyColumn.length < 1)) {
+      throw new Error(`actorForeignKeyColumn must be a non-blank string, got: ${String(args.actorForeignKeyColumn)}`)
+    }
   }
 
   /**
@@ -178,11 +193,33 @@ export default class SyncEnvelopeReplayService {
 
   /**
    * Loads the previously stored sync/change row for stale-client comparison.
-   * @param {{actor: ?, context: Record<string, ?>, mutation: import("./sync-envelope-replay-service.js").SyncReplayMutation}} _args - Actor, batch context, and mutation.
+   *
+   * Defaults to a sync-model lookup by actor and resource identity when a sync
+   * model is configured; otherwise apps override this hook.
+   * @param {{actor: ?, context: Record<string, ?>, mutation: import("./sync-envelope-replay-service.js").SyncReplayMutation}} args - Actor, batch context, and mutation.
    * @returns {Promise<?>} Existing sync row.
    */
-  async findExistingReplaySync(_args) {
-    return null
+  async findExistingReplaySync({actor, mutation}) {
+    if (!this.syncModel) return null
+
+    return await this.syncModel.findBy({
+      [this.actorForeignKeyColumn]: this.replayActorId(actor),
+      resource_id: mutation.resourceId,
+      resource_type: mutation.resourceType
+    })
+  }
+
+  /**
+   * Resolves the persisted actor id used by model-backed default hooks.
+   * @param {?} actor - Actor returned from authenticateReplay.
+   * @returns {?} Actor id.
+   */
+  replayActorId(actor) {
+    if (!actor || typeof actor !== "object" || typeof actor.id !== "function") {
+      throw new Error("SyncEnvelopeReplayService model-backed defaults require an actor with an id() method from authenticateReplay")
+    }
+
+    return actor.id()
   }
 
   /**
@@ -238,10 +275,45 @@ export default class SyncEnvelopeReplayService {
 
   /**
    * Persists one normalized mutation into the app sync/change store.
-   * @param {{actor: ?, context: Record<string, ?>, existingSync: ?, applyResult: ?, mutation: import("./sync-envelope-replay-service.js").SyncReplayMutation, shouldApply: boolean}} _args - Replay persistence arguments.
+   *
+   * Defaults to a stale-guarded sync-model upsert (with server re-sequencing on
+   * updates) when a sync model is configured; otherwise apps override this hook.
+   * @param {{actor: ?, context: Record<string, ?>, existingSync: ?, applyResult: ?, mutation: import("./sync-envelope-replay-service.js").SyncReplayMutation, shouldApply: boolean}} args - Replay persistence arguments.
    * @returns {Promise<void>}
    */
-  async persistReplayMutation(_args) {}
+  async persistReplayMutation({actor, existingSync, mutation}) {
+    if (!this.syncModel) return
+
+    const attributes = this.replayPersistAttributes({actor, mutation})
+
+    if (existingSync) {
+      const existingClientUpdatedAt = this.existingReplaySyncClientUpdatedAt(existingSync)
+
+      if (existingClientUpdatedAt && mutation.clientUpdatedAt <= existingClientUpdatedAt) return
+
+      existingSync.assign(attributes)
+      await existingSync.advanceServerSequence()
+      await existingSync.save()
+    } else {
+      await this.syncModel.create(attributes)
+    }
+  }
+
+  /**
+   * Builds the sync-model attributes persisted by the model-backed default.
+   * @param {{actor: ?, mutation: import("./sync-envelope-replay-service.js").SyncReplayMutation}} args - Actor and mutation.
+   * @returns {Record<string, ?>} Sync row attributes.
+   */
+  replayPersistAttributes({actor, mutation}) {
+    return {
+      [this.actorForeignKeyColumn]: this.replayActorId(actor),
+      client_updated_at: mutation.clientUpdatedAt,
+      data: mutation.serializedData,
+      resource_id: mutation.resourceId,
+      resource_type: mutation.resourceType,
+      sync_type: mutation.syncType
+    }
+  }
 
   /**
    * Runs side effects after a successful mutation replay and persistence.

--- a/src/sync/sync-resource-base.js
+++ b/src/sync/sync-resource-base.js
@@ -1,0 +1,143 @@
+// @ts-check
+
+import {forcedNonBlankStringParam} from "typanic"
+
+import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
+import SyncModelChangeFeedService from "./sync-model-change-feed-service.js"
+
+/**
+ * Optional client-declared sync scope carried on a changes request.
+ * @typedef {object} SerializedChangesScope
+ * @property {Record<string, ?>} conditions - Plain attribute conditions from the client query.
+ * @property {string} resourceType - Client resource/model name the scope was declared for.
+ */
+
+/**
+ * Base resource for Velocious sync endpoints.
+ *
+ * Velocious owns the changes/replay orchestration (scope parsing, feed paging,
+ * replay delegation, response shape) while apps subclass and only declare
+ * authorization, feed scoping, and their replay service.
+ * @template {typeof import("../database/record/index.js").default} [TModelClass=typeof import("../database/record/index.js").default]
+ * @augments {FrontendModelBaseResource<TModelClass>}
+ */
+export default class SyncResourceBase extends FrontendModelBaseResource {
+  /**
+   * Returns a stable change-feed page after app authorization.
+   * @returns {Promise<Record<string, ?>>} Change-feed page result.
+   */
+  async changes() {
+    const params = this.params()
+    const scope = this.changesScope(params)
+
+    await this.authorizeChanges({params, scope})
+
+    return await this.changeFeedService({params, scope}).changes()
+  }
+
+  /**
+   * Replays client sync envelopes through the app replay service.
+   * @returns {Promise<Record<string, ?>>} Replay result with per-sync states.
+   */
+  async replay() {
+    const result = await this.buildReplayService().replay(this.params())
+
+    if (result.status === "error") return result
+
+    return {status: "success", syncs: result.syncs}
+  }
+
+  /**
+   * Parses the optional client-declared scope from request params.
+   * @param {Record<string, ?>} params - Request params.
+   * @returns {SerializedChangesScope | null} Parsed scope, or null when the client sent none.
+   */
+  changesScope(params) {
+    const scope = params.scope
+
+    if (scope === undefined || scope === null) return null
+
+    if (typeof scope !== "object" || Array.isArray(scope)) {
+      throw new Error(`Sync changes scope must be an object, got: ${String(scope)}`)
+    }
+
+    const scopeParams = /** @type {Record<string, ?>} */ (scope)
+    const resourceType = forcedNonBlankStringParam(scopeParams, "resourceType")
+    const conditions = scopeParams.conditions
+
+    if (!conditions || typeof conditions !== "object" || Array.isArray(conditions)) {
+      throw new Error(`Sync changes scope.conditions must be an object, got: ${String(conditions)}`)
+    }
+
+    return {conditions: /** @type {Record<string, ?>} */ (conditions), resourceType}
+  }
+
+  /**
+   * Builds the change-feed service serving this changes request.
+   * @param {{params: Record<string, ?>, scope: SerializedChangesScope | null}} args - Request params and parsed scope.
+   * @returns {{changes: () => Promise<Record<string, ?>>}} Change-feed service.
+   */
+  changeFeedService({params, scope}) {
+    return new SyncModelChangeFeedService({
+      modelClass: this.syncModelClass(),
+      params,
+      scopeQuery: ({query}) => this.scopeChangesQuery({params, query, scope})
+    })
+  }
+
+  /**
+   * Builds the app replay service handling this replay request.
+   * @returns {import("./sync-envelope-replay-service.js").default} Replay service instance.
+   */
+  buildReplayService() {
+    const ReplayServiceClass = this.replayServiceClass()
+
+    return new ReplayServiceClass(this.replayServiceArgs())
+  }
+
+  /**
+   * Returns constructor args for the app replay service.
+   * @returns {Record<string, ?>} Replay service constructor args.
+   */
+  replayServiceArgs() {
+    return {}
+  }
+
+  /**
+   * Returns the sync model class backing the change feed.
+   * @returns {typeof import("../database/record/index.js").default} Sync model class.
+   */
+  syncModelClass() {
+    const modelClass = /** @type {typeof SyncResourceBase} */ (this.constructor).ModelClass
+
+    if (!modelClass) throw new Error(`${this.constructor.name} must define static ModelClass`)
+
+    return modelClass
+  }
+
+  /**
+   * Authorizes the current context for reading the requested changes.
+   * @param {{params: Record<string, ?>, scope: SerializedChangesScope | null}} _args - Request params and parsed scope.
+   * @returns {Promise<void>} Resolves when access is allowed; throws otherwise.
+   */
+  async authorizeChanges(_args) {
+    throw new Error("SyncResourceBase#authorizeChanges must be implemented")
+  }
+
+  /**
+   * Applies app visibility scoping onto the change-feed query.
+   * @param {{params: Record<string, ?>, query: import("../database/query/model-class-query.js").default, scope: SerializedChangesScope | null}} _args - Request params, feed query, and parsed scope.
+   * @returns {void}
+   */
+  scopeChangesQuery(_args) {
+    throw new Error("SyncResourceBase#scopeChangesQuery must be implemented")
+  }
+
+  /**
+   * Returns the app replay service class handling replay mutations.
+   * @returns {typeof import("./sync-envelope-replay-service.js").default} Replay service class.
+   */
+  replayServiceClass() {
+    throw new Error("SyncResourceBase#replayServiceClass must be implemented")
+  }
+}


### PR DESCRIPTION
## Summary

Second step of moving generic sync behavior into Velocious (follows #839). Servers using the Velocious sync framework now only declare configuration — authorization, feed scoping, and their replay service — while Velocious owns the endpoint orchestration:

- **`SyncResourceBase`** (`src/sync/sync-resource-base.js`): sync resource base with `changes()` (parses an optional client-declared `scope` param `{resourceType, conditions}`, runs `authorizeChanges`, serves a `SyncModelChangeFeedService` page scoped through `scopeChangesQuery`) and `replay()` (delegates to the app's `replayServiceClass()` and shapes the response). Unimplemented hooks fail loudly. The `scope` request param is optional and additive, so existing clients are unaffected.
- **Model-backed defaults in `SyncEnvelopeReplayService`**: passing `syncModel` (+ optional `actorForeignKeyColumn`, default `authentication_token_id`) enables default `findExistingReplaySync` (actor + resource identity lookup) and `persistReplayMutation` (stale-guarded upsert that re-sequences via `advanceServerSequence` on update). Apps override only when deviating — this removes duplicated boilerplate from consuming replay services.
- **Route auto-mount from configuration**: `sync.api = {resourceClass, mountPath?}` auto-registers `POST /velocious/sync/changes` + `/replay` during `initialize()` (validated at configuration time, mounted once, controller lazily imported). The manual `route.mount(SyncApiController, ...)` path keeps working, so this is non-breaking.

## Validation

- `VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/sync` — 52 tests green (8 new resource-base, 5 new replay-defaults, 6 new mount tests)
- `npm run typecheck`, `npm run lint`, `npm run build` — clean

## Follow-ups (separate PRs)

Next: a declarative client-side `SyncClient` (query-declared sync scopes, automatic mutation tracking via model lifecycle callbacks, online-gated auto-replay).