### PR TITLE
Add automatic mutation tracking to SyncClient

### DIFF
--- a/changelog.d/20260702220000-sync-client-mutation-tracking.md
+++ b/changelog.d/20260702220000-sync-client-mutation-tracking.md
@@ -1,0 +1,5 @@
+# Changelog
+
+- Add automatic mutation tracking to `SyncClient`: resources with `track` enabled register model lifecycle callbacks on `start()` so local creates/updates/destroys queue pending sync rows (with the declared local-only stripping, boolean coercion, and syncType/trackedData mapping) and schedule an immediate online-gated replay — no app-side queue calls. Records written by pull-apply are excluded via echo suppression, and `stop()` unregisters all tracking callbacks.
+- Add `VelociousDatabaseRecord.unregisterLifecycleCallback(callbackName, callback)`.
+- `SyncApiClient.resourceApplier`/`applyResourceSync`/`destroySyncedResource` accept an optional `onRecord` hook tagging records for the duration of a remote apply.

--- a/docs/sync-client.md
+++ b/docs/sync-client.md
@@ -45,11 +45,32 @@ The query is serialized into a `{resourceType, conditions}` scope (only plain at
 
 Devices migrating from a pre-scope cursor store can seed newly declared scopes through the `legacyCursor({scope})` config hook, avoiding a full re-pull.
 
+## Automatic mutation tracking
+
+Resources with `track` enabled queue sync rows automatically when their local models change — no app-side queue calls:
+
+```js
+resources: {
+  TicketScan: {
+    modelClass: TicketScan,
+    track: true, // or {operations: ["update"]}
+    syncType: ({operation}) => operation === "create" ? "scanAttempt" : "update",
+    trackedData: ({record}) => ({...record.attributes(), deviceId: currentDeviceId()})
+  }
+}
+
+await syncClient.start() // registers afterCreate/afterUpdate/afterDestroy callbacks
+```
+
+`start()` registers model lifecycle callbacks for every tracked resource (destroys queue `"delete"` sync rows); `stop()` unregisters them. Records written by pull-apply are excluded (echo suppression), so applying remote changes never queues them back to the server.
+
 ## Local changes and replay
 
 ```js
 await syncClient.queue({resource: ticketScan, syncType: "scanAttempt"})
 ```
+
+Explicit `queue()` stays available for command-style mutations whose payload carries more than the record's attributes.
 
 `queue()` persists a pending row on the app's `syncModel` (stripping `localOnlyAttributes`, coercing `booleanAttributes`) and schedules an immediate background replay. Replays are single-flighted and online-gated; rows are marked successful only after the backend acknowledges them, so offline or rejected changes stay pending for the next attempt. Background failures go to the `onError` config hook (rethrown when none is configured). `waitForScheduledReplay()` awaits the last scheduled attempt (useful in tests and shutdown flows).
 

--- a/spec/database/record/unregister-lifecycle-callback-spec.js
+++ b/spec/database/record/unregister-lifecycle-callback-spec.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../src/testing/test.js"
+import VelociousDatabaseRecord from "../../../src/database/record/index.js"
+
+describe("database - record - unregister lifecycle callback", () => {
+  it("removes a registered lifecycle callback", () => {
+    class CallbackModel extends VelociousDatabaseRecord {}
+
+    const callback = async () => {}
+
+    CallbackModel.afterUpdate(callback)
+
+    expect(CallbackModel.getLifecycleCallbacksMap().afterUpdate.length).toEqual(1)
+
+    CallbackModel.unregisterLifecycleCallback("afterUpdate", callback)
+
+    expect(CallbackModel.getLifecycleCallbacksMap().afterUpdate.length).toEqual(0)
+  })
+
+  it("ignores callbacks that were never registered", () => {
+    class CallbackModel extends VelociousDatabaseRecord {}
+
+    CallbackModel.unregisterLifecycleCallback("afterUpdate", async () => {})
+
+    expect(CallbackModel.getLifecycleCallbacksMap().afterUpdate).toEqual(undefined)
+  })
+})

--- a/spec/sync/sync-client-spec.js
+++ b/spec/sync/sync-client-spec.js
@@ -356,4 +356,227 @@ describe("sync client", () => {
 
     expect(SyncClient.current()).toEqual(harness.client)
   })
+
+  it("automatically queues tracked model mutations and replays them", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {
+          booleanAttributes: ["accepted"],
+          localOnlyAttributes: ["localOnly"],
+          modelClass: TrackedScan,
+          syncType: ({operation}) => operation === "create" ? "scanAttempt" : "update",
+          track: true
+        }
+      }
+    })
+
+    await harness.client.start()
+
+    const record = buildTrackedRecord(TrackedScan, {accepted: 1, localOnly: "internal", ticketId: "t-1"})
+
+    await triggerLifecycle(TrackedScan, "afterCreate", record)
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.syncModel.rows.length).toEqual(1)
+    expect(harness.syncModel.rows[0].attributes.syncType).toEqual("scanAttempt")
+    expect(harness.syncModel.rows[0].attributes.data).toEqual({accepted: true, ticketId: "t-1"})
+    expect(harness.syncModel.rows[0].attributes.state).toEqual("success")
+    expect(harness.postReplayCalls.length).toEqual(1)
+  })
+
+  it("tracks only the configured operations", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: {operations: ["update"]}}
+      }
+    })
+
+    await harness.client.start()
+
+    expect(Object.keys(TrackedScan.lifecycleCallbacks)).toEqual(["afterUpdate"])
+  })
+
+  it("maps tracked destroys to delete sync rows", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: true}
+      }
+    })
+
+    harness.state.online = false
+
+    await harness.client.start()
+
+    const record = buildTrackedRecord(TrackedScan, {ticketId: "t-1"})
+
+    await triggerLifecycle(TrackedScan, "afterDestroy", record)
+
+    expect(harness.syncModel.rows[0].attributes.syncType).toEqual("delete")
+  })
+
+  it("uses trackedData to build tracked payloads", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {
+          modelClass: TrackedScan,
+          track: true,
+          trackedData: ({operation, record}) => ({deviceId: "device-1", operation, ticketId: record.attributes().ticketId})
+        }
+      }
+    })
+
+    harness.state.online = false
+
+    await harness.client.start()
+
+    const record = buildTrackedRecord(TrackedScan, {ticketId: "t-1"})
+
+    await triggerLifecycle(TrackedScan, "afterUpdate", record)
+
+    expect(harness.syncModel.rows[0].attributes.data).toEqual({deviceId: "device-1", operation: "update", ticketId: "t-1"})
+  })
+
+  it("does not queue tracked mutations for records written by pull-apply", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const record = buildTrackedRecord(TrackedScan, {ticketId: "t-1"})
+
+    record.assign = () => {}
+    record.isChanged = () => true
+    record.save = async () => {
+      await triggerLifecycle(TrackedScan, "afterUpdate", record)
+    }
+
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {
+          attributes: ({data}) => ({ticketId: data.ticketId}),
+          findRecord: async () => record,
+          modelClass: TrackedScan,
+          track: true
+        }
+      }
+    })
+
+    harness.state.changesResponses.push({
+      nextCursor: {id: "s-1", serverSequence: 1, updatedAt: "2026-07-01T10:00:00.000Z"},
+      status: "success",
+      syncs: [{data: {ticketId: "t-2"}, id: "s-1", resourceId: "scan-1", resourceType: "TrackedScan", syncType: "update"}],
+      upToCursor: null
+    })
+
+    await harness.client.start()
+    await harness.client.sync(fakeQuery("TrackedScan", {event_id: 5}))
+    await harness.client.waitForScheduledReplay()
+
+    expect(harness.syncModel.rows.length).toEqual(0)
+
+    await triggerLifecycle(TrackedScan, "afterUpdate", record)
+
+    expect(harness.syncModel.rows.length).toEqual(1)
+  })
+
+  it("unregisters tracking callbacks when stopped", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: true}
+      }
+    })
+
+    await harness.client.start()
+
+    expect(TrackedScan.lifecycleCallbacks.afterCreate.length).toEqual(1)
+
+    harness.client.stop()
+
+    expect(TrackedScan.lifecycleCallbacks.afterCreate.length).toEqual(0)
+    expect(TrackedScan.lifecycleCallbacks.afterUpdate.length).toEqual(0)
+    expect(TrackedScan.lifecycleCallbacks.afterDestroy.length).toEqual(0)
+  })
+
+  it("fails loudly on invalid track configuration", async () => {
+    const TrackedScan = buildTrackedModelClass("TrackedScan")
+
+    const harness = buildHarness({
+      resources: {
+        TrackedScan: {modelClass: TrackedScan, track: {operations: ["upsert"]}}
+      }
+    })
+
+    await expect(async () => await harness.client.start()).toThrow(/track\.operations/u)
+  })
 })
