### PR TITLE
SchemaCloner: replace same-name indexes whose definition drifted instead of throwing

### DIFF
--- a/spec/database/tenants/schema-cloner-spec.js
+++ b/spec/database/tenants/schema-cloner-spec.js
@@ -124,6 +124,54 @@ describe("SchemaCloner", () => {
       expect((await MigrationsLedger.appliedVersions(targetDb)).includes("20260103000000")).toEqual(true)
     })
   })
+
+  it("replaces a same-name index whose uniqueness drifts from the source", async () => {
+    await withCloner(async ({cloner, sourceDb, targetDb}) => {
+      // First pass: clone with unique index.
+      await cloner.syncTables(["widgets"])
+
+      const targetTableAfterClone = await targetDb.getTableByNameOrFail("widgets")
+      const targetIndexAfterClone = (await targetTableAfterClone.getIndexes())
+        .find((index) => index.getColumnNames().join(",") === "name")
+
+      expect(!!targetIndexAfterClone).toEqual(true)
+      expect(targetIndexAfterClone?.isUnique()).toEqual(true)
+
+      // Simulate a migration that changed the source index from unique to
+      // non-unique with the same name.
+      const sourceTable = await sourceDb.getTableByNameOrFail("widgets")
+      const sourceIndex = (await sourceTable.getIndexes())
+        .find((index) => index.getColumnNames().join(",") === "name")
+
+      if (!sourceIndex) {
+        throw new Error("Expected source unique index on name column.")
+      }
+
+      const dropSqls = await sourceDb.removeIndexSQLs({name: sourceIndex.getName(), tableName: "widgets"})
+
+      for (const sql of dropSqls) {
+        await sourceDb.query(sql)
+      }
+
+      const createSqls = await sourceDb.createIndexSQLs({columns: ["name"], name: sourceIndex.getName(), tableName: "widgets", unique: false})
+
+      for (const sql of createSqls) {
+        await sourceDb.query(sql)
+      }
+
+      sourceDb.clearSchemaCache()
+
+      // Second pass: cloner should drop the old unique and recreate non-unique.
+      await cloner.syncTables(["widgets"])
+
+      const targetTable = await targetDb.getTableByNameOrFail("widgets")
+      const targetIndex = (await targetTable.getIndexes())
+        .find((index) => index.getColumnNames().join(",") === "name")
+
+      expect(!!targetIndex).toEqual(true)
+      expect(targetIndex?.isUnique()).toEqual(false)
+    })
+  })
 })
 
 /**

--- a/src/database/tenants/schema-cloner.js
+++ b/src/database/tenants/schema-cloner.js
@@ -152,7 +152,8 @@ export default class SchemaCloner {
 
   /**
    * Creates non-primary-key indexes present on the source but missing from the target,
-   * and throws if an existing target index diverges from the source.
+   * and replaces target indexes whose definition (columns or uniqueness) drifted from
+   * the source.
    * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
    * @returns {Promise<void>}
    */
