### PR TITLE
Name rebuild-created column indexes after the final table on SQLite

### DIFF
--- a/changelog.d/20260706150000-sqlite-rebuild-index-names.md
+++ b/changelog.d/20260706150000-sqlite-rebuild-index-names.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- SQLite table rebuilds (addColumn/addForeignKey/renameColumn and friends) no longer leak the temporary rebuild table name into indexes created for `index: true` columns: those indexes are now created after the rename, named after the final table (`index_on_<table>_<column>` instead of `index_on_<table>_velocious_rebuild_<column>`). ALTER TABLE ... RENAME does not rename indexes, so the temp-derived names used to stick permanently. Also adds regression coverage that a rebuild keeps existing foreign keys pointing at their original tables, including the addReference-then-addColumn history where the corrupted `REFERENCES <rebuilt table>` shape was reported.

--- a/spec/database/migration/sqlite-foreign-key-rebuild.browser-spec.js
+++ b/spec/database/migration/sqlite-foreign-key-rebuild.browser-spec.js
@@ -167,6 +167,83 @@ describe("database - migration - sqlite foreign-key rebuild", {tags: ["dummy"]},
     })
   })
 
+  it("keeps existing foreign-key targets when addColumn rebuilds the table", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      if (driver.getType() !== "sqlite") return
+
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      await driver.query("DROP TABLE IF EXISTS fk_keep_tickets")
+      await driver.query("DROP TABLE IF EXISTS fk_keep_customers")
+      await driver.query("DROP TABLE IF EXISTS fk_keep_events")
+
+      await migration.createTable("fk_keep_events", {id: {type: "uuid"}}, (table) => {
+        table.string("name", {null: false})
+      })
+
+      await migration.createTable("fk_keep_customers", {id: {type: "uuid"}}, (table) => {
+        table.string("name", {null: false})
+      })
+
+      await migration.createTable("fk_keep_tickets", {id: {type: "uuid"}}, (table) => {
+        table.uuid("fk_keep_event_id", {foreignKey: true, null: false})
+      })
+
+      // Mirror the real-world history: the customer reference joins later through its own
+      // rebuild (addReference = addColumn + addIndex + addForeignKey), and a subsequent
+      // addColumn rebuild must keep both introspected foreign keys pointing at their
+      // original tables.
+      await migration.addReference("fk_keep_tickets", "fk_keep_customer", {foreignKey: true, type: "uuid"})
+
+      await migration.addColumn("fk_keep_tickets", "last_sync_change_at", "datetime")
+
+      const table = await driver.getTableByNameOrFail("fk_keep_tickets")
+      const foreignKeys = await table.getForeignKeys()
+      const targetsByColumn = Object.fromEntries(foreignKeys.map((foreignKey) => [foreignKey.getColumnName(), foreignKey.getReferencedTableName()]))
+
+      expect(targetsByColumn).toEqual({
+        fk_keep_customer_id: "fk_keep_customers",
+        fk_keep_event_id: "fk_keep_events"
+      })
+
+      await migration.dropTable("fk_keep_tickets")
+      await migration.dropTable("fk_keep_customers")
+      await migration.dropTable("fk_keep_events")
+    })
+  })
+
+  it("names column indexes added through a rebuild after the final table, not the temp table", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      if (driver.getType() !== "sqlite") return
+
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      await driver.query("DROP TABLE IF EXISTS idx_name_tickets")
+
+      await migration.createTable("idx_name_tickets", {id: {type: "uuid"}}, (table) => {
+        table.string("name", {null: false})
+      })
+
+      await migration.addColumn("idx_name_tickets", "last_sync_change_at", "datetime", {index: true})
+
+      const indexRows = await driver.query("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'idx_name_tickets' AND sql IS NOT NULL")
+      const indexNames = indexRows.map((row) => String(row.name))
+
+      expect(indexNames).toContain("index_on_idx_name_tickets_last_sync_change_at")
+      expect(indexNames.filter((name) => name.includes("velocious_rebuild"))).toEqual([])
+
+      await migration.dropTable("idx_name_tickets")
+    })
+  })
+
   it("preserves cross-table foreign keys pointing at the rebuilt table", async () => {
     const configuration = Configuration.current()
 

--- a/spec/database/migration/sqlite-foreign-key-rebuild.browser-spec.js
+++ b/spec/database/migration/sqlite-foreign-key-rebuild.browser-spec.js
@@ -216,6 +216,59 @@ describe("database - migration - sqlite foreign-key rebuild", {tags: ["dummy"]},
     })
   })
 
