### PR TITLE
Reactive magnitude counter-cache + state-machine polish

### DIFF
--- a/spec/database/record/counter-cache-magnitude-spec.js
+++ b/spec/database/record/counter-cache-magnitude-spec.js
@@ -2,10 +2,16 @@
 
 import {registerMagnitudeCounterCache} from "../../../src/database/record/counter-cache-magnitude.js"
 
+/** The mock DB the parent counter UPDATEs are recorded against, set per test. */
+let currentMockDb = /** @type {ReturnType<typeof createMockDb> | null} */ (null)
+
 /** Mock parent model (the belongsTo target that holds the counter column). */
 class MockParent {
   /** @returns {string} */
   static tableName() { return "docker_servers" }
+
+  /** @returns {ReturnType<typeof createMockDb>} */
+  static connection() { return /** @type {ReturnType<typeof createMockDb>} */ (currentMockDb) }
 }
 
 /** Mock belongsTo relationship pointing at {@link MockParent}. */
@@ -34,22 +40,23 @@ function createMockDb() {
 }
 
 /**
- * Minimal mock record class wired for the magnitude counter-cache: attribute-keyed
- * `_attributes`, column-keyed `_changes`, plus the relationship/connection metadata
- * the feature reads.
+ * Minimal mock record modelling Velocious's representation: `_attributes` holds
+ * committed (old) column values, `_changes` holds pending (new) column values,
+ * `changes()` derives `[old, new]`, and `readAttribute` reads change-over-committed
+ * and casts declared boolean columns.
  */
 class MockBuildBase {
   /** @type {Record<string, ?>} */
   _attributes = {}
 
-  /** @type {Record<string, [?, ?]>} */
+  /** @type {Record<string, ?>} */
   _changes = {}
 
   /** @type {Array<{callback: Function, name: string}>} */
   static _registeredCallbacks = []
 
-  /** @type {ReturnType<typeof createMockDb>} */
-  static _mockDb
+  /** @type {Set<string>} */
+  static _booleanColumns = new Set()
 
   /** @returns {typeof MockBuildBase} */
   getModelClass() { return /** @type {typeof MockBuildBase} */ (this.constructor) }
@@ -57,20 +64,36 @@ class MockBuildBase {
   /** @returns {string} */
   static getModelName() { return "Build" }
 
-  /** @param {string} name @returns {?} */
-  readAttribute(name) { return this._attributes[name] }
+  /** @param {string} attribute @returns {?} */
+  readAttribute(attribute) {
+    const column = this.getModelClass().getAttributeNameToColumnNameMap()[attribute] || attribute
+    const raw = column in this._changes ? this._changes[column] : this._attributes[column]
+
+    if (this.getModelClass()._booleanColumns.has(column)) {
+      if (raw === 1) return true
+      if (raw === 0) return false
+    }
+
+    return raw
+  }
 
   /** @returns {Record<string, [?, ?]>} */
-  changes() { return this._changes }
+  changes() {
+    /** @type {Record<string, [?, ?]>} */
+    const result = {}
+
+    for (const column in this._changes) {
+      result[column] = [this._attributes[column], this._changes[column]]
+    }
+
+    return result
+  }
 
   /** @returns {Record<string, string>} */
-  static getAttributeNameToColumnNameMap() { return {dockerServerId: "docker_server_id", status: "status"} }
+  static getAttributeNameToColumnNameMap() { return {active: "active", dockerServerId: "docker_server_id", status: "status"} }
 
   /** @returns {typeof mockRelationship} */
   static getRelationshipByName() { return mockRelationship }
-
-  /** @returns {ReturnType<typeof createMockDb>} */
-  static connection() { return this._mockDb }
 
   /** @param {Function} callback */
   static beforeSave(callback) { this._registeredCallbacks.push({callback, name: "beforeSave"}) }
@@ -88,10 +111,10 @@ class MockBuildBase {
     }
   }
 
-  /** Simulates save(): beforeSave (changes visible) → clear changes (reload) → afterSave. */
+  /** Simulates save(): beforeSave (changes visible) → commit (changes folded in) → afterSave. */
   async save() {
     await this._runCallbacks("beforeSave")
-    this._attributes.id = this._attributes.id || "mock-build-id"
+    this._attributes = {...this._attributes, ...this._changes, id: this._attributes.id || "mock-build-id"}
     this._changes = {}
     await this._runCallbacks("afterSave")
   }
@@ -99,7 +122,7 @@ class MockBuildBase {
 
 /**
  * @param {typeof MockBuildBase} ModelClass
- * @param {{attributes: Record<string, ?>, changes?: Record<string, [?, ?]>}} args
+ * @param {{attributes: Record<string, ?>, changes?: Record<string, ?>}} args
  * @returns {MockBuildBase}
  */
 function buildRecord(ModelClass, {attributes, changes = {}}) {
@@ -111,18 +134,22 @@ function buildRecord(ModelClass, {attributes, changes = {}}) {
   return record
 }
 
-/** @returns {typeof MockBuildBase} */
-function registeredModelClass() {
+/**
+ * @param {{booleanColumns?: string[], magnitude?: (value: ?) => number, sourceAttribute?: string}} [options]
+ * @returns {typeof MockBuildBase}
+ */
+function registeredModelClass(options = {}) {
   class TestBuild extends MockBuildBase {}
 
   TestBuild._registeredCallbacks = []
-  TestBuild._mockDb = createMockDb()
+  TestBuild._booleanColumns = new Set(options.booleanColumns || [])
+  currentMockDb = createMockDb()
 
   registerMagnitudeCounterCache(/** @type {?} */ (TestBuild), {
     belongsTo: "dockerServer",
     counterColumn: "running_builds_count",
-    magnitude: (status) => status === "running" ? 1 : 0,
-    sourceAttribute: "status"
+    magnitude: options.magnitude || ((status) => status === "running" ? 1 : 0),
+    sourceAttribute: options.sourceAttribute || "status"
   })
 
   return TestBuild
@@ -132,13 +159,13 @@ describe("magnitudeCounterCache", {databaseCleaning: {transaction: true}}, () =>
   it("increments the parent counter by 1 when a build enters running", async () => {
     const TestBuild = registeredModelClass()
     const build = buildRecord(TestBuild, {
-      attributes: {dockerServerId: "srv1", id: "b1", status: "running"},
-      changes: {status: ["queued", "running"]}
+      attributes: {docker_server_id: "srv1", id: "b1", status: "queued"},
+      changes: {status: "running"}
     })
 
     await build.save()
 
-    expect(TestBuild._mockDb.queries).toEqual([
+    expect(currentMockDb?.queries).toEqual([
       "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + 1 WHERE `id` = 'srv1'"
     ])
   })
@@ -147,13 +174,13 @@ describe("magnitudeCounterCache", {databaseCleaning: {transaction: true}}, () =>
     for (const terminalStatus of ["passed", "failed", "timed_out", "cancelled", "restarted", "crashed"]) {
       const TestBuild = registeredModelClass()
       const build = buildRecord(TestBuild, {
-        attributes: {dockerServerId: "srv1", id: "b1", status: terminalStatus},
-        changes: {status: ["running", terminalStatus]}
+        attributes: {docker_server_id: "srv1", id: "b1", status: "running"},
+        changes: {status: terminalStatus}
       })
 
       await build.save()
 
-      expect(TestBuild._mockDb.queries).toEqual([
+      expect(currentMockDb?.queries).toEqual([
         "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'"
       ])
     }
@@ -162,25 +189,25 @@ describe("magnitudeCounterCache", {databaseCleaning: {transaction: true}}, () =>
   it("does not touch the counter when the status did not change", async () => {
     const TestBuild = registeredModelClass()
     const build = buildRecord(TestBuild, {
-      attributes: {dockerServerId: "srv1", id: "b1", status: "running"},
-      changes: {duration_label: ["10s", "11s"]}
+      attributes: {docker_server_id: "srv1", id: "b1", status: "running"},
+      changes: {duration_label: "11s"}
     })
 
     await build.save()
 
-    expect(TestBuild._mockDb.queries).toEqual([])
+    expect(currentMockDb?.queries).toEqual([])
   })
 
   it("moves the count between parents when the foreign key changes while running", async () => {
     const TestBuild = registeredModelClass()
     const build = buildRecord(TestBuild, {
-      attributes: {dockerServerId: "srv2", id: "b1", status: "running"},
-      changes: {docker_server_id: ["srv1", "srv2"]}
+      attributes: {docker_server_id: "srv1", id: "b1", status: "running"},
+      changes: {docker_server_id: "srv2"}
     })
 
     await build.save()
 
-    expect(TestBuild._mockDb.queries).toEqual([
+    expect(currentMockDb?.queries).toEqual([
       "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'",
       "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + 1 WHERE `id` = 'srv2'"
     ])
@@ -188,11 +215,31 @@ describe("magnitudeCounterCache", {databaseCleaning: {transaction: true}}, () =>
 
   it("decrements the parent counter when a running build is destroyed", async () => {
     const TestBuild = registeredModelClass()
-    const build = buildRecord(TestBuild, {attributes: {dockerServerId: "srv1", id: "b1", status: "running"}})
+    const build = buildRecord(TestBuild, {attributes: {docker_server_id: "srv1", id: "b1", status: "running"}})
 
     await build._runCallbacks("afterDestroy")
 
-    expect(TestBuild._mockDb.queries).toEqual([
+    expect(currentMockDb?.queries).toEqual([
+      "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'"
+    ])
+  })
+
+  it("normalizes the old source value through the read cast (declared boolean 1 -> true)", async () => {
+    // magnitude keys off the CAST value; the old value must be cast the same way,
+    // otherwise the raw stored `1` reads as `!== true` and the decrement is missed.
+    const TestBuild = registeredModelClass({
+      booleanColumns: ["active"],
+      magnitude: (active) => active === true ? 1 : 0,
+      sourceAttribute: "active"
+    })
+    const build = buildRecord(TestBuild, {
+      attributes: {active: 1, docker_server_id: "srv1", id: "b1"},
+      changes: {active: 0}
+    })
+
+    await build.save()
+
+    expect(currentMockDb?.queries).toEqual([
       "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'"
     ])
   })

--- a/spec/database/record/counter-cache-magnitude-spec.js
+++ b/spec/database/record/counter-cache-magnitude-spec.js
@@ -1,0 +1,199 @@
+// @ts-check
+
+import {registerMagnitudeCounterCache} from "../../../src/database/record/counter-cache-magnitude.js"
+
+/** Mock parent model (the belongsTo target that holds the counter column). */
+class MockParent {
+  /** @returns {string} */
+  static tableName() { return "docker_servers" }
+}
+
+/** Mock belongsTo relationship pointing at {@link MockParent}. */
+const mockRelationship = {
+  getForeignKey: () => "docker_server_id",
+  getPrimaryKey: () => "id",
+  getTargetModelClass: () => MockParent
+}
+
+/** Creates a mock DB connection that records the UPDATE statements issued. */
+function createMockDb() {
+  /** @type {string[]} */
+  const queries = []
+
+  return {
+    queries,
+    /** @param {string} sql */
+    query: async (sql) => { queries.push(sql.replace(/\s+/g, " ").trim()) },
+    /** @param {string} table */
+    quoteTable: (table) => `\`${table}\``,
+    /** @param {string} column */
+    quoteColumn: (column) => `\`${column}\``,
+    /** @param {?} value */
+    quote: (value) => `'${value}'`
+  }
+}
+
+/**
+ * Minimal mock record class wired for the magnitude counter-cache: attribute-keyed
+ * `_attributes`, column-keyed `_changes`, plus the relationship/connection metadata
+ * the feature reads.
+ */
+class MockBuildBase {
+  /** @type {Record<string, ?>} */
+  _attributes = {}
+
+  /** @type {Record<string, [?, ?]>} */
+  _changes = {}
+
+  /** @type {Array<{callback: Function, name: string}>} */
+  static _registeredCallbacks = []
+
+  /** @type {ReturnType<typeof createMockDb>} */
+  static _mockDb
+
+  /** @returns {typeof MockBuildBase} */
+  getModelClass() { return /** @type {typeof MockBuildBase} */ (this.constructor) }
+
+  /** @returns {string} */
+  static getModelName() { return "Build" }
+
+  /** @param {string} name @returns {?} */
+  readAttribute(name) { return this._attributes[name] }
+
+  /** @returns {Record<string, [?, ?]>} */
+  changes() { return this._changes }
+
+  /** @returns {Record<string, string>} */
+  static getAttributeNameToColumnNameMap() { return {dockerServerId: "docker_server_id", status: "status"} }
+
+  /** @returns {typeof mockRelationship} */
+  static getRelationshipByName() { return mockRelationship }
+
+  /** @returns {ReturnType<typeof createMockDb>} */
+  static connection() { return this._mockDb }
+
+  /** @param {Function} callback */
+  static beforeSave(callback) { this._registeredCallbacks.push({callback, name: "beforeSave"}) }
+
+  /** @param {Function} callback */
+  static afterSave(callback) { this._registeredCallbacks.push({callback, name: "afterSave"}) }
+
+  /** @param {Function} callback */
+  static afterDestroy(callback) { this._registeredCallbacks.push({callback, name: "afterDestroy"}) }
+
+  /** @param {string} name */
+  async _runCallbacks(name) {
+    for (const entry of this.getModelClass()._registeredCallbacks) {
+      if (entry.name === name) await entry.callback(this)
+    }
+  }
+
+  /** Simulates save(): beforeSave (changes visible) → clear changes (reload) → afterSave. */
+  async save() {
+    await this._runCallbacks("beforeSave")
+    this._attributes.id = this._attributes.id || "mock-build-id"
+    this._changes = {}
+    await this._runCallbacks("afterSave")
+  }
+}
+
+/**
+ * @param {typeof MockBuildBase} ModelClass
+ * @param {{attributes: Record<string, ?>, changes?: Record<string, [?, ?]>}} args
+ * @returns {MockBuildBase}
+ */
+function buildRecord(ModelClass, {attributes, changes = {}}) {
+  const record = new ModelClass()
+
+  record._attributes = {...attributes}
+  record._changes = {...changes}
+
+  return record
+}
+
+/** @returns {typeof MockBuildBase} */
+function registeredModelClass() {
+  class TestBuild extends MockBuildBase {}
+
+  TestBuild._registeredCallbacks = []
+  TestBuild._mockDb = createMockDb()
+
+  registerMagnitudeCounterCache(/** @type {?} */ (TestBuild), {
+    belongsTo: "dockerServer",
+    counterColumn: "running_builds_count",
+    magnitude: (status) => status === "running" ? 1 : 0,
+    sourceAttribute: "status"
+  })
+
+  return TestBuild
+}
+
+describe("magnitudeCounterCache", {databaseCleaning: {transaction: true}}, () => {
+  it("increments the parent counter by 1 when a build enters running", async () => {
+    const TestBuild = registeredModelClass()
+    const build = buildRecord(TestBuild, {
+      attributes: {dockerServerId: "srv1", id: "b1", status: "running"},
+      changes: {status: ["queued", "running"]}
+    })
+
+    await build.save()
+
+    expect(TestBuild._mockDb.queries).toEqual([
+      "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + 1 WHERE `id` = 'srv1'"
+    ])
+  })
+
+  it("decrements the parent counter by 1 when a build leaves running (any terminal state)", async () => {
+    for (const terminalStatus of ["passed", "failed", "timed_out", "cancelled", "restarted", "crashed"]) {
+      const TestBuild = registeredModelClass()
+      const build = buildRecord(TestBuild, {
+        attributes: {dockerServerId: "srv1", id: "b1", status: terminalStatus},
+        changes: {status: ["running", terminalStatus]}
+      })
+
+      await build.save()
+
+      expect(TestBuild._mockDb.queries).toEqual([
+        "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'"
+      ])
+    }
+  })
+
+  it("does not touch the counter when the status did not change", async () => {
+    const TestBuild = registeredModelClass()
+    const build = buildRecord(TestBuild, {
+      attributes: {dockerServerId: "srv1", id: "b1", status: "running"},
+      changes: {duration_label: ["10s", "11s"]}
+    })
+
+    await build.save()
+
+    expect(TestBuild._mockDb.queries).toEqual([])
+  })
+
+  it("moves the count between parents when the foreign key changes while running", async () => {
+    const TestBuild = registeredModelClass()
+    const build = buildRecord(TestBuild, {
+      attributes: {dockerServerId: "srv2", id: "b1", status: "running"},
+      changes: {docker_server_id: ["srv1", "srv2"]}
+    })
+
+    await build.save()
+
+    expect(TestBuild._mockDb.queries).toEqual([
+      "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'",
+      "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + 1 WHERE `id` = 'srv2'"
+    ])
+  })
+
+  it("decrements the parent counter when a running build is destroyed", async () => {
+    const TestBuild = registeredModelClass()
+    const build = buildRecord(TestBuild, {attributes: {dockerServerId: "srv1", id: "b1", status: "running"}})
+
+    await build._runCallbacks("afterDestroy")
+
+    expect(TestBuild._mockDb.queries).toEqual([
+      "UPDATE `docker_servers` SET `running_builds_count` = COALESCE(`running_builds_count`, 0) + -1 WHERE `id` = 'srv1'"
+    ])
+  })
+})

--- a/spec/database/record/state-machine-spec.js
+++ b/spec/database/record/state-machine-spec.js
@@ -469,6 +469,67 @@ describe("stateMachine", {databaseCleaning: {transaction: true}}, () => {
     expect(/** @type {any} */ (TestBuild).getStateMachineStateNames()).toContain("queued")
   })
 
+  it("does not double-register transition hooks when declared twice (idempotent)", () => {
+    class TestBuild extends MockModelBase {
+      /** @param {string} value */
+      setStatus(value) { this._setAttribute("status", value) }
+    }
+
+    TestBuild._registeredCallbacks = []
+
+    const definition = {
+      column: "status",
+      events: {queue: {from: "new", to: "queued"}},
+      initial: "new",
+      states: {new: {}, queued: {}}
+    }
+
+    stateMachine(TestBuild, definition)
+    stateMachine(TestBuild, definition)
+
+    const beforeSaveCount = TestBuild._registeredCallbacks.filter((entry) => entry.name === "beforeSave").length
+    const afterSaveCount = TestBuild._registeredCallbacks.filter((entry) => entry.name === "afterSave").length
+
+    expect(beforeSaveCount).toEqual(1)
+    expect(afterSaveCount).toEqual(1)
+  })
+
+  it("runs beforeExit/afterExit for the state being left, around the entered state's hooks", async () => {
+    /** @type {string[]} */
+    const callOrder = []
+
+    class TestBuild extends MockModelBase {
+      /** @param {string} value */
+      setStatus(value) { this._setAttribute("status", value) }
+    }
+
+    TestBuild._registeredCallbacks = []
+
+    stateMachine(TestBuild, {
+      column: "status",
+      events: {fail: {from: "running", to: "failed"}},
+      initial: "new",
+      states: {
+        failed: {
+          afterEnter: () => { callOrder.push("failed-afterEnter") },
+          beforeEnter: () => { callOrder.push("failed-beforeEnter") }
+        },
+        running: {
+          afterExit: () => { callOrder.push("running-afterExit") },
+          beforeExit: () => { callOrder.push("running-beforeExit") }
+        }
+      }
+    })
+
+    const build = new TestBuild({id: "123", status: "running"})
+
+    build.fail()
+    await build._runBeforeSaveCallbacks()
+    await build._runAfterSaveCallbacks()
+
+    expect(callOrder).toEqual(["running-beforeExit", "failed-beforeEnter", "failed-afterEnter", "running-afterExit"])
+  })
+
   it("defaults to 'state' column when not specified", () => {
     class TestServer extends MockModelBase {
       /** @param {string} value */

--- a/src/database/record/counter-cache-magnitude.js
+++ b/src/database/record/counter-cache-magnitude.js
@@ -99,7 +99,7 @@ function computePendingMagnitudeDelta(record, definition) {
   const foreignKeyColumn = record.getModelClass().getRelationshipByName(definition.belongsTo).getForeignKey()
 
   const newSource = record.readAttribute(definition.sourceAttribute)
-  const oldSource = sourceColumn in changes ? changes[sourceColumn][0] : newSource
+  const oldSource = oldSourceValueThroughReadCast(record, definition.sourceAttribute, sourceColumn, changes, newSource)
 
   const newParentId = currentParentId(record, definition)
   const oldParentId = foreignKeyColumn in changes ? changes[foreignKeyColumn][0] : newParentId
@@ -144,6 +144,39 @@ async function applyPendingMagnitudeDelta(record, definition, pending) {
 }
 
 /**
+ * Reads the pre-save value of the source attribute through the normal read/cast
+ * path, so `magnitude` receives the old value in the same shape as the new one
+ * (e.g. a declared boolean as `true`/`false`, not the raw stored `1`/`0`). Drops
+ * the pending change so `readAttribute` falls back to the committed value and
+ * applies the same cast a fresh read would, then restores the pending change.
+ * @param {import("./index.js").default} record - Record being saved.
+ * @param {string} sourceAttribute - Source attribute name.
+ * @param {string} sourceColumn - Source column name.
+ * @param {Record<string, [?, ?]>} changes - The record's pre-save changes (column-keyed).
+ * @param {?} currentValue - The current (new) read value, returned when the source did not change.
+ * @returns {?} The read-cast pre-save value.
+ */
+function oldSourceValueThroughReadCast(record, sourceAttribute, sourceColumn, changes, currentValue) {
+  if (!(sourceColumn in changes)) {
+    return currentValue
+  }
+
+  /**
+   * Dynamic record.
+   * @type {?} */
+  const dynamicRecord = record
+  const pendingChange = dynamicRecord._changes[sourceColumn]
+
+  delete dynamicRecord._changes[sourceColumn]
+
+  try {
+    return record.readAttribute(sourceAttribute)
+  } finally {
+    dynamicRecord._changes[sourceColumn] = pendingChange
+  }
+}
+
+/**
  * Reads the record's current foreign-key value for the counter-cache parent.
  * @param {import("./index.js").default} record - Record whose parent is targeted.
  * @param {MagnitudeCounterCacheDefinition} definition - Counter cache definition.
@@ -172,7 +205,9 @@ async function incrementParentCounter(record, definition, parentId, amount) {
     throw new Error(`magnitudeCounterCache on ${modelClass.getModelName()} could not resolve the "${definition.belongsTo}" parent model class`)
   }
 
-  const db = modelClass.connection()
+  // Update through the PARENT model's connection: the row being modified belongs
+  // to the parent, which may live on a different database/tenant than the child.
+  const db = parentModelClass.connection()
   const counterColumnSql = db.quoteColumn(definition.counterColumn)
   const truncatedAmount = Math.trunc(amount)
 

--- a/src/database/record/counter-cache-magnitude.js
+++ b/src/database/record/counter-cache-magnitude.js
@@ -16,7 +16,6 @@
  * captured in `beforeSave` (Velocious clears `changes()` during the post-update
  * reload) and consumed in `afterSave`, so the increment commits atomically with
  * the row it reflects.
- *
  * @typedef {{
  *   belongsTo: string,
  *   counterColumn: string,
@@ -152,7 +151,7 @@ async function applyPendingMagnitudeDelta(record, definition, pending) {
  * @param {import("./index.js").default} record - Record being saved.
  * @param {string} sourceAttribute - Source attribute name.
  * @param {string} sourceColumn - Source column name.
- * @param {Record<string, [?, ?]>} changes - The record's pre-save changes (column-keyed).
+ * @param {Record<string, ?>} changes - The record's pre-save changes (column-keyed).
  * @param {?} currentValue - The current (new) read value, returned when the source did not change.
  * @returns {?} The read-cast pre-save value.
  */

--- a/src/database/record/counter-cache-magnitude.js
+++ b/src/database/record/counter-cache-magnitude.js
@@ -1,0 +1,206 @@
+// @ts-check
+
+/**
+ * Reactive counter-cache driven by a per-record magnitude.
+ *
+ * Maintains a counter column on a `belongsTo` parent as the running sum of each
+ * child's magnitude — a small number derived from one source attribute (e.g.
+ * `1` while a build's `status` is `running`, else `0`). On every create, update
+ * and destroy the change in magnitude is applied to the parent as a single
+ * atomic increment (`SET col = col + delta`), and when the foreign key changes
+ * the magnitude is moved from the old parent to the new one.
+ *
+ * Because the counter is derived from the source attribute and diffed on every
+ * write, it follows that attribute automatically no matter which code path wrote
+ * it — there is no per-transition increment/decrement to forget. The old value is
+ * captured in `beforeSave` (Velocious clears `changes()` during the post-update
+ * reload) and consumed in `afterSave`, so the increment commits atomically with
+ * the row it reflects.
+ *
+ * @typedef {{
+ *   belongsTo: string,
+ *   counterColumn: string,
+ *   sourceAttribute: string,
+ *   magnitude: (sourceValue: ?) => number
+ * }} MagnitudeCounterCacheDefinition
+ */
+
+/**
+ * Captured pending magnitude change stashed on a record between beforeSave and afterSave.
+ * @typedef {{newMagnitude: number, oldMagnitude: number, newParentId: ?, oldParentId: ?}} PendingMagnitudeDelta
+ */
+
+/**
+ * Registers a reactive magnitude counter-cache on a model class.
+ * @param {typeof import("./index.js").default} modelClass - Model class to add the counter cache to.
+ * @param {MagnitudeCounterCacheDefinition} definition - Counter cache definition.
+ * @returns {void}
+ */
+export function registerMagnitudeCounterCache(modelClass, definition) {
+  /**
+   * Dynamic class.
+   * @type {?} */
+  const dynamicClass = modelClass
+  const registeredFlag = `_magnitudeCounterCacheRegistered_${definition.counterColumn}`
+
+  // Idempotent per counter column: re-declaring (or subclassing) must not double-register.
+  if (Object.prototype.hasOwnProperty.call(dynamicClass, registeredFlag) && dynamicClass[registeredFlag]) {
+    return
+  }
+
+  dynamicClass[registeredFlag] = true
+
+  const pendingKey = `_magnitudeCounterCachePending_${definition.counterColumn}`
+
+  modelClass.beforeSave(async function (record) {
+    /**
+     * Dynamic record.
+     * @type {?} */
+    const dynamicRecord = record
+
+    dynamicRecord[pendingKey] = computePendingMagnitudeDelta(record, definition)
+  })
+
+  modelClass.afterSave(async function (record) {
+    /**
+     * Dynamic record.
+     * @type {?} */
+    const dynamicRecord = record
+    const pending = /** @type {PendingMagnitudeDelta | null} */ (dynamicRecord[pendingKey])
+
+    dynamicRecord[pendingKey] = null
+
+    if (pending) {
+      await applyPendingMagnitudeDelta(record, definition, pending)
+    }
+  })
+
+  modelClass.afterDestroy(async function (record) {
+    const magnitude = definition.magnitude(record.readAttribute(definition.sourceAttribute))
+    const parentId = currentParentId(record, definition)
+
+    if (parentId && magnitude !== 0) {
+      await incrementParentCounter(record, definition, parentId, -magnitude)
+    }
+  })
+}
+
+/**
+ * Diffs the source attribute (and foreign key) across the pending save to capture
+ * how the parent counter should move. Runs in beforeSave, where `changes()` still
+ * holds the pre-save values.
+ * @param {import("./index.js").default} record - Record being saved.
+ * @param {MagnitudeCounterCacheDefinition} definition - Counter cache definition.
+ * @returns {PendingMagnitudeDelta} The captured magnitude change.
+ */
+function computePendingMagnitudeDelta(record, definition) {
+  const changes = record.changes()
+  const sourceColumn = columnNameForAttribute(record, definition.sourceAttribute)
+  const foreignKeyColumn = record.getModelClass().getRelationshipByName(definition.belongsTo).getForeignKey()
+
+  const newSource = record.readAttribute(definition.sourceAttribute)
+  const oldSource = sourceColumn in changes ? changes[sourceColumn][0] : newSource
+
+  const newParentId = currentParentId(record, definition)
+  const oldParentId = foreignKeyColumn in changes ? changes[foreignKeyColumn][0] : newParentId
+
+  return {
+    newMagnitude: definition.magnitude(newSource),
+    oldMagnitude: definition.magnitude(oldSource),
+    newParentId,
+    oldParentId
+  }
+}
+
+/**
+ * Applies a captured magnitude change to the parent counter(s) as atomic increments.
+ * @param {import("./index.js").default} record - Record that was saved.
+ * @param {MagnitudeCounterCacheDefinition} definition - Counter cache definition.
+ * @param {PendingMagnitudeDelta} pending - The captured magnitude change.
+ * @returns {Promise<void>}
+ */
+async function applyPendingMagnitudeDelta(record, definition, pending) {
+  const {newMagnitude, oldMagnitude, newParentId, oldParentId} = pending
+
+  if (oldParentId === newParentId) {
+    const delta = newMagnitude - oldMagnitude
+
+    if (newParentId && delta !== 0) {
+      await incrementParentCounter(record, definition, newParentId, delta)
+    }
+
+    return
+  }
+
+  // The foreign key moved: take the old magnitude off the old parent and put the
+  // new magnitude on the new parent.
+  if (oldParentId && oldMagnitude !== 0) {
+    await incrementParentCounter(record, definition, oldParentId, -oldMagnitude)
+  }
+
+  if (newParentId && newMagnitude !== 0) {
+    await incrementParentCounter(record, definition, newParentId, newMagnitude)
+  }
+}
+
+/**
+ * Reads the record's current foreign-key value for the counter-cache parent.
+ * @param {import("./index.js").default} record - Record whose parent is targeted.
+ * @param {MagnitudeCounterCacheDefinition} definition - Counter cache definition.
+ * @returns {?} The current foreign-key value.
+ */
+function currentParentId(record, definition) {
+  const foreignKeyColumn = record.getModelClass().getRelationshipByName(definition.belongsTo).getForeignKey()
+
+  return record.readAttribute(attributeNameForColumn(record, foreignKeyColumn))
+}
+
+/**
+ * Atomically adds `amount` to the parent's counter column for one parent row.
+ * @param {import("./index.js").default} record - Child record (for connection + relationship metadata).
+ * @param {MagnitudeCounterCacheDefinition} definition - Counter cache definition.
+ * @param {?} parentId - Parent primary-key value.
+ * @param {number} amount - Signed integer to add.
+ * @returns {Promise<void>}
+ */
+async function incrementParentCounter(record, definition, parentId, amount) {
+  const modelClass = record.getModelClass()
+  const relationship = modelClass.getRelationshipByName(definition.belongsTo)
+  const parentModelClass = relationship.getTargetModelClass()
+
+  if (!parentModelClass) {
+    throw new Error(`magnitudeCounterCache on ${modelClass.getModelName()} could not resolve the "${definition.belongsTo}" parent model class`)
+  }
+
+  const db = modelClass.connection()
+  const counterColumnSql = db.quoteColumn(definition.counterColumn)
+  const truncatedAmount = Math.trunc(amount)
+
+  await db.query(
+    `UPDATE ${db.quoteTable(parentModelClass.tableName())} ` +
+    `SET ${counterColumnSql} = COALESCE(${counterColumnSql}, 0) + ${truncatedAmount} ` +
+    `WHERE ${db.quoteColumn(relationship.getPrimaryKey())} = ${db.quote(parentId)}`
+  )
+}
+
+/**
+ * Resolves the column name backing an attribute name.
+ * @param {import("./index.js").default} record - Record.
+ * @param {string} attributeName - Attribute name.
+ * @returns {string} The column name for the attribute (falls back to the attribute name).
+ */
+function columnNameForAttribute(record, attributeName) {
+  return record.getModelClass().getAttributeNameToColumnNameMap()[attributeName] || attributeName
+}
+
+/**
+ * Resolves the attribute name backing a column name.
+ * @param {import("./index.js").default} record - Record.
+ * @param {string} columnName - Column name.
+ * @returns {string} The attribute name for the column (falls back to the column name).
+ */
+function attributeNameForColumn(record, columnName) {
+  const map = record.getModelClass().getAttributeNameToColumnNameMap()
+
+  return Object.keys(map).find((attributeName) => map[attributeName] === columnName) || columnName
+}

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -47,6 +47,8 @@ import {defineModelScope} from "../../utils/model-scope.js"
 import { normalizeDateStringForWrite, normalizeDateValueForRead, normalizeDateValueForWrite } from "../datetime-storage.js"
 import {formatValue} from "../../utils/format-value.js"
 import {captureCreateAuditChanges, captureUpdateAuditChanges, createAudit, createCreateAudit, createDestroyAudit, createUpdateAudit, registerAuditCallback, registerAuditing, withoutAudit} from "./auditing.js"
+import {registerMagnitudeCounterCache} from "./counter-cache-magnitude.js"
+import {stateMachine} from "./state-machine.js"
 import ValidatorsFormat from "./validators/format.js"
 import ValidatorsLength from "./validators/length.js"
 import ValidatorsPresence from "./validators/presence.js"
@@ -666,6 +668,30 @@ class VelociousDatabaseRecord {
    */
   static audited() {
     registerAuditing(this)
+  }
+
+  /**
+   * Declares an aasm-style state machine on this model: named states, events
+   * (guarded transitions), and enter/exit + before/after transition hooks. See
+   * `state-machine.js`. Generates `event()` / `eventAndSave()` / `canEvent()`
+   * transition methods per declared event.
+   * @param {import("./state-machine.js").StateMachineDefinition} definition - State machine definition.
+   * @returns {void}
+   */
+  static stateMachine(definition) {
+    stateMachine(this, definition)
+  }
+
+  /**
+   * Maintains a counter column on a `belongsTo` parent as the sum of a per-record
+   * magnitude, kept current by atomic increments diffed on every create/update/
+   * destroy (and moved between parents when the foreign key changes). See
+   * `counter-cache-magnitude.js`.
+   * @param {import("./counter-cache-magnitude.js").MagnitudeCounterCacheDefinition} definition - Counter cache definition.
+   * @returns {void}
+   */
+  static magnitudeCounterCache(definition) {
+    registerMagnitudeCounterCache(this, definition)
   }
 
   /**

--- a/src/database/record/state-machine.js
+++ b/src/database/record/state-machine.js
@@ -10,7 +10,9 @@
  * }} StateMachineDefinition
  * @typedef {{
  *   beforeEnter?: (model: import("./index.js").default) => void | Promise<void>,
- *   afterEnter?: (model: import("./index.js").default) => void | Promise<void>
+ *   afterEnter?: (model: import("./index.js").default) => void | Promise<void>,
+ *   beforeExit?: (model: import("./index.js").default) => void | Promise<void>,
+ *   afterExit?: (model: import("./index.js").default) => void | Promise<void>
  * }} StateDefinition
  * @typedef {{
  *   from: string | string[],
@@ -68,6 +70,14 @@ export function stateMachine(ModelClass, definition) {
    * @type {?} */
   const dynamicClass = ModelClass
 
+  // Idempotent: re-declaring on the same class (or a re-evaluated module) must not
+  // register the before/after-save transition hooks twice. Guard on an own property
+  // so a subclass declaring its own machine is unaffected by the parent's flag.
+  if (Object.prototype.hasOwnProperty.call(dynamicClass, "_stateMachineRegistered") && dynamicClass._stateMachineRegistered) {
+    return
+  }
+
+  dynamicClass._stateMachineRegistered = true
   dynamicClass._stateMachineDefinition = definition
   dynamicClass._stateMachineColumn = column
 
@@ -229,7 +239,13 @@ export function stateMachine(ModelClass, definition) {
       await eventDef.before(model)
     }
 
-    // Run state-level beforeEnter callback
+    // Run the exited state's beforeExit, then the entered state's beforeEnter
+    const fromStateDefinition = definition.states[pending.from]
+
+    if (fromStateDefinition?.beforeExit) {
+      await fromStateDefinition.beforeExit(model)
+    }
+
     const stateDefinition = definition.states[pending.to]
 
     if (stateDefinition?.beforeEnter) {
@@ -252,11 +268,17 @@ export function stateMachine(ModelClass, definition) {
     // Clear the pending transition now that save is complete
     dynamicModel[PENDING_TRANSITION_KEY] = null
 
-    // Run state-level afterEnter callback
+    // Run the entered state's afterEnter, then the exited state's afterExit
     const stateDefinition = definition.states[pending.to]
 
     if (stateDefinition?.afterEnter) {
       await stateDefinition.afterEnter(model)
+    }
+
+    const fromStateDefinition = definition.states[pending.from]
+
+    if (fromStateDefinition?.afterExit) {
+      await fromStateDefinition.afterExit(model)
     }
 
     // Run event-level after callback


### PR DESCRIPTION
Two model-behavior features (both declared statically, mirroring `audited()`), foundational for fixing TensorBuzz's docker-server build-slot leak by making a docker server's `running_builds_count` a reactive counter of builds in `running` status.

## `Model.stateMachine(definition)`
The aasm-style engine already in `state-machine.js`, now:
- **Exposed as a static** on the base record class (`Build.stateMachine({...})`), like `audited()`.
- **Idempotent** — an own-property guard so re-declaring/subclassing can't double-register the before/after-save transition hooks (the old free function double-registered).
- **`beforeExit`/`afterExit` state hooks** added for aasm parity (fire for the state being *left*, around the entered state's enter hooks).

Unchanged: per-event `event()` / `eventAndSave()` / `canEvent()` / `canEventAsync()`, event `before`/`after`, state `beforeEnter`/`afterEnter`, the `{from,to}` pending-transition stash.

## `Model.magnitudeCounterCache({belongsTo, counterColumn, sourceAttribute, magnitude})`
New reactive counter-cache (port of the in-house `awesome_counter_cache` idea). Maintains a counter column on a `belongsTo` parent as the running sum of each child's **magnitude** — a number derived from one source attribute (e.g. `1` while `status === "running"`, else `0`).

- The magnitude change is captured in `beforeSave` (Velocious clears `changes()` during the post-update reload) and applied in `afterSave` as **one atomic increment** (`SET col = col + delta`).
- Moves the magnitude between parents when the foreign key changes; decrements on destroy.
- Because it diffs the source attribute on **every** write, the counter follows that attribute regardless of which code path wrote it — there's no per-transition increment/decrement to forget (the exact robustness property that fixes the downstream slot leak, where cancel/restart paths currently forget to decrement).

## Tests
`state-machine-spec.js`: idempotent guard, exit-hook ordering. New `counter-cache-magnitude-spec.js`: enter→+1 / leave→−1 (every terminal state) exactly once, no-op when the source is unchanged, FK-reassignment moves the count, destroy decrements. `npm run lint` + full build green; 20 specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)