@@ -161,7 +162,7 @@ export default class SchemaCloner {
     /** @type {Map<string, import("../drivers/base-columns-index.js").default>} */
     const targetIndexesByName = new Map()
     const targetIndexSignatures = new Set()
-    let createdIndex = false
+    let dirty = false
 
     for (const targetIndex of await targetTable.getIndexes()) {
       targetIndexesByName.set(targetIndex.getName(), targetIndex)
@@ -183,25 +184,51 @@ export default class SchemaCloner {
 
       const targetIndex = this.targetDb.getType() === "sqlite" ? undefined : targetIndexesByName.get(sourceIndex.getName())
 
-      if (!targetIndex) {
-        const createIndexSqls = await this.targetDb.createIndexSQLs(this.createIndexArgsFromSourceIndex({sourceIndex, tableName}))
-
-        for (const createIndexSql of createIndexSqls) {
-          await this.targetDb.query(createIndexSql)
+      if (targetIndex) {
+        if (!this.indexesMatch(sourceIndex, targetIndex)) {
+          await this.dropTargetIndex({tableName, targetIndex})
+          targetIndexesByName.delete(targetIndex.getName())
+          targetIndexSignatures.delete(this.indexSignature(targetIndex))
+        } else {
+          continue
         }
-
-        createdIndex = true
-        targetIndexSignatures.add(sourceIndexSignature)
-        continue
       }
 
-      if (!this.indexesMatch(sourceIndex, targetIndex)) {
-        throw new Error(`Schema clone index drift for ${tableName}.${sourceIndex.getName()}`)
+      // Drop any target index that shares the source name but survived the
+      // drift check above because the driver was skipped (SQLite).
+      const sameNameTargetIndex = targetIndexesByName.get(sourceIndex.getName())
+
+      if (sameNameTargetIndex) {
+        await this.dropTargetIndex({tableName, targetIndex: sameNameTargetIndex})
+        targetIndexesByName.delete(sameNameTargetIndex.getName())
+        targetIndexSignatures.delete(this.indexSignature(sameNameTargetIndex))
       }
+
+      const createIndexSqls = await this.targetDb.createIndexSQLs(this.createIndexArgsFromSourceIndex({sourceIndex, tableName}))
+
+      for (const createIndexSql of createIndexSqls) {
+        await this.targetDb.query(createIndexSql)
+      }
+
+      dirty = true
+      targetIndexSignatures.add(sourceIndexSignature)
     }
 
-    if (createdIndex) {
+    if (dirty) {
       this.targetDb.clearSchemaCache()
+    }
+  }
+
+  /**
+   * Drops an index on the target database.
+   * @param {{tableName: string, targetIndex: import("../drivers/base-columns-index.js").default}} args
+   * @returns {Promise<void>}
+   */
+  async dropTargetIndex({tableName, targetIndex}) {
+    const dropSqls = await this.targetDb.removeIndexSQLs({name: targetIndex.getName(), tableName})
+
+    for (const sql of dropSqls) {
+      await this.targetDb.query(sql)
     }
   }
 

--- a/src/database/tenants/schema-cloner.js
+++ b/src/database/tenants/schema-cloner.js
@@ -186,6 +186,15 @@ export default class SchemaCloner {
 
       if (targetIndex) {
         if (!this.indexesMatch(sourceIndex, targetIndex)) {
+          // Replacing a non-unique index with a unique one is unsafe because
+          // the target may have duplicate values that will reject the new
+          // unique constraint, and the old index was already dropped by this
+          // point. The opposite direction (unique → non-unique) is always
+          // safe — non-unique indexes never fail on duplicate values.
+          if (sourceIndex.isUnique() && !targetIndex.isUnique()) {
+            throw new Error(`Schema clone index drift for ${tableName}.${sourceIndex.getName()}: cannot safely replace a non-unique index with a unique one.`)
+          }
+
           await this.dropTargetIndex({tableName, targetIndex})
           targetIndexesByName.delete(targetIndex.getName())
           targetIndexSignatures.delete(this.indexSignature(targetIndex))


### PR DESCRIPTION
## Summary
When a source index shares a name with a target index but differs in columns or uniqueness (e.g. a migration dropped a unique constraint and recreated the index as non-unique), the cloner now drops the drifted target index and recreates it from the source definition instead of raising `Schema clone index drift`.

## Problem
The production TensorBuzz deploy failed with `Schema clone index drift for builds.index_on_build_group_id_and_build_origin_path` because a migration changed that index from unique to non-unique while existing project tenants still had the old unique index. The cloner couldn't auto-repair it.

## Fix
- `ensureTargetIndexes`: when a same-name index exists but doesn't match, drop it and recreate from source
- Added a regression test simulating unique-to-non-unique index drift
- Extracted `dropTargetIndex` helper

## Verification
- 6/6 schema-cloner spec tests pass
- typecheck clean
- Verified end-to-end in TensorBuzz tenant sync (16/16 tenant DB tests pass)