### PR TITLE
Diagnose MSSQL constraint-toggle lock waits in test reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "diggerize": "^1.0.5",
         "ejs": "^6.0.1",
         "env-sense": "^1.0.2",
-        "epic-locks": "^1.0.7",
+        "epic-locks": "^1.0.8",
         "escape-string-regexp": "^1.0.5",
         "eventemitter3": "^5.0.1",
         "gettext-universal": "^1.0.23",
@@ -6463,9 +6463,9 @@
       "license": "ISC"
     },
     "node_modules/epic-locks": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/epic-locks/-/epic-locks-1.0.7.tgz",
-      "integrity": "sha512-zAxc3RL3Mx1TH5G9uEy//UBDCzP9MC6H4kx8Mjt8sPmGfjXFU286u8jwm5rOQMe0X7v60BGP8uMlYKZXPJRTiQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/epic-locks/-/epic-locks-1.0.8.tgz",
+      "integrity": "sha512-0SKT1jF9jkv88Nah5llceSFyFTKLcmIcUDCCYe1mcXTTLTb+O5AvkTmC69jVJOIurAR6//MvjOorM8DFxr2Qjg==",
       "license": "ISC"
     },
     "node_modules/error-stack-parser": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "diggerize": "^1.0.5",
     "ejs": "^6.0.1",
     "env-sense": "^1.0.2",
-    "epic-locks": "^1.0.7",
+    "epic-locks": "^1.0.8",
     "escape-string-regexp": "^1.0.5",
     "eventemitter3": "^5.0.1",
     "gettext-universal": "^1.0.23",

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -192,26 +192,43 @@ export default class VelociousDatabaseDriversMssql extends Base{
   }
 
   /**
-   * Snapshots every user session other than this one that holds an open
-   * transaction or is running a request, with its last statement, wait state,
-   * and blocking session — enough to identify a connection that leaked a lock.
+   * Snapshots the sessions that could be blocking a constraint toggle in THIS
+   * database — every session other than this one that holds a lock in `DB_ID()`
+   * or is running a request against it — with its last statement, wait state,
+   * and blocking session, enough to identify a connection that leaked a lock.
+   * Scoped to the current database so a multi-database server does not leak
+   * unrelated sessions' SQL into the error and bury the real blocker.
    * @returns {Promise<string>} - JSON snapshot, or a "(none)" marker.
    */
   async _captureBlockingSessionsForDebug() {
-    const rows = await this.query(
-      "SELECT s.session_id AS sessionId, s.status AS sessionStatus, s.login_time AS loginTime, " +
-      "s.last_request_start_time AS lastRequestStart, s.last_request_end_time AS lastRequestEnd, " +
-      "s.open_transaction_count AS openTransactionCount, r.status AS requestStatus, r.command AS command, " +
-      "r.wait_type AS waitType, r.wait_time AS waitTimeMs, r.blocking_session_id AS blockingSessionId, " +
-      "CAST(ib.event_info AS NVARCHAR(MAX)) AS lastSql " +
-      "FROM sys.dm_exec_sessions s " +
-      "LEFT JOIN sys.dm_exec_requests r ON r.session_id = s.session_id " +
-      "OUTER APPLY sys.dm_exec_input_buffer(s.session_id, NULL) ib " +
-      "WHERE s.is_user_process = 1 AND s.session_id <> @@SPID " +
-      "AND (s.open_transaction_count > 0 OR r.session_id IS NOT NULL)"
-    )
+    const rows = await this.query(`
+      WITH lock_sessions AS (
+        SELECT DISTINCT request_session_id AS session_id
+        FROM sys.dm_tran_locks
+        WHERE resource_database_id = DB_ID()
+      )
+      SELECT
+        s.session_id AS sessionId,
+        s.status AS sessionStatus,
+        s.login_time AS loginTime,
+        s.last_request_start_time AS lastRequestStart,
+        s.last_request_end_time AS lastRequestEnd,
+        s.open_transaction_count AS openTransactionCount,
+        r.status AS requestStatus,
+        r.command AS command,
+        r.wait_type AS waitType,
+        r.wait_time AS waitTimeMs,
+        r.blocking_session_id AS blockingSessionId,
+        CAST(ib.event_info AS NVARCHAR(MAX)) AS lastSql
+      FROM sys.dm_exec_sessions s
+      LEFT JOIN sys.dm_exec_requests r ON r.session_id = s.session_id
+      OUTER APPLY sys.dm_exec_input_buffer(s.session_id, NULL) ib
+      WHERE s.is_user_process = 1
+        AND s.session_id <> @@SPID
+        AND (s.session_id IN (SELECT session_id FROM lock_sessions) OR r.database_id = DB_ID())
+    `)
 
-    if (rows.length === 0) return "(none — no other user session had an open transaction or active request when queried)"
+    if (rows.length === 0) return "(none — no other session held a lock or ran a request in this database when queried)"
 
     return JSON.stringify(rows, null, 2)
   }

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -148,12 +148,72 @@ export default class VelociousDatabaseDriversMssql extends Base{
     return digg(rows, 0, "db_name")
   }
 
+  /**
+   * Disables every foreign key constraint (bulk `NOCHECK`).
+   * @returns {Promise<void>} - Resolves when foreign keys are disabled.
+   */
   async disableForeignKeys() {
-    await this.query("EXEC sp_MSforeachtable \"ALTER TABLE ? NOCHECK CONSTRAINT all\"")
+    await this._execConstraintToggle("EXEC sp_MSforeachtable \"ALTER TABLE ? NOCHECK CONSTRAINT all\"", "disableForeignKeys")
   }
 