+
+/**
+ * Builds a fake model class implementing the lifecycle-callback registration contract.
+ * @param {string} name - Model class name.
+ * @returns {?} Fake trackable model class.
+ */
+function buildTrackedModelClass(name) {
+  const klass = class {
+    /** @type {Record<string, Array<Function>>} */
+    static lifecycleCallbacks = {}
+
+    /** @param {Function} callback - Lifecycle callback. @returns {void} */
+    static afterCreate(callback) {
+      (this.lifecycleCallbacks.afterCreate ||= []).push(callback)
+    }
+
+    /** @param {Function} callback - Lifecycle callback. @returns {void} */
+    static afterUpdate(callback) {
+      (this.lifecycleCallbacks.afterUpdate ||= []).push(callback)
+    }
+
+    /** @param {Function} callback - Lifecycle callback. @returns {void} */
+    static afterDestroy(callback) {
+      (this.lifecycleCallbacks.afterDestroy ||= []).push(callback)
+    }
+
+    /** @param {string} callbackName - Callback type. @param {Function} callback - Registered callback. @returns {void} */
+    static unregisterLifecycleCallback(callbackName, callback) {
+      const callbacks = this.lifecycleCallbacks[callbackName]
+
+      if (!callbacks) return
+
+      const index = callbacks.indexOf(callback)
+
+      if (index >= 0) callbacks.splice(index, 1)
+    }
+  }
+
+  Object.defineProperty(klass, "name", {value: name})
+
+  return klass
+}
+
+/**
+ * Builds a fake record instance of a tracked model class.
+ * @param {?} modelClass - Tracked model class.
+ * @param {Record<string, ?>} attributes - Record attributes.
+ * @returns {?} Fake record.
+ */
+function buildTrackedRecord(modelClass, attributes) {
+  const record = Object.create(modelClass.prototype)
+
+  record.id = () => "scan-1"
+  record.attributes = () => attributes
+
+  return record
+}
+
+/**
+ * Invokes the registered lifecycle callbacks like the record layer would.
+ * @param {?} modelClass - Tracked model class.
+ * @param {string} callbackName - Callback type.
+ * @param {?} record - Mutated record.
+ * @returns {Promise<void>}
+ */
+async function triggerLifecycle(modelClass, callbackName, record) {
+  for (const callback of modelClass.lifecycleCallbacks[callbackName] || []) {
+    await callback(record)
+  }
+}

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -536,6 +536,22 @@ class VelociousDatabaseRecord {
   }
 
   /**
+   * Runs unregister lifecycle callback.
+   * @param {"afterCreate" | "afterDestroy" | "afterSave" | "afterUpdate" | "beforeCreate" | "beforeDestroy" | "beforeSave" | "beforeUpdate" | "beforeValidation"} callbackName - Callback type.
+   * @param {LifecycleCallbackType} callback - Previously registered callback.
+   * @returns {void}
+   */
+  static unregisterLifecycleCallback(callbackName, callback) {
+    const callbacks = this.getLifecycleCallbacksMap()[callbackName]
+
+    if (!callbacks) return
+
+    const callbackIndex = callbacks.indexOf(callback)
+
+    if (callbackIndex >= 0) callbacks.splice(callbackIndex, 1)
+  }
+
+  /**
    * Runs before validation.
    * @template R
    * @this {ModelConstructor<R>}

--- a/src/sync/sync-api-client.js
+++ b/src/sync/sync-api-client.js
@@ -255,43 +255,49 @@ export default class SyncApiClient {
    * mechanics stay here; apps only declare which models/attributes/hooks are
    * allowed for each resource type.
    * @param {Record<string, SyncResourceConfig>} resources - Resource policy map.
+   * @param {(record: ?) => () => void} [onRecord] - Called with each record about to be written; returns a release callback invoked after the write (used for echo suppression).
    * @returns {(sync: SyncChangeEnvelope) => Promise<SyncChangeApplyResult>} Sync apply callback.
    */
