### PR TITLE
Allow quickSearchColumns and writableAttributes as resource static config

### DIFF
--- a/changelog.d/20260703150000-resource-static-config-keys.md
+++ b/changelog.d/20260703150000-resource-static-config-keys.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Fixed app boot for `SyncResourceBase` subclasses on 1.0.494: the new `quickSearchColumns`/`writableAttributes` statics are now registered in the declarative resource-config key allowlist, so `assertKnownResourceStaticConfigProperties` no longer rejects them ("Unknown arguments: quickSearchColumns, writableAttributes").

--- a/spec/sync/sync-resource-base-spec.js
+++ b/spec/sync/sync-resource-base-spec.js
@@ -4,6 +4,7 @@ import {describe, expect, it} from "../../src/testing/test.js"
 import SyncEnvelopeReplayService from "../../src/sync/sync-envelope-replay-service.js"
 import SyncModelChangeFeedService from "../../src/sync/sync-model-change-feed-service.js"
 import SyncResourceBase from "../../src/sync/sync-resource-base.js"
+import {frontendModelResourceConfigurationFromDefinition} from "../../src/frontend-models/resource-definition.js"
 import SyncEntry from "../dummy/src/models/sync-entry.js"
 import VelociousError from "../../src/velocious-error.js"
 
@@ -291,6 +292,19 @@ async function createQuickSearchEntry({resourceId, syncType}) {
 
   return entry
 }
+
+describe("sync resource base - registration", () => {
+  it("passes the declarative static config assertion when registered as a frontend-model resource", () => {
+    class RegisteredSyncResource extends SyncResourceBase {
+      static ModelClass = SyncEntry
+      static attributes = {id: true}
+    }
+
+    const configuration = frontendModelResourceConfigurationFromDefinition(RegisteredSyncResource)
+
+    if (!configuration) throw new Error("Expected a normalized resource configuration")
+  })
+})
 
 describe("sync resource base - quick search", {tags: ["dummy"], databaseCleaning: {transaction: false, truncate: true}}, () => {
   it("expands quickSearch searches to LIKE conditions over the declared columns", async () => {

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -40,11 +40,13 @@ const RESOURCE_STATIC_CONFIG_KEYS = new Set([
   "modelName",
   "ModelClass",
   "primaryKey",
+  "quickSearchColumns",
   "relationships",
   "server",
   "SharedResource",
   "sync",
-  "translatedAttributes"
+  "translatedAttributes",
+  "writableAttributes"
 ])
 
 /**


### PR DESCRIPTION
## Summary

Hotfix for a 1.0.494 regression: #846 added `static quickSearchColumns`/`writableAttributes` to `SyncResourceBase` but did not register them in `RESOURCE_STATIC_CONFIG_KEYS`, so `assertKnownResourceStaticConfigProperties` (which walks each registered resource's prototype chain) fails app boot for **any** `SyncResourceBase` subclass with `Unknown arguments: quickSearchColumns, writableAttributes`. This is what's failing ticket-app #1392's CI (every job that boots ticket-server).

One-line allowlist fix + a regression spec that registers a `SyncResourceBase` subclass through `frontendModelResourceConfigurationFromDefinition` (red before, green after).

## Validation

- `spec/sync` — 148 tests green (147 + new regression)
- `spec/frontend-models/base-spec.js` — 100 green
- typecheck / lint / build clean
- Verified against ticket-server's real failing case via git pin (see PR comment / downstream #1392)