### PR TITLE
Report unhandled rejections in the test runner instead of dying silently

### DIFF
--- a/spec/testing/test-runner-async-crash-spec.js
+++ b/spec/testing/test-runner-async-crash-spec.js
@@ -1,0 +1,41 @@
+import {describe, expect, it} from "../../src/testing/test.js"
+import TestRunner from "../../src/testing/test-runner.js"
+
+/** @returns {TestRunner} A runner with a stub configuration (recordAsyncCrash touches no config). */
+function buildRunner() {
+  return new TestRunner({
+    configuration: /** @type {any} */ ({}),
+    excludeTags: [],
+    includeTags: [],
+    testFiles: []
+  })
+}
+
+describe("TestRunner - async crash reporting", () => {
+  it("turns an unhandled rejection into a visible failure instead of a silent process death", () => {
+    const runner = buildRunner()
+
+    expect(runner.getFailedTests()).toEqual(0)
+
+    // Simulates run()'s process.on("unhandledRejection") handler firing for a
+    // detached fire-and-forget rejection (the "silent test-runner death" cause).
+    runner.recordAsyncCrash("unhandledRejection", new Error("detached async boom"))
+
+    expect(runner.getFailedTests()).toEqual(1)
+
+    const details = runner.getFailedTestDetails()
+
+    expect(details.length).toEqual(1)
+    expect(details[0].error.message).toEqual("detached async boom")
+    expect(details[0].fullDescription.includes("unhandledRejection")).toEqual(true)
+  })
+
+  it("wraps a non-Error rejection reason in an Error so the run still reports it", () => {
+    const runner = buildRunner()
+
+    runner.recordAsyncCrash("unhandledRejection", "string reason")
+
+    expect(runner.getFailedTests()).toEqual(1)
+    expect(runner.getFailedTestDetails()[0].error.message.includes("string reason")).toEqual(true)
+  })
+})

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -678,7 +678,17 @@ export default class TestRunner {
      * @param {unknown} reason - Rejection reason.
      * @returns {void}
      */
-    const onUnhandledRejection = (reason) => this.recordAsyncCrash("unhandledRejection", reason)
+    const onUnhandledRejection = (reason) => {
+      // If a test attached its OWN unhandledRejection listener, it is
+      // intentionally observing/triggering the rejection (e.g. beacon
+      // error-reporting-spec.js) — Node dispatches to EVERY listener, so also
+      // failing the suite here would break those tests. Defer to the test's
+      // handler; only treat a rejection as a silent-death crash when ours is the
+      // sole listener (no persistent framework listener exists to mask this).
+      if (process.listenerCount("unhandledRejection") > 1) return
+
+      this.recordAsyncCrash("unhandledRejection", reason)
+    }
 
     process.on("unhandledRejection", onUnhandledRejection)
 
@@ -691,6 +701,15 @@ export default class TestRunner {
           descriptions: [],
           indentLevel: 0
         })
