### PR TITLE
Add default tenant-database provisioning (create/drop)

### DIFF
--- a/changelog.d/20260702194950-default-tenant-database-provisioning.md
+++ b/changelog.d/20260702194950-default-tenant-database-provisioning.md
@@ -1,0 +1,9 @@
+Add default tenant-database provisioning so `db:tenants:create`, `db:tenants:drop`
+and `Tenant.drop` work without each app reimplementing it. When a tenant-database
+provider does not define `createDatabase`/`dropDatabase`, the framework now uses a
+built-in driver-agnostic default (`src/tenants/default-tenant-database-provisioning.js`):
+file-backed drivers (sqlite) create the database by ensuring the tenant connection
+and treat drop as a no-op, while server drivers (mysql, pgsql, …) connect to the
+configured maintenance database (`useDatabase`) and run the driver's own
+`createDatabaseSql`/`dropDatabaseSql` after validating the tenant database name.
+Providers can still override either hook for custom provisioning.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -60,6 +60,9 @@ export default new Configuration({
         // cross-tenant dependent: "restrict" checks.
         return await Project.where({tenantState: "migrated"}).select(["id", "databaseName"]).toArray()
       },
+      // Optional: override only if you need custom creation (grants, structure
+      // loading, …). Omit it and the framework's driver-agnostic default runs
+      // (see below), so most apps do not implement createDatabase/dropDatabase.
       createDatabase: async ({databaseConfiguration, tenant}) => {
         // App-specific database creation, grants, and structure loading.
       },
@@ -86,7 +89,9 @@ npx velocious db:tenants:migrate projectTenant
 npx velocious db:tenants:drop projectTenant
 ```
 
-`db:tenants:drop` drops every listed tenant's database through the provider's `dropDatabase` hook (define it alongside `createDatabase`). Like the other lifecycle commands it honors `--parallel`.
+`db:tenants:drop` drops every listed tenant's database through the provider's `dropDatabase` hook. Like the other lifecycle commands it honors `--parallel`.
+
+`createDatabase`/`dropDatabase` are optional. When a provider omits them, `db:tenants:create`, `db:tenants:drop`, and `Tenant.drop` fall back to the framework default (`src/tenants/default-tenant-database-provisioning.js`): file-backed drivers (sqlite) create by ensuring the tenant connection and treat drop as a no-op, while server drivers (mysql, pgsql, …) connect to the maintenance database (`useDatabase`) and run the driver's own `createDatabaseSql`/`dropDatabaseSql` after validating the tenant database name. Define your own hook only when you need custom provisioning.
 
 Tenant lifecycle commands run one tenant at a time by default. Add `--parallel` to process up to 20 tenants at once, or pass a positive integer to choose a different concurrency:
 

--- a/spec/cli/commands/db/tenants/drop-spec.js
+++ b/spec/cli/commands/db/tenants/drop-spec.js
@@ -82,7 +82,7 @@ describe("Cli - Commands - db:tenants:drop", () => {
     }
   })
 
-  it("throws when the provider does not define dropDatabase", async () => {
+  it("drops tenants through the framework default when the provider does not define dropDatabase", async () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenants-drop-missing-"))
     const configuration = new Configuration({
       database: {
@@ -133,15 +133,9 @@ describe("Cli - Commands - db:tenants:drop", () => {
     })
 
     try {
-      let caughtError = null
+      const result = await cli.execute()
 
-      try {
-        await cli.execute()
-      } catch (error) {
-        caughtError = error
-      }
-
-      expect(caughtError instanceof Error && caughtError.message.includes("must define dropDatabase")).toEqual(true)
+      expect(result).toEqual({identifier: "projectTenant", tenantCount: 1})
     } finally {
       await configuration.closeDatabaseConnections()
       await fs.rm(directory, {force: true, recursive: true})

--- a/spec/tenants/default-tenant-database-provisioning-spec.js
+++ b/spec/tenants/default-tenant-database-provisioning-spec.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+import {createTenantDatabase, dropTenantDatabase} from "../../src/tenants/default-tenant-database-provisioning.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class FakeDriver {
+  /** @type {FakeDriver[]} */
+  static instances = []
+
+  /** @param {Record<string, any>} config */
+  constructor(config) {
+    this.config = config
+    /** @type {string[]} */
+    this.queries = []
+    this.connected = false
+    this.closed = false
+    FakeDriver.instances.push(this)
+  }
+
+  async connect() { this.connected = true }
+  async close() { this.closed = true }
+  /** @param {string} sql */
+  async query(sql) { this.queries.push(sql) }
+  /** @param {string} name @returns {string[]} */
+  createDatabaseSql(name) { return [`CREATE DATABASE \`${name}\``] }
+  /** @param {string} name @returns {string[]} */
+  dropDatabaseSql(name) { return [`DROP DATABASE IF EXISTS \`${name}\``] }
+}
+
+const mysqlConfig = () => /** @type {any} */ ({type: "mysql", driver: FakeDriver, database: "tenant_db", useDatabase: "maintenance_db"})
+
+describe("default tenant database provisioning", () => {
+  it("creates a server tenant database through the maintenance connection and the driver's createDatabaseSql", async () => {
+    FakeDriver.instances = []
+
+    await createTenantDatabase({configuration: /** @type {any} */ ({}), databaseConfiguration: mysqlConfig(), tenant: {}})
+
+    const driver = FakeDriver.instances[0]
+
+    expect(driver.config.database).toEqual("maintenance_db")
+    expect(driver.queries).toEqual(["CREATE DATABASE `tenant_db`"])
+    expect(driver.connected).toEqual(true)
+    expect(driver.closed).toEqual(true)
+  })
+
+  it("drops a server tenant database through the driver's dropDatabaseSql", async () => {
+    FakeDriver.instances = []
+
+    await dropTenantDatabase({configuration: /** @type {any} */ ({}), databaseConfiguration: mysqlConfig()})
+
+    expect(FakeDriver.instances[0].queries).toEqual(["DROP DATABASE IF EXISTS `tenant_db`"])
+    expect(FakeDriver.instances[0].closed).toEqual(true)
+  })
+
+  it("rejects an unsafe tenant database name before issuing DDL", async () => {
+    FakeDriver.instances = []
+    let threw = false
+
+    try {
+      await dropTenantDatabase({configuration: /** @type {any} */ ({}), databaseConfiguration: /** @type {any} */ ({...mysqlConfig(), database: "tenant_db; DROP"})})
+    } catch {
+      threw = true
+    }
+
+    expect(threw).toEqual(true)
+    expect(FakeDriver.instances.filter((driver) => driver.queries.length > 0).length).toEqual(0)
+  })
+
+  it("treats a file-backed (sqlite) drop as a no-op with no maintenance connection", async () => {
+    FakeDriver.instances = []
+
+    await dropTenantDatabase({configuration: /** @type {any} */ ({}), databaseConfiguration: /** @type {any} */ ({type: "sqlite", driver: FakeDriver, database: "tenant_db"})})
+
+    expect(FakeDriver.instances.length).toEqual(0)
+  })
+})

