### PR TITLE
Initialize audited relationships during model setup

### DIFF
--- a/spec/database/record/auditing.browser-spec.js
+++ b/spec/database/record/auditing.browser-spec.js
@@ -215,6 +215,13 @@ async function expectUuidColumn(driver, tableName, columnName) {
 }
 
 describe("Record - auditing", {tags: ["dummy"]}, () => {
+  it("registers audit relationships during model initialization", async () => {
+    await withAuditScratchTables(async ({SharedAuditWidget, Widget}) => {
+      expect("audits" in SharedAuditWidget.getRelationshipsMap()).toEqual(true)
+      expect("audits" in Widget.getRelationshipsMap()).toEqual(true)
+    })
+  })
+
   it("records automatic and manual audits for audited models", async () => {
     await withAuditScratchTables(async ({driver, SharedAuditWidget}) => {
       /** @type {Array<{action: string, recordId: number | string}>} */

--- a/spec/database/record/auditing.browser-spec.js
+++ b/spec/database/record/auditing.browser-spec.js
@@ -1,9 +1,11 @@
 // @ts-check
 
 import Configuration from "../../../src/configuration.js"
+import Current from "../../../src/current.js"
 import {AuditEvents} from "../../../src/database/record/auditing.js"
 import DatabaseRecord from "../../../src/database/record/index.js"
 import Migration from "../../../src/database/migration/index.js"
+import {createTenantTestConfiguration} from "../../helpers/tenant-test-helpers.js"
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
@@ -220,6 +222,117 @@ describe("Record - auditing", {tags: ["dummy"]}, () => {
       expect("audits" in SharedAuditWidget.getRelationshipsMap()).toEqual(true)
       expect("audits" in Widget.getRelationshipsMap()).toEqual(true)
     })
+  })
+
+  it("uses a consumer Audit model registered after an audited model initializes", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const configuration = Configuration.current()
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const modelClasses = configuration.getModelClasses()
+      const previousAudit = modelClasses.Audit
+      const previousSharedAuditWidget = modelClasses.SharedAuditWidget
+
+      class SharedAuditWidget extends DatabaseRecord {
+        /** @returns {string} - Table name. */
+        static tableName() { return "shared_audit_widgets" }
+      }
+
+      class Audit extends DatabaseRecord {
+        /** @returns {string} - Table name. */
+        static tableName() { return "audits" }
+      }
+
+      try {
+        await dropAuditScratchTables(driver)
+        await migration.createTable("shared_audit_widgets", (table) => {
+          table.string("name")
+          table.timestamps()
+        })
+
+        SharedAuditWidget.audited()
+        await SharedAuditWidget.initializeRecord({configuration})
+        await Audit.initializeRecord({configuration})
+
+        const widget = await SharedAuditWidget.create({name: "Late audit model widget"})
+        const audits = await widget.audits().toArray()
+
+        expect(audits.length).toBeGreaterThanOrEqual(1)
+        expect(audits[0]).toBeInstanceOf(Audit)
+      } finally {
+        restoreModelClass(modelClasses, "Audit", previousAudit)
+        restoreModelClass(modelClasses, "SharedAuditWidget", previousSharedAuditWidget)
+        await dropAuditScratchTables(driver)
+      }
+    })
+  })
+
+  it("does not cache shared audits for tenant-switched models initialized outside tenant scope", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-audit-tenant")
+    const tenant = {slug: "alpha"}
+    const modelClasses = configuration.getModelClasses()
+    let previousConfiguration
+    const previousGadget = modelClasses.Gadget
+
+    class Gadget extends DatabaseRecord {
+      /** @returns {string} - Table name. */
+      static tableName() { return "gadgets" }
+    }
+
+    Gadget.switchesTenantDatabase(({tenant: currentTenant}) => currentTenant ? "projectTenant" : undefined)
+    Gadget.audited()
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // Ignore missing current configuration.
+      }
+
+      configuration.setCurrent()
+
+      await configuration.ensureConnections(async (dbs) => {
+        const migration = new Migration({configuration, databaseIdentifier: "default", db: dbs.default})
+
+        await migration.createSharedAuditTables()
+        await migration.createTable("gadgets", (table) => {
+          table.string("name")
+          table.timestamps()
+        })
+        await Gadget.initializeRecord({configuration})
+      })
+
+      await configuration.runWithTenant(tenant, async () => {
+        await configuration.ensureConnections(async (dbs) => {
+          const migration = new Migration({configuration, databaseIdentifier: "projectTenant", db: dbs.projectTenant})
+
+          await migration.createSharedAuditTables()
+          await migration.createTable("gadgets", (table) => {
+            table.string("name")
+            table.timestamps()
+          })
+          await migration.createDedicatedAuditTable("gadgets")
+
+          const gadget = await Gadget.create({name: "Tenant gadget"})
+          const dedicatedRows = /** @type {Array<{action: string, gadget_id: number | string}>} */ (await dbs.projectTenant.query(`
+            SELECT
+              audit_actions.action AS action,
+              gadget_audits.gadget_id AS gadget_id
+            FROM ${dbs.projectTenant.quoteTable("gadget_audits")}
+            INNER JOIN ${dbs.projectTenant.quoteTable("audit_actions")} ON ${dbs.projectTenant.quoteTable("audit_actions")}.${dbs.projectTenant.quoteColumn("id")} = ${dbs.projectTenant.quoteTable("gadget_audits")}.${dbs.projectTenant.quoteColumn("audit_action_id")}
+            WHERE gadget_audits.gadget_id = ${dbs.projectTenant.quote(gadget.id())}
+          `))
+          const sharedRows = (await auditRows(dbs.projectTenant)).filter((row) => row.auditableType === "Gadget")
+
+          expect(dedicatedRows.map((row) => [row.action, row.gadget_id])).toContainEqual(["create", gadget.id()])
+          expect(sharedRows).toEqual([])
+        })
+      })
+    } finally {
+      previousConfiguration?.setCurrent()
+      restoreModelClass(modelClasses, "Gadget", previousGadget)
+      await cleanup()
+    }
   })
 
   it("records automatic and manual audits for audited models", async () => {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -15,6 +15,7 @@ import {digg} from "diggerize"
 import gettextConfig from "gettext-universal/build/src/config.js"
 import translate from "gettext-universal/build/src/translate.js"
 import Ability from "./authorization/ability.js"
+import {initializeAuditedModelRelationships} from "./database/record/auditing.js"
 import EventEmitter from "./utils/event-emitter.js"
 import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channel-subscribers.js"
 import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
@@ -1807,6 +1808,7 @@ export default class VelociousConfiguration {
       }
 
       await this.getEnvironmentHandler().initializePackageModels(this)
+      await initializeAuditedModelRelationships(this)
 
       await this.getEnvironmentHandler().initializeFrontendModelWebsocketPublishers(this)
     }

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -55,6 +55,8 @@ const dedicatedTableCache = new Map()
 /** @type {Map<string, typeof import("./index.js").default>} */
 const auditClassCache = new Map()
 
+const generatedAuditRelationships = new WeakSet()
+
 // ---------------------------------------------------------------------------
 // Global event bus (like ActiveRecordAuditable::Events)
 // ---------------------------------------------------------------------------
@@ -152,10 +154,7 @@ async function resolveAuditTableData(modelClass) {
   modelClass._auditTableData = tableData
   modelClass._auditTableResolved = true
 
-  // Register relationships now that we know the table type.
-  if (!modelClass._relationshipExists("audits")) {
-    modelClass.hasMany("audits", (query) => query.order({column: "created_at", direction: "DESC"}), {klass: tableData.auditClass, foreignKey: tableData.foreignKey, polymorphic: !tableData.dedicated})
-  }
+  registerAuditRelationship(modelClass, tableData)
 
   return tableData
 }
@@ -196,16 +195,8 @@ async function buildAuditTableData(modelClass) {
     }
   }
 