-  static resourceApplier(resources) {
-    return async (sync) => await this.applyResourceSync({resources, sync})
+  static resourceApplier(resources, onRecord) {
+    return async (sync) => await this.applyResourceSync({onRecord, resources, sync})
   }
 
   /**
    * Applies one sync row using declarative resource policy.
-   * @param {{resources: Record<string, SyncResourceConfig>, sync: SyncChangeEnvelope}} args - Apply args.
+   * @param {{resources: Record<string, SyncResourceConfig>, sync: SyncChangeEnvelope, onRecord?: (record: ?) => () => void}} args - Apply args.
    * @returns {Promise<SyncChangeApplyResult>} Apply result.
    */
-  static async applyResourceSync({resources, sync}) {
+  static async applyResourceSync({onRecord, resources, sync}) {
     const resourceType = sync.resourceType()
     const resource = resourceType ? resources[resourceType] : undefined
 
     if (!resource || !resource.enabled) return {changed: false, resourceType}
 
     if (sync.syncType() === "delete") {
-      return {changed: await this.destroySyncedResource({resource, sync}), resourceType}
+      return {changed: await this.destroySyncedResource({onRecord, resource, sync}), resourceType}
     }
 
     const data = this.syncData(sync)
     const record = resource.findRecord ? await resource.findRecord({data, resourceId: sync.resourceId(), sync}) : await resource.modelClass.findOrInitializeBy({id: data.id ?? sync.resourceId()})
     const attributes = await resource.attributes({data, record, sync})
+    const releaseRecord = onRecord ? onRecord(record) : null
     let changed = false
 
-    record.assign(attributes)
+    try {
+      record.assign(attributes)
 
-    if (record.isChanged()) {
-      await record.save()
-      changed = true
-    }
+      if (record.isChanged()) {
+        await record.save()
+        changed = true
+      }
 
-    if (resource.afterApply) {
-      const hookChanged = await resource.afterApply({attributes, data, record, sync})
+      if (resource.afterApply) {
+        const hookChanged = await resource.afterApply({attributes, data, record, sync})
 
-      changed ||= hookChanged === true
+        changed ||= hookChanged === true
+      }
+    } finally {
+      if (releaseRecord) releaseRecord()
     }
 
     return {changed, resourceType}
@@ -299,16 +305,23 @@ export default class SyncApiClient {
 
   /**
    * Destroys a synced resource via its declared model policy.
-   * @param {{resource: SyncResourceConfig, sync: SyncChangeEnvelope}} args - Destroy args.
+   * @param {{resource: SyncResourceConfig, sync: SyncChangeEnvelope, onRecord?: (record: ?) => () => void}} args - Destroy args.
    * @returns {Promise<boolean>} Whether a local row was destroyed.
    */
-  static async destroySyncedResource({resource, sync}) {
+  static async destroySyncedResource({onRecord, resource, sync}) {
     const id = sync.resourceId()
     const record = resource.findRecordForDelete ? await resource.findRecordForDelete({resourceId: id, sync}) : await resource.modelClass.findBy({id})
 
     if (!record) return false
 
-    await record.destroy()
+    const releaseRecord = onRecord ? onRecord(record) : null
+
+    try {
+      await record.destroy()
+    } finally {
+      if (releaseRecord) releaseRecord()
+    }
+
     return true
   }
 

--- a/src/sync/sync-client.js
+++ b/src/sync/sync-client.js
@@ -11,6 +11,9 @@ import {currentSyncClient, setCurrentSyncClient} from "./sync-client-registry.js
 
 let clientCounter = 0
 
+/** @type {{create: "afterCreate", update: "afterUpdate", destroy: "afterDestroy"}} */
+const TRACKED_CALLBACK_NAMES = {create: "afterCreate", destroy: "afterDestroy", update: "afterUpdate"}
+
 /**
  * Declarative client-side sync driver.
  *
@@ -53,6 +56,103 @@ export default class SyncClient {
     this._scheduledReplay = null
     /** @type {Record<string, import("./sync-api-client-types.js").SyncResourceConfig> | null} */
     this._pullResourceConfigs = null
+    /** @type {Array<{callback: (record: ?) => Promise<void>, callbackName: "afterCreate" | "afterUpdate" | "afterDestroy", modelClass: ?}>} */
+    this._trackedCallbacks = []
+    /** @type {WeakSet<object>} */
+    this._remoteApplyRecords = new WeakSet()
+    this._started = false
+  }
+
+  /**
+   * Registers automatic mutation tracking for every resource with `track` enabled:
+   * local model creates/updates/destroys queue pending sync rows and schedule an
+   * immediate replay attempt, without app-side queue calls.
+   * @returns {Promise<void>}
+   */
+  async start() {
+    if (this._started) return
+
+    this._started = true
+
+    for (const [resourceType, resourceConfig] of Object.entries(this.config.resources)) {
+      const operations = this.trackedOperations({resourceConfig, resourceType})
+
+      for (const operation of operations) {
+        const callbackName = TRACKED_CALLBACK_NAMES[operation]
+        const callback = this.trackedMutationCallback({operation, resourceConfig})
+
+        resourceConfig.modelClass[callbackName](callback)
+        this._trackedCallbacks.push({callback, callbackName, modelClass: resourceConfig.modelClass})
+      }
+    }
+  }
+
+  /**
+   * Unregisters all tracking callbacks (tests, sign-out, hot reload).
+   * @returns {void}
+   */
+  stop() {
+    for (const {callback, callbackName, modelClass} of this._trackedCallbacks) {
+      modelClass.unregisterLifecycleCallback(callbackName, callback)
+    }
+
+    this._trackedCallbacks = []
+    this._started = false
+  }
+
+  /**
+   * Resolves and validates the tracked operations for a resource config.
+   * @param {{resourceConfig: import("./sync-client-types.js").SyncClientResourceConfig, resourceType: string}} args - Resource config and name.
+   * @returns {Array<"create" | "update" | "destroy">} Tracked operations.
+   */
+  trackedOperations({resourceConfig, resourceType}) {
+    const track = resourceConfig.track
+
+    if (track === undefined || track === false) return []
+    if (track === true) return ["create", "update", "destroy"]
+
+    if (!track || typeof track !== "object" || !Array.isArray(track.operations) || track.operations.length === 0) {
+      throw new Error(`SyncClient resource ${resourceType} track must be true or {operations: [...]}`)
+    }
+
+    for (const operation of track.operations) {
+      if (!(operation in TRACKED_CALLBACK_NAMES)) {
+        throw new Error(`SyncClient resource ${resourceType} track.operations must be create/update/destroy, got: ${String(operation)}`)
+      }
+    }
+
+    return track.operations
+  }
+
+  /**
+   * Builds the lifecycle callback queueing one tracked mutation.
+   * @param {{operation: "create" | "update" | "destroy", resourceConfig: import("./sync-client-types.js").SyncClientResourceConfig}} args - Operation and resource config.
+   * @returns {(record: ?) => Promise<void>} Lifecycle callback.
+   */
+  trackedMutationCallback({operation, resourceConfig}) {
+    return async (record) => {
+      if (this.isRemoteApply(record)) return
+
+      await SyncApiClient.queueLocalSync({
+        booleanAttributes: resourceConfig.booleanAttributes || [],
+        data: resourceConfig.trackedData ? resourceConfig.trackedData({operation, record}) : undefined,
+        localOnlyAttributes: resourceConfig.localOnlyAttributes || [],
+        resource: record,
+        syncModel: this.config.syncModel,
+        syncType: this.defaultSyncType({operation, record, resourceConfig})
+      })
+
+      this.scheduleReplay()
+    }
+  }
+
+  /**
+   * Whether a record is currently being written by pull-apply (echo suppression).
+   * @param {?} record - Local model record.
+   * @returns {boolean} Whether the record write originates from a remote change.
+   */
+  isRemoteApply(record) {
+    return this._remoteApplyRecords.has(record)
   }
 
   /**
@@ -113,7 +213,11 @@ export default class SyncClient {
     await SyncApiClient.singleFlight(`velocious-sync-client-pull-${this._clientNumber}`, async () => {
       const authenticationToken = await this.config.authenticationToken()
       const scopeStore = this.scopeStore()
-      const applySync = SyncApiClient.resourceApplier(this.pullResourceConfigs())
+      const applySync = SyncApiClient.resourceApplier(this.pullResourceConfigs(), (record) => {
+        this._remoteApplyRecords.add(record)
+
+        return () => this._remoteApplyRecords.delete(record)
+      })
       const result = {
         changed: false,
         pages: 0,


### PR DESCRIPTION
## Summary

Fourth step of moving generic sync behavior into Velocious (stacked on #841 — will retarget to master when it merges). Local model mutations now sync themselves:

- **Automatic mutation tracking**: resources with `track: true` (or `{operations: [...]}`) register `afterCreate`/`afterUpdate`/`afterDestroy` lifecycle callbacks on `syncClient.start()`. Tracked mutations queue pending sync rows through the same declarative policy as explicit `queue()` calls (local-only stripping, boolean coercion, `syncType`/`trackedData` mapping; destroys map to `"delete"`), then schedule an immediate online-gated replay. Queued rows are byte-identical to explicitly queued ones, so existing pending rows and the server replay path are unaffected.
- **Echo suppression**: records written by pull-apply are tagged for the duration of the apply (`onRecord` hook threaded through `SyncApiClient.applyResourceSync`/`destroySyncedResource`), so applying remote changes never queues them back to the server.
- **`stop()`** unregisters all tracking callbacks (sign-out, tests, hot reload), backed by a new `VelociousDatabaseRecord.unregisterLifecycleCallback`.

## Validation

- `VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/sync` — 89 tests green (7 new tracking tests: auto-queue + replay, per-operation tracking, destroy→delete, trackedData, echo suppression, stop/unregister, invalid track config)
- `spec/database/record/unregister-lifecycle-callback-spec.js` — 2 tests green
- `npm run typecheck`, `npm run lint` — clean