+
+        // A rejection scheduled by the final test (a detached rejected promise,
+        // or an afterCommit callback rejecting as the suite drains) is reported
+        // by Node on a LATER turn. Drain a few turns while the handler is still
+        // attached — and connections still open — so those late rejections are
+        // recorded instead of escaping to the default crash path after cleanup.
+        for (let drainTurn = 0; drainTurn < 3; drainTurn++) {
+          await new Promise((resolve) => setImmediate(resolve))
+        }
       })
     } finally {
       process.off("unhandledRejection", onUnhandledRejection)

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -187,6 +187,8 @@ export default class TestRunner {
     this._testsCount = 0
     this._activeAfterAllScopes = []
     this._failedTestDetails = []
+    /** @type {{fullDescription: string, filePath: string, line: number} | null} */
+    this._lastTestContext = null
   }
 
   /**
@@ -638,16 +640,61 @@ export default class TestRunner {
    * Runs run.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async run() {
-    await this.getConfiguration().ensureConnections({name: "Test runner suite"}, async () => {
-      await this.runTests({
-        afterEaches: [],
-        beforeEaches: [],
-        tests,
-        descriptions: [],
-        indentLevel: 0
-      })
+  /**
+   * Records an asynchronous crash (an unhandled promise rejection detached from
+   * any await, e.g. a `void connection.afterCommit(async () => broadcast(...))`
+   * frontend-model publish) as a real, visible, attributed test failure.
+   *
+   * Without this, such a rejection has no handler, so on modern Node the process
+   * is TERMINATED — the run ends with no reported failures and CI just sees a
+   * crashed/retried shard with an empty result (the recurring "silent
+   * test-runner death": invisible and impossible to diagnose). Turning it into a
+   * failure makes the run go red with something debuggable instead of vanishing.
+   * @param {"unhandledRejection"} kind - Async-crash kind.
+   * @param {unknown} reason - Rejection reason.
+   * @returns {void}
+   */
+  recordAsyncCrash(kind, reason) {
+    const error = reason instanceof Error ? reason : new Error(`${kind}: ${String(reason)}`)
+    const near = this._lastTestContext
+    const attribution = near ? `, near test: ${near.fullDescription} (${near.filePath}:${near.line})` : ""
+
+    this._failedTests = (this._failedTests || 0) + 1
+    this._failedTestDetails.push({
+      fullDescription: `<${kind} during test run${attribution}>`,
+      filePath: near ? near.filePath : "<test runner>",
+      line: near ? near.line : 0,
+      error,
+      consoleOutput: undefined
     })
+
+    console.error(picocolors.red(`\n[test-runner] ${kind} during the test run — this would otherwise terminate the process silently and surface only as a crashed/retried shard with zero reported failures.${attribution}`))
+    console.error(error)
+  }
+
+  async run() {
+    /**
+     * Handles a process-level unhandled rejection during the run.
+     * @param {unknown} reason - Rejection reason.
+     * @returns {void}
+     */
+    const onUnhandledRejection = (reason) => this.recordAsyncCrash("unhandledRejection", reason)
+
+    process.on("unhandledRejection", onUnhandledRejection)
+
+    try {
+      await this.getConfiguration().ensureConnections({name: "Test runner suite"}, async () => {
+        await this.runTests({
+          afterEaches: [],
+          beforeEaches: [],
+          tests,
+          descriptions: [],
+          indentLevel: 0
+        })
+      })
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection)
+    }
   }
 
   /**
@@ -798,6 +845,14 @@ export default class TestRunner {
                     await beforeEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
                   }
 
+                  // Record which test is running so an async crash (an unhandled
+                  // rejection detached from any await) that fires during or shortly
+                  // after this test can be attributed to it in run()'s handler.
+                  this._lastTestContext = {
+                    fullDescription: this.buildFullDescription(descriptions, testDescription),
+                    filePath: testData.filePath ?? "<unknown>",
+                    line: testData.line ?? 0
+                  }
                   await testData.function(testArgs)
                   this._successfulTests++
                 } finally {


### PR DESCRIPTION
## Problem
A fire-and-forget promise rejection during a test run — the frontend-model publisher's detached `void connection.afterCommit(async () => broadcast(...))`, or any other unawaited async work that rejects — has **no handler**, so on modern Node the whole test process is **terminated**. The run ends with **no reported failures**, and CI just sees a crashed/retried shard with an empty result. That's the recurring **"silent test-runner death"**: invisible and impossible to diagnose. (Consumers work around individual triggers — e.g. disabling Beacon in the test env — but the general flaw remains for any other detached rejection.)

## Fix
Install a process-level `unhandledRejection` handler for the duration of `run()` that turns such a rejection into a real, **visible, attributed** failure — the error plus the nearest running test's description/file/line — via a new `recordAsyncCrash()`. The run goes **red with a debuggable error** instead of vanishing. `_lastTestContext` is tracked per test so the failure points near its origin.

## Verification
- Repro: a detached late rejection now reports `<unhandledRejection during test run, near test: ...>` and exits non-zero, instead of silently killing the process.
- Unit spec `spec/testing/test-runner-async-crash-spec.js` for `recordAsyncCrash`.
- `tsc -b` + `eslint` clean.

Branched off the commit TensorBuzz currently pins (`797eff24`) so TB can consume this fix surgically; the fix commit cherry-picks cleanly onto master (test-runner.js is identical on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)