-  const cacheKey = `shared:${modelClass.getConfiguredDatabaseIdentifier()}`
-  let auditClass = auditClassCache.get(cacheKey)
-
-  if (!auditClass) {
-    auditClass = sharedAuditClass(modelClass)
-    auditClassCache.set(cacheKey, auditClass)
-  }
-
   return {
-    auditClass,
+    auditClass: cachedSharedAuditClass(modelClass),
     dedicated: false,
     foreignKey: "auditable_id",
     tableName: "audits"
@@ -219,26 +210,21 @@ async function buildAuditTableData(modelClass) {
  * @returns {Promise<boolean>} Whether the table exists.
  */
 async function dedicatedTableExistsForConnection(modelClass, tableName) {
-  const cacheKey = `${modelClass.getConfiguredDatabaseIdentifier()}:${tableName}`
+  const databaseIdentifier = modelClass.getDatabaseIdentifier()
+  const cacheKey = `${databaseIdentifier}:${tableName}`
   const cached = dedicatedTableCache.get(cacheKey)
 
   if (typeof cached === "boolean") {
     return cached
   }
 
-  try {
-    const connection = modelClass.connection()
+  const connection = modelClass.connection()
+  const table = await connection.getTableByName(tableName, {throwError: false})
+  const exists = Boolean(table)
 
-    await connection.getTableByName(tableName)
+  dedicatedTableCache.set(cacheKey, exists)
 
-    dedicatedTableCache.set(cacheKey, true)
-
-    return true
-  } catch {
-    dedicatedTableCache.set(cacheKey, false)
-
-    return false
-  }
+  return exists
 }
 
 // ---------------------------------------------------------------------------
@@ -265,8 +251,29 @@ function sharedAuditClass(modelClass) {
   }
 
   Object.defineProperty(Audit, "modelName", {value: "Audit", writable: false})
+  applyAuditClassDatabaseRouting(modelClass, Audit)
 
   return /** @type {typeof import("./index.js").default} */ (Audit)
+}
+
+/**
+ * Returns the cached framework-owned shared Audit class for a database.
+ * @param {AuditedModelClass} modelClass - Any audited model class.
+ * @returns {typeof import("./index.js").default} Shared Audit model class.
+ */
+function cachedSharedAuditClass(modelClass) {
+  const routingKey = modelClass.hasTenantDatabaseIdentifierResolver()
+    ? `tenant:${modelClass.getModelName()}`
+    : `database:${modelClass.getConfiguredDatabaseIdentifier()}`
+  const cacheKey = `shared:${routingKey}`
+  let auditClass = auditClassCache.get(cacheKey)
+
+  if (!auditClass) {
+    auditClass = sharedAuditClass(modelClass)
+    auditClassCache.set(cacheKey, auditClass)
+  }
+
+  return auditClass
 }
 
 /**
@@ -291,9 +298,24 @@ function dedicatedAuditClass(modelClass, tableName) {
   }
 
   Object.defineProperty(ModelAudit, "modelName", {value: `${modelName}Audit`, writable: false})
+  applyAuditClassDatabaseRouting(modelClass, ModelAudit)
   ModelAudit.belongsTo(modelKey, {className: modelName})
 
   return /** @type {typeof import("./index.js").default} */ (ModelAudit)
+}
+
+/**
+ * Makes framework-owned audit classes read the same database as the audited model.
+ * @param {AuditedModelClass} modelClass - Audited source model class.
+ * @param {typeof import("./index.js").default} auditClass - Generated audit class.
+ * @returns {void}
+ */
+function applyAuditClassDatabaseRouting(modelClass, auditClass) {
+  auditClass.setDatabaseIdentifier(modelClass.getConfiguredDatabaseIdentifier())
+
+  if (modelClass.hasTenantDatabaseIdentifierResolver()) {
+    auditClass.switchesTenantDatabase(({tenant}) => modelClass.getTenantDatabaseIdentifier(tenant))
+  }
 }
 
 /**
@@ -339,6 +361,7 @@ function registerAuditing(modelClass) {
   }
 
   modelClass._auditLifecycleCallbacksRegistered = true
+  registerAuditRelationship(modelClass)
   modelClass.beforeCreate("captureCreateAuditChanges")
   modelClass.afterCreate("createCreateAudit")
   modelClass.beforeUpdate("captureUpdateAuditChanges")
@@ -349,16 +372,105 @@ function registerAuditing(modelClass) {
 /**
  * Initializes audit metadata for audited model classes.
  * @param {typeof import("./index.js").default} modelClass - Model class to initialize.
+ * @param {{resolveTableData?: boolean}} [args] - Initialization options.
  * @returns {Promise<void>}
  */