--- a/spec/tenants/tenant-spec.js
+++ b/spec/tenants/tenant-spec.js
@@ -161,17 +161,19 @@ describe("Tenant", () => {
     })
   })
 
-  it("throws when dropping a tenant whose provider has no dropDatabase hook", async () => {
+  it("drops through the framework default when the provider has no dropDatabase hook", async () => {
     await withConfiguration({listTenants: () => []}, async ({configuration}) => {
       let caughtError = null
 
+      // No provider.dropDatabase — the framework's default provisioning handles it
+      // (a no-op for the file-backed test driver) instead of requiring a hook.
       try {
         await Tenant.drop({configuration, identifier: "projectTenant", tenant: {slug: "alpha"}})
       } catch (error) {
         caughtError = error
       }
 
-      expect(caughtError instanceof Error && caughtError.message.includes("must define dropDatabase")).toEqual(true)
+      expect(caughtError).toEqual(null)
     })
   })
 })

--- a/src/cli/commands/db/tenants/create.js
+++ b/src/cli/commands/db/tenants/create.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import BaseCommand from "../../../base-command.js"
+import {createTenantDatabase} from "../../../../tenants/default-tenant-database-provisioning.js"
 import TenantDatabaseCommandHelper from "../../../tenant-database-command-helper.js"
 
 export default class DbTenantsCreate extends BaseCommand {
@@ -14,13 +15,14 @@ export default class DbTenantsCreate extends BaseCommand {
       identifier: this.processArgs?.[1]
     })
     const provider = helper.provider