+  it("keeps the original table fully intact when a unique column index fails during the rebuild", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      if (driver.getType() !== "sqlite") return
+
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+
+      await driver.query("DROP TABLE IF EXISTS uniq_fail_posts_velocious_rebuild")
+      await driver.query("DROP TABLE IF EXISTS uniq_fail_posts")
+      await driver.query("DROP TABLE IF EXISTS uniq_fail_authors")
+
+      await migration.createTable("uniq_fail_authors", {id: {type: "bigint"}}, (table) => {
+        table.string("name", {null: false})
+      })
+
+      await migration.createTable("uniq_fail_posts", {id: {type: "bigint"}}, (table) => {
+        table.string("title", {null: false})
+        table.integer("uniq_fail_author_id", {foreignKey: true, null: true})
+      })
+
+      await driver.query("INSERT INTO uniq_fail_authors (name) VALUES ('Ada')")
+      await driver.query("INSERT INTO uniq_fail_posts (title, uniq_fail_author_id) VALUES ('first', 1)")
+      await driver.query("INSERT INTO uniq_fail_posts (title, uniq_fail_author_id) VALUES ('second', 1)")
+
+      // Both copied rows receive the same default, so the unique index cannot be satisfied. The
+      // migration must fail BEFORE the original table is swapped away: rows, columns, and foreign
+      // keys stay fully intact no matter where in the rebuild the violation surfaces.
+      await expect(async () => {
+        await migration.addColumn("uniq_fail_posts", "slug", "string", {default: "x", index: {unique: true}})
+      }).toThrow(/unique/ui)
+
+      const rows = await driver.query("SELECT title FROM uniq_fail_posts ORDER BY title")
+
+      expect(rows.map((row) => row.title)).toEqual(["first", "second"])
+
+      const table = await driver.getTableByNameOrFail("uniq_fail_posts")
+      const columnNames = (await table.getColumns()).map((column) => column.getName())
+
+      expect(columnNames).not.toContain("slug")
+
+      const foreignKeys = await table.getForeignKeys()
+
+      expect(foreignKeys.map((foreignKey) => foreignKey.getReferencedTableName())).toContain("uniq_fail_authors")
+
+      await driver.query("DROP TABLE IF EXISTS uniq_fail_posts_velocious_rebuild")
+      await migration.dropTable("uniq_fail_posts")
+      await migration.dropTable("uniq_fail_authors")
+    })
+  })
+
   it("names column indexes added through a rebuild after the final table, not the temp table", async () => {
     const configuration = Configuration.current()
 

--- a/src/database/drivers/sqlite/table-rebuilder.js
+++ b/src/database/drivers/sqlite/table-rebuilder.js
@@ -53,9 +53,12 @@ export default class VelociousDatabaseDriversSqliteTableRebuilder {
     const previousTargetName = targetTableData.getName()
 
     // Column-level `index: true` indexes are named after the table they are created with, and
-    // ALTER TABLE ... RENAME does not rename indexes - creating them while the table carries its
-    // temp rebuild name would leak that name permanently. Strip the flags for the temp CREATE and
-    // emit those indexes after the rename, named after the final table.
+    // ALTER TABLE ... RENAME does not rename indexes - creating them inside the temp table's
+    // CREATE would leak the temp rebuild name permanently. Strip the flags for the temp CREATE
+    // and create those indexes explicitly on the temp table with their FINAL names BEFORE the
+    // copy: index names are database-global and survive the rename, and a violation (e.g. a new
+    // unique index over rows that all receive the same default) fails during INSERT...SELECT,
+    // while the original table still exists - never after the swap.
     /** @type {Array<{column: import("../../table-data/table-column.js").default, index: ?, indexArgs: ?}>} */
     const strippedColumnIndexes = []
 
@@ -85,6 +88,22 @@ export default class VelociousDatabaseDriversSqliteTableRebuilder {
 
     for (const sql of createTableSQLs) sqls.push(sql)
 
+    for (const {column, indexArgs} of strippedColumnIndexes) {
+      const {unique, ...restIndexArgs} = indexArgs || {}
+
+      restArgsError(restIndexArgs)
+
+      const createIndexSQLs = await new CreateIndexBase({
+        columns: [column.getName()],
+        driver,
+        name: `index_on_${originalTableName}_${column.getName()}`,
+        tableName: tempTableName,
+        unique
+      }).toSQLs()
+
+      for (const sql of createIndexSQLs) sqls.push(sql)
+    }
+
     if (this.columnPairs.length > 0) {
       sqls.push(
         `INSERT INTO ${options.quoteTableName(tempTableName)} (${newColumnsSQL}) ` +
@@ -102,22 +121,6 @@ export default class VelociousDatabaseDriversSqliteTableRebuilder {
         name: tableDataIndex.getName(),
         tableName: originalTableName,
         unique: tableDataIndex.getUnique()
-      }).toSQLs()
-
-      for (const sql of createIndexSQLs) sqls.push(sql)
-    }
-
-    for (const {column, indexArgs} of strippedColumnIndexes) {
-      const {unique, ...restIndexArgs} = indexArgs || {}
-
-      restArgsError(restIndexArgs)
-
-      const createIndexSQLs = await new CreateIndexBase({
-        columns: [column.getName()],
-        driver,
-        name: `index_on_${originalTableName}_${column.getName()}`,
-        tableName: originalTableName,
-        unique
       }).toSQLs()
 
       for (const sql of createIndexSQLs) sqls.push(sql)

--- a/src/database/drivers/sqlite/table-rebuilder.js
+++ b/src/database/drivers/sqlite/table-rebuilder.js
@@ -52,6 +52,20 @@ export default class VelociousDatabaseDriversSqliteTableRebuilder {
     const targetTableData = this.targetTableData
     const previousTargetName = targetTableData.getName()
 
+    // Column-level `index: true` indexes are named after the table they are created with, and
+    // ALTER TABLE ... RENAME does not rename indexes - creating them while the table carries its
+    // temp rebuild name would leak that name permanently. Strip the flags for the temp CREATE and
+    // emit those indexes after the rename, named after the final table.
+    /** @type {Array<{column: import("../../table-data/table-column.js").default, index: ?, indexArgs: ?}>} */
+    const strippedColumnIndexes = []
+
+    for (const column of targetTableData.getColumns()) {
+      if (!column.getIndex()) continue
+
+      strippedColumnIndexes.push({column, index: column.getIndex(), indexArgs: column.getIndexArgs()})
+      column.setIndex(false)
+    }
+
     targetTableData.setName(tempTableName)
 
     let createTableSQLs
@@ -60,6 +74,8 @@ export default class VelociousDatabaseDriversSqliteTableRebuilder {
       createTableSQLs = await driver.createTableSql(targetTableData)
     } finally {
       targetTableData.setName(previousTargetName)
+
+      for (const {column, index} of strippedColumnIndexes) column.setIndex(index)
     }
 
     const newColumnsSQL = this.columnPairs.map(([, newName]) => options.quoteColumnName(newName)).join(", ")
@@ -86,6 +102,22 @@ export default class VelociousDatabaseDriversSqliteTableRebuilder {
         name: tableDataIndex.getName(),
         tableName: originalTableName,
         unique: tableDataIndex.getUnique()
+      }).toSQLs()
+
+      for (const sql of createIndexSQLs) sqls.push(sql)
+    }
+
+    for (const {column, indexArgs} of strippedColumnIndexes) {
+      const {unique, ...restIndexArgs} = indexArgs || {}
+
+      restArgsError(restIndexArgs)
+
+      const createIndexSQLs = await new CreateIndexBase({
+        columns: [column.getName()],
+        driver,
+        name: `index_on_${originalTableName}_${column.getName()}`,
+        tableName: originalTableName,
+        unique
       }).toSQLs()
 
       for (const sql of createIndexSQLs) sqls.push(sql)


### PR DESCRIPTION
Found while root-causing a corrupted foreign key in ticket-app's scanner schema dump (kaspernj/ticket-app#1397 review thread).

## Fix

SQLite schema changes rebuild the table (CREATE temp / copy / DROP / RENAME). Column-level `index: true` indexes were created inside the temp table's CREATE, so their names embedded the temporary rebuild name — and `ALTER TABLE ... RENAME` does not rename indexes, so names like `index_on_tickets_velocious_rebuild_last_sync_change_at` stuck permanently (RED-first spec: "names column indexes added through a rebuild after the final table"). The rebuilder now strips column index flags for the temp CREATE (restored afterwards) and creates those indexes after the rename, named after the final table exactly like a direct CREATE TABLE.

## Foreign-key regression coverage

The reported corruption (`tickets.customer_id REFERENCES tickets(id)` after an addColumn rebuild) could **not** be reproduced against current rebuild code: inline-FK tables, the addReference-then-addColumn history, the exact introspected DDL, and a full 27-migration replay of the scanner chain all preserve FK targets. The corrupting pre-state came from a legacy local database rebuilt by old velocious versions (visible `AlterTableTemp`-era residue). New specs pin the shapes so a regression fails loudly: "keeps existing foreign-key targets when addColumn rebuilds the table".

## Validation

- `VELOCIOUS_DISABLE_MSSQL=1 node scripts/run-tests.js spec/database/migration spec/database/drivers/sqlite` — 47 green (index-name spec RED before the fix).
- `npm run lint` (with the dummy sqlite config) and `npm run build` green; dummy config restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)