### PR TITLE
Add declarative SyncClient with query-declared sync scopes

### DIFF
--- a/changelog.d/20260702210000-declarative-sync-client.md
+++ b/changelog.d/20260702210000-declarative-sync-client.md
@@ -1,0 +1,5 @@
+# Changelog
+
+- Add a declarative client-side `SyncClient` (`src/sync/sync-client.js`): apps configure resources, transport, auth, and connectivity once; Velocious owns sync-scope persistence (auto-created `velocious_sync_scopes` table), per-scope cursors, pull paging/apply, declarative local queueing, and online-gated single-flighted replay. Scopes are declared from model queries — `syncClient.sync(Event.where({partnerId}))` or `Event.where({partnerId}).sync()` — and sent to the server in each changes payload. New-scope cursors can be seeded through a `legacyCursor` hook so existing devices don't re-pull everything. See `docs/sync-client.md`.
+- Add `getWheres`/`getJoins`/`getLimit`/`getOffset`/`getOrders` accessors to the query layer and `sync()`/`unsync()` on model queries (delegating through a dependency-free sync-client registry so client bundles stay lean).
+- Extract the shared stable JSON serializer into `src/sync/stable-json.js`.

--- a/changelog.d/20260702220000-sync-client-mutation-tracking.md
+++ b/changelog.d/20260702220000-sync-client-mutation-tracking.md
@@ -1,0 +1,5 @@
+# Changelog
+
+- Add automatic mutation tracking to `SyncClient`: resources with `track` enabled register model lifecycle callbacks on `start()` so local creates/updates/destroys queue pending sync rows (with the declared local-only stripping, boolean coercion, and syncType/trackedData mapping) and schedule an immediate online-gated replay — no app-side queue calls. Records written by pull-apply are excluded via echo suppression, and `stop()` unregisters all tracking callbacks.
+- Add `VelociousDatabaseRecord.unregisterLifecycleCallback(callbackName, callback)`.
+- `SyncApiClient.resourceApplier`/`applyResourceSync`/`destroySyncedResource` accept an optional `onRecord` hook tagging records for the duration of a remote apply.

--- a/docs/offline-sync.md
+++ b/docs/offline-sync.md
@@ -264,6 +264,10 @@ The proof should validate that shared resources, offline grants, local mutation 
 - How much snapshot integrity data is required for peer bootstrap in v1.
 - Whether frontend-local resources are generated automatically from shared resources or configured explicitly per app.
 
+## Implemented slice: declarative sync client
+
+`SyncClient` implements the declarative client-side driver: query-declared sync scopes with per-scope cursors, pull paging/apply, declarative local queueing, and online-gated replay. See `docs/sync-client.md`.
+
 ## Implemented slice: local mutation log
 
 Velocious has a client-side local mutation log for the first local-first/offline write path. It is intentionally small and append-only: frontend code records what the user tried to do, applies the allowed change optimistically to the in-memory model instance, and leaves server replay/conflict resolution to later sync pipeline steps.

--- a/docs/sync-client.md
+++ b/docs/sync-client.md
@@ -1,0 +1,58 @@
+# Declarative sync client
+
+`SyncClient` (`src/sync/sync-client.js`) is the declarative client-side sync driver. Apps configure resources, transport, auth, and connectivity once; Velocious owns scope persistence, per-scope cursors, pull paging and apply, local queueing, and online-gated replay.
+
+## Configuration
+
+```js
+import SyncClient from "velocious/build/src/sync/sync-client.js"
+
+const syncClient = new SyncClient({
+  authenticationToken: () => getUser().getAuthenticationToken(),
+  isOnline: async () => (await Network.getNetworkStateAsync()).isConnected !== false,
+  postChanges: (payload) => ServerConnection.current().post("/velocious/sync/changes", payload),
+  postReplay: (payload) => ServerConnection.current().post("/velocious/sync/replay", payload),
+  syncModel: Sync,
+  resources: {
+    Ticket: {
+      modelClass: Ticket,
+      attributes: ({data}) => ({name: data.name}),
+      findRecord: async ({data}) => await Ticket.findOrInitializeBy({id: data.id})
+    },
+    TicketScan: {
+      modelClass: TicketScan,
+      booleanAttributes: ["accepted", "rejected"],
+      localOnlyAttributes: ["id", "createdAt", "updatedAt"],
+      syncType: ({operation}) => operation === "create" ? "scanAttempt" : "update"
+    }
+  }
+})
+
+syncClient.setCurrent()
+```
+
+Invalid configuration fails loudly at construction time. See `src/sync/sync-client-types.js` for the full config typedefs.
+
+## Declaring sync scopes from queries
+
+```js
+await syncClient.sync(Event.where({partnerId}))
+// or, with a current sync client registered:
+await Event.where({partnerId}).sync()
+```
+
+The query is serialized into a `{resourceType, conditions}` scope (only plain attribute equality conditions are supported — joins, orders, limits, raw SQL, and negations fail loudly), persisted in the framework-owned `velocious_sync_scopes` table (auto-created; process-local memory when no database is configured), and pulled immediately when online. `pull()` iterates every active scope with its own persisted cursor and sends the scope in each `postChanges` payload so the server can enforce access per scope. `unsync(query)` / `query.unsync()` deactivates a scope.
+
+Devices migrating from a pre-scope cursor store can seed newly declared scopes through the `legacyCursor({scope})` config hook, avoiding a full re-pull.
+
+## Local changes and replay
+
+```js
+await syncClient.queue({resource: ticketScan, syncType: "scanAttempt"})
+```
+
+`queue()` persists a pending row on the app's `syncModel` (stripping `localOnlyAttributes`, coercing `booleanAttributes`) and schedules an immediate background replay. Replays are single-flighted and online-gated; rows are marked successful only after the backend acknowledges them, so offline or rejected changes stay pending for the next attempt. Background failures go to the `onError` config hook (rethrown when none is configured). `waitForScheduledReplay()` awaits the last scheduled attempt (useful in tests and shutdown flows).
+
+## Server side
+
+The server counterpart is `SyncResourceBase` (`src/sync/sync-resource-base.js`) plus the auto-mounted sync endpoints (`sync.api` configuration option) — see `docs/offline-sync.md`.