-
-    if (typeof provider.createDatabase !== "function") {
-      throw new Error(`Tenant database provider for ${helper.identifier} must define createDatabase to use db:tenants:create`)
-    }
+    // Providers may customize creation, but the generic driver-agnostic provisioning
+    // is the framework default so apps do not reimplement it.
+    const createDatabase = typeof provider.createDatabase === "function"
+      ? provider.createDatabase.bind(provider)
+      : createTenantDatabase
 
     const tenantCount = await helper.eachTenant(async ({databaseConfiguration, tenant}) => {
-      await provider.createDatabase?.({
+      await createDatabase({
         configuration: this.getConfiguration(),
         databaseConfiguration,
         identifier: helper.identifier,

--- a/src/cli/commands/db/tenants/drop.js
+++ b/src/cli/commands/db/tenants/drop.js
@@ -1,12 +1,13 @@
 // @ts-check
 
 import BaseCommand from "../../../base-command.js"
+import {dropTenantDatabase} from "../../../../tenants/default-tenant-database-provisioning.js"
 import TenantDatabaseCommandHelper from "../../../tenant-database-command-helper.js"
 
 export default class DbTenantsDrop extends BaseCommand {
   /**
    * Drops the tenant database/schema for every listed tenant through the provider's
-   * `dropDatabase` hook.
+   * `dropDatabase` hook, or the framework default when the provider defines none.
    * @returns {Promise<{identifier: string, tenantCount: number} | void>} - Result in test mode.
    */
   async execute() {
@@ -15,13 +16,12 @@ export default class DbTenantsDrop extends BaseCommand {
       identifier: this.processArgs?.[1]
     })
     const provider = helper.provider
-
-    if (typeof provider.dropDatabase !== "function") {
-      throw new Error(`Tenant database provider for ${helper.identifier} must define dropDatabase to use db:tenants:drop`)
-    }
+    const dropDatabase = typeof provider.dropDatabase === "function"
+      ? provider.dropDatabase.bind(provider)
+      : dropTenantDatabase
 
     const tenantCount = await helper.eachTenant(async ({databaseConfiguration, tenant}) => {
-      await provider.dropDatabase?.({
+      await dropDatabase({
         configuration: this.getConfiguration(),
         databaseConfiguration,
         identifier: helper.identifier,

--- a/src/tenants/default-tenant-database-provisioning.js
+++ b/src/tenants/default-tenant-database-provisioning.js
@@ -1,0 +1,124 @@
+// @ts-check
+
+/**
+ * Default tenant-database provisioning used by `db:tenants:create`,
+ * `db:tenants:drop`, and `Tenant.drop` when a tenant-database provider does not
+ * define its own `createDatabase`/`dropDatabase`. This is the generic,
+ * driver-agnostic lifecycle every app on the tenant framework needs, so it lives
+ * in the framework instead of being reimplemented in each consuming project.
+ *
+ * File-backed drivers (sqlite) have no server-side CREATE/DROP DATABASE — the file
+ * is created on connect and left in place on drop — so creating just ensures the
+ * tenant's connection and dropping is a no-op. Server drivers (mysql, pgsql, …)
+ * connect to the configured maintenance database (`useDatabase`) and run the
+ * driver's own `createDatabaseSql`/`dropDatabaseSql`.
+ */
+
+const SAFE_TENANT_DATABASE_NAME = /^[a-z0-9_]+$/
+
+/**
+ * Whether the driver stores each database as a local file instead of on a server.
+ * @param {import("../configuration-types.js").DatabaseConfigurationType} databaseConfiguration - Resolved tenant database configuration.
+ * @returns {boolean} - True for file-backed drivers such as sqlite.
+ */
+function fileBackedDriver(databaseConfiguration) {
+  return databaseConfiguration.type === "sqlite"
+}
+
+/**
+ * Validates the tenant database name against a strict allowlist before it is
+ * interpolated into DDL.
+ * @param {import("../configuration-types.js").DatabaseConfigurationType} databaseConfiguration - Resolved tenant database configuration.
+ * @returns {string} - The validated tenant database name.
+ */
+function guardedDatabaseName(databaseConfiguration) {
+  const databaseName = databaseConfiguration.database
+
+  if (!databaseName || !SAFE_TENANT_DATABASE_NAME.test(databaseName)) {
+    throw new Error(`Unsafe tenant database name: ${databaseName}`)
+  }
+
+  return databaseName
+}
+
+/**
+ * Opens a driver connected to the server's maintenance database (`useDatabase`),
+ * from which `CREATE DATABASE` / `DROP DATABASE` for the tenant can be issued.
+ * @param {import("../configuration-types.js").DatabaseConfigurationType} databaseConfiguration - Resolved tenant database configuration.
+ * @param {import("../configuration.js").default} configuration - The Velocious configuration.
+ * @returns {import("../database/drivers/base.js").default} - A driver bound to the maintenance database.
+ */
+function maintenanceConnection(databaseConfiguration, configuration) {
+  const DriverClass = databaseConfiguration.driver
+
+  if (!DriverClass) {
+    throw new Error("Tenant database configuration is missing a driver.")
+  }
+
+  if (!databaseConfiguration.useDatabase) {
+    throw new Error("Tenant database configuration is missing a maintenance database in useDatabase.")
+  }
+
+  return new DriverClass({...databaseConfiguration, database: databaseConfiguration.useDatabase}, configuration)
+}
+
+/**
+ * Creates the tenant database for one tenant.
+ * @param {{configuration: import("../configuration.js").default, databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}} args - Provisioning arguments.
+ * @returns {Promise<void>} - Resolves once the tenant database exists.
+ */
+export async function createTenantDatabase({configuration, databaseConfiguration, tenant}) {
+  if (fileBackedDriver(databaseConfiguration)) {
+    await configuration.runWithTenant(tenant, async () => {
+      await configuration.ensureConnections(async () => {})
+    })
+
+    return
+  }
+
+  const databaseName = guardedDatabaseName(databaseConfiguration)
+  const connection = maintenanceConnection(databaseConfiguration, configuration)
+
+  await connection.connect()
+
+  try {
+    const sqls = connection.createDatabaseSql(databaseName, {
+      databaseCharset: databaseConfiguration.databaseCharset,
+      databaseCollation: databaseConfiguration.databaseCollation,
+      ifNotExists: true
+    })
+
+    for (const sql of sqls) {
+      await connection.query(sql)
+    }
+  } finally {
+    await connection.close()
+  }
+}
+
+/**
+ * Drops the tenant database for one tenant. Uses `DROP DATABASE IF EXISTS`, so it
+ * is a safe no-op for a tenant that was never fully provisioned.
+ * @param {{configuration: import("../configuration.js").default, databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType}} args - Provisioning arguments.
+ * @returns {Promise<void>} - Resolves once the tenant database is gone.
+ */
+export async function dropTenantDatabase({configuration, databaseConfiguration}) {
+  if (fileBackedDriver(databaseConfiguration)) {
+    return
+  }
+
+  const databaseName = guardedDatabaseName(databaseConfiguration)
+  const connection = maintenanceConnection(databaseConfiguration, configuration)
+
+  await connection.connect()
+
+  try {
+    const sqls = connection.dropDatabaseSql(databaseName, {ifExists: true})
+
+    for (const sql of sqls) {
+      await connection.query(sql)
+    }
+  } finally {
+    await connection.close()
+  }
+}

--- a/src/tenants/tenant.js
+++ b/src/tenants/tenant.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import Current from "../current.js"
+import {dropTenantDatabase} from "./default-tenant-database-provisioning.js"
 import TenantIterator from "./tenant-iterator.js"
 
 /**
@@ -80,10 +81,9 @@ export default class Tenant {
    */
   static async drop({identifier, tenant, configuration = Current.configuration()}) {
     const provider = configuration.getTenantDatabaseProvider(identifier)
-
-    if (typeof provider.dropDatabase !== "function") {
-      throw new Error(`Tenant database provider for ${identifier} must define dropDatabase to drop a tenant`)
-    }
+    const dropDatabase = typeof provider.dropDatabase === "function"
+      ? provider.dropDatabase.bind(provider)
+      : dropTenantDatabase
 
     await configuration.runWithTenant(tenant, async () => {
       // Guard against an unresolved tenant. resolveDatabaseConfiguration falls back to the
@@ -94,7 +94,7 @@ export default class Tenant {
         throw new Error(`Tenant database identifier ${identifier} is inactive for tenant: ${TenantIterator.tenantLabel(tenant)}`)
       }
 
-      await provider.dropDatabase?.({
+      await dropDatabase({
         configuration,
         databaseConfiguration: configuration.resolveDatabaseConfiguration(identifier),
         identifier,


### PR DESCRIPTION
## Summary

Gives the tenant framework a default database-provisioning lifecycle so apps no longer have to implement `createDatabase`/`dropDatabase` in every tenant-database provider:

- **`src/tenants/default-tenant-database-provisioning.js`**: used by `db:tenants:create`, `db:tenants:drop`, and `Tenant.drop` when the provider omits the hook. File-backed drivers (sqlite) create by ensuring the tenant connection and treat drop as a safe no-op; server drivers (mysql, pgsql, ...) connect through the maintenance database (`useDatabase`) and run the driver's `createDatabaseSql`/`dropDatabaseSql` after validating the tenant database name. Providers can still override for custom provisioning.
- The pre-existing `db:tenants:drop` spec asserted the removed "must define dropDatabase" error; it now asserts the framework-default behavior. New coverage in `spec/tenants/default-tenant-database-provisioning-spec.js` (create via maintenance connection, drop via `dropDatabaseSql`, unsafe-name rejection, sqlite no-op).

## Provenance / housekeeping

This is the tenant work originally committed as `b3640272` — it landed on the `sync-review-fixes` checkout (and thus rode along inside #843) and was also pushed as the PR-less branch `tenant-db-default-provisioning`. This PR carries the same change cherry-picked cleanly onto master, with an unrelated sync-spec hunk (already part of #843) excluded.

- If #843 merges first, this PR reduces to a no-op/duplicate patch and merges cleanly (or can be closed).
- If this PR merges first, #843's copy of the same patch merges cleanly as already-applied.
- The stacked branch `tenant-db-default-provisioning` is superseded by this PR and can be deleted.

## Validation

- `spec/tenants` — 12 tests green
- `spec/cli/commands/db/tenants` — 10 tests green
- `npx tsc --noEmit`, `npm run lint` — clean