+  /**
+   * Re-enables and re-validates every foreign key constraint (`WITH CHECK`).
+   * @returns {Promise<void>} - Resolves when foreign keys are enabled.
+   */
   async enableForeignKeys() {
-    await this.query("EXEC sp_MSforeachtable @command1=\"print '?'\", @command2=\"ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all\"")
+    await this._execConstraintToggle("EXEC sp_MSforeachtable @command1=\"print '?'\", @command2=\"ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all\"", "enableForeignKeys")
+  }
+
+  /**
+   * Runs a bulk constraint-toggle statement. `ALTER TABLE ... NOCHECK/CHECK
+   * CONSTRAINT` needs a schema-modification lock on every table, so if the
+   * request times out it is almost always blocked by another session that is
+   * still holding a lock (a leaked/uncommitted connection). On a timeout,
+   * capture which sessions were blocking so the real culprit is named instead
+   * of leaving a bare "Request failed to complete in 15000ms".
+   * @param {string} sql - Constraint-toggle SQL.
+   * @param {string} label - Operation label for the error.
+   * @returns {Promise<void>} - Resolves when the toggle completes.
+   */
+  async _execConstraintToggle(sql, label) {
+    try {
+      await this.query(sql)
+    } catch (error) {
+      if (error instanceof Error && /Timeout: Request failed to complete/i.test(error.message)) {
+        const snapshot = await this._captureBlockingSessionsForDebug().catch(
+          (diagError) => `(blocking diagnostics query failed: ${diagError instanceof Error ? diagError.message : diagError})`
+        )
+
+        throw new Error(`${error.message}\n\n[${label} blocked] other user sessions with open transactions or active requests:\n${snapshot}`, {cause: error})
+      }
+
+      throw error
+    }
+  }
+
+  /**
+   * Snapshots every user session other than this one that holds an open
+   * transaction or is running a request, with its last statement, wait state,
+   * and blocking session — enough to identify a connection that leaked a lock.
+   * @returns {Promise<string>} - JSON snapshot, or a "(none)" marker.
+   */
+  async _captureBlockingSessionsForDebug() {
+    const rows = await this.query(
+      "SELECT s.session_id AS sessionId, s.status AS sessionStatus, s.login_time AS loginTime, " +
+      "s.last_request_start_time AS lastRequestStart, s.last_request_end_time AS lastRequestEnd, " +
+      "s.open_transaction_count AS openTransactionCount, r.status AS requestStatus, r.command AS command, " +
+      "r.wait_type AS waitType, r.wait_time AS waitTimeMs, r.blocking_session_id AS blockingSessionId, " +
+      "CAST(ib.event_info AS NVARCHAR(MAX)) AS lastSql " +
+      "FROM sys.dm_exec_sessions s " +
+      "LEFT JOIN sys.dm_exec_requests r ON r.session_id = s.session_id " +
+      "OUTER APPLY sys.dm_exec_input_buffer(s.session_id, NULL) ib " +
+      "WHERE s.is_user_process = 1 AND s.session_id <> @@SPID " +
+      "AND (s.open_transaction_count > 0 OR r.session_id IS NOT NULL)"
+    )
+
+    if (rows.length === 0) return "(none — no other user session had an open transaction or active request when queried)"
+
+    return JSON.stringify(rows, null, 2)
   }
 
   /**


### PR DESCRIPTION
## What
Adds a permanent MSSQL diagnostic: when a constraint-toggle in the between-test `truncateAllTables` reset times out, capture and attach the sessions that could be blocking it.

The reset runs `disableForeignKeys` → `sp_MSforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"`, which takes a **schema-modification (Sch-M) lock on every table**. A 15s "Request failed to complete" there is a **lock wait**, not a slow query (the statement is instant and the SQL Server container is healthy). Until now the error named no culprit.

On such a timeout, `disableForeignKeys`/`enableForeignKeys` now snapshot every other user session **in the current database** (`DB_ID()`) that holds a lock or is running a request — session id, status, last statement (`sys.dm_exec_input_buffer`), wait type/time, blocking session, open-transaction count — and attach it to the thrown error. Scoped to `DB_ID()` (via `sys.dm_tran_locks.resource_database_id`) so a multi-database server never leaks unrelated sessions' SQL. Happy path is unchanged: the snapshot runs only in the timeout `catch`.

## Why keep it permanently
The flake is intermittent and did not reproduce across ~6 sequential CI runs here, which points at **CI host resource contention** (other heavy builds running in parallel starving the test process) rather than a code-level lock leak. Either way, the next occurrence will now name the exact blocker (or show "(none)" if nothing in this DB was holding a lock — evidence for host starvation) instead of a bare timeout. It costs nothing on the happy path, so it stays.

## Notes
- The `ci: provoke/hammer ...` commits are empty CI-reproduction triggers; they collapse away on squash-merge (only the two diagnostic commits carry content).
- Codex review (scope diagnostics to `DB_ID()`) addressed and resolved.

## Verification
- `npm run build` + `npm run lint` (eslint + typecheck + fallow) green. MSSQL behavior is exercised only by the MSSQL CI shards (no local SQL Server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Also folded in
- Bump `epic-locks` `^1.0.7` → `^1.0.8` (adopts the release; velocious only deep-imports `epic-locks/build/mutex.js`, so no behavior change — build + typecheck green).