--- a/docs/sync-client.md
+++ b/docs/sync-client.md
@@ -45,11 +45,32 @@ The query is serialized into a `{resourceType, conditions}` scope (only plain at
 
 Devices migrating from a pre-scope cursor store can seed newly declared scopes through the `legacyCursor({scope})` config hook, avoiding a full re-pull.
 
+## Automatic mutation tracking
+
+Resources with `track` enabled queue sync rows automatically when their local models change — no app-side queue calls:
+
+```js
+resources: {
+  TicketScan: {
+    modelClass: TicketScan,
+    track: true, // or {operations: ["update"]}
+    syncType: ({operation}) => operation === "create" ? "scanAttempt" : "update",
+    trackedData: ({record}) => ({...record.attributes(), deviceId: currentDeviceId()})
+  }
+}
+
+await syncClient.start() // registers afterCreate/afterUpdate/afterDestroy callbacks
+```
+
+`start()` registers model lifecycle callbacks for every tracked resource (destroys queue `"delete"` sync rows); `stop()` unregisters them. Records written by pull-apply are excluded (echo suppression), so applying remote changes never queues them back to the server.
+
 ## Local changes and replay
 
 ```js
 await syncClient.queue({resource: ticketScan, syncType: "scanAttempt"})
 ```
+
+Explicit `queue()` stays available for command-style mutations whose payload carries more than the record's attributes.
 
 `queue()` persists a pending row on the app's `syncModel` (stripping `localOnlyAttributes`, coercing `booleanAttributes`) and schedules an immediate background replay. Replays are single-flighted and online-gated; rows are marked successful only after the backend acknowledges them, so offline or rejected changes stay pending for the next attempt. Background failures go to the `onError` config hook (rethrown when none is configured). `waitForScheduledReplay()` awaits the last scheduled attempt (useful in tests and shutdown flows).
 

--- a/spec/database/record/unregister-lifecycle-callback-spec.js
+++ b/spec/database/record/unregister-lifecycle-callback-spec.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../src/testing/test.js"
+import VelociousDatabaseRecord from "../../../src/database/record/index.js"
+
+describe("database - record - unregister lifecycle callback", () => {
+  it("removes a registered lifecycle callback", () => {
+    class CallbackModel extends VelociousDatabaseRecord {}
+
+    const callback = async () => {}
+
+    CallbackModel.afterUpdate(callback)
+
+    expect(CallbackModel.getLifecycleCallbacksMap().afterUpdate.length).toEqual(1)
+
+    CallbackModel.unregisterLifecycleCallback("afterUpdate", callback)
+
+    expect(CallbackModel.getLifecycleCallbacksMap().afterUpdate.length).toEqual(0)
+  })
+
+  it("ignores callbacks that were never registered", () => {
+    class CallbackModel extends VelociousDatabaseRecord {}
+
+    CallbackModel.unregisterLifecycleCallback("afterUpdate", async () => {})
+
+    expect(CallbackModel.getLifecycleCallbacksMap().afterUpdate).toEqual(undefined)
+  })
+})

--- a/spec/sync/query-scope-spec.js
+++ b/spec/sync/query-scope-spec.js
@@ -1,0 +1,58 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {scopeKey, serializedScopeFromQuery} from "../../src/sync/query-scope.js"
+import Task from "../dummy/src/models/task.js"
+
+describe("sync query scope", {tags: ["dummy"]}, () => {
+  it("serializes plain attribute conditions into a resource scope", () => {
+    const scope = serializedScopeFromQuery(Task.where({name: "Test task", projectId: 5}))
+
+    expect(scope).toEqual({conditions: {name: "Test task", project_id: 5}, resourceType: "Task"})
+  })
+
+  it("merges chained where conditions into one scope", () => {
+    const scope = serializedScopeFromQuery(Task.where({projectId: 5}).where({name: "Test task"}))
+
+    expect(scope).toEqual({conditions: {name: "Test task", project_id: 5}, resourceType: "Task"})
+  })
+
+  it("produces a stable scope key regardless of condition order", () => {
+    const scopeA = serializedScopeFromQuery(Task.where({name: "Test task", projectId: 5}))
+    const scopeB = serializedScopeFromQuery(Task.where({projectId: 5}).where({name: "Test task"}))
+
+    expect(scopeKey(scopeA)).toEqual(scopeKey(scopeB))
+  })
+
+  it("supports array conditions", () => {
+    const scope = serializedScopeFromQuery(Task.where({projectId: [1, 2]}))
+
+    expect(scope).toEqual({conditions: {project_id: [1, 2]}, resourceType: "Task"})
+  })
+
+  it("fails loudly on raw SQL conditions", async () => {
+    await expect(() => serializedScopeFromQuery(Task.where("name = 'Test task'")))
+      .toThrow(/only supports plain attribute conditions/u)
+  })
+
+  it("fails loudly on negated conditions", async () => {
+    await expect(() => serializedScopeFromQuery(Task.where({projectId: 5}).whereNot({name: "Test task"})))
+      .toThrow(/only supports plain attribute conditions/u)
+  })
+
+  it("fails loudly on joins, orders, limits and offsets", async () => {
+    await expect(() => serializedScopeFromQuery(Task.where({projectId: 5}).joins({project: true})))
+      .toThrow(/does not support joins/u)
+    await expect(() => serializedScopeFromQuery(Task.where({projectId: 5}).order("name")))
+      .toThrow(/does not support orders/u)
+    await expect(() => serializedScopeFromQuery(Task.where({projectId: 5}).limit(10)))
+      .toThrow(/does not support limit/u)
+    await expect(() => serializedScopeFromQuery(Task.where({projectId: 5}).offset(10)))
+      .toThrow(/does not support offset/u)
+  })
+
+  it("fails loudly on non-scalar condition values", async () => {
+    await expect(() => serializedScopeFromQuery(Task.where({name: {nested: true}})))
+      .toThrow(/must be scalar/u)
+  })
+})

--- a/spec/sync/query-scope-spec.js
+++ b/spec/sync/query-scope-spec.js
@@ -51,6 +51,17 @@ describe("sync query scope", {tags: ["dummy"]}, () => {
       .toThrow(/does not support offset/u)
   })
 
+  it("fails loudly on conflicting duplicate conditions", async () => {
+    await expect(() => serializedScopeFromQuery(Task.where({projectId: 5}).where({projectId: 6})))
+      .toThrow(/conflicting conditions/u)
+  })
+
+  it("allows repeating an identical condition", () => {
+    const scope = serializedScopeFromQuery(Task.where({projectId: 5}).where({projectId: 5}))
+
+    expect(scope.conditions).toEqual({project_id: 5})
+  })
+
   it("fails loudly on non-scalar condition values", async () => {
     await expect(() => serializedScopeFromQuery(Task.where({name: {nested: true}})))
       .toThrow(/must be scalar/u)

--- a/spec/sync/query-sync-sugar-spec.js
+++ b/spec/sync/query-sync-sugar-spec.js
@@ -1,0 +1,40 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {setCurrentSyncClient} from "../../src/sync/sync-client-registry.js"
+import Task from "../dummy/src/models/task.js"
+
+describe("query sync sugar", {tags: ["dummy"]}, () => {
+  it("delegates query.sync() and query.unsync() to the current sync client", async () => {
+    /** @type {Array<string>} */
+    const calls = []
+    const fakeClient = {
+      /** @param {?} query - Declared query. @returns {Promise<?>} Fake result. */
+      sync: async (query) => {
+        calls.push(`sync:${query.getModelClass().getModelName()}`)
+
+        return {pulled: null, scope: null}
+      },
+      /** @param {?} query - Undeclared query. @returns {Promise<void>} */
+      unsync: async (query) => {
+        calls.push(`unsync:${query.getModelClass().getModelName()}`)
+      }
+    }
+
+    setCurrentSyncClient(fakeClient)
+
+    try {
+      await Task.where({projectId: 5}).sync()
+      await Task.where({projectId: 5}).unsync()
+    } finally {
+      setCurrentSyncClient(null)
+    }
+
+    expect(calls).toEqual(["sync:Task", "unsync:Task"])
+  })
+
+  it("fails loudly when no sync client is configured", async () => {
+    await expect(async () => await Task.where({projectId: 5}).sync())
+      .toThrow(/No sync client configured/u)
+  })
+})

--- a/spec/sync/sync-client-spec.js
+++ b/spec/sync/sync-client-spec.js
@@ -356,4 +356,227 @@ describe("sync client", () => {
 
     expect(SyncClient.current()).toEqual(harness.client)
   })
+
+  it("automatically queues tracked model mutations and replays them", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {
+          booleanAttributes: ["accepted"],
+          localOnlyAttributes: ["localOnly"],
+          modelClass: TrackedScan,
+          syncType: ({operation}) => operation === "create" ? "scanAttempt" : "update",
+          track: true
+        }
+      }
+    })
+
+    await harness.client.start()
+
+    const record = buildTrackedRecord(TrackedScan, {accepted: 1, localOnly: "internal", ticketId: "t-1"})
+
+    await triggerLifecycle(TrackedScan, "afterCreate", record)
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.syncModel.rows.length).toEqual(1)
+    expect(harness.syncModel.rows[0].attributes.syncType).toEqual("scanAttempt")
+    expect(harness.syncModel.rows[0].attributes.data).toEqual({accepted: true, ticketId: "t-1"})
+    expect(harness.syncModel.rows[0].attributes.state).toEqual("success")
+    expect(harness.postReplayCalls.length).toEqual(1)
+  })
+
+  it("tracks only the configured operations", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: {operations: ["update"]}}
+      }
+    })
+
+    await harness.client.start()
+
+    expect(Object.keys(TrackedScan.lifecycleCallbacks)).toEqual(["afterUpdate"])
+  })
+
+  it("maps tracked destroys to delete sync rows", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: true}
+      }
+    })
+
+    harness.state.online = false
+
+    await harness.client.start()
+
+    const record = buildTrackedRecord(TrackedScan, {ticketId: "t-1"})
+
+    await triggerLifecycle(TrackedScan, "afterDestroy", record)
+
+    expect(harness.syncModel.rows[0].attributes.syncType).toEqual("delete")
+  })
+
+  it("uses trackedData to build tracked payloads", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {
+          modelClass: TrackedScan,
+          track: true,
+          trackedData: ({operation, record}) => ({deviceId: "device-1", operation, ticketId: record.attributes().ticketId})
+        }
+      }
+    })
+
+    harness.state.online = false
+
+    await harness.client.start()
+
+    const record = buildTrackedRecord(TrackedScan, {ticketId: "t-1"})
+
+    await triggerLifecycle(TrackedScan, "afterUpdate", record)
+
+    expect(harness.syncModel.rows[0].attributes.data).toEqual({deviceId: "device-1", operation: "update", ticketId: "t-1"})
+  })
+
+  it("does not queue tracked mutations for records written by pull-apply", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const record = buildTrackedRecord(TrackedScan, {ticketId: "t-1"})
+
+    record.assign = () => {}
+    record.isChanged = () => true
+    record.save = async () => {
+      await triggerLifecycle(TrackedScan, "afterUpdate", record)
+    }
+
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {
+          attributes: ({data}) => ({ticketId: data.ticketId}),
+          findRecord: async () => record,
+          modelClass: TrackedScan,
+          track: true
+        }
+      }
+    })
+
+    harness.state.changesResponses.push({
+      nextCursor: {id: "s-1", serverSequence: 1, updatedAt: "2026-07-01T10:00:00.000Z"},
+      status: "success",
+      syncs: [{data: {ticketId: "t-2"}, id: "s-1", resourceId: "scan-1", resourceType: "TrackedScan", syncType: "update"}],
+      upToCursor: null
+    })
+
+    await harness.client.start()
+    await harness.client.sync(fakeQuery("TrackedScan", {event_id: 5}))
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.syncModel.rows.length).toEqual(0)
+
+    await triggerLifecycle(TrackedScan, "afterUpdate", record)
+
+    expect(harness.syncModel.rows.length).toEqual(1)
+  })
+
+  it("unregisters tracking callbacks when stopped", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: true}
+      }
+    })
+
+    await harness.client.start()
+
+    expect(TrackedScan.lifecycleCallbacks.afterCreate.length).toEqual(1)
+
+    harness.client.stop()
+
+    expect(TrackedScan.lifecycleCallbacks.afterCreate.length).toEqual(0)
+    expect(TrackedScan.lifecycleCallbacks.afterUpdate.length).toEqual(0)
+    expect(TrackedScan.lifecycleCallbacks.afterDestroy.length).toEqual(0)
+  })
+
+  it("fails loudly on invalid track configuration", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: {operations: ["upsert"]}}
+      }
+    })
+
+    await expect(async () => await harness.client.start()).toThrow(/track\.operations/u)
+  })
 })
+
+/**
+ * Builds a fake model class implementing the lifecycle-callback registration contract.
+ * @param {string} name - Model class name.
+ * @returns {?} Fake trackable model class.
+ */
+function buildTrackedModelClass(name) {
+  const klass = class {
+    /** @type {Record<string, Array<Function>>} */
+    static lifecycleCallbacks = {}
+
+    /** @param {Function} callback - Lifecycle callback. @returns {void} */
+    static afterCreate(callback) {
+      (this.lifecycleCallbacks.afterCreate ||= []).push(callback)
+    }
+
+    /** @param {Function} callback - Lifecycle callback. @returns {void} */
+    static afterUpdate(callback) {
+      (this.lifecycleCallbacks.afterUpdate ||= []).push(callback)
+    }
+
+    /** @param {Function} callback - Lifecycle callback. @returns {void} */
+    static afterDestroy(callback) {
+      (this.lifecycleCallbacks.afterDestroy ||= []).push(callback)
+    }
+
+    /** @param {string} callbackName - Callback type. @param {Function} callback - Registered callback. @returns {void} */
+    static unregisterLifecycleCallback(callbackName, callback) {
+      const callbacks = this.lifecycleCallbacks[callbackName]
+
+      if (!callbacks) return
+
+      const index = callbacks.indexOf(callback)
+
+      if (index >= 0) callbacks.splice(index, 1)
+    }
+  }
+
+  Object.defineProperty(klass, "name", {value: name})
+
+  return klass
+}
+
+/**
+ * Builds a fake record instance of a tracked model class.
+ * @param {?} modelClass - Tracked model class.
+ * @param {Record<string, ?>} attributes - Record attributes.
+ * @returns {?} Fake record.
+ */
+function buildTrackedRecord(modelClass, attributes) {
+  const record = Object.create(modelClass.prototype)
+
+  record.id = () => "scan-1"
+  record.attributes = () => attributes
+
+  return record
+}
+
+/**
+ * Invokes the registered lifecycle callbacks like the record layer would.
+ * @param {?} modelClass - Tracked model class.
+ * @param {string} callbackName - Callback type.
+ * @param {?} record - Mutated record.
+ * @returns {Promise<void>}
+ */
+async function triggerLifecycle(modelClass, callbackName, record) {
+  for (const callback of modelClass.lifecycleCallbacks[callbackName] || []) {
+    await callback(record)
+  }
+}