-async function initializeAuditing(modelClass) {
+async function initializeAuditing(modelClass, args = {}) {
+  const {resolveTableData = false} = args
   const auditedModelClass = /** @type {AuditedModelClass} */ (modelClass)
 
   if (!auditedModelClass._auditLifecycleCallbacksRegistered) {
     return
   }
 
-  await resolveAuditTableData(auditedModelClass)
+  registerAuditRelationship(auditedModelClass)
+
+  if (resolveTableData && auditedModelClass._initialized && canResolveAuditTableData(auditedModelClass)) {
+    await resolveAuditTableData(auditedModelClass)
+  }
+}
+
+/**
+ * Resolves audit metadata after application and package model classes are registered.
+ * @param {import("../../configuration.js").default} configuration - Configuration whose models should be finalized.
+ * @returns {Promise<void>}
+ */
+async function initializeAuditedModelRelationships(configuration) {
+  for (const modelClass of Object.values(configuration.getModelClasses())) {
+    await initializeAuditing(modelClass, {resolveTableData: true})
+  }
+}
+
+/**
+ * Registers the audits relationship without forcing audit table detection.
+ * @param {AuditedModelClass} modelClass - Model class to audit.
+ * @param {AuditTableData} [tableData] - Resolved audit table data when available.
+ * @returns {void}
+ */
+function registerAuditRelationship(modelClass, tableData = defaultAuditRelationshipTableData(modelClass)) {
+  if (modelClass._relationshipExists("audits")) {
+    const relationship = modelClass.getRelationshipByName("audits")
+
+    if (generatedAuditRelationships.has(relationship)) {
+      relationship.className = undefined
+      relationship.klass = tableData.auditClass
+      relationship.foreignKey = tableData.foreignKey
+      relationship._explicitForeignKey = tableData.foreignKey
+      relationship._polymorphic = !tableData.dedicated
+      relationship._polymorphicTypeColumn = undefined
+    }
+
+    return
+  }
+
+  modelClass.hasMany("audits", auditRelationshipScope, {
+    foreignKey: tableData.foreignKey,
+    klass: tableData.auditClass,
+    polymorphic: !tableData.dedicated
+  })
+  generatedAuditRelationships.add(modelClass.getRelationshipByName("audits"))
+}
+
+/**
+ * Returns unresolved shared-audit defaults for early relationship registration.
+ * @param {AuditedModelClass} modelClass - Model class to audit.
+ * @returns {AuditTableData} Shared audit relationship defaults.
+ */
+function defaultAuditRelationshipTableData(modelClass) {
+  return {
+    auditClass: cachedSharedAuditClass(modelClass),
+    dedicated: false,
+    foreignKey: "auditable_id",
+    tableName: "audits"
+  }
+}
+
+/**
+ * Applies default audit ordering to generated audit relationships.
+ * @param {import("../query/model-class-query.js").default<typeof import("./index.js").default>} query - Audit query.
+ * @returns {import("../query/model-class-query.js").default<typeof import("./index.js").default>} Ordered audit query.
+ */
+function auditRelationshipScope(query) {
+  return query.order({column: "created_at", direction: "DESC"})
+}
+
+/**
+ * Checks whether the current tenant context can resolve audit table data.
+ * @param {AuditedModelClass} modelClass - Model class to inspect.
+ * @returns {boolean} Whether audit table data can be resolved in the current scope.
+ */
+function canResolveAuditTableData(modelClass) {
+  if (!modelClass.hasTenantDatabaseIdentifierResolver()) {
+    return true
+  }
+
+  const tenantDatabaseIdentifier = modelClass.getTenantDatabaseIdentifier()
+
+  if (!tenantDatabaseIdentifier) {
+    return false
+  }
+
+  return modelClass._getConfiguration().isDatabaseIdentifierActive(tenantDatabaseIdentifier)
 }
 
 // ---------------------------------------------------------------------------
@@ -826,6 +938,7 @@ export {
   createUpdateAudit,
   createSharedAuditTablesMigration,
   dedicatedAuditTableNameForTable,
+  initializeAuditedModelRelationships,
   initializeAuditing,
   registerAuditCallback,
   registerAuditing,

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -346,6 +346,21 @@ function registerAuditing(modelClass) {
   modelClass.afterDestroy("createDestroyAudit")
 }
 
+/**
+ * Initializes audit metadata for audited model classes.
+ * @param {typeof import("./index.js").default} modelClass - Model class to initialize.
+ * @returns {Promise<void>}
+ */
+async function initializeAuditing(modelClass) {
+  const auditedModelClass = /** @type {AuditedModelClass} */ (modelClass)
+
+  if (!auditedModelClass._auditLifecycleCallbacksRegistered) {
+    return
+  }
+
+  await resolveAuditTableData(auditedModelClass)
+}
+
 // ---------------------------------------------------------------------------
 // Creating audits
 // ---------------------------------------------------------------------------
@@ -811,6 +826,7 @@ export {
   createUpdateAudit,
   createSharedAuditTablesMigration,
   dedicatedAuditTableNameForTable,
+  initializeAuditing,
   registerAuditCallback,
   registerAuditing,
   withoutAudit

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -46,7 +46,7 @@ import singularizeModelName from "../../utils/singularize-model-name.js"
 import {defineModelScope} from "../../utils/model-scope.js"
 import { normalizeDateStringForWrite, normalizeDateValueForRead, normalizeDateValueForWrite } from "../datetime-storage.js"
 import {formatValue} from "../../utils/format-value.js"
-import {captureCreateAuditChanges, captureUpdateAuditChanges, createAudit, createCreateAudit, createDestroyAudit, createUpdateAudit, registerAuditCallback, registerAuditing, withoutAudit} from "./auditing.js"
+import {captureCreateAuditChanges, captureUpdateAuditChanges, createAudit, createCreateAudit, createDestroyAudit, createUpdateAudit, initializeAuditing, registerAuditCallback, registerAuditing, withoutAudit} from "./auditing.js"
 import {registerMagnitudeCounterCache} from "./counter-cache-magnitude.js"
 import {stateMachine} from "./state-machine.js"
 import ValidatorsFormat from "./validators/format.js"
@@ -1533,6 +1533,7 @@ class VelociousDatabaseRecord {
     }
 
     await this._defineTranslationMethods()
+    await initializeAuditing(this)
     this._initialized = true
   }
 


### PR DESCRIPTION
## Summary
- Resolve audited model audit-table metadata during model initialization so the auto-registered audits relationship exists before frontend-resource validation runs.
- Keep the existing lazy audit resolution path for direct audit calls.
- Add a regression covering shared and dedicated audit relationships after model initialization.

## Verification
- npm run test -- spec/database/record/auditing.browser-spec.js
- npm run test -- spec/database/record/auditing.browser-spec.js spec/cli/commands/generate/base-models-spec.js
- npm run build
- npm run lint