### PR TITLE
Expose frontend-model attribute validation errors safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Frontend-model HTTP requests always use `credentials: "include"` so shared custo
 
 Unexpected frontend-model endpoint failures stay client-safe in production with `errorMessage: "Request failed."`.
 Invalid client query descriptors, such as unknown `select`, `where`, `search`, `joins`, `preload`, `group`, `sort`, `pluck`, or Ransack attributes, return the specific frontend-model query error message with `velocious.code: "frontend-model-query-error"` and are not emitted as framework errors.
+Invalid frontend-model write attributes and attachment names, including attributes rejected by `permittedParams()`, return the specific safe error message with `velocious.code: "frontend-model-attribute-error"` and are not emitted as framework errors.
 In `development` and `test`, Velocious also includes `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` fields so browser/system-test failures are easier to diagnose without exposing those details in production.
 Other non-production environments, such as `staging`, keep the same client-safe default unless you explicitly opt in with `exposeInternalErrorsToClients: true`:
 

--- a/changelog.d/202607111310-client-safe-frontend-model-attribute-errors.md
+++ b/changelog.d/202607111310-client-safe-frontend-model-attribute-errors.md
@@ -1,0 +1,1 @@
+- Frontend-model writes now return client-safe, actionable errors with `velocious.code: "frontend-model-attribute-error"` when `permittedParams()` rejects an attribute or attachment name, or when an unknown write attribute or attachment name is supplied. Unexpected endpoint errors remain sanitized as `"Request failed."`.

--- a/docs/frontend-model-resources.md
+++ b/docs/frontend-model-resources.md
@@ -122,7 +122,7 @@ async refresh(age) { /* ... */ }
 ## Nested-attribute writes
 - Resources opt in to nested writes by overriding `permittedParams(arg)` to return a Rails-style flat array mixing attribute-name strings with `{<relationshipName>Attributes: [...]}` objects.
 - Model-level `Model.acceptsNestedAttributesFor(name, options)` is **required** in addition to the resource declaration. Policy options like `allowDestroy`/`limit`/`rejectIf` live on the model, not in the permit array.
-- `permittedParams(arg)` is **strict by default** — the default returns `[]`, permitting nothing. Submitting an attribute or nested key that is not in the permit raises an error.
+- `permittedParams(arg)` is **strict by default** — the default returns `[]`, permitting nothing. Submitting an attribute or nested key that is not in the permit returns a client-safe error with `velocious.code: "frontend-model-attribute-error"`, including the rejected attribute names.
 - Include `"_destroy"` inside a nested permit to allow `{_destroy: true}` entries for that relationship; the model must also declare `allowDestroy: true`.
 - Include attachment names in the permit when nested entries should attach files, for example `{tasksAttributes: ["name", "descriptionFile"]}`.
 - `belongsTo` nested attributes are saved before the parent so the parent foreign key can be assigned. `hasOne` and `hasMany` nested attributes are saved after the parent.

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -1497,7 +1497,8 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
       const persisted = await Task.find(task.id())
 
       expect(payload.status).toEqual("error")
-      expect(payload.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
+      expect(payload.errorMessage).toEqual("Frontend model write attributes not permitted by permittedParams(): identifier")
+      expect(payload.velocious).toEqual({code: "frontend-model-attribute-error"})
       expect(persisted.name()).toEqual("Update computed attr")
       expect(persisted.identifier()).toEqual(`task-${task.id()}`)
     })

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -3,6 +3,7 @@
 import AuthorizationBaseResource from "../authorization/base-resource.js"
 import * as inflection from "inflection"
 import isPlainObject from "../utils/plain-object.js"
+import VelociousError from "../velocious-error.js"
 
 /**
  * Built-in frontend-model resource action.
@@ -958,10 +959,10 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     }
 
     if (notPermittedAttachments.length > 0) {
-      throw new Error(`Frontend model attachment names not permitted by permittedParams(): ${notPermittedAttachments.join(", ")}`)
+      throw VelociousError.safe(`Frontend model attachment names not permitted by permittedParams(): ${notPermittedAttachments.join(", ")}`, {code: "frontend-model-attribute-error"})
     }
     if (invalidAttachments.length > 0) {
-      throw new Error(`Invalid frontend model attachment names: ${invalidAttachments.join(", ")}`)
+      throw VelociousError.safe(`Invalid frontend model attachment names: ${invalidAttachments.join(", ")}`, {code: "frontend-model-attribute-error"})
     }
   }
 
@@ -1808,11 +1809,11 @@ function filterWritableFrontendModelAttributes(
   }
 
   if (notPermittedAttributes.length > 0) {
-    throw new Error(`Frontend model write attributes not permitted by permittedParams(): ${notPermittedAttributes.join(", ")}`)
+    throw VelociousError.safe(`Frontend model write attributes not permitted by permittedParams(): ${notPermittedAttributes.join(", ")}`, {code: "frontend-model-attribute-error"})
   }
 
   if (invalidAttributes.length > 0) {
-    throw new Error(`Invalid frontend model write attributes: ${invalidAttributes.join(", ")}`)
+    throw VelociousError.safe(`Invalid frontend model write attributes: ${invalidAttributes.join(", ")}`, {code: "frontend-model-attribute-error"})
   }
 
   return writableAttributes


### PR DESCRIPTION
## Problem

`filterWritableFrontendModelAttributes()` throws plain `Error` instances for attribute and attachment validation failures. The frontend-model controller sanitizes those errors to `"Request failed."`, leaving API clients without an actionable explanation.

## Fix

Throw `VelociousError.safe()` with `code: "frontend-model-attribute-error"` for:

- attributes rejected by `permittedParams()`
- invalid write attributes
- attachment names rejected by `permittedParams()`
- invalid attachment names

The existing frontend-model error serialization already exposes safe Velocious errors, so this avoids downstream string matching and preserves sanitization for unexpected/internal failures.

## Verification

- `npx tsc --noEmit`