--- a/spec/sync/sync-client-spec.js
+++ b/spec/sync/sync-client-spec.js
@@ -1,0 +1,359 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import SyncClient from "../../src/sync/sync-client.js"
+
+class Ticket {}
+class TicketScan {}
+
+/** @returns {Configuration} Database-less configuration so the scope store uses memory storage. */
+function buildConfiguration() {
+  return new Configuration({
+    database: {test: {}},
+    directory: "/tmp/velocious-sync-client-spec",
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    locales: ["en"]
+  })
+}
+
+/**
+ * Builds a fake local pending-sync model compatible with the sync client.
+ * @returns {?} Fake sync model with a rows array.
+ */
+function buildFakeSyncModel() {
+  /** @type {Array<?>} */
+  const rows = []
+  let nextId = 1
+
+  /**
+   * @param {Record<string, ?>} attributes - Row attributes.
+   * @returns {?} Fake sync row.
+   */
+  const buildRow = (attributes) => {
+    const row = {
+      attributes: {...attributes, id: nextId++},
+      createdAt: () => new Date("2026-07-01T10:00:00.000Z"),
+      data: () => row.attributes.data,
+      id: () => row.attributes.id,
+      resource: () => null,
+      resourceId: () => row.attributes.resourceId,
+      resourceType: () => row.attributes.resourceType,
+      syncType: () => row.attributes.syncType,
+      /** @param {Record<string, ?>} newAttributes - Updated attributes. @returns {Promise<void>} */
+      update: async (newAttributes) => {
+        Object.assign(row.attributes, newAttributes)
+      },
+      updatedAt: () => new Date("2026-07-01T10:00:00.000Z")
+    }
+
+    return row
+  }
+
+  return {
+    /** @param {Record<string, ?>} attributes - Row attributes. @returns {Promise<?>} Created row. */
+    create: async (attributes) => {
+      const row = buildRow(attributes)
+
+      rows.push(row)
+
+      return row
+    },
+    /** @param {{resourceId: string, resourceType: string}} conditions - Lookup conditions. @returns {Promise<?>} Existing row. */
+    findBy: async ({resourceId, resourceType}) => rows.find((row) => row.attributes.resourceId === resourceId && row.attributes.resourceType === resourceType) || null,
+    preload: () => ({
+      /** @param {{state: string}} conditions - Where conditions. @returns {?} Chainable query. */
+      where: ({state}) => ({
+        order: () => ({
+          toArray: async () => rows.filter((row) => row.attributes.state === state)
+        })
+      })
+    }),
+    rows
+  }
+}
+
+/**
+ * Builds a fake query for a resource type with plain conditions.
+ * @param {string} resourceType - Resource/model name.
+ * @param {Record<string, ?>} conditions - Attribute conditions.
+ * @returns {?} Fake model query.
+ */
+function fakeQuery(resourceType, conditions) {
+  return {
+    getGroups: () => [],
+    getJoins: () => [],
+    getLimit: () => null,
+    getModelClass: () => ({getModelName: () => resourceType}),
+    getOffset: () => null,
+    getOrders: () => [],
+    getWheres: () => [{hash: conditions}]
+  }
+}
+
+/**
+ * Builds a sync client harness with recording fakes.
+ * @param {Record<string, ?>} [overrides] - Config overrides.
+ * @returns {?} Harness with client, fakes, and recorded calls.
+ */
+function buildHarness(overrides = {}) {
+  /** @type {Array<Record<string, ?>>} */
+  const postChangesCalls = []
+  /** @type {Array<Record<string, ?>>} */
+  const postReplayCalls = []
+  /** @type {Array<Error>} */
+  const errors = []
+  const syncModel = buildFakeSyncModel()
+  const ticketRecord = {
+    assignedAttributes: /** @type {Record<string, ?> | null} */ (null),
+    /** @param {Record<string, ?>} attributes - Applied attributes. @returns {void} */
+    assign(attributes) {
+      this.assignedAttributes = attributes
+    },
+    isChanged: () => true,
+    save: async () => {},
+    saved: false
+  }
+  const state = {
+    changesResponses: /** @type {Array<Record<string, ?>>} */ ([]),
+    online: true,
+    replayResponse: /** @type {Record<string, ?> | ((payload: Record<string, ?>) => Record<string, ?>)} */ ({status: "success", syncs: []})
+  }
+  const client = new SyncClient({
+    authenticationToken: () => "token-1",
+    configuration: buildConfiguration(),
+    isOnline: () => state.online,
+    onError: (error) => {
+      errors.push(error)
+    },
+    postChanges: async (payload) => {
+      postChangesCalls.push(payload)
+
+      return state.changesResponses.shift() || {nextCursor: null, status: "success", syncs: [], upToCursor: null}
+    },
+    postReplay: async (payload) => {
+      postReplayCalls.push(payload)
+
+      if (typeof state.replayResponse === "function") return state.replayResponse(payload)
+
+      return {
+        ...state.replayResponse,
+        syncs: state.replayResponse.syncs.length > 0
+          ? state.replayResponse.syncs
+          : payload.syncs.map((sync) => ({id: sync.id, syncState: "successful"}))
+      }
+    },
+    resources: {
+      Ticket: {
+        attributes: ({data}) => ({name: data.name}),
+        findRecord: async () => ticketRecord,
+        modelClass: Ticket
+      },
+      TicketScan: {
+        booleanAttributes: ["accepted"],
+        localOnlyAttributes: ["localOnly"],
+        modelClass: TicketScan,
+        syncType: ({operation}) => operation === "create" ? "scanAttempt" : "update"
+      }
+    },
+    syncModel,
+    ...overrides
+  })
+
+  return {client, errors, postChangesCalls, postReplayCalls, state, syncModel, ticketRecord}
+}
+
+/**
+ * Builds a fake scan record for queueing tests.
+ * @returns {?} Fake TicketScan record.
+ */
+function buildScanRecord() {
+  const record = Object.create(TicketScan.prototype)
+
+  record.id = () => "scan-1"
+  record.attributes = () => ({accepted: 1, localOnly: "internal", ticketId: "t-1"})
+
+  return record
+}
+
+describe("sync client", () => {
+  it("declares a scope and pulls it with the scope in the changes payload", async () => {
+    const harness = buildHarness()
+
+    harness.state.changesResponses.push({
+      nextCursor: {id: "s-1", serverSequence: 3, updatedAt: "2026-07-01T10:00:00.000Z"},
+      status: "success",
+      syncs: [{data: {name: "New name"}, id: "s-1", resourceId: "t-1", resourceType: "Ticket", syncType: "update"}],
+      upToCursor: {id: "s-1", serverSequence: 3, updatedAt: "2026-07-01T10:00:00.000Z"}
+    })
+
+    const result = await harness.client.sync(fakeQuery("Ticket", {partner_id: 5}))
+
+    expect(harness.postChangesCalls.length).toEqual(1)
+    expect(harness.postChangesCalls[0].authenticationToken).toEqual("token-1")
+    expect(harness.postChangesCalls[0].scope).toEqual({conditions: {partner_id: 5}, resourceType: "Ticket"})
+    expect(harness.ticketRecord.assignedAttributes).toEqual({name: "New name"})
+    expect(result.pulled?.syncedCount).toEqual(1)
+  })
+
+  it("sends the persisted scope cursor on subsequent pulls", async () => {
+    const harness = buildHarness()
+
+    harness.state.changesResponses.push({
+      nextCursor: {id: "s-1", serverSequence: 3, updatedAt: "2026-07-01T10:00:00.000Z"},
+      status: "success",
+      syncs: [{data: {name: "New name"}, id: "s-1", resourceId: "t-1", resourceType: "Ticket", syncType: "update"}],
+      upToCursor: null
+    })
+
+    await harness.client.sync(fakeQuery("Ticket", {partner_id: 5}))
+    await harness.client.pull()
+
+    expect(harness.postChangesCalls.length).toEqual(2)
+    expect(harness.postChangesCalls[1].afterId).toEqual("s-1")
+    expect(harness.postChangesCalls[1].afterServerSequence).toEqual(3)
+    expect(harness.postChangesCalls[1].afterUpdatedAt).toEqual("2026-07-01T10:00:00.000Z")
+  })
+
+  it("seeds new scope cursors from the legacyCursor hook", async () => {
+    const harness = buildHarness({
+      legacyCursor: async () => JSON.stringify({id: "legacy-1", serverSequence: 7, updatedAt: "2026-06-30T10:00:00.000Z"})
+    })
+
+    await harness.client.sync(fakeQuery("Ticket", {partner_id: 5}))
+
+    expect(harness.postChangesCalls.length).toEqual(1)
+    expect(harness.postChangesCalls[0].afterId).toEqual("legacy-1")
+    expect(harness.postChangesCalls[0].afterServerSequence).toEqual(7)
+  })
+
+  it("does not pull while offline and pulls declared scopes once online", async () => {
+    const harness = buildHarness()
+
+    harness.state.online = false
+
+    const result = await harness.client.sync(fakeQuery("Ticket", {partner_id: 5}))
+
+    expect(result.pulled).toEqual(null)
+    expect(harness.postChangesCalls.length).toEqual(0)
+
+    harness.state.online = true
+
+    await harness.client.pull()
+
+    expect(harness.postChangesCalls.length).toEqual(1)
+    expect(harness.postChangesCalls[0].scope).toEqual({conditions: {partner_id: 5}, resourceType: "Ticket"})
+  })
+
+  it("pulls every active scope with its own cursor and stops pulling unsynced scopes", async () => {
+    const harness = buildHarness()
+
+    harness.state.online = false
+    await harness.client.sync(fakeQuery("Ticket", {partner_id: 5}))
+    await harness.client.sync(fakeQuery("Ticket", {partner_id: 6}))
+    harness.state.online = true
+
+    await harness.client.pull()
+
+    expect(harness.postChangesCalls.map((call) => call.scope.conditions.partner_id)).toEqual([5, 6])
+
+    await harness.client.unsync(fakeQuery("Ticket", {partner_id: 5}))
+    await harness.client.pull()
+
+    expect(harness.postChangesCalls.length).toEqual(3)
+    expect(harness.postChangesCalls[2].scope.conditions.partner_id).toEqual(6)
+  })
+
+  it("queues local changes declaratively and replays them immediately when online", async () => {
+    const harness = buildHarness()
+    const syncRow = await harness.client.queue({resource: buildScanRecord(), syncType: "scanAttempt"})
+
+    expect(syncRow.attributes.data).toEqual({accepted: true, ticketId: "t-1"})
+    expect(syncRow.attributes.syncType).toEqual("scanAttempt")
+
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.postReplayCalls.length).toEqual(1)
+    expect(harness.postReplayCalls[0].syncs[0].resourceType).toEqual("TicketScan")
+    expect(syncRow.attributes.state).toEqual("success")
+    expect(harness.errors).toEqual([])
+  })
+
+  it("keeps queued rows pending while offline", async () => {
+    const harness = buildHarness()
+
+    harness.state.online = false
+
+    const syncRow = await harness.client.queue({resource: buildScanRecord()})
+
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.postReplayCalls.length).toEqual(0)
+    expect(syncRow.attributes.state).toEqual("pending")
+  })
+
+  it("keeps rows pending and reports the error when the replay request fails", async () => {
+    const harness = buildHarness()
+
+    harness.state.replayResponse = () => {
+      throw new Error("Network down")
+    }
+
+    const syncRow = await harness.client.queue({resource: buildScanRecord()})
+
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.errors.map((error) => error.message)).toEqual(["Network down"])
+    expect(syncRow.attributes.state).toEqual("pending")
+  })
+
+  it("keeps rows pending when the backend does not acknowledge success", async () => {
+    const harness = buildHarness()
+
+    harness.state.replayResponse = (payload) => ({
+      status: "success",
+      syncs: payload.syncs.map((sync) => ({id: sync.id, syncState: "failed"}))
+    })
+
+    const syncRow = await harness.client.queue({resource: buildScanRecord()})
+
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.errors.length).toEqual(1)
+    expect(syncRow.attributes.state).toEqual("pending")
+  })
+
+  it("fails loudly when queueing a resource type that is not configured", async () => {
+    const harness = buildHarness()
+
+    class UnknownModel {}
+
+    const record = Object.create(UnknownModel.prototype)
+
+    await expect(async () => await harness.client.queue({resource: record}))
+      .toThrow(/No sync resource configured for: UnknownModel/u)
+  })
+
+  it("fails loudly on invalid configuration", async () => {
+    await expect(() => new SyncClient(/** @type {?} */ ({}))).toThrow(/postChanges/u)
+    await expect(() => new SyncClient(/** @type {?} */ ({
+      authenticationToken: () => "token",
+      postChanges: async () => ({}),
+      postReplay: async () => ({}),
+      resources: {},
+      syncModel: {}
+    }))).toThrow(/resources/u)
+  })
+
+  it("exposes a current sync client singleton", async () => {
+    const harness = buildHarness()
+
+    harness.client.setCurrent()
+
+    expect(SyncClient.current()).toEqual(harness.client)
+  })
+})

--- a/spec/sync/sync-client-spec.js
+++ b/spec/sync/sync-client-spec.js
@@ -327,6 +327,25 @@ describe("sync client", () => {
     expect(syncRow.attributes.state).toEqual("pending")
   })
 
+  it("fails loudly instead of skipping pulled changes without an applyable resource", async () => {
+    const harness = buildHarness()
+
+    harness.state.changesResponses.push({
+      nextCursor: {id: "s-1", serverSequence: 1, updatedAt: "2026-07-01T10:00:00.000Z"},
+      status: "success",
+      syncs: [{data: {name: "Someone"}, id: "s-1", resourceId: "c-1", resourceType: "Customer", syncType: "update"}],
+      upToCursor: null
+    })
+
+    await expect(async () => await harness.client.sync(fakeQuery("Ticket", {partner_id: 5})))
+      .toThrow(/No sync resource with pull attributes configured for pulled change: Customer/u)
+
+    await harness.client.pull()
+
+    expect(harness.postChangesCalls.length).toEqual(2)
+    expect(harness.postChangesCalls[1].afterId).toEqual(undefined)
+  })
+
   it("fails loudly when queueing a resource type that is not configured", async () => {
     const harness = buildHarness()
 

--- a/spec/sync/sync-scope-store-spec.js
+++ b/spec/sync/sync-scope-store-spec.js
@@ -44,6 +44,19 @@ describe("sync scope store", {tags: ["dummy"], databaseCleaning: {transaction: f
     expect(await store.loadCursor(secondScopeRow)).toEqual(null)
   })
 
+  it("stores long scope identities in a fixed-size digest key", async () => {
+    const store = buildStore()
+    const longName = "n".repeat(400)
+    const scopeRow = await store.findOrCreateScope(serializedScopeFromQuery(Task.where({name: longName, projectId: 5})))
+
+    expect(scopeRow.scopeDigest.length).toEqual(36)
+
+    const reusedRow = await store.findOrCreateScope(serializedScopeFromQuery(Task.where({projectId: 5}).where({name: longName})))
+
+    expect(reusedRow.id).toEqual(scopeRow.id)
+    expect((await store.activeScopes()).length).toEqual(1)
+  })
+
   it("deactivates and reactivates scopes", async () => {
     const store = buildStore()
     const scope = serializedScopeFromQuery(Task.where({projectId: 5}))

--- a/spec/sync/sync-scope-store-spec.js
+++ b/spec/sync/sync-scope-store-spec.js
@@ -1,0 +1,61 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {serializedScopeFromQuery} from "../../src/sync/query-scope.js"
+import SyncScopeStore from "../../src/sync/sync-scope-store.js"
+import Configuration from "../../src/configuration.js"
+import Task from "../dummy/src/models/task.js"
+
+/** @returns {SyncScopeStore} Store bound to the current (dummy) configuration. */
+function buildStore() {
+  return new SyncScopeStore({configuration: Configuration.current()})
+}
+
+describe("sync scope store", {tags: ["dummy"], databaseCleaning: {transaction: false, truncate: true}}, () => {
+  it("stores an active scope row with no cursor when a scope is declared", async () => {
+    const store = buildStore()
+    const scope = serializedScopeFromQuery(Task.where({projectId: 5}))
+    const scopeRow = await store.findOrCreateScope(scope)
+
+    expect(scopeRow.resourceType).toEqual("Task")
+    expect(scopeRow.conditions).toEqual({project_id: 5})
+    expect(scopeRow.state).toEqual("active")
+    expect(scopeRow.cursorPayload).toEqual(null)
+  })
+
+  it("reuses the existing scope row when the same scope is declared twice", async () => {
+    const store = buildStore()
+    const scope = serializedScopeFromQuery(Task.where({projectId: 5}))
+    const firstRow = await store.findOrCreateScope(scope)
+    const secondRow = await store.findOrCreateScope(serializedScopeFromQuery(Task.where({projectId: 5})))
+
+    expect(secondRow.id).toEqual(firstRow.id)
+    expect((await store.activeScopes()).length).toEqual(1)
+  })
+
+  it("persists cursors per scope independently", async () => {
+    const store = buildStore()
+    const firstScopeRow = await store.findOrCreateScope(serializedScopeFromQuery(Task.where({projectId: 5})))
+    const secondScopeRow = await store.findOrCreateScope(serializedScopeFromQuery(Task.where({projectId: 6})))
+
+    await store.saveCursor(firstScopeRow, {id: "sync-1", serverSequence: 11, updatedAt: "2026-07-01T10:00:00.000Z"})
+
+    expect(JSON.parse(String(await store.loadCursor(firstScopeRow)))).toEqual({id: "sync-1", serverSequence: 11, updatedAt: "2026-07-01T10:00:00.000Z"})
+    expect(await store.loadCursor(secondScopeRow)).toEqual(null)
+  })
+
+  it("deactivates and reactivates scopes", async () => {
+    const store = buildStore()
+    const scope = serializedScopeFromQuery(Task.where({projectId: 5}))
+
+    await store.findOrCreateScope(scope)
+    await store.deactivate(scope)
+
+    expect((await store.activeScopes()).length).toEqual(0)
+
+    const reactivatedRow = await store.findOrCreateScope(scope)
+
+    expect(reactivatedRow.state).toEqual("active")
+    expect((await store.activeScopes()).length).toEqual(1)
+  })
+})

--- a/src/database/query/index.js
+++ b/src/database/query/index.js
@@ -236,16 +236,46 @@ export default class VelociousDatabaseQuery {
   }
 
   /**
+   * Runs get joins.
+   * @returns {Array<?>} - The joins.
+   */
+  getJoins() { return this._joins }
+
+  /**
+   * Runs get limit.
+   * @returns {number | null} - The limit.
+   */
+  getLimit() { return this._limit }
+
+  /**
+   * Runs get offset.
+   * @returns {number | null} - The offset.
+   */
+  getOffset() { return this._offset }
+
+  /**
    * Runs get options.
    * @returns {import("../query-parser/options.js").default} - The options options.
    */
   getOptions() { return this.driver.options() }
 
   /**
+   * Runs get orders.
+   * @returns {Array<?>} - The orders.
+   */
+  getOrders() { return this._orders }
+
+  /**
    * Runs get selects.
    * @returns {Array<import("./select-base.js").default>} - The selects.
    */
   getSelects() { return this._selects }
+
+  /**
+   * Runs get wheres.
+   * @returns {Array<import("./where-base.js").default>} - The wheres.
+   */
+  getWheres() { return this._wheres }
 
   /**
    * Runs from.

--- a/src/database/query/model-class-query.js
+++ b/src/database/query/model-class-query.js
@@ -3,6 +3,7 @@
 import {incorporate} from "incorporator"
 import * as inflection from "inflection"
 import {isPlainObject} from "is-plain-object"
+import {currentSyncClient} from "../../sync/sync-client-registry.js"
 import Logger from "../../logger.js"
 import Preloader from "./preloader.js"
 import {normalizeQueryDataSpec, runQueryData} from "./query-data.js"
@@ -1113,6 +1114,22 @@ export default class VelociousDatabaseQueryModelClassQuery extends DatabaseQuery
    */
   queryLogName(operation) {
     return `${this.getModelClass().name} ${operation}`
+  }
+
+  /**
+   * Declares this query as a sync scope on the current sync client.
+   * @returns {Promise<?>} - Declared scope and pull result.
+   */
+  async sync() {
+    return await currentSyncClient().sync(this)
+  }
+
+  /**
+   * Deactivates this query's sync scope on the current sync client.
+   * @returns {Promise<void>} - Resolves when the scope is deactivated.
+   */
+  async unsync() {
+    await currentSyncClient().unsync(this)
   }
 }
 

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -536,6 +536,22 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * Runs unregister lifecycle callback.
+   * @param {"afterCreate" | "afterDestroy" | "afterSave" | "afterUpdate" | "beforeCreate" | "beforeDestroy" | "beforeSave" | "beforeUpdate" | "beforeValidation"} callbackName - Callback type.
+   * @param {LifecycleCallbackType} callback - Previously registered callback.
+   * @returns {void}
+   */
+  static unregisterLifecycleCallback(callbackName, callback) {
+    const callbacks = this.getLifecycleCallbacksMap()[callbackName]
+
+    if (!callbacks) return
+
+    const callbackIndex = callbacks.indexOf(callback)
+
+    if (callbackIndex >= 0) callbacks.splice(callbackIndex, 1)
+  }
+
+  /**
    * Runs before validation.
    * @template R
    * @this {ModelConstructor<R>}

--- a/src/sync/query-scope.js
+++ b/src/sync/query-scope.js
@@ -30,7 +30,13 @@ export function serializedScopeFromQuery(query) {
     }
 
     for (const [attributeName, value] of Object.entries(whereHash)) {
-      conditions[attributeName] = scalarConditionValue(attributeName, value)
+      const conditionValue = scalarConditionValue(attributeName, value)
+
+      if (attributeName in conditions && stableJsonStringify(conditions[attributeName]) !== stableJsonStringify(conditionValue)) {
+        throw new Error(`sync(query) got conflicting conditions for: ${attributeName}`)
+      }
+
+      conditions[attributeName] = conditionValue
     }
   }
 

--- a/src/sync/query-scope.js
+++ b/src/sync/query-scope.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+import stableJsonStringify from "./stable-json.js"
+
+/**
+ * Serializes a model query into a transportable sync scope.
+ *
+ * Only plain attribute equality conditions are supported: the scope must be
+ * expressible as `{resourceType, conditions}` so servers can match it against
+ * their change feeds. Anything else (raw SQL, negations, joins, orders,
+ * limits, offsets, groups) fails loudly.
+ * @param {import("../database/query/model-class-query.js").default<?>} query - Model query declaring the sync scope.
+ * @returns {import("./sync-client-types.js").SerializedSyncScope} Serialized sync scope.
+ */
+export function serializedScopeFromQuery(query) {
+  if (query.getJoins().length > 0) throw new Error("sync(query) does not support joins")
+  if (query.getOrders().length > 0) throw new Error("sync(query) does not support orders")
+  if (query.getLimit() !== null && query.getLimit() !== undefined) throw new Error("sync(query) does not support limit")
+  if (query.getOffset() !== null && query.getOffset() !== undefined) throw new Error("sync(query) does not support offset")
+  if (query.getGroups().length > 0) throw new Error("sync(query) does not support groups")
+
+  const modelClass = query.getModelClass()
+  const conditions = /** @type {Record<string, ?>} */ ({})
+
+  for (const where of query.getWheres()) {
+    const whereHash = /** @type {{hash?: Record<string, ?>}} */ (where).hash
+
+    if (!whereHash || typeof whereHash !== "object" || Array.isArray(whereHash) || /** @type {{where?: ?}} */ (where).where) {
+      throw new Error(`sync(query) only supports plain attribute conditions, got: ${where.constructor.name}`)
+    }
+
+    for (const [attributeName, value] of Object.entries(whereHash)) {
+      conditions[attributeName] = scalarConditionValue(attributeName, value)
+    }
+  }
+
+  return {conditions, resourceType: modelClass.getModelName()}
+}
+
+/**
+ * Returns a stable canonical key identifying a sync scope.
+ * @param {import("./sync-client-types.js").SerializedSyncScope} scope - Serialized sync scope.
+ * @returns {string} Stable scope key.
+ */
+export function scopeKey(scope) {
+  return `${scope.resourceType}:${stableJsonStringify(scope.conditions)}`
+}
+
+/**
+ * Validates one scope condition value as a scalar or array of scalars.
+ * @param {string} attributeName - Condition attribute name for error messages.
+ * @param {?} value - Condition value.
+ * @returns {?} Validated condition value.
+ */
+function scalarConditionValue(attributeName, value) {
+  if (Array.isArray(value)) {
+    for (const item of value) validateScalar(attributeName, item)
+
+    return value
+  }
+
+  validateScalar(attributeName, value)
+
+  return value
+}
+
+/**
+ * Validates one scalar condition value.
+ * @param {string} attributeName - Condition attribute name for error messages.
+ * @param {?} value - Condition value.
+ * @returns {void}
+ */
+function validateScalar(attributeName, value) {
+  if (value === null) return
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return
+
+  throw new Error(`sync(query) condition values must be scalar, got ${typeof value} for: ${attributeName}`)
+}

--- a/src/sync/server-change-feed.js
+++ b/src/sync/server-change-feed.js
@@ -2,6 +2,7 @@
 
 import {randomUUID} from "crypto"
 import TableData from "../database/table-data/index.js"
+import stableJsonStringify from "./stable-json.js"
 
 const DEFAULT_RETENTION_SIZE = 10000
 const DEFAULT_PAGE_SIZE = 100
@@ -462,31 +463,6 @@ function scopesEqual(changeScope, requestedScope) {
   if (requestedScope === undefined) return true
 
   return stableJsonStringify(changeScope || null) === stableJsonStringify(requestedScope)
-}
-
-/**
- * Stable JSON serialization for persisted sync scopes.
- * @param {?} value - JSON-compatible value.
- * @returns {string} - Stable JSON representation.
- */
-function stableJsonStringify(value) {
-  return JSON.stringify(stableJsonValue(value))
-}
-
-/**
- * Produces a recursively key-sorted JSON value.
- * @param {?} value - JSON-compatible value.
- * @returns {?} - Stable JSON-compatible value.
- */
-function stableJsonValue(value) {
-  if (Array.isArray(value)) return value.map((item) => stableJsonValue(item))
-  if (!value || typeof value !== "object") return value
-
-  return Object.keys(value).sort().reduce((memo, key) => {
-    memo[key] = stableJsonValue(value[key])
-
-    return memo
-  }, /** @type {Record<string, ?>} */ ({}))
 }
 
 /**

--- a/src/sync/stable-json.js
+++ b/src/sync/stable-json.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/**
+ * Serializes a JSON-compatible value with recursively sorted object keys, so
+ * equal values always produce byte-identical strings (used for sync scope and
+ * change-feed identity comparisons).
+ * @param {?} value - JSON-compatible value.
+ * @returns {string} - Stable JSON string.
+ */
+export default function stableJsonStringify(value) {
+  return JSON.stringify(stableJsonValue(value))
+}
+
+/**
+ * Produces a recursively key-sorted JSON value.
+ * @param {?} value - JSON-compatible value.
+ * @returns {?} - Stable JSON-compatible value.
+ */
+function stableJsonValue(value) {
+  if (Array.isArray(value)) return value.map((item) => stableJsonValue(item))
+  if (!value || typeof value !== "object") return value
+
+  return Object.keys(value).sort().reduce((memo, key) => {
+    memo[key] = stableJsonValue(value[key])
+
+    return memo
+  }, /** @type {Record<string, ?>} */ ({}))
+}

--- a/src/sync/sync-api-client.js
+++ b/src/sync/sync-api-client.js
@@ -255,43 +255,49 @@ export default class SyncApiClient {
    * mechanics stay here; apps only declare which models/attributes/hooks are
    * allowed for each resource type.
    * @param {Record<string, SyncResourceConfig>} resources - Resource policy map.
+   * @param {(record: ?) => () => void} [onRecord] - Called with each record about to be written; returns a release callback invoked after the write (used for echo suppression).
    * @returns {(sync: SyncChangeEnvelope) => Promise<SyncChangeApplyResult>} Sync apply callback.
    */
-  static resourceApplier(resources) {
-    return async (sync) => await this.applyResourceSync({resources, sync})
+  static resourceApplier(resources, onRecord) {
+    return async (sync) => await this.applyResourceSync({onRecord, resources, sync})
   }
 
   /**
    * Applies one sync row using declarative resource policy.
-   * @param {{resources: Record<string, SyncResourceConfig>, sync: SyncChangeEnvelope}} args - Apply args.
+   * @param {{resources: Record<string, SyncResourceConfig>, sync: SyncChangeEnvelope, onRecord?: (record: ?) => () => void}} args - Apply args.
    * @returns {Promise<SyncChangeApplyResult>} Apply result.
    */
-  static async applyResourceSync({resources, sync}) {
+  static async applyResourceSync({onRecord, resources, sync}) {
     const resourceType = sync.resourceType()
     const resource = resourceType ? resources[resourceType] : undefined
 
     if (!resource || !resource.enabled) return {changed: false, resourceType}
 
     if (sync.syncType() === "delete") {
-      return {changed: await this.destroySyncedResource({resource, sync}), resourceType}
+      return {changed: await this.destroySyncedResource({onRecord, resource, sync}), resourceType}
     }
 
     const data = this.syncData(sync)
     const record = resource.findRecord ? await resource.findRecord({data, resourceId: sync.resourceId(), sync}) : await resource.modelClass.findOrInitializeBy({id: data.id ?? sync.resourceId()})
     const attributes = await resource.attributes({data, record, sync})
+    const releaseRecord = onRecord ? onRecord(record) : null
     let changed = false
 
-    record.assign(attributes)
+    try {
+      record.assign(attributes)
 
-    if (record.isChanged()) {
-      await record.save()
-      changed = true
-    }
+      if (record.isChanged()) {
+        await record.save()
+        changed = true
+      }
 
-    if (resource.afterApply) {
-      const hookChanged = await resource.afterApply({attributes, data, record, sync})
+      if (resource.afterApply) {
+        const hookChanged = await resource.afterApply({attributes, data, record, sync})
 
-      changed ||= hookChanged === true
+        changed ||= hookChanged === true
+      }
+    } finally {
+      if (releaseRecord) releaseRecord()
     }
 
     return {changed, resourceType}
@@ -299,16 +305,23 @@ export default class SyncApiClient {
 
   /**
    * Destroys a synced resource via its declared model policy.
-   * @param {{resource: SyncResourceConfig, sync: SyncChangeEnvelope}} args - Destroy args.
+   * @param {{resource: SyncResourceConfig, sync: SyncChangeEnvelope, onRecord?: (record: ?) => () => void}} args - Destroy args.
    * @returns {Promise<boolean>} Whether a local row was destroyed.
    */
-  static async destroySyncedResource({resource, sync}) {
+  static async destroySyncedResource({onRecord, resource, sync}) {
     const id = sync.resourceId()
     const record = resource.findRecordForDelete ? await resource.findRecordForDelete({resourceId: id, sync}) : await resource.modelClass.findBy({id})
 
     if (!record) return false
 
-    await record.destroy()
+    const releaseRecord = onRecord ? onRecord(record) : null
+
+    try {
+      await record.destroy()
+    } finally {
+      if (releaseRecord) releaseRecord()
+    }
+
     return true
   }
 

--- a/src/sync/sync-client-registry.js
+++ b/src/sync/sync-client-registry.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+/**
+ * Registry for the app's current sync client.
+ *
+ * Kept dependency-free so client-bundled modules (like the query layer) can
+ * delegate to a configured sync client without importing the sync stack.
+ */
+
+/** @type {?} */
+let currentClient = null
+
+/**
+ * Registers the current sync client.
+ * @param {?} client - Configured sync client (or null to clear).
+ * @returns {void}
+ */
+export function setCurrentSyncClient(client) {
+  currentClient = client
+}
+
+/**
+ * Returns the current sync client.
+ * @returns {?} Current sync client.
+ */
+export function currentSyncClient() {
+  if (!currentClient) throw new Error("No sync client configured - create a SyncClient and call setCurrent() on it first")
+
+  return currentClient
+}

--- a/src/sync/sync-client-types.js
+++ b/src/sync/sync-client-types.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+/**
+ * Client-declared sync scope serialized from a model query.
+ * @typedef {object} SerializedSyncScope
+ * @property {Record<string, ?>} conditions - Plain attribute conditions from the query.
+ * @property {string} resourceType - Resource/model name the scope was declared for.
+ */
+
+/**
+ * Declarative per-resource sync policy.
+ * @typedef {object} SyncClientResourceConfig
+ * @property {?} modelClass - Local model class for this resource.
+ * @property {import("./sync-api-client-types.js").SyncResourceConfig["attributes"]} [attributes] - Pull-apply attribute mapper. Required for resources that receive pulled changes.
+ * @property {import("./sync-api-client-types.js").SyncResourceConfig["findRecord"]} [findRecord] - Custom pull-apply record resolver.
+ * @property {import("./sync-api-client-types.js").SyncResourceConfig["findRecordForDelete"]} [findRecordForDelete] - Custom pull-apply delete resolver.
+ * @property {import("./sync-api-client-types.js").SyncResourceConfig["afterApply"]} [afterApply] - Post-apply hook.
+ * @property {string[]} [booleanAttributes] - Attributes coerced through sync boolean parsing when queueing.
+ * @property {string[]} [localOnlyAttributes] - Attributes stripped from queued payloads.
+ * @property {(args: {operation: "create" | "update" | "destroy", record: ?}) => string} [syncType] - Maps a mutation operation to a sync type. Defaults to the operation name with destroy mapped to "delete".
+ * @property {(args: {operation: "create" | "update" | "destroy", record: ?}) => Record<string, ?>} [trackedData] - Custom queued-payload builder for tracked mutations.
+ * @property {boolean | {operations: Array<"create" | "update" | "destroy">}} [track] - Enables automatic mutation tracking through model lifecycle callbacks.
+ */
+
+/**
+ * Declarative sync client configuration.
+ * @typedef {object} SyncClientConfig
+ * @property {() => string | Promise<string>} authenticationToken - Resolves the auth token sent with sync requests.
+ * @property {number} [batchSize] - Max syncs per request.
+ * @property {import("../configuration.js").default} [configuration] - Configuration owning the scope-store database. Defaults to the current configuration.
+ * @property {() => boolean | Promise<boolean>} [isOnline] - Connectivity gate for pulls and replays. Defaults to always online.
+ * @property {(args: {scope: SerializedSyncScope}) => string | null | Promise<string | null>} [legacyCursor] - Seeds a newly declared scope's cursor (e.g. from a pre-scope cursor store) so devices don't re-pull everything.
+ * @property {(error: Error) => void} [onError] - Reports background replay/pull failures. Defaults to rethrowing.
+ * @property {(payload: import("./sync-api-client-types.js").SyncChangesRequest & {scope: SerializedSyncScope}) => Promise<import("./sync-api-client-types.js").SyncChangesResponse>} postChanges - Posts one changes request.
+ * @property {(payload: {authenticationToken: string, syncs: Array<Record<string, ?>>}) => Promise<import("./sync-api-client-types.js").SyncReplayResponse>} postReplay - Posts one replay request.
+ * @property {Record<string, SyncClientResourceConfig>} resources - Declarative resource policies keyed by resource/model name.
+ * @property {import("./sync-scope-store.js").default} [scopeStore] - Scope store override.
+ * @property {?} syncModel - Local pending-sync model class.
+ */
+
+export {}

--- a/src/sync/sync-client.js
+++ b/src/sync/sync-client.js
@@ -11,6 +11,9 @@ import {currentSyncClient, setCurrentSyncClient} from "./sync-client-registry.js
 
 let clientCounter = 0
 
+/** @type {{create: "afterCreate", update: "afterUpdate", destroy: "afterDestroy"}} */
+const TRACKED_CALLBACK_NAMES = {create: "afterCreate", destroy: "afterDestroy", update: "afterUpdate"}
+
 /**
  * Declarative client-side sync driver.
  *
@@ -53,6 +56,103 @@ export default class SyncClient {
     this._scheduledReplay = null
     /** @type {Record<string, import("./sync-api-client-types.js").SyncResourceConfig> | null} */
     this._pullResourceConfigs = null
+    /** @type {Array<{callback: (record: ?) => Promise<void>, callbackName: "afterCreate" | "afterUpdate" | "afterDestroy", modelClass: ?}>} */
+    this._trackedCallbacks = []
+    /** @type {WeakSet<object>} */
+    this._remoteApplyRecords = new WeakSet()
+    this._started = false
+  }
+
+  /**
+   * Registers automatic mutation tracking for every resource with `track` enabled:
+   * local model creates/updates/destroys queue pending sync rows and schedule an
+   * immediate replay attempt, without app-side queue calls.
+   * @returns {Promise<void>}
+   */
+  async start() {
+    if (this._started) return
+
+    this._started = true
+
+    for (const [resourceType, resourceConfig] of Object.entries(this.config.resources)) {
+      const operations = this.trackedOperations({resourceConfig, resourceType})
+
+      for (const operation of operations) {
+        const callbackName = TRACKED_CALLBACK_NAMES[operation]
+        const callback = this.trackedMutationCallback({operation, resourceConfig})
+
+        resourceConfig.modelClass[callbackName](callback)
+        this._trackedCallbacks.push({callback, callbackName, modelClass: resourceConfig.modelClass})
+      }
+    }
+  }
+
+  /**
+   * Unregisters all tracking callbacks (tests, sign-out, hot reload).
+   * @returns {void}
+   */
+  stop() {
+    for (const {callback, callbackName, modelClass} of this._trackedCallbacks) {
+      modelClass.unregisterLifecycleCallback(callbackName, callback)
+    }
+
+    this._trackedCallbacks = []
+    this._started = false
+  }
+
+  /**
+   * Resolves and validates the tracked operations for a resource config.
+   * @param {{resourceConfig: import("./sync-client-types.js").SyncClientResourceConfig, resourceType: string}} args - Resource config and name.
+   * @returns {Array<"create" | "update" | "destroy">} Tracked operations.
+   */
+  trackedOperations({resourceConfig, resourceType}) {
+    const track = resourceConfig.track
+
+    if (track === undefined || track === false) return []
+    if (track === true) return ["create", "update", "destroy"]
+
+    if (!track || typeof track !== "object" || !Array.isArray(track.operations) || track.operations.length === 0) {
+      throw new Error(`SyncClient resource ${resourceType} track must be true or {operations: [...]}`)
+    }
+
+    for (const operation of track.operations) {
+      if (!(operation in TRACKED_CALLBACK_NAMES)) {
+        throw new Error(`SyncClient resource ${resourceType} track.operations must be create/update/destroy, got: ${String(operation)}`)
+      }
+    }
+
+    return track.operations
+  }
+
+  /**
+   * Builds the lifecycle callback queueing one tracked mutation.
+   * @param {{operation: "create" | "update" | "destroy", resourceConfig: import("./sync-client-types.js").SyncClientResourceConfig}} args - Operation and resource config.
+   * @returns {(record: ?) => Promise<void>} Lifecycle callback.
+   */
+  trackedMutationCallback({operation, resourceConfig}) {
+    return async (record) => {
+      if (this.isRemoteApply(record)) return
+
+      await SyncApiClient.queueLocalSync({
+        booleanAttributes: resourceConfig.booleanAttributes || [],
+        data: resourceConfig.trackedData ? resourceConfig.trackedData({operation, record}) : undefined,
+        localOnlyAttributes: resourceConfig.localOnlyAttributes || [],
+        resource: record,
+        syncModel: this.config.syncModel,
+        syncType: this.defaultSyncType({operation, record, resourceConfig})
+      })
+
+      this.scheduleReplay()
+    }
+  }
+
+  /**
+   * Whether a record is currently being written by pull-apply (echo suppression).
+   * @param {?} record - Local model record.
+   * @returns {boolean} Whether the record write originates from a remote change.
+   */
+  isRemoteApply(record) {
+    return this._remoteApplyRecords.has(record)
   }
 
   /**
@@ -113,7 +213,11 @@ export default class SyncClient {
     await SyncApiClient.singleFlight(`velocious-sync-client-pull-${this._clientNumber}`, async () => {
       const authenticationToken = await this.config.authenticationToken()
       const scopeStore = this.scopeStore()
-      const applySync = SyncApiClient.resourceApplier(this.pullResourceConfigs())
+      const applySync = SyncApiClient.resourceApplier(this.pullResourceConfigs(), (record) => {
+        this._remoteApplyRecords.add(record)
+
+        return () => this._remoteApplyRecords.delete(record)
+      })
       const result = {
         changed: false,
         pages: 0,

--- a/src/sync/sync-client.js
+++ b/src/sync/sync-client.js
@@ -213,11 +213,26 @@ export default class SyncClient {
     await SyncApiClient.singleFlight(`velocious-sync-client-pull-${this._clientNumber}`, async () => {
       const authenticationToken = await this.config.authenticationToken()
       const scopeStore = this.scopeStore()
-      const applySync = SyncApiClient.resourceApplier(this.pullResourceConfigs(), (record) => {
+      const pullResourceConfigs = this.pullResourceConfigs()
+      const applier = SyncApiClient.resourceApplier(pullResourceConfigs, (record) => {
         this._remoteApplyRecords.add(record)
 
         return () => this._remoteApplyRecords.delete(record)
       })
+      /**
+       * Applies one pulled change, failing loudly instead of silently skipping unconfigured resources.
+       * @param {import("./sync-api-client-types.js").SyncChangeEnvelope} sync - Pulled change.
+       * @returns {Promise<import("./sync-api-client-types.js").SyncChangeApplyResult>} Apply result.
+       */
+      const applySync = async (sync) => {
+        const resourceType = sync.resourceType()
+
+        if (!resourceType || !pullResourceConfigs[resourceType]) {
+          throw new Error(`No sync resource with pull attributes configured for pulled change: ${String(resourceType)}`)
+        }
+
+        return await applier(sync)
+      }
       const result = {
         changed: false,
         pages: 0,

--- a/src/sync/sync-client.js
+++ b/src/sync/sync-client.js
@@ -1,0 +1,308 @@
+// @ts-check
+
+import {forcedFunction} from "typanic"
+
+import Configuration from "../configuration.js"
+
+import {serializedScopeFromQuery} from "./query-scope.js"
+import SyncApiClient from "./sync-api-client.js"
+import SyncScopeStore from "./sync-scope-store.js"
+import {currentSyncClient, setCurrentSyncClient} from "./sync-client-registry.js"
+
+let clientCounter = 0
+
+/**
+ * Declarative client-side sync driver.
+ *
+ * Apps configure resources, transport, auth, and connectivity once; Velocious
+ * owns scope persistence, per-scope cursors, pull paging/apply, local queueing,
+ * and online-gated replay. Declare sync interest from queries:
+ *
+ *     const syncClient = new SyncClient({...})
+ *     syncClient.setCurrent()
+ *     await syncClient.sync(Event.where({partnerId}))
+ */
+export default class SyncClient {
+  /**
+   * Creates a declarative sync client.
+   * @param {import("./sync-client-types.js").SyncClientConfig} config - Sync client configuration.
+   */
+  constructor(config) {
+    if (!config || typeof config !== "object") throw new Error("SyncClient requires a configuration object")
+
+    forcedFunction(config.postChanges, "SyncClient config.postChanges")
+    forcedFunction(config.postReplay, "SyncClient config.postReplay")
+    forcedFunction(config.authenticationToken, "SyncClient config.authenticationToken")
+
+    if (!config.syncModel) throw new Error("SyncClient requires config.syncModel")
+    if (!config.resources || typeof config.resources !== "object" || Object.keys(config.resources).length === 0) {
+      throw new Error("SyncClient requires at least one entry in config.resources")
+    }
+
+    for (const [resourceType, resource] of Object.entries(config.resources)) {
+      if (!resource || typeof resource !== "object" || !resource.modelClass) {
+        throw new Error(`SyncClient resource ${resourceType} must declare a modelClass`)
+      }
+    }
+
+    this.config = config
+    this._clientNumber = ++clientCounter
+    /** @type {import("./sync-scope-store.js").default | null} */
+    this._scopeStore = config.scopeStore || null
+    /** @type {Promise<void> | null} */
+    this._scheduledReplay = null
+    /** @type {Record<string, import("./sync-api-client-types.js").SyncResourceConfig> | null} */
+    this._pullResourceConfigs = null
+  }
+
+  /**
+   * Registers this client as the app's current sync client.
+   * @returns {void}
+   */
+  setCurrent() {
+    setCurrentSyncClient(this)
+  }
+
+  /**
+   * Returns the app's current sync client.
+   * @returns {SyncClient} Current sync client.
+   */
+  static current() {
+    return /** @type {SyncClient} */ (currentSyncClient())
+  }
+
+  /**
+   * Declares (or re-activates) a sync scope from a model query and pulls it when online.
+   * @param {import("../database/query/model-class-query.js").default<?>} query - Query declaring the sync scope.
+   * @returns {Promise<{scope: import("./sync-client-types.js").SerializedSyncScope, pulled: import("./sync-api-client-types.js").SyncChangesResult | null}>} Declared scope and pull result (null while offline).
+   */
+  async sync(query) {
+    const scope = serializedScopeFromQuery(query)
+    const scopeStore = this.scopeStore()
+    const scopeRow = await scopeStore.findOrCreateScope(scope)
+
+    if (!scopeRow.cursorPayload && this.config.legacyCursor) {
+      const legacyCursorPayload = await this.config.legacyCursor({scope})
+      const legacyCursor = SyncApiClient.syncCursorFromPayload(legacyCursorPayload)
+
+      if (legacyCursor) await scopeStore.saveCursor(scopeRow, legacyCursor)
+    }
+
+    return {pulled: await this.pull(), scope}
+  }
+
+  /**
+   * Deactivates the sync scope declared by a model query.
+   * @param {import("../database/query/model-class-query.js").default<?>} query - Query whose scope should stop syncing.
+   * @returns {Promise<void>}
+   */
+  async unsync(query) {
+    await this.scopeStore().deactivate(serializedScopeFromQuery(query))
+  }
+
+  /**
+   * Pulls changes for every active scope with per-scope cursors (single-flighted, online-gated).
+   * @returns {Promise<import("./sync-api-client-types.js").SyncChangesResult | null>} Combined pull result, or null while offline.
+   */
+  async pull() {
+    if (!(await this.isOnline())) return null
+
+    /** @type {import("./sync-api-client-types.js").SyncChangesResult | null} */
+    let combinedResult = null
+
+    await SyncApiClient.singleFlight(`velocious-sync-client-pull-${this._clientNumber}`, async () => {
+      const authenticationToken = await this.config.authenticationToken()
+      const scopeStore = this.scopeStore()
+      const applySync = SyncApiClient.resourceApplier(this.pullResourceConfigs())
+      const result = {
+        changed: false,
+        pages: 0,
+        resourceChanged: /** @type {Record<string, boolean>} */ ({}),
+        resourceCounts: /** @type {Record<string, number>} */ ({}),
+        syncedCount: 0
+      }
+
+      for (const scopeRow of await scopeStore.activeScopes()) {
+        const scopeResult = await SyncApiClient.pullChanges({
+          applySync,
+          authenticationToken,
+          batchSize: this.config.batchSize,
+          loadCursor: async () => await scopeStore.loadCursor(scopeRow),
+          postChanges: async (payload) => await this.config.postChanges({
+            ...payload,
+            scope: {conditions: scopeRow.conditions, resourceType: scopeRow.resourceType}
+          }),
+          saveCursor: async (cursor) => await scopeStore.saveCursor(scopeRow, cursor)
+        })
+
+        result.changed ||= scopeResult.changed
+        result.pages += scopeResult.pages
+        result.syncedCount += scopeResult.syncedCount
+
+        for (const [resourceType, count] of Object.entries(scopeResult.resourceCounts)) {
+          result.resourceCounts[resourceType] = (result.resourceCounts[resourceType] || 0) + count
+        }
+        for (const [resourceType, changed] of Object.entries(scopeResult.resourceChanged)) {
+          result.resourceChanged[resourceType] ||= changed
+        }
+      }
+
+      combinedResult = result
+    })
+
+    return combinedResult
+  }
+
+  /**
+   * Queues a local model change as a pending sync row and schedules an immediate
+   * replay attempt (kept pending while offline or when the backend rejects it).
+   * @param {{resource: ?, data?: Record<string, ?>, syncType?: string}} args - Queue args.
+   * @returns {Promise<?>} Pending local sync row.
+   */
+  async queue({data, resource, syncType}) {
+    const resourceConfig = this.resourceConfigFor(resource)
+    const syncRow = await SyncApiClient.queueLocalSync({
+      booleanAttributes: resourceConfig.booleanAttributes || [],
+      data,
+      localOnlyAttributes: resourceConfig.localOnlyAttributes || [],
+      resource,
+      syncModel: this.config.syncModel,
+      syncType: syncType ?? this.defaultSyncType({operation: "update", record: resource, resourceConfig})
+    })
+
+    this.scheduleReplay()
+
+    return syncRow
+  }
+
+  /**
+   * Drains pending local sync rows to the backend (single-flighted, online-gated).
+   * Rows are only marked successful after the backend acknowledges them.
+   * @returns {Promise<void>}
+   */
+  async replayPending() {
+    if (!(await this.isOnline())) return
+
+    await SyncApiClient.singleFlight(`velocious-sync-client-replay-${this._clientNumber}`, async () => {
+      await SyncApiClient.replayLocalSyncs({
+        authenticationToken: await this.config.authenticationToken(),
+        batchSize: this.config.batchSize,
+        postReplay: this.config.postReplay,
+        syncModel: this.config.syncModel
+      })
+    })
+  }
+
+  /**
+   * Schedules a background replay attempt without blocking the caller.
+   * Failures go to config.onError (or rethrow when none is configured).
+   * @returns {void}
+   */
+  scheduleReplay() {
+    this._scheduledReplay = (async () => {
+      try {
+        await this.replayPending()
+      } catch (error) {
+        this.reportError(/** @type {Error} */ (error))
+      }
+    })()
+  }
+
+  /**
+   * Awaits the last scheduled background replay (useful in tests and shutdown flows).
+   * @returns {Promise<void>}
+   */
+  async waitForScheduledReplay() {
+    if (this._scheduledReplay) await this._scheduledReplay
+  }
+
+  /**
+   * Reports a background sync failure.
+   * @param {Error} error - Background failure.
+   * @returns {void}
+   */
+  reportError(error) {
+    if (this.config.onError) {
+      this.config.onError(error)
+      return
+    }
+
+    throw error
+  }
+
+  /**
+   * Resolves connectivity through the configured gate.
+   * @returns {Promise<boolean>} Whether the backend is considered reachable.
+   */
+  async isOnline() {
+    if (!this.config.isOnline) return true
+
+    return (await this.config.isOnline()) !== false
+  }
+
+  /**
+   * Returns the scope store backing declared scopes and cursors.
+   * @returns {import("./sync-scope-store.js").default} Scope store.
+   */
+  scopeStore() {
+    this._scopeStore ||= new SyncScopeStore({configuration: this.config.configuration || Configuration.current()})
+
+    return this._scopeStore
+  }
+
+  /**
+   * Resolves the declared resource config for a local record.
+   * @param {?} resource - Local model record.
+   * @returns {import("./sync-client-types.js").SyncClientResourceConfig} Declared resource config.
+   */
+  resourceConfigFor(resource) {
+    const resourceType = resource?.constructor?.name
+    const resourceConfig = resourceType ? this.config.resources[resourceType] : undefined
+
+    if (!resourceConfig) throw new Error(`No sync resource configured for: ${resourceType || String(resource)}`)
+
+    return resourceConfig
+  }
+
+  /**
+   * Resolves the sync type for a mutation through the resource config.
+   * @param {{operation: "create" | "update" | "destroy", record: ?, resourceConfig: import("./sync-client-types.js").SyncClientResourceConfig}} args - Mutation args.
+   * @returns {string} Sync type.
+   */
+  defaultSyncType({operation, record, resourceConfig}) {
+    if (resourceConfig.syncType) return resourceConfig.syncType({operation, record})
+    if (operation === "destroy") return "delete"
+
+    return operation
+  }
+
+  /**
+   * Derives the pull-apply resource configs from the declared resources.
+   * @returns {Record<string, import("./sync-api-client-types.js").SyncResourceConfig>} Pull-apply resource configs.
+   */
+  pullResourceConfigs() {
+    this._pullResourceConfigs ||= /** @type {Record<string, import("./sync-api-client-types.js").SyncResourceConfig>} */ (Object.fromEntries(
+      Object.entries(this.config.resources)
+        .filter(([, resource]) => Boolean(resource.attributes))
+        .map(([resourceType, resource]) => [resourceType, {
+          afterApply: resource.afterApply,
+          attributes: /** @type {import("./sync-api-client-types.js").SyncResourceConfig["attributes"]} */ (resource.attributes),
+          enabled: true,
+          findRecord: resource.findRecord,
+          findRecordForDelete: resource.findRecordForDelete,
+          modelClass: resource.modelClass
+        }])
+    ))
+
+    return this._pullResourceConfigs
+  }
+}
+
+/**
+ * Declares a sync scope on the current sync client.
+ * @param {import("../database/query/model-class-query.js").default<?>} query - Query declaring the sync scope.
+ * @returns {Promise<{scope: import("./sync-client-types.js").SerializedSyncScope, pulled: import("./sync-api-client-types.js").SyncChangesResult | null}>} Declared scope and pull result.
+ */
+export async function sync(query) {
+  return await SyncClient.current().sync(query)
+}

--- a/src/sync/sync-scope-store.js
+++ b/src/sync/sync-scope-store.js
@@ -1,0 +1,316 @@
+// @ts-check
+
+import TableData from "../database/table-data/index.js"
+import UUID from "pure-uuid"
+
+import {scopeKey} from "./query-scope.js"
+import stableJsonStringify from "./stable-json.js"
+
+const TABLE_NAME = "velocious_sync_scopes"
+
+/**
+ * @typedef {object} SyncScopeRow
+ * @property {Record<string, ?>} conditions - Scope attribute conditions.
+ * @property {string | null} cursorPayload - Persisted cursor JSON payload.
+ * @property {string} id - Scope row id.
+ * @property {string} resourceType - Scope resource/model name.
+ * @property {string} scopeKey - Stable canonical scope key.
+ * @property {string} state - Scope state ("active" or "removed").
+ */
+
+/**
+ * Framework-owned local persistence for declared sync scopes and their cursors.
+ *
+ * Backed by an auto-created `velocious_sync_scopes` table on the configured
+ * database, with a process-local memory fallback when no database is
+ * configured (mirroring the server change-feed store).
+ */
+export default class SyncScopeStore {
+  /**
+   * Creates a sync scope store.
+   * @param {object} args - Options.
+   * @param {import("../configuration.js").default} args.configuration - Configuration owning the database.
+   * @param {string} [args.databaseIdentifier] - Database identifier.
+   */
+  constructor({configuration, databaseIdentifier = "default"}) {
+    this.configuration = configuration
+    this.databaseIdentifier = databaseIdentifier
+    /** @type {Map<string, SyncScopeRow>} */
+    this._memoryScopes = new Map()
+    this._isReady = false
+    /** @type {Promise<void> | null} */
+    this._readyPromise = null
+  }
+
+  /**
+   * Ensures the backing table exists.
+   * @returns {Promise<void>} Resolves when ready.
+   */
+  async ensureReady() {
+    if (this._isReady) return
+
+    if (this._usesMemoryStorage()) {
+      this._isReady = true
+      return
+    }
+
+    if (this._readyPromise) return await this._readyPromise
+
+    this._readyPromise = this._withDb(async (db) => {
+      await this._ensureScopesTable(db)
+      this._isReady = true
+    })
+
+    try {
+      await this._readyPromise
+    } finally {
+      if (!this._isReady) this._readyPromise = null
+    }
+  }
+
+  /**
+   * Finds or creates the scope row for a serialized scope, reactivating removed scopes.
+   * @param {import("./sync-client-types.js").SerializedSyncScope} scope - Serialized sync scope.
+   * @returns {Promise<SyncScopeRow>} Persisted scope row.
+   */
+  async findOrCreateScope(scope) {
+    await this.ensureReady()
+
+    const key = scopeKey(scope)
+
+    if (this._usesMemoryStorage()) {
+      const existingScope = this._memoryScopes.get(key)
+
+      if (existingScope) {
+        if (existingScope.state !== "active") existingScope.state = "active"
+
+        return existingScope
+      }
+
+      const newScope = {
+        conditions: scope.conditions,
+        cursorPayload: null,
+        id: new UUID(4).format(),
+        resourceType: scope.resourceType,
+        scopeKey: key,
+        state: "active"
+      }
+
+      this._memoryScopes.set(key, newScope)
+
+      return newScope
+    }
+
+    return await this._withDb(async (db) => {
+      const existingRow = await this._rowByScopeKey(db, key)
+
+      if (existingRow) {
+        if (existingRow.state !== "active") {
+          await db.update({conditions: {id: existingRow.id}, data: {state: "active", updated_at: new Date()}, tableName: TABLE_NAME})
+          existingRow.state = "active"
+        }
+
+        return existingRow
+      }
+
+      await db.insert({
+        tableName: TABLE_NAME,
+        data: {
+          conditions_json: stableJsonStringify(scope.conditions),
+          created_at: new Date(),
+          cursor_json: null,
+          id: new UUID(4).format(),
+          resource_type: scope.resourceType,
+          scope_key: key,
+          state: "active",
+          updated_at: new Date()
+        }
+      })
+
+      const createdRow = await this._rowByScopeKey(db, key)
+
+      if (!createdRow) throw new Error("Failed to persist sync scope")
+
+      return createdRow
+    })
+  }
+
+  /**
+   * Returns all active scope rows.
+   * @returns {Promise<SyncScopeRow[]>} Active scope rows.
+   */
+  async activeScopes() {
+    await this.ensureReady()
+
+    if (this._usesMemoryStorage()) {
+      return [...this._memoryScopes.values()].filter((scope) => scope.state === "active")
+    }
+
+    return await this._withDb(async (db) => {
+      const rows = /** @type {Array<Record<string, ?>>} */ (await db
+        .newQuery()
+        .from(TABLE_NAME)
+        .where({state: "active"})
+        .order("created_at ASC")
+        .results())
+
+      return rows.map((row) => this._normalizeScopeRow(row))
+    })
+  }
+
+  /**
+   * Loads the persisted cursor payload for a scope row.
+   * @param {SyncScopeRow} scopeRow - Scope row.
+   * @returns {Promise<string | null>} Cursor JSON payload.
+   */
+  async loadCursor(scopeRow) {
+    await this.ensureReady()
+
+    if (this._usesMemoryStorage()) {
+      return this._memoryScopes.get(scopeRow.scopeKey)?.cursorPayload ?? null
+    }
+
+    return await this._withDb(async (db) => {
+      const row = await this._rowByScopeKey(db, scopeRow.scopeKey)
+
+      return row ? row.cursorPayload : null
+    })
+  }
+
+  /**
+   * Persists the acknowledged cursor for a scope row.
+   * @param {SyncScopeRow} scopeRow - Scope row.
+   * @param {import("./sync-api-client-types.js").SyncCursor} cursor - Acknowledged cursor.
+   * @returns {Promise<void>}
+   */
+  async saveCursor(scopeRow, cursor) {
+    if (!cursor) return
+
+    await this.ensureReady()
+
+    const cursorPayload = JSON.stringify(cursor)
+
+    if (this._usesMemoryStorage()) {
+      const memoryScope = this._memoryScopes.get(scopeRow.scopeKey)
+
+      if (!memoryScope) throw new Error(`No sync scope found for: ${scopeRow.scopeKey}`)
+
+      memoryScope.cursorPayload = cursorPayload
+      return
+    }
+
+    await this._withDb(async (db) => {
+      await db.update({
+        conditions: {scope_key: scopeRow.scopeKey},
+        data: {cursor_json: cursorPayload, updated_at: new Date()},
+        tableName: TABLE_NAME
+      })
+    })
+  }
+
+  /**
+   * Deactivates the scope row for a serialized scope.
+   * @param {import("./sync-client-types.js").SerializedSyncScope} scope - Serialized sync scope.
+   * @returns {Promise<void>}
+   */
+  async deactivate(scope) {
+    await this.ensureReady()
+
+    const key = scopeKey(scope)
+
+    if (this._usesMemoryStorage()) {
+      const memoryScope = this._memoryScopes.get(key)
+
+      if (memoryScope) memoryScope.state = "removed"
+
+      return
+    }
+
+    await this._withDb(async (db) => {
+      await db.update({conditions: {scope_key: key}, data: {state: "removed", updated_at: new Date()}, tableName: TABLE_NAME})
+    })
+  }
+
+  /**
+   * Whether the store runs without a configured database.
+   * @returns {boolean} Whether memory storage is used.
+   */
+  _usesMemoryStorage() {
+    try {
+      return !this.configuration.getDatabaseConfiguration()[this.databaseIdentifier]
+    } catch {
+      return true
+    }
+  }
+
+  /**
+   * Runs a callback with a database connection.
+   * @template Result
+   * @param {(db: import("../database/drivers/base.js").default) => Promise<Result>} callback - Database callback.
+   * @returns {Promise<Result>} Callback result.
+   */
+  async _withDb(callback) {
+    return await this.configuration.ensureConnections({name: "Sync scope store"}, async (dbs) => {
+      const db = dbs[this.databaseIdentifier]
+
+      if (!db) throw new Error(`No database connection available for identifier: ${this.databaseIdentifier}`)
+
+      return await callback(db)
+    })
+  }
+
+  /**
+   * Ensures the scopes table exists.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>}
+   */
+  async _ensureScopesTable(db) {
+    if (await db.tableExists(TABLE_NAME)) return
+
+    const table = new TableData(TABLE_NAME, {ifNotExists: true})
+
+    table.string("id", {null: false, primaryKey: true})
+    table.string("scope_key", {index: true, null: false})
+    table.string("resource_type", {index: true, null: false})
+    table.text("conditions_json", {null: false})
+    table.text("cursor_json", {null: true})
+    table.string("state", {index: true, null: false})
+    table.datetime("created_at", {null: false})
+    table.datetime("updated_at", {null: false})
+
+    await db.createTable(table)
+  }
+
+  /**
+   * Resolves a scope row by its stable key.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {string} key - Stable scope key.
+   * @returns {Promise<SyncScopeRow | null>} Scope row or null.
+   */
+  async _rowByScopeKey(db, key) {
+    const rows = /** @type {Array<Record<string, ?>>} */ (await db
+      .newQuery()
+      .from(TABLE_NAME)
+      .where({scope_key: key})
+      .limit(1)
+      .results())
+
+    return rows[0] ? this._normalizeScopeRow(rows[0]) : null
+  }
+
+  /**
+   * Normalizes a raw scope table row.
+   * @param {Record<string, ?>} row - Raw table row.
+   * @returns {SyncScopeRow} Normalized scope row.
+   */
+  _normalizeScopeRow(row) {
+    return {
+      conditions: /** @type {Record<string, ?>} */ (JSON.parse(String(row.conditions_json))),
+      cursorPayload: row.cursor_json === null || row.cursor_json === undefined ? null : String(row.cursor_json),
+      id: String(row.id),
+      resourceType: String(row.resource_type),
+      scopeKey: String(row.scope_key),
+      state: String(row.state)
+    }
+  }
+}

--- a/src/sync/sync-scope-store.js
+++ b/src/sync/sync-scope-store.js
@@ -7,6 +7,17 @@ import {scopeKey} from "./query-scope.js"
 import stableJsonStringify from "./stable-json.js"
 
 const TABLE_NAME = "velocious_sync_scopes"
+const SCOPE_DIGEST_PREFIX = "velocious-sync-scope:"
+
+/**
+ * Digests a serialized scope into a fixed-size deterministic key, so scope
+ * identities with long condition values fit an indexed string column.
+ * @param {import("./sync-client-types.js").SerializedSyncScope} scope - Serialized sync scope.
+ * @returns {string} Deterministic UUIDv5 digest of the canonical scope key.
+ */
+function scopeDigestForScope(scope) {
+  return new UUID(5, "ns:URL", `${SCOPE_DIGEST_PREFIX}${scopeKey(scope)}`).format()
+}
 
 /**
  * @typedef {object} SyncScopeRow
@@ -14,7 +25,7 @@ const TABLE_NAME = "velocious_sync_scopes"
  * @property {string | null} cursorPayload - Persisted cursor JSON payload.
  * @property {string} id - Scope row id.
  * @property {string} resourceType - Scope resource/model name.
- * @property {string} scopeKey - Stable canonical scope key.
+ * @property {string} scopeDigest - Fixed-size deterministic digest of the canonical scope key.
  * @property {string} state - Scope state ("active" or "removed").
  */
 
@@ -76,10 +87,10 @@ export default class SyncScopeStore {
   async findOrCreateScope(scope) {
     await this.ensureReady()
 
-    const key = scopeKey(scope)
+    const digest = scopeDigestForScope(scope)
 
     if (this._usesMemoryStorage()) {
-      const existingScope = this._memoryScopes.get(key)
+      const existingScope = this._memoryScopes.get(digest)
 
       if (existingScope) {
         if (existingScope.state !== "active") existingScope.state = "active"
@@ -92,17 +103,17 @@ export default class SyncScopeStore {
         cursorPayload: null,
         id: new UUID(4).format(),
         resourceType: scope.resourceType,
-        scopeKey: key,
+        scopeDigest: digest,
         state: "active"
       }
 
-      this._memoryScopes.set(key, newScope)
+      this._memoryScopes.set(digest, newScope)
 
       return newScope
     }
 
     return await this._withDb(async (db) => {
-      const existingRow = await this._rowByScopeKey(db, key)
+      const existingRow = await this._rowByScopeDigest(db, digest)
 
       if (existingRow) {
         if (existingRow.state !== "active") {
@@ -121,13 +132,13 @@ export default class SyncScopeStore {
           cursor_json: null,
           id: new UUID(4).format(),
           resource_type: scope.resourceType,
-          scope_key: key,
+          scope_digest: digest,
           state: "active",
           updated_at: new Date()
         }
       })
 
-      const createdRow = await this._rowByScopeKey(db, key)
+      const createdRow = await this._rowByScopeDigest(db, digest)
 
       if (!createdRow) throw new Error("Failed to persist sync scope")
 
@@ -167,11 +178,11 @@ export default class SyncScopeStore {
     await this.ensureReady()
 
     if (this._usesMemoryStorage()) {
-      return this._memoryScopes.get(scopeRow.scopeKey)?.cursorPayload ?? null
+      return this._memoryScopes.get(scopeRow.scopeDigest)?.cursorPayload ?? null
     }
 
     return await this._withDb(async (db) => {
-      const row = await this._rowByScopeKey(db, scopeRow.scopeKey)
+      const row = await this._rowByScopeDigest(db, scopeRow.scopeDigest)
 
       return row ? row.cursorPayload : null
     })
@@ -191,9 +202,9 @@ export default class SyncScopeStore {
     const cursorPayload = JSON.stringify(cursor)
 
     if (this._usesMemoryStorage()) {
-      const memoryScope = this._memoryScopes.get(scopeRow.scopeKey)
+      const memoryScope = this._memoryScopes.get(scopeRow.scopeDigest)
 
-      if (!memoryScope) throw new Error(`No sync scope found for: ${scopeRow.scopeKey}`)
+      if (!memoryScope) throw new Error(`No sync scope found for: ${scopeRow.scopeDigest}`)
 
       memoryScope.cursorPayload = cursorPayload
       return
@@ -201,7 +212,7 @@ export default class SyncScopeStore {
 
     await this._withDb(async (db) => {
       await db.update({
-        conditions: {scope_key: scopeRow.scopeKey},
+        conditions: {scope_digest: scopeRow.scopeDigest},
         data: {cursor_json: cursorPayload, updated_at: new Date()},
         tableName: TABLE_NAME
       })
@@ -216,10 +227,10 @@ export default class SyncScopeStore {
   async deactivate(scope) {
     await this.ensureReady()
 
-    const key = scopeKey(scope)
+    const digest = scopeDigestForScope(scope)
 
     if (this._usesMemoryStorage()) {
-      const memoryScope = this._memoryScopes.get(key)
+      const memoryScope = this._memoryScopes.get(digest)
 
       if (memoryScope) memoryScope.state = "removed"
 
@@ -227,7 +238,7 @@ export default class SyncScopeStore {
     }
 
     await this._withDb(async (db) => {
-      await db.update({conditions: {scope_key: key}, data: {state: "removed", updated_at: new Date()}, tableName: TABLE_NAME})
+      await db.update({conditions: {scope_digest: digest}, data: {state: "removed", updated_at: new Date()}, tableName: TABLE_NAME})
     })
   }
 
@@ -270,7 +281,7 @@ export default class SyncScopeStore {
     const table = new TableData(TABLE_NAME, {ifNotExists: true})
 
     table.string("id", {null: false, primaryKey: true})
-    table.string("scope_key", {index: true, null: false})
+    table.string("scope_digest", {index: true, null: false})
     table.string("resource_type", {index: true, null: false})
     table.text("conditions_json", {null: false})
     table.text("cursor_json", {null: true})
@@ -282,16 +293,16 @@ export default class SyncScopeStore {
   }
 
   /**
-   * Resolves a scope row by its stable key.
+   * Resolves a scope row by its digest.
    * @param {import("../database/drivers/base.js").default} db - Database connection.
-   * @param {string} key - Stable scope key.
+   * @param {string} digest - Fixed-size scope digest.
    * @returns {Promise<SyncScopeRow | null>} Scope row or null.
    */
-  async _rowByScopeKey(db, key) {
+  async _rowByScopeDigest(db, digest) {
     const rows = /** @type {Array<Record<string, ?>>} */ (await db
       .newQuery()
       .from(TABLE_NAME)
-      .where({scope_key: key})
+      .where({scope_digest: digest})
       .limit(1)
       .results())
 
@@ -309,7 +320,7 @@ export default class SyncScopeStore {
       cursorPayload: row.cursor_json === null || row.cursor_json === undefined ? null : String(row.cursor_json),
       id: String(row.id),
       resourceType: String(row.resource_type),
-      scopeKey: String(row.scope_key),
+      scopeDigest: String(row.scope_digest),
       state: String(row.state)
     }
   }


### PR DESCRIPTION
## Summary

Third step of moving generic sync behavior into Velocious (follows #839 and #840). Adds the declarative client-side sync driver so apps declare *what* to sync and Velocious handles *how*:

- **`SyncClient`** (`src/sync/sync-client.js`): configured once with resources, transport (`postChanges`/`postReplay`), auth, and an `isOnline` gate. Owns:
  - **Query-declared scopes** — `syncClient.sync(Event.where({partnerId}))` serializes the query into a `{resourceType, conditions}` scope (only plain attribute conditions; joins/orders/limits/raw SQL/negations fail loudly), persists it, and pulls it when online. `unsync(query)` deactivates.
  - **Per-scope cursors** — each active scope pulls with its own persisted cursor; the scope rides along in every changes payload so servers can enforce access per scope. New scopes can seed their cursor via a `legacyCursor` hook (no full re-pull for devices migrating from app-managed cursor keys).
  - **Declarative local queueing** — `queue({resource, ...})` resolves the per-resource policy (local-only stripping, boolean coercion, syncType mapping) and schedules an immediate background replay; single-flighted, online-gated, rows marked successful only after backend acknowledgement, failures reported through `onError`.
- **`SyncScopeStore`** (`src/sync/sync-scope-store.js`): framework-owned scope/cursor persistence in an auto-created `velocious_sync_scopes` table (memory fallback without a database), mirroring the server change-feed store.
- **Query sugar** — `Event.where({partnerId}).sync()` / `.unsync()` on model queries, delegating through a dependency-free registry (`sync-client-registry.js`) so the query layer pulls in none of the sync stack; the browser-bundle guard spec stays green.
- Query layer gains `getWheres`/`getJoins`/`getLimit`/`getOffset`/`getOrders` accessors; the shared stable JSON serializer moves to `src/sync/stable-json.js` (server change feed now imports it).

## Validation

- `VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/sync` — 82 tests green (8 query-scope, 4 scope-store, 12 sync-client, 2 query-sugar new)
- `node scripts/run-tests.js spec/database/query` — 66 tests green (query layer touched)
- `spec/configuration-browser-bundle-spec.js` — green (client bundle stays clean)
- `npm run typecheck`, `npm run lint`, `npm run build` — clean

## Follow-up (separate PR)

Automatic mutation tracking: registering model lifecycle callbacks from the `track` resource config so local saves/destroys queue sync rows without app-side `queue()` calls (config surface for it is already in the typedefs).