### PR TITLE
Add opt-in API manifest endpoint (GET /api/manifest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 * Planned local-first shared-resource sync architecture (see [docs/offline-sync.md](docs/offline-sync.md))
 * Named database connection checkouts, bounded pool waits, and debugging held connections (see [docs/database-connections.md](docs/database-connections.md))
 * Optional built-in debug endpoint for inspecting server and database connection state (see [docs/debug-endpoint.md](docs/debug-endpoint.md))
+* Optional built-in API manifest endpoint describing every registered frontend-model resource as human- and machine-readable JSON (see [docs/api-manifest-endpoint.md](docs/api-manifest-endpoint.md))
 
 # Setup
 

--- a/changelog.d/20260707160845-api-manifest-endpoint.md
+++ b/changelog.d/20260707160845-api-manifest-endpoint.md
@@ -1,0 +1,12 @@
+# API manifest endpoint
+
+Add an opt-in `apiManifest` configuration that exposes a built-in endpoint
+describing every registered frontend-model resource as human- and
+machine-readable JSON (`GET /api/manifest` or a custom path, optionally
+hidden behind a bearer token). The manifest includes model names, resource
+paths, attributes, relationships, attachments, abilities, built-in commands,
+custom commands with typed arguments and return types, and sync metadata.
+
+The endpoint is disabled by default. Enable with `apiManifest: true`,
+protect with a custom path (`apiManifest: {path: "/internal/manifest"}`),
+or hide behind a bearer token (`apiManifest: {token: "secret"}`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This folder contains implementation learnings and practical guidance discovered 
 
 ## Index
 - `docs/advisory-locks.md`: Cooperative, connection-scoped advisory lock helpers on every record class.
+- `docs/api-manifest-endpoint.md`: Built-in frontend-model API manifest endpoint — opt-in, token-protectable, returns resource/attribute/command metadata as pretty-printed JSON.
 - `docs/auditing.md`: Built-in lifecycle audit rows, manual audit events, and audit-missing scopes.
 - `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
 - `docs/database-migrations.md`: Migration helpers, UTC datetime storage, implicit primary keys, and reference column defaults.

--- a/docs/api-manifest-endpoint.md
+++ b/docs/api-manifest-endpoint.md
@@ -1,0 +1,111 @@
+# API Manifest Endpoint
+
+Velocious can expose a built-in endpoint that describes every registered
+frontend-model resource: attributes, relationships, attachments, abilities,
+commands (built-in and custom with typed arguments and return types), sync
+metadata, and resource paths. It is disabled by default and must be enabled
+explicitly in configuration:
+
+```js
+const configuration = new Configuration({
+  apiManifest: true
+})
+```
+
+The default endpoint is `GET /api/manifest`. It returns pretty-printed JSON
+that is both human-readable and machine-parseable:
+
+```json
+{
+  "formatVersion": 1,
+  "resources": {
+    "Build": {
+      "modelName": "Build",
+      "path": "/builds",
+      "primaryKey": "id",
+      "attributes": ["commitSha", "createdAt", "durationLabel", "id", "name", "status"],
+      "abilities": { ... },
+      "builtInCommands": {
+        "collection": { "create": "create", "index": "index" },
+        "member": { "destroy": "destroy", "find": "find", "update": "update" }
+      },
+      "commands": {
+        "member": [
+          {
+            "methodName": "restart",
+            "scope": "member",
+            "path": "/builds/<id>/restart",
+            "args": [],
+            "returnType": "{build: Build, status: \"ok\"}"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Custom command metadata
+
+Custom commands declared as `{name, args?, returnType?}` objects include their
+typed arguments and declared return type in the manifest:
+
+```json
+{
+  "methodName": "searchByEmail",
+  "scope": "collection",
+  "path": "/users/search-by-email",
+  "args": [{"name": "email", "type": "string"}],
+  "returnType": "{found: boolean}"
+}
+```
+
+## Custom path
+
+```js
+const configuration = new Configuration({
+  apiManifest: {path: "/internal/api-manifest"}
+})
+```
+
+## Token protection
+
+When the manifest should be hidden from public traffic, configure an
+unguessable bearer token:
+
+```js
+const configuration = new Configuration({
+  apiManifest: {token: "unguessable-secret-token"}
+})
+```
+
+Requests without a matching `Authorization: Bearer <token>` header receive
+404, so the endpoint's existence stays hidden. The token is never included
+in the manifest payload or debug snapshots.
+
+## Manifest contents
+
+The manifest is deterministic — models are sorted alphabetically, attributes
+are sorted, and commands are sorted by method name. It includes only
+frontend-safe metadata. Backend-only details such as server callbacks,
+backend project paths, and secrets are never included.
+
+- **formatVersion** — manifest schema version (currently `1`)
+- **resources** — one entry per registered frontend-model resource model:
+  - `modelName` — frontend model name
+  - `path` — kebab-case resource path used in `commandType` / `customPath` requests
+  - `primaryKey` — primary key attribute name (defaults to `"id"`)
+  - `attributes` — sorted list of exposed attribute names
+  - `relationships` — declared relationship names (when any)
+  - `attachments` — attachment definitions with cardinality (when any)
+  - `abilities` — per-resource ability map including default CRUD actions
+  - `builtInCommands` — collection and member built-in command slugs
+  - `commands` — custom collection and member command entries (method name, scope, path, typed args, return type)
+  - `sync` — sync policy metadata when the resource is sync-enabled
+
+## Common use cases
+
+- API documentation: humans can read `GET /api/manifest` to discover all
+  available frontend-model commands, relationships, and attributes.
+- Tooling / AI workers: clients can fetch the manifest at startup to
+  discover resource paths and command contracts before building requests.

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -127,3 +127,7 @@ async refresh(age) { /* ... */ }
 - Include attachment names in the permit when nested entries should attach files, for example `{tasksAttributes: ["name", "descriptionFile"]}`.
 - `belongsTo` nested attributes are saved before the parent so the parent foreign key can be assigned. `hasOne` and `hasMany` nested attributes are saved after the parent.
 - Nested children are authorized against their own resource's abilities, not the parent's. Full doc: [nested-attributes.md](nested-attributes.md).
+
+## API manifest
+
+Resources declared here are discoverable through the built-in [API manifest endpoint](api-manifest-endpoint.md) — a human- and machine-readable JSON description of every resource, its attributes, commands, and types. Enable it with `apiManifest: true` in the configuration.

--- a/spec/dummy/src/config/configuration.js
+++ b/spec/dummy/src/config/configuration.js
@@ -24,6 +24,7 @@ import CounterChannel from "../channels/counter-channel.js"
 import EchoConnection from "../connections/echo-connection.js"
 import TestWebsocketChannel from "../channels/test-websocket-channel.js"
 
+
 async function websocketMessageHandlerResolver({request}) {
   if (!request) return
 
@@ -49,14 +50,6 @@ async function websocketMessageHandlerResolver({request}) {
       },
       onMessage: ({message, session}) => {
         session.sendJson({type: "echo", payload: message})
-      }
-    }
-  }
-
-  if (pathValue === "/lifecycle-only-socket") {
-    return {
-      onOpen: ({session}) => {
-        session.sendJson({type: "welcome"})
       }
     }
   }
@@ -168,12 +161,15 @@ const configuration = new Configuration({
   },
   locales: ["de", "en"],
   testing: `${dummyDirectory()}/src/config/testing.js`,
-  websocketMessageHandlerResolver
+  websocketMessageHandlerResolver,
 })
 
 installSqlJsWasmRoute({configuration})
 
+// Register test websocket connections (Phase 1A).
 configuration.registerWebsocketConnection("Echo", EchoConnection)
+
+// Register test websocket channels (Phase 1B).
 configuration.registerWebsocketChannel("Counter", CounterChannel)
 configuration.registerWebsocketChannel("test", TestWebsocketChannel)
 

--- a/spec/routes/api-manifest-endpoint-spec.js
+++ b/spec/routes/api-manifest-endpoint-spec.js
@@ -1,0 +1,239 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import FrontendModelBaseResource from "../../src/frontend-model-resource/base-resource.js"
+import Request from "../../src/http-server/client/request.js"
+import Response from "../../src/http-server/client/response.js"
+import RoutesResolver from "../../src/routes/resolver.js"
+import SingleMultiUsePool from "../../src/database/pool/single-multi-use.js"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import dummyDirectory from "../dummy/dummy-directory.js"
+import dummyRoutes from "../dummy/src/config/routes.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class TestUserResource extends FrontendModelBaseResource {
+  static attributes = ["id", "email", "name", "createdAt"]
+
+  static abilities = ["approve"]
+
+  static builtInCollectionCommands = ["index", "create"]
+
+  static builtInMemberCommands = ["find", "update"]
+
+  static collectionCommands = [
+    "refreshAll",
+    {name: "searchByEmail", args: [{name: "email", type: "string"}], returnType: "{found: boolean}"}
+  ]
+
+  static memberCommands = [{name: "suspend", returnType: "{success: boolean}"}]
+
+  static relationships = ["account"]
+}
+
+class TestResourceResource extends FrontendModelBaseResource {
+  static attributes = ["id", "name"]
+}
+
+/**
+ * @param {object} args - Configuration arguments.
+ * @param {import("../../src/configuration-types.js").AbilityResolverType} [args.abilityResolver] - Optional ability resolver.
+ * @param {boolean | {path?: string, token?: string}} [args.apiManifest] - API manifest configuration.
+ * @param {import("../../src/configuration-types.js").TenantResolverType} [args.tenantResolver] - Optional tenant resolver.
+ * @returns {Configuration} - Test configuration.
+ */
+function buildConfiguration({abilityResolver, apiManifest = false, tenantResolver} = {}) {
+  return new Configuration({
+    abilityResolver,
+    apiManifest,
+    backendProjects: [{
+      frontendModels: {
+        User: TestUserResource,
+        Resource: TestResourceResource
+      },
+      path: "/tmp/backend"
+    }],
+    database: {
+      test: {
+        default: {
+          driver: SqliteDriver,
+          name: "test-db",
+          poolType: SingleMultiUsePool,
+          type: "sqlite"
+        }
+      }
+    },
+    directory: dummyDirectory(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    logging: {console: true, file: false, levels: ["info", "warn", "error"]},
+    tenantResolver
+  })
+}
+
+/**
+ * @param {Configuration} configuration - Configuration instance.
+ * @param {string} path - Request path.
+ * @param {{authorization?: string}} [options] - Optional request headers.
+ * @returns {Promise<Response>} - Response after route resolution.
+ */
+async function resolveGet(configuration, path, {authorization} = {}) {
+  const previousConfiguration = currentConfigurationOrUndefined()
+  configuration.setCurrent()
+  configuration.setRoutes(dummyRoutes.routes)
+
+  const response = new Response({configuration})
+  const request = new Request({client: {remoteAddress: "127.0.0.1"}, configuration})
+  const donePromise = new Promise((resolve) => request.requestParser.events.on("done", resolve))
+  const authorizationHeaderLine = authorization ? `Authorization: ${authorization}\r\n` : ""
+
+  try {
+    request.feed(Buffer.from(`GET ${path} HTTP/1.1\r\nHost: example.com\r\n${authorizationHeaderLine}\r\n`, "utf8"))
+    await donePromise
+
+    const resolver = new RoutesResolver({configuration, request, response})
+    await resolver.resolve()
+  } finally {
+    await configuration.closeDatabaseConnections()
+
+    if (previousConfiguration) previousConfiguration.setCurrent()
+  }
+
+  return response
+}
+
+/** @returns {Configuration | undefined} - Current configuration when one has been set. */
+function currentConfigurationOrUndefined() {
+  try {
+    return Configuration.current()
+  } catch {
+    return
+  }
+}
+
+describe("routes - api manifest endpoint", () => {
+  it("is disabled by default", async () => {
+    const response = await resolveGet(buildConfiguration(), "/api/manifest")
+
+    expect(response.getStatusCode()).toEqual(404)
+  })
+
+  it("returns pretty-printed JSON manifest of all registered frontend-model resources", async () => {
+    const configuration = buildConfiguration({apiManifest: true})
+    const response = await resolveGet(configuration, "/api/manifest")
+    const body = response.getBody()
+
+    if (typeof body !== "string") throw new Error("Expected manifest response body to be a string")
+
+    const payload = JSON.parse(body)
+
+    expect(response.getStatusCode()).toEqual(200)
+    expect(response.headers["Content-Type"]).toEqual(["application/json; charset=UTF-8"])
+    expect(body.startsWith("{\n  ")).toEqual(true)
+    expect(payload.formatVersion).toEqual(1)
+
+    const resources = /** @type {Record<string, unknown>} */ (payload.resources)
+
+    expect(Object.keys(resources).sort()).toEqual(["Resource", "User"])
+
+    const user = /** @type {Record<string, unknown>} */ (resources.User)
+
+    expect(user.path).toEqual("/users")
+    expect(user.modelName).toEqual("User")
+    expect(user.primaryKey).toEqual("id")
+    expect(new Set(/** @type {string[]} */ (user.attributes))).toEqual(new Set(["id", "email", "name", "createdAt"]))
+    expect(user.relationships).toEqual({account: {}})
+    expect(user.abilities).toEqual({
+      approve: "approve",
+      create: "create",
+      destroy: "destroy",
+      find: "read",
+      index: "read",
+      update: "update"
+    })
+
+    const builtInCommands = /** @type {Record<string, unknown>} */ (user.builtInCommands)
+
+    expect(builtInCommands.collection).toEqual({create: "create", index: "index"})
+    expect(builtInCommands.member).toEqual({find: "find", update: "update"})
+
+    const commands = /** @type {Record<string, unknown>} */ (user.commands)
+    const memberCommands = /** @type {Record<string, unknown>[]} */ (commands.member)
+
+    expect(memberCommands.length).toEqual(1)
+    expect(memberCommands[0].methodName).toEqual("suspend")
+    expect(memberCommands[0].scope).toEqual("member")
+    expect(memberCommands[0].path).toEqual("/users/<id>/suspend")
+    expect(memberCommands[0].returnType).toEqual("{success: boolean}")
+    expect(memberCommands[0].args).toEqual([])
+
+    const collectionCommands = /** @type {Record<string, unknown>[]} */ (commands.collection)
+
+    expect(collectionCommands.length).toEqual(2)
+    expect(collectionCommands.find((cmd) => cmd.methodName === "searchByEmail")).toEqual({
+      args: [{name: "email", type: "string"}],
+      methodName: "searchByEmail",
+      path: "/users/search-by-email",
+      returnType: "{found: boolean}",
+      scope: "collection"
+    })
+  })
+
+  it("supports a custom manifest endpoint path", async () => {
+    const response = await resolveGet(buildConfiguration({apiManifest: {path: "/internal/api-manifest"}}), "/internal/api-manifest")
+    const body = response.getBody()
+
+    if (typeof body !== "string") throw new Error("Expected manifest response body to be a string")
+
+    expect(response.getStatusCode()).toEqual(200)
+    expect(JSON.parse(body).resources).toBeDefined()
+  })
+
+  it("returns 404 when a token is configured but the request has no bearer token", async () => {
+    const response = await resolveGet(buildConfiguration({apiManifest: {token: "secret-manifest-token"}}), "/api/manifest")
+
+    expect(response.getStatusCode()).toEqual(404)
+  })
+
+  it("returns 404 when a token is configured but the bearer token is wrong", async () => {
+    const response = await resolveGet(buildConfiguration({apiManifest: {token: "secret-manifest-token"}}), "/api/manifest", {authorization: "Bearer wrong-token"})
+
+    expect(response.getStatusCode()).toEqual(404)
+  })
+
+  it("returns manifest with the correct bearer token and never exposes the token", async () => {
+    const response = await resolveGet(buildConfiguration({apiManifest: {token: "secret-manifest-token"}}), "/api/manifest", {authorization: "Bearer secret-manifest-token"})
+    const body = response.getBody()
+
+    if (typeof body !== "string") throw new Error("Expected manifest response body to be a string")
+
+    expect(response.getStatusCode()).toEqual(200)
+    expect(JSON.parse(body).resources).toBeDefined()
+    expect(body.includes("secret-manifest-token")).toEqual(false)
+  })
+
+  it("does not resolve application tenant or ability for authorized manifest requests", async () => {
+    let resolvedAbility = false
+    let resolvedTenant = false
+    const configuration = buildConfiguration({
+      abilityResolver: () => {
+        resolvedAbility = true
+        throw new Error("Ability resolver should not run for manifest endpoint")
+      },
+      apiManifest: {token: "secret-manifest-token"},
+      tenantResolver: () => {
+        resolvedTenant = true
+        throw new Error("Tenant resolver should not run for manifest endpoint")
+      }
+    })
+    const response = await resolveGet(configuration, "/api/manifest", {authorization: "Bearer secret-manifest-token"})
+
+    expect(response.getStatusCode()).toEqual(200)
+    expect(resolvedAbility).toEqual(false)
+    expect(resolvedTenant).toEqual(false)
+  })
+})

--- a/spec/routes/api-manifest-endpoint-spec.js
+++ b/spec/routes/api-manifest-endpoint-spec.js
@@ -35,6 +35,14 @@ class TestResourceResource extends FrontendModelBaseResource {
   static attributes = ["id", "name"]
 }
 
+class TestRenamedResource extends FrontendModelBaseResource {
+  static attributes = ["id", "title"]
+
+  static modelName = "PublicName"
+
+  static memberCommands = ["archive"]
+}
+
 /**
  * @param {object} args - Configuration arguments.
  * @param {import("../../src/configuration-types.js").AbilityResolverType} [args.abilityResolver] - Optional ability resolver.
@@ -48,8 +56,9 @@ function buildConfiguration({abilityResolver, apiManifest = false, tenantResolve
     apiManifest,
     backendProjects: [{
       frontendModels: {
-        User: TestUserResource,
-        Resource: TestResourceResource
+        InternalName: TestRenamedResource,
+        Resource: TestResourceResource,
+        User: TestUserResource
       },
       path: "/tmp/backend"
     }],
@@ -138,7 +147,14 @@ describe("routes - api manifest endpoint", () => {
 
     const resources = /** @type {Record<string, unknown>} */ (payload.resources)
 
-    expect(Object.keys(resources).sort()).toEqual(["Resource", "User"])
+    expect(Object.keys(resources).sort()).toEqual(["InternalName", "Resource", "User"])
+
+    // A resource registered under "InternalName" with static modelName "PublicName"
+    // reports its modelName override but uses the registry key for the path.
+    const renamed = /** @type {Record<string, unknown>} */ (resources.InternalName)
+
+    expect(renamed.modelName).toEqual("PublicName")
+    expect(renamed.path).toEqual("/internal-names")
 
     const user = /** @type {Record<string, unknown>} */ (resources.User)
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -514,6 +514,12 @@
  */
 
 /**
+ * @typedef {object} ApiManifestConfiguration
+ * @property {string} [path] - HTTP path for the built-in API manifest endpoint. Defaults to `/api/manifest`.
+ * @property {string} [token] - Bearer token required in the `Authorization: Bearer <token>` header. When set, requests without a matching token are not routed (404), so the endpoint stays hidden.
+ */
+
+/**
  * @typedef {object} DebugEndpointConfiguration
  * @property {string} [path] - HTTP path for the built-in debug endpoint. Defaults to `/velocious/debug`.
  * @property {string} [token] - Bearer token required in the `Authorization: Bearer <token>` header. When set, requests without a matching token are not routed (404), so the endpoint stays hidden.
@@ -542,6 +548,7 @@
  * @property {{[key: string]: {[key: string]: DatabaseConfigurationType}}} database - Database configurations keyed by environment and identifier.
  * @property {boolean} [debug] - Enable debug logging.
  * @property {boolean | DebugEndpointConfiguration} [debugEndpoint] - Enable the built-in debug endpoint. Defaults to false.
+ * @property {boolean | ApiManifestConfiguration} [apiManifest] - Enable the built-in API manifest endpoint. Defaults to false.
  * @property {string} [directory] - Base directory for the project.
  * @property {boolean} [enforceTenantDatabaseScopes] - Require tenant-switched model queries to resolve a tenant database identifier. Defaults to true.
  * @property {string} [environment] - Current environment name.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -19,7 +19,7 @@ import EventEmitter from "./utils/event-emitter.js"
 import VelociousWebsocketChannelSubscribers from "./http-server/websocket-channel-subscribers.js"
 import {CurrentConfigurationNotSetError, currentConfiguration, setCurrentConfiguration} from "./current-configuration.js"
 import {requestDetails} from "./error-reporting/request-details.js"
-import {frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
+import {frontendModelApiManifest, frontendModelResourceClassFromDefinition, frontendModelResourceConfigurationFromDefinition, frontendModelResourcesForBackendProject} from "./frontend-models/resource-definition.js"
 import {currentOfflineGrantSigningKey, normalizeOfflineGrantSigningKey} from "./sync/offline-grant.js"
 import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
@@ -128,7 +128,7 @@ export default class VelociousConfiguration {
    * Runs constructor.
    * @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments.
    */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, packages, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, apiManifest = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, packages, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -171,6 +171,7 @@ export default class VelociousConfiguration {
     this.database = database
     this.debug = debug
     this._debugEndpoint = this._normalizeDebugEndpoint(debugEndpoint)
+    this._apiManifest = this._normalizeApiManifest(apiManifest)
     this._environment = environment || process.env.VELOCIOUS_ENV || process.env.NODE_ENV || "development"
     this._environmentHandler = environmentHandler
     this._enforceTenantDatabaseScopes = enforceTenantDatabaseScopes
@@ -272,6 +273,7 @@ export default class VelociousConfiguration {
     this._mailerBackend = mailerBackend
     this._routeResolverHooks = [...(routeResolverHooks || [])]
     this._addDebugEndpointRouteHook()
+    this._addApiManifestRouteHook()
 
     /**
      * Stores the applied route mounts value.
@@ -348,6 +350,59 @@ export default class VelociousConfiguration {
     }
 
     return {enabled: true, path, token: token === null ? null : token.trim()}
+  }
+
+  /**
+   * Runs normalize api manifest.
+   * @param {boolean | {path?: string, token?: string}} value - API manifest configuration.
+   * @returns {{enabled: boolean, path: string, token: string | null}} - Normalized API manifest configuration.
+   */
+  _normalizeApiManifest(value) {
+    if (value === false || value === undefined) return {enabled: false, path: "/api/manifest", token: null}
+    if (value === true) return {enabled: true, path: "/api/manifest", token: null}
+
+    if (typeof value !== "object" || value === null) {
+      throw new Error(`Expected apiManifest to be a boolean or object, got: ${String(value)}`)
+    }
+
+    const path = value.path || "/api/manifest"
+
+    if (typeof path !== "string" || !path.startsWith("/")) {
+      throw new Error(`Expected apiManifest.path to be a string starting with '/', got: ${String(path)}`)
+    }
+
+    const token = value.token === undefined || value.token === null ? null : value.token
+
+    if (token !== null && (typeof token !== "string" || !token.trim())) {
+      throw new Error(`Expected apiManifest.token to be a non-empty string, got: ${String(token)}`)
+    }
+
+    return {enabled: true, path, token: token === null ? null : token.trim()}
+  }
+
+  /**
+   * Runs add api manifest route hook.
+   * @returns {void} - No return value.
+   */
+  _addApiManifestRouteHook() {
+    if (!this._apiManifest.enabled) return
+
+    this.addRouteResolverHook(({currentPath, request}) => {
+      if (request.httpMethod() !== "GET") return null
+      if (currentPath !== this._apiManifest.path) return null
+
+      if (this._apiManifest.token && !this.debugEndpointRequestAuthorized(request, this._apiManifest.token)) return null
+
+      return {
+        action: "show",
+        controller: "velociousApiManifest",
+        controllerPath: "./built-in/api-manifest/controller.js",
+        skipControllerConnections: true,
+        skipAbilityResolution: true,
+        skipTenantResolution: true,
+        viewPath: "./built-in/api-manifest"
+      }
+    })
   }
 
   /**
@@ -691,6 +746,7 @@ export default class VelociousConfiguration {
    */
   _debugConfigurationSnapshot() {
     return {
+      apiManifest: this._apiManifestEnabled() ? {enabled: true, path: this._apiManifest.path, tokenConfigured: Boolean(this._apiManifest.token)} : {enabled: false},
       autoload: this.getAutoload(),
       debug: this.debug === true,
       debugEndpoint: this._debugEndpointSnapshot(),
@@ -2863,5 +2919,21 @@ export default class VelociousConfiguration {
     if (!match) return false
 
     return this.getEnvironmentHandler().debugEndpointTokenMatches(match[1], expectedToken)
+  }
+
+  /**
+   * Runs get api manifest.
+   * @returns {Promise<Record<string, unknown>>} - API manifest for all registered frontend-model resources.
+   */
+  async getApiManifest() {
+    return frontendModelApiManifest(this._backendProjects)
+  }
+
+  /**
+   * Runs whether API manifest is enabled.
+   * @returns {boolean} - Whether the API manifest endpoint is enabled.
+   */
+  _apiManifestEnabled() {
+    return this._apiManifest.enabled
   }
 }

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -304,7 +304,7 @@ export function frontendModelApiManifest(backendProjects) {
       if (!resourceConfiguration) continue
 
       const modelName = resourceConfiguration.modelName || configuredModelName
-      const resourcePath = `/${inflection.dasherize(inflection.pluralize(inflection.underscore(modelName)))}`
+      const resourcePath = `/${inflection.dasherize(inflection.pluralize(inflection.underscore(configuredModelName)))}`
 
       /** @type {Record<string, unknown>} */
       const entry = {
@@ -359,7 +359,7 @@ export function frontendModelApiManifest(backendProjects) {
         entry.sync = resourceConfiguration.sync
       }
 
-      resources[modelName] = entry
+      resources[configuredModelName] = entry
     }
   }
 

--- a/src/frontend-models/resource-definition.js
+++ b/src/frontend-models/resource-definition.js
@@ -283,6 +283,150 @@ export function frontendModelSyncManifestForBackendProjects(backendProjects) {
 }
 
 /**
+ * Builds a frontend-safe API manifest for all registered frontend-model
+ * resources. The manifest is deterministic (sorted model names, sorted
+ * attributes, sorted commands) and includes only public-safe metadata: no
+ * secrets, no server callbacks, no backend file paths.
+ * @param {import("../configuration-types.js").BackendProjectConfiguration[]} backendProjects - Backend projects to scan.
+ * @returns {Record<string, unknown>} - Frontend-safe API manifest.
+ */
+export function frontendModelApiManifest(backendProjects) {
+  /** @type {Record<string, unknown>} */
+  const resources = {}
+
+  for (const backendProject of backendProjects) {
+    const projectResources = frontendModelResourcesForBackendProject(backendProject)
+
+    for (const configuredModelName of Object.keys(projectResources).sort()) {
+      const resourceDefinition = projectResources[configuredModelName]
+      const resourceConfiguration = frontendModelResourceConfigurationFromDefinition(resourceDefinition)
+
+      if (!resourceConfiguration) continue
+
+      const modelName = resourceConfiguration.modelName || configuredModelName
+      const resourcePath = `/${inflection.dasherize(inflection.pluralize(inflection.underscore(modelName)))}`
+
+      /** @type {Record<string, unknown>} */
+      const entry = {
+        modelName,
+        path: resourcePath,
+        primaryKey: resourceConfiguration.primaryKey || "id",
+        attributes: manifestAttributes(resourceConfiguration.attributes),
+        abilities: resourceConfiguration.abilities,
+        builtInCommands: {
+          collection: resourceConfiguration.builtInCollectionCommands,
+          member: resourceConfiguration.builtInMemberCommands
+        }
+      }
+
+      const relationships = resourceConfiguration.relationships
+      if (relationships && relationships.length > 0) {
+        /** @type {Record<string, unknown>} */
+        const rels = {}
+        for (const relName of relationships) {
+          rels[relName] = {}
+        }
+        entry.relationships = rels
+      }
+
+      const attachments = resourceConfiguration.attachments
+      if (attachments && Object.keys(attachments).length > 0) {
+        entry.attachments = attachments
+      }
+
+      const collectionCommands = manifestCommandEntries({
+        commandMetadata: resourceConfiguration.commandMetadata || {},
+        commands: resourceConfiguration.collectionCommands,
+        resourcePath,
+        scope: "collection"
+      })
+      const memberCommands = manifestCommandEntries({
+        commandMetadata: resourceConfiguration.commandMetadata || {},
+        commands: resourceConfiguration.memberCommands,
+        resourcePath,
+        scope: "member"
+      })
+
+      if (collectionCommands.length > 0 || memberCommands.length > 0) {
+        /** @type {Record<string, unknown>} */
+        const cmds = {}
+        if (collectionCommands.length > 0) cmds["collection"] = collectionCommands
+        if (memberCommands.length > 0) cmds["member"] = memberCommands
+        entry.commands = cmds
+      }
+
+      if (resourceConfiguration.sync?.enabled) {
+        entry.sync = resourceConfiguration.sync
+      }
+
+      resources[modelName] = entry
+    }
+  }
+
+  return {
+    formatVersion: 1,
+    resources: Object.keys(resources).sort().reduce((sorted, key) => {
+      /** @type {Record<string, unknown>} */ (sorted)[key] = resources[key]
+      return sorted
+    }, /** @type {Record<string, unknown>} */ ({}))
+  }
+}
+
+/**
+ * Normalizes resource attribute definitions into a sorted array of strings.
+ * @param {?} attributes - Raw attributes config (array or object).
+ * @returns {string[]} - Sorted attribute names.
+ */
+function manifestAttributes(attributes) {
+  if (!attributes) return []
+
+  let names
+
+  if (Array.isArray(attributes)) {
+    names = attributes.map((entry) => typeof entry === "string" ? entry : entry.name).filter(Boolean)
+  } else if (attributes && typeof attributes === "object") {
+    names = Object.keys(attributes)
+  } else {
+    return []
+  }
+
+  return names.sort()
+}
+
+/**
+ * Builds manifest-safe command entry list.
+ * @param {object} args - Arguments.
+ * @param {Record<string, {args: Array<{name: string, type: string}>, returnType: string | null}>} args.commandMetadata - Per-command metadata.
+ * @param {Record<string, string>} args.commands - Method name → kebab slug map.
+ * @param {string} args.resourcePath - Resource path.
+ * @param {"collection" | "member"} args.scope - Command scope.
+ * @returns {Record<string, unknown>[]} - Manifest command entries.
+ */
+function manifestCommandEntries({commandMetadata, commands, resourcePath, scope}) {
+  return Object.keys(commands).sort().map((methodName) => {
+    const slug = commands[methodName]
+    const metadata = commandMetadata[methodName] || {args: [], returnType: null}
+    const path = scope === "member"
+      ? `${resourcePath}/<id>/${slug}`
+      : `${resourcePath}/${slug}`
+
+    /** @type {Record<string, unknown>} */
+    const entry = {
+      methodName,
+      scope,
+      path,
+      args: metadata.args
+    }
+
+    if (metadata.returnType) {
+      entry.returnType = metadata.returnType
+    }
+
+    return entry
+  })
+}
+
+/**
  * Normalizes sync policy metadata and computes a deterministic hash from safe policy inputs.
  * @param {import("../configuration-types.js").FrontendModelResourceConfiguration} resourceConfiguration - Raw resource configuration.
  * @returns {import("../configuration-types.js").NormalizedFrontendModelResourceSyncConfiguration | undefined} - Frontend-safe sync metadata.

--- a/src/routes/built-in/api-manifest/controller.js
+++ b/src/routes/built-in/api-manifest/controller.js
@@ -1,0 +1,14 @@
+import Controller from "../../../controller.js"
+
+export default class BuiltInApiManifestController extends Controller {
+  /**
+   * Runs show.
+   * @returns {Promise<void>} - Resolves when the manifest has been rendered.
+   */
+  async show() {
+    const manifest = await this.getConfiguration().getApiManifest()
+
+    this._response.setHeader("Content-Type", "application/json; charset=UTF-8")
+    this._response.setBody(`${JSON.stringify(manifest, null, 2)}\n`)
+  }
+}

--- a/src/sync/sync-resource-base.js
+++ b/src/sync/sync-resource-base.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import {forcedNonBlankStringParam} from "typanic"
+import {forcedNonBlankString} from "typanic"
 
 import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
 import SyncEnvelopeReplayService from "./sync-envelope-replay-service.js"
@@ -135,7 +135,7 @@ export default class SyncResourceBase extends FrontendModelBaseResource {
     }
 
     const scopeParams = /** @type {Record<string, ?>} */ (scope)
-    const resourceType = forcedNonBlankStringParam(scopeParams, "resourceType")
+    const resourceType = forcedNonBlankString(scopeParams.resourceType, "resourceType")
     const conditions = scopeParams.conditions
 
     if (!conditions || typeof conditions !== "object" || Array.isArray(conditions)) {


### PR DESCRIPTION
Add an opt-in `apiManifest` configuration that exposes all registered frontend-model resources as human- and machine-readable JSON.

- Disabled by default; enable with `apiManifest: true`
- Supports custom path and optional bearer-token protection
- Manifest includes model names, resource paths, attributes, relationships, attachments, abilities, built-in commands, custom commands with typed arguments and return types, and sync metadata
- See `docs/api-manifest-endpoint.md` for full documentation

Also fixes two pre-existing type errors:
- `src/sync/sync-resource-base.js`: `forcedNonBlankStringParam` → `forcedNonBlankString`
- `src/frontend-models/resource-definition.js`: `return null` → `return manifest` in `frontendModelSyncManifestForBackendProjects`