### PR TITLE
Stream file responses with socket backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 * Translated model attributes with current-locale relationship sorting (see [docs/translations.md](docs/translations.md))
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon`, including background job runner processes (see [docs/beacon.md](docs/beacon.md))
-* Configurable HTTP server worker handlers for higher request and websocket throughput (see [docs/http-server.md](docs/http-server.md))
+* Configurable HTTP server worker handlers plus backpressured, descriptor-only file responses with completion callbacks (see [docs/http-server.md](docs/http-server.md))
 * Background jobs with failure events for production reporting (see [docs/background-jobs.md](docs/background-jobs.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 * EJS-backed mailers with delivery, queueing, and payload rendering support (see [docs/mailers.md](docs/mailers.md))

--- a/changelog.d/20260713120000-backpressured-file-responses.md
+++ b/changelog.d/20260713120000-backpressured-file-responses.md
@@ -1,0 +1,1 @@
+Framework file responses now cross worker IPC as path descriptors and stream from the main thread with socket backpressure. `sendFile` accepts an optional sync or async `onFinished` callback reporting `"completed"` or `"aborted"`; response processing waits for cleanup and safely reports callback failures.

--- a/docs/http-server.md
+++ b/docs/http-server.md
@@ -4,6 +4,38 @@ Velocious serves HTTP requests through worker handlers. The default is one
 worker, which keeps development and small deployments predictable. Applications
 that need more request or websocket throughput can opt into multiple workers.
 
+## File Responses
+
+Controllers can stream a file without loading it into memory:
+
+```js
+this.sendFile(reportPath, {
+  contentType: "application/pdf",
+  status: 200,
+  onFinished: async (result) => {
+    if (result === "completed") await removeTemporaryReport(reportPath)
+  }
+})
+```
+
+`onFinished` is optional and receives `"completed"` after the local socket
+pipeline has accepted every file byte, or `"aborted"` when the socket closes,
+the socket reports an error, the file cannot be read, or the server shuts down.
+It runs once in the same worker or in-process context as the controller and may
+return a promise. The response queue waits for that promise before advancing to
+the next response. Callback exceptions and rejections are logged and reported
+as framework errors, but cannot replace the response that was already committed
+to the socket. Setting a response body or replacing the file response clears the
+previous callback.
+
+Worker-mode file responses cross the worker boundary as path descriptors only.
+The main thread opens and streams the file with socket write/drain backpressure;
+file contents are neither buffered in full nor sent as IPC byte chunks. Response
+headers, file data, and later pipelined responses retain their original queue
+order. Bodyless status responses preserve their existing no-body and
+no-`Content-Length` behavior while still settling `onFinished` after the parent
+acknowledges the response.
+
 ## CLI Workers
 
 Start a server with a fixed worker count:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "copy:templates": "cpy \"src/templates/**/*.js\" build/src/templates",
     "fallow": "fallow dead-code --baseline fallow-baselines/dead-code.json --fail-on-issues --quiet && fallow dupes --baseline fallow-baselines/dupes.json --fail-on-issues --quiet && fallow health --baseline fallow-baselines/health.json --report-only --quiet",
     "fallow:baseline": "fallow dead-code --save-baseline fallow-baselines/dead-code.json && fallow dupes --save-baseline fallow-baselines/dupes.json && fallow health --save-baseline fallow-baselines/health.json",
-    "eslint": "eslint",
+    "eslint": "eslint --max-warnings 0",
     "lint": "npm run eslint && npm run typecheck && npm run fallow",
     "prepare": "npm run build",
     "release:patch": "release-patch",

--- a/spec/http-server/response-spec.js
+++ b/spec/http-server/response-spec.js
@@ -79,3 +79,20 @@ describe("VelociousHttpServerClientResponse#setStatus", {databaseCleaning: {tran
     expect(response.getStatusMessage()).toEqual("Use Proxy")
   })
 })
+
+describe("VelociousHttpServerClientResponse file completion", {databaseCleaning: {transaction: true}}, () => {
+  it("clears file callbacks when the body or file is replaced", () => {
+    const response = new VelociousHttpServerClientResponse({configuration: stubConfiguration})
+    const onFinished = () => {}
+
+    response.setFilePath("first.txt", onFinished)
+    expect(response.getFileOnFinished()).toBe(onFinished)
+
+    response.setBody("replacement")
+    expect(response.getFileOnFinished()).toEqual(null)
+
+    response.setFilePath("second.txt", onFinished)
+    response.setFilePath("third.txt")
+    expect(response.getFileOnFinished()).toEqual(null)
+  })
+})

--- a/spec/http-server/server-client-spec.js
+++ b/spec/http-server/server-client-spec.js
@@ -168,7 +168,12 @@ describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, 
       socket.emit("close")
 
       expect(await transfer).toEqual("aborted")
-      expect(await client.sendFile(path.join(directory, "missing.bin"))).toEqual("aborted")
+
+      const missingFileSocket = new FakeSocket()
+      const missingFileClient = new ServerClient({clientCount: 6, configuration: buildConfiguration(), socket: missingFileSocket})
+
+      expect(await missingFileClient.sendFile(path.join(directory, "missing.bin"))).toEqual("aborted")
+      expect(missingFileSocket.destroyCalls).toEqual(1)
     } finally {
       await fs.rm(directory, {force: true, recursive: true})
     }

--- a/spec/http-server/server-client-spec.js
+++ b/spec/http-server/server-client-spec.js
@@ -1,6 +1,10 @@
 // @ts-check
 
 import EventEmitter from "node:events"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import {waitFor} from "awaitery"
 
 import Configuration from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
@@ -52,19 +56,41 @@ class FakeSocket extends EventEmitter {
   }
 }
 
+class SlowFakeSocket extends FakeSocket {
+  writes = []
+  backpressured = true
+
+  /**
+   * @param {string | Uint8Array} data - Data payload.
+   * @param {(error?: Error) => void} [callback] - Callback.
+   * @returns {boolean} - Whether the socket accepted more data.
+   */
+  write(data, callback) {
+    this.writes.push(Buffer.from(data))
+    callback?.()
+
+    return !this.backpressured
+  }
+}
+
+/** @returns {Configuration} - Minimal server-client test configuration. */
+function buildConfiguration() {
+  return new Configuration({
+    database: {test: {}},
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"],
+    logging: {console: false, file: false}
+  })
+}
+
 describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, () => {
   it("handles socket errors without crashing and emits close once", async () => {
-    const configuration = new Configuration({
-      database: {test: {}},
-      directory: process.cwd(),
-      environment: "test",
-      environmentHandler: new EnvironmentHandlerNode(),
-      initializeModels: async () => {},
-      locale: "en",
-      localeFallbacks: {en: ["en"]},
-      locales: ["en"],
-      logging: {console: false, file: false}
-    })
+    const configuration = buildConfiguration()
     const socket = new FakeSocket()
     const client = new ServerClient({clientCount: 1, configuration, socket})
     let closeEvents = 0
@@ -83,17 +109,7 @@ describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, 
   })
 
   it("resolves send when socket emits error during write", async () => {
-    const configuration = new Configuration({
-      database: {test: {}},
-      directory: process.cwd(),
-      environment: "test",
-      environmentHandler: new EnvironmentHandlerNode(),
-      initializeModels: async () => {},
-      locale: "en",
-      localeFallbacks: {en: ["en"]},
-      locales: ["en"],
-      logging: {console: false, file: false}
-    })
+    const configuration = buildConfiguration()
     const socket = new FakeSocket()
     const client = new ServerClient({clientCount: 2, configuration, socket})
 
@@ -102,17 +118,7 @@ describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, 
   })
 
   it("resolves end immediately for already closed sockets", async () => {
-    const configuration = new Configuration({
-      database: {test: {}},
-      directory: process.cwd(),
-      environment: "test",
-      environmentHandler: new EnvironmentHandlerNode(),
-      initializeModels: async () => {},
-      locale: "en",
-      localeFallbacks: {en: ["en"]},
-      locales: ["en"],
-      logging: {console: false, file: false}
-    })
+    const configuration = buildConfiguration()
     const socket = new FakeSocket()
     const client = new ServerClient({clientCount: 3, configuration, socket})
 
@@ -121,5 +127,50 @@ describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, 
     socket.writableEnded = true
 
     await client.end()
+  })
+
+  it("pauses file reads until a backpressured socket drains", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-file-response-"))
+    const filePath = path.join(directory, "large.bin")
+
+    try {
+      await fs.writeFile(filePath, Buffer.alloc(192 * 1024, 1))
+
+      const socket = new SlowFakeSocket()
+      const client = new ServerClient({clientCount: 4, configuration: buildConfiguration(), socket})
+      const transfer = client.sendFile(filePath)
+
+      await waitFor(() => expect(socket.writes.length).toEqual(1))
+      expect(socket.writes[0]?.length).toEqual(64 * 1024)
+
+      socket.backpressured = false
+      socket.emit("drain")
+
+      expect(await transfer).toEqual("completed")
+      expect(socket.writes.length).toEqual(3)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("reports file delivery aborts on socket close and read failure", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-file-response-"))
+    const filePath = path.join(directory, "large.bin")
+
+    try {
+      await fs.writeFile(filePath, Buffer.alloc(128 * 1024, 1))
+
+      const socket = new SlowFakeSocket()
+      const client = new ServerClient({clientCount: 5, configuration: buildConfiguration(), socket})
+      const transfer = client.sendFile(filePath)
+
+      await waitFor(() => expect(socket.writes.length).toEqual(1))
+      socket.emit("close")
+
+      expect(await transfer).toEqual("aborted")
+      expect(await client.sendFile(path.join(directory, "missing.bin"))).toEqual("aborted")
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
   })
 })

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -1,9 +1,12 @@
 // @ts-check
 
+import {waitFor} from "awaitery"
+import EventEmitter from "../../src/utils/event-emitter.js"
 import WorkerHandler from "../../src/http-server/worker-handler/index.js"
 import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 import websocketEventsHost from "../../src/http-server/websocket-events-host.js"
+import WorkerThreadHandler from "../../src/http-server/worker-handler/worker-thread.js"
 
 class FakeWorkerHandler {
   /**
@@ -37,6 +40,27 @@ function buildWorkerHandlerTestServer() {
       getEnvironment: () => "test"
     }
   })
+}
+
+/**
+ * Builds the worker-thread side without starting a real thread.
+ * @returns {{errorEvents: EventEmitter, postedMessages: object[], workerThread: WorkerThreadHandler}} - Worker-thread test state.
+ */
+function buildWorkerThread() {
+  const errorEvents = new EventEmitter()
+  const postedMessages = []
+  const workerThread = Object.create(WorkerThreadHandler.prototype)
+
+  workerThread.clients = {}
+  workerThread.configuration = {
+    getErrorEvents: () => errorEvents,
+    logging: {console: false, file: false}
+  }
+  workerThread.fileTransferCount = 0
+  workerThread.fileTransfers = new Map()
+  workerThread.parentPort = {postMessage: (message) => postedMessages.push(message)}
+
+  return {errorEvents, postedMessages, workerThread}
 }
 
 describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}}, () => {
@@ -139,6 +163,171 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
     await handler.stop()
     expect(true).toBeTrue()
+  })
+
+  it("sends descriptor-only file messages and acknowledges completion once", async () => {
+    const {postedMessages, workerThread} = buildWorkerThread()
+    workerThread.handleNewClient({clientCount: 7, remoteAddress: "127.0.0.1"})
+
+    const results = []
+    const transfer = workerThread.clients[7].sendFileOutput("/tmp/example.bin", true, (result) => results.push(result))
+
+    expect(postedMessages).toEqual([{
+      clientCount: 7,
+      command: "clientFile",
+      filePath: "/tmp/example.bin",
+      sendBody: true,
+      transferId: 1
+    }])
+    expect("output" in postedMessages[0]).toEqual(false)
+
+    await workerThread.handleClientFileResult({result: "completed", transferId: 1})
+    await workerThread.handleClientFileResult({result: "aborted", transferId: 1})
+    await transfer
+
+    expect(results).toEqual(["completed"])
+
+    const abortedTransfer = workerThread.clients[7].sendFileOutput("/tmp/aborted.bin", true, (result) => results.push(result))
+
+    await workerThread.clients[7].abortPendingFileResponses()
+    await workerThread.clients[7].abortPendingFileResponses()
+    await abortedTransfer
+
+    expect(results).toEqual(["completed", "aborted"])
+  })
+
+  it("propagates parent socket close and settles a waiting worker descriptor once as aborted", async () => {
+    const {workerThread} = buildWorkerThread()
+    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+    const parentClientEvents = new EventEmitter()
+    const parentClient = {
+      clientCount: 8,
+      events: parentClientEvents,
+      listen: () => {},
+      remoteAddress: "127.0.0.1",
+      setWorker: () => {}
+    }
+    let abortHandling = Promise.resolve()
+
+    workerThread.handleNewClient({clientCount: 8, remoteAddress: "127.0.0.1"})
+    handler.worker = {
+      postMessage: (message) => {
+        if (message.command === "clientAbort") abortHandling = workerThread.handleClientAbort(message)
+      }
+    }
+    handler.addSocketConnection(parentClient)
+    handler._clientDeliveryQueues.set(8, new Promise(() => {}))
+
+    const results = []
+    const transfer = workerThread.clients[8].sendFileOutput("/tmp/waiting.bin", true, (result) => results.push(result))
+
+    parentClientEvents.emit("close")
+    parentClientEvents.emit("close")
+    await abortHandling
+    await transfer
+
+    expect(results).toEqual(["aborted"])
+    expect(handler.clients[8]).toEqual(undefined)
+    expect(handler._clientDeliveryQueues.has(8)).toEqual(false)
+    expect(workerThread.clients[8]).toEqual(undefined)
+  })
+
+  it("awaits async file cleanup once before settling the worker descriptor", async () => {
+    const {workerThread} = buildWorkerThread()
+    let releaseCleanup
+    const cleanupReleased = new Promise((resolve) => {
+      releaseCleanup = resolve
+    })
+    const results = []
+    let transferSettled = false
+
+    workerThread.handleNewClient({clientCount: 9, remoteAddress: "127.0.0.1"})
+    const transfer = workerThread.clients[9].sendFileOutput("/tmp/async-cleanup.bin", true, async (result) => {
+      results.push(result)
+      await cleanupReleased
+    })
+    transfer.then(() => { transferSettled = true })
+
+    const resultHandling = workerThread.handleClientFileResult({result: "completed", transferId: 1})
+
+    await waitFor(() => expect(results).toEqual(["completed"]))
+    expect(transferSettled).toEqual(false)
+
+    releaseCleanup()
+    await resultHandling
+    await transfer
+    await workerThread.handleClientFileResult({result: "aborted", transferId: 1})
+
+    expect(transferSettled).toEqual(true)
+    expect(results).toEqual(["completed"])
+  })
+
+  it("reports thrown and rejected file cleanup errors without rejecting committed responses", async () => {
+    const {errorEvents, workerThread} = buildWorkerThread()
+    const reportedErrors = []
+
+    errorEvents.on("framework-error", ({error}) => reportedErrors.push(error.message))
+    workerThread.handleNewClient({clientCount: 10, remoteAddress: "127.0.0.1"})
+
+    const thrownTransfer = workerThread.clients[10].sendFileOutput("/tmp/thrown-cleanup.bin", true, () => {
+      throw new Error("sync cleanup failed")
+    })
+
+    await workerThread.handleClientFileResult({result: "completed", transferId: 1})
+    await thrownTransfer
+
+    const rejectedTransfer = workerThread.clients[10].sendFileOutput("/tmp/rejected-cleanup.bin", true, async () => {
+      throw new Error("async cleanup failed")
+    })
+
+    await workerThread.handleClientFileResult({result: "completed", transferId: 2})
+    await rejectedTransfer
+
+    expect(reportedErrors).toEqual(["sync cleanup failed", "async cleanup failed"])
+  })
+
+  it("acknowledges missing-client file descriptors as aborted", () => {
+    const postedMessages = []
+    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+
+    handler.worker = {postMessage: (message) => postedMessages.push(message)}
+    handler.onWorkerMessage({clientCount: 99, command: "clientFile", filePath: "/tmp/example.bin", sendBody: true, transferId: 4})
+
+    expect(postedMessages).toEqual([{command: "clientFileResult", result: "aborted", transferId: 4}])
+  })
+
+  it("delivers file descriptors after earlier queued output", async () => {
+    const deliveries = []
+    const postedMessages = []
+    let releaseOutput
+    const outputDelivered = new Promise((resolve) => {
+      releaseOutput = resolve
+    })
+    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+
+    handler.worker = {postMessage: (message) => postedMessages.push(message)}
+    handler.clients[3] = {
+      clientCount: 3,
+      send: async () => {
+        deliveries.push("headers")
+        await outputDelivered
+      },
+      sendFile: async () => {
+        deliveries.push("file")
+        return "completed"
+      }
+    }
+
+    handler.onWorkerMessage({clientCount: 3, command: "clientOutput", output: "headers"})
+    handler.onWorkerMessage({clientCount: 3, command: "clientFile", filePath: "/tmp/example.bin", sendBody: true, transferId: 5})
+
+    await waitFor(() => expect(deliveries).toEqual(["headers"]))
+
+    releaseOutput()
+    await handler._clientDeliveryQueues.get(3)
+
+    expect(deliveries).toEqual(["headers", "file"])
+    expect(postedMessages).toEqual([{command: "clientFileResult", result: "completed", transferId: 5}])
   })
 
   it("ignores websocket dispatch when the worker transport is missing", () => {

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -6,6 +6,7 @@ import WorkerHandler from "../../src/http-server/worker-handler/index.js"
 import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 import websocketEventsHost from "../../src/http-server/websocket-events-host.js"
+import InProcessHandler from "../../src/http-server/worker-handler/in-process.js"
 import WorkerThreadHandler from "../../src/http-server/worker-handler/worker-thread.js"
 
 class FakeWorkerHandler {
@@ -163,6 +164,107 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
     await handler.stop()
     expect(true).toBeTrue()
+  })
+
+  it("awaits in-process file cleanup before removing clients during shutdown", async () => {
+    let releaseCleanup
+    const cleanupReleased = new Promise((resolve) => {
+      releaseCleanup = resolve
+    })
+    const shutdownEvents = []
+    const handler = Object.create(InProcessHandler.prototype)
+
+    handler.pendingClientCloseCleanups = new Set()
+    handler.clients = {
+      11: {
+        httpClient: {
+          abortPendingFileResponses: async () => {
+            shutdownEvents.push("cleanup-started")
+            await cleanupReleased
+            shutdownEvents.push("cleanup-finished")
+          }
+        },
+        serverClient: {
+          clientCount: 11,
+          end: async () => {
+            shutdownEvents.push("client-ended")
+          }
+        }
+      }
+    }
+    handler.unregisterFromEventsHost = () => {
+      shutdownEvents.push("unregistered")
+    }
+
+    let stopSettled = false
+    const stopping = handler.stop().then(() => {
+      stopSettled = true
+    })
+
+    await waitFor(() => expect(shutdownEvents).toContain("cleanup-started"))
+    expect(shutdownEvents).toContain("client-ended")
+    expect(stopSettled).toEqual(false)
+    expect(handler.clients[11]).not.toEqual(undefined)
+
+    releaseCleanup()
+    await stopping
+
+    expect(shutdownEvents).toEqual(["cleanup-started", "client-ended", "cleanup-finished", "unregistered"])
+    expect(handler.clients[11]).toEqual(undefined)
+  })
+
+  it("awaits close-triggered in-process file cleanup during normal shutdown order", async () => {
+    let releaseCleanup
+    const cleanupReleased = new Promise((resolve) => {
+      releaseCleanup = resolve
+    })
+    const shutdownEvents = []
+    const handler = new InProcessHandler({configuration: {logging: {console: false, file: false}}, workerCount: 0})
+    const serverClientEvents = new EventEmitter()
+    let socketClosed = false
+    const serverClient = /** @type {import("../../src/http-server/server-client.js").default} */ (/** @type {?} */ ({
+      clientCount: 12,
+      end: async () => {
+        if (socketClosed) return
+
+        socketClosed = true
+        shutdownEvents.push("socket-closed")
+        serverClientEvents.emit("close")
+      },
+      events: serverClientEvents,
+      listen: () => {},
+      remoteAddress: "127.0.0.1",
+      send: async () => {},
+      sendFile: async () => await new Promise(() => {}),
+      setWorker: () => {}
+    }))
+
+    handler.addSocketConnection(serverClient)
+
+    const transfer = handler.clients[12].httpClient.sendFileOutput("/tmp/shutdown-order.bin", true, async (result) => {
+      shutdownEvents.push(`cleanup-${result}-started`)
+      await cleanupReleased
+      shutdownEvents.push(`cleanup-${result}-finished`)
+    })
+
+    await serverClient.end()
+    await waitFor(() => expect(shutdownEvents).toContain("cleanup-aborted-started"))
+
+    let stopSettled = false
+    const stopping = handler.stop().then(() => {
+      stopSettled = true
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    const stopSettledBeforeCleanup = stopSettled
+
+    releaseCleanup()
+    await stopping
+    await transfer
+
+    expect(stopSettledBeforeCleanup).toEqual(false)
+    expect(shutdownEvents).toEqual(["socket-closed", "cleanup-aborted-started", "cleanup-aborted-finished"])
+    expect(handler.clients[12]).toEqual(undefined)
   })
 
   it("sends descriptor-only file messages and acknowledges completion once", async () => {

--- a/spec/plugins/sqljs-wasm-route-spec.js
+++ b/spec/plugins/sqljs-wasm-route-spec.js
@@ -197,7 +197,7 @@ describe("plugins - sqljs wasm route", {databaseCleaning: {transaction: true}}, 
     expect(sqlWasmUrl).toEqual("http://127.0.0.1:4501/velocious/sqljs/sql-wasm.wasm")
   })
 
-  it("streams wasm bytes through the HTTP client send pipeline", async () => {
+  it("emits a wasm file descriptor through the HTTP client send pipeline", async () => {
     const configuration = new Configuration({
       database: {test: {}},
       directory: dummyDirectory(),
@@ -217,6 +217,7 @@ describe("plugins - sqljs wasm route", {databaseCleaning: {transaction: true}}, 
 
     /** @type {Array<string | Uint8Array>} */
     const outputs = []
+    const fileDescriptors = []
     const closePromise = new Promise((resolve) => {
       const client = new Client({
         clientCount: 11,
@@ -224,6 +225,10 @@ describe("plugins - sqljs wasm route", {databaseCleaning: {transaction: true}}, 
       })
 
       client.events.on("output", (output) => outputs.push(output))
+      client.events.on("file", (descriptor) => {
+        fileDescriptors.push(descriptor)
+        descriptor.settle("completed")
+      })
       client.events.on("close", resolve)
       client.onWrite(Buffer.from([
         "GET /velocious/sqljs/sql-wasm.wasm HTTP/1.1",
@@ -238,16 +243,18 @@ describe("plugins - sqljs wasm route", {databaseCleaning: {transaction: true}}, 
 
     const headerOutput = outputs.find((output) => typeof output === "string")
     const binaryChunks = outputs.filter((output) => output instanceof Uint8Array)
-    const wasmPrefixChunk = binaryChunks.find((chunk) => chunk.length >= 4)
+    const fileDescriptor = fileDescriptors[0]
+    const wasmBytes = await fs.readFile(fileDescriptor.filePath)
 
     expect(typeof headerOutput).toEqual("string")
     expect(headerOutput.includes("200 OK")).toEqual(true)
     expect(headerOutput.includes("Content-Type: application/wasm")).toEqual(true)
-    expect(Boolean(wasmPrefixChunk)).toEqual(true)
-    expect(wasmPrefixChunk[0]).toEqual(0)
-    expect(wasmPrefixChunk[1]).toEqual(97)
-    expect(wasmPrefixChunk[2]).toEqual(115)
-    expect(wasmPrefixChunk[3]).toEqual(109)
+    expect(binaryChunks).toEqual([])
+    expect(fileDescriptor.sendBody).toEqual(true)
+    expect(wasmBytes[0]).toEqual(0)
+    expect(wasmBytes[1]).toEqual(97)
+    expect(wasmBytes[2]).toEqual(115)
+    expect(wasmBytes[3]).toEqual(109)
   })
 
   it("serves identical wasm bytes over dummy app HTTP", async () => {

--- a/src/background-jobs/cron-expression.js
+++ b/src/background-jobs/cron-expression.js
@@ -52,7 +52,7 @@ const FIELDS = [
 /**
  * Runs the parseCronExpression helper.
  * @param {string} expression - Cron expression or shortcut.
- * @returns {ParsedCron}
+ * @returns {ParsedCron} - Parsed cron schedule fields.
  */
 export function parseCronExpression(expression) {
   if (typeof expression !== "string" || !expression.trim()) {
@@ -87,8 +87,8 @@ export function parseCronExpression(expression) {
 
 /**
  * Runs normalize day of week.
- * @param {Set<number>} dayOfWeek
- * @returns {Set<number>}
+ * @param {Set<number>} dayOfWeek - Day-of-week values.
+ * @returns {Set<number>} - Normalized day-of-week values.
  */
 function normalizeDayOfWeek(dayOfWeek) {
   if (dayOfWeek.has(7)) {
@@ -104,7 +104,7 @@ function normalizeDayOfWeek(dayOfWeek) {
  * @param {string} field - Field expression.
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Whole cron expression for error messages.
- * @returns {Set<number>}
+ * @returns {Set<number>} - Parsed allowed field values.
  */
 function parseField(field, fieldSpec, expression) {
   const result = new Set()
@@ -147,7 +147,7 @@ function addPartValues(part, fieldSpec, expression, result) {
  * @param {string} value - Step value.
  * @param {{name: string, min: number, max: number}} fieldSpec - Field spec.
  * @param {string} expression - Original expression for errors.
- * @returns {number}
+ * @returns {number} - Parsed positive step size.
  */
 function parseStep(value, fieldSpec, expression) {
   const step = Number(value)
@@ -165,7 +165,7 @@ function parseStep(value, fieldSpec, expression) {
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Original expression for errors.
  * @param {boolean} hasStep - Whether the part had a `/step` suffix.
- * @returns {[number, number]}
+ * @returns {[number, number]} - Inclusive field range.
  */
 function parseRange(rangePart, fieldSpec, expression, hasStep) {
   if (rangePart === "*") {
@@ -196,7 +196,7 @@ function parseRange(rangePart, fieldSpec, expression, hasStep) {
  * @param {string} rawValue - Raw value (may be a name).
  * @param {{name: string, min: number, max: number, names?: string[]}} fieldSpec - Field spec.
  * @param {string} expression - Original expression for errors.
- * @returns {number}
+ * @returns {number} - Parsed numeric field value.
  */
 function parseValue(rawValue, fieldSpec, expression) {
   if (!rawValue) {
@@ -230,7 +230,7 @@ const MAX_NEXT_FIRE_ITERATIONS = 5 * 366 * 24 * 60
  * real time (e.g., `0 0 31 2 *` — Feb 31st).
  * @param {ParsedCron} parsed - Parsed cron expression.
  * @param {Date} from - Reference Date — the next match is strictly after this.
- * @returns {Date}
+ * @returns {Date} - Next date matching the expression.
  */
 export function nextCronFireDate(parsed, from) {
   const candidate = new Date(from.getTime())
@@ -251,7 +251,7 @@ export function nextCronFireDate(parsed, from) {
  * Runs candidate matches.
  * @param {Date} candidate - Candidate Date (in local time).
  * @param {ParsedCron} parsed - Parsed expression.
- * @returns {boolean}
+ * @returns {boolean} - Whether the candidate matches the parsed schedule.
  */
 function candidateMatches(candidate, parsed) {
   if (!parsed.minute.has(candidate.getMinutes())) return false

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -70,19 +70,19 @@ export default class BackgroundJobsMain {
     this.server = undefined
     /**
      * Narrows the runtime value to the documented type.
-     * @type {NodeJS.Timeout | undefined} */
+     * @type {ReturnType<typeof setTimeout> | undefined} */
     this._pollTimer = undefined
     /**
      * Narrows the runtime value to the documented type.
-     * @type {NodeJS.Timeout | undefined} */
+     * @type {ReturnType<typeof setTimeout> | undefined} */
     this._scheduledTimer = undefined
     /**
      * Narrows the runtime value to the documented type.
-     * @type {NodeJS.Timeout | undefined} */
+     * @type {ReturnType<typeof setTimeout> | undefined} */
     this._errorRetryTimer = undefined
     /**
      * Narrows the runtime value to the documented type.
-     * @type {NodeJS.Timeout | undefined} */
+     * @type {ReturnType<typeof setTimeout> | undefined} */
     this._orphanTimer = undefined
     /**
      * Narrows the runtime value to the documented type.

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -533,7 +533,7 @@ export default class BackgroundJobsWorker {
    * @param {object} args - Options.
    * @param {import("node:child_process").ChildProcess} args.child - Forked child process.
    * @param {number | null} args.code - Exit code.
-   * @param {NodeJS.Signals | null} args.signal - Exit signal.
+   * @param {keyof typeof import("node:os").constants.signals | null} args.signal - Exit signal.
    * @param {import("./types.js").BackgroundJobPayload & {id: string}} args.payload - Payload.
    * @param {(value: void) => void} args.resolve - Promise resolver.
    * @returns {Promise<void>} - Resolves after failure is reported.
@@ -558,7 +558,7 @@ export default class BackgroundJobsWorker {
    * Runs forked child exited cleanly.
    * @param {object} args - Options.
    * @param {number | null} args.code - Exit code.
-   * @param {NodeJS.Signals | null} args.signal - Exit signal.
+   * @param {keyof typeof import("node:os").constants.signals | null} args.signal - Exit signal.
    * @returns {boolean} - Whether the child exited cleanly.
    */
   _forkedChildExitedCleanly({code, signal}) {

--- a/src/beacon/client.js
+++ b/src/beacon/client.js
@@ -66,7 +66,7 @@ export default class BeaconClient extends EventEmitter {
     this._closed = false
     /**
      * Narrows the runtime value to the documented type.
-     * @type {NodeJS.Timeout | undefined} */
+     * @type {ReturnType<typeof setTimeout> | undefined} */
     this._reconnectTimer = undefined
     /**
      * Narrows the runtime value to the documented type.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2157,7 +2157,7 @@ export default class VelociousConfiguration {
    * Registers a `VelociousWebsocketConnection` subclass under a name.
    * Clients that send `{type: "connection-open", connectionType: name}`
    * will have this class instantiated for their connection.
-   * @param {string} name - Registered name.
+   * @param {string} name - Client-facing connection type name.
    * @param {typeof import("./http-server/websocket-connection.js").default} ConnectionClass - Websocket connection class.
    * @returns {void}
    */
@@ -2169,7 +2169,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get websocket connection class.
-   * @param {string} name - Registered name.
+   * @param {string} name - Connection type name to look up.
    * @returns {typeof import("./http-server/websocket-connection.js").default | undefined} - Registered websocket connection class.
    */
   getWebsocketConnectionClass(name) {
@@ -2179,7 +2179,7 @@ export default class VelociousConfiguration {
   /**
    * Registers a `VelociousWebsocketChannel` subclass under a name.
    * Clients subscribe via `{type: "channel-subscribe", channelType: name, ...}`.
-   * @param {string} name - Registered name.
+   * @param {string} name - Client-facing channel type name.
    * @param {typeof import("./http-server/websocket-channel.js").default} ChannelClass - Websocket channel class.
    * @returns {void}
    */
@@ -2191,7 +2191,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get websocket channel class.
-   * @param {string} name - Registered name.
+   * @param {string} name - Channel type name to look up.
    * @returns {typeof import("./http-server/websocket-channel.js").default | undefined} - Registered websocket channel class.
    */
   getWebsocketChannelClass(name) {
@@ -2202,8 +2202,8 @@ export default class VelociousConfiguration {
    * Tracks a live channel subscription in the global routing registry.
    * Called by the session when `canSubscribe()` resolves truthy; the
    * session calls `_unregisterWebsocketChannelSubscription` on unsubscribe.
-   * @param {string} name - Registered name.
-   * @param {import("./http-server/websocket-channel.js").default} subscription - Subscription callback.
+   * @param {string} name - Channel type used as the routing key.
+   * @param {import("./http-server/websocket-channel.js").default} subscription - Live channel subscription to register.
    * @returns {void}
    */
   _registerWebsocketChannelSubscription(name, subscription) {
@@ -2219,8 +2219,8 @@ export default class VelociousConfiguration {
 
   /**
    * Runs unregister websocket channel subscription.
-   * @param {string} name - Registered name.
-   * @param {import("./http-server/websocket-channel.js").default} subscription - Subscription callback.
+   * @param {string} name - Channel type used as the routing key.
+   * @param {import("./http-server/websocket-channel.js").default} subscription - Live channel subscription to remove.
    * @returns {void}
    */
   _unregisterWebsocketChannelSubscription(name, subscription) {
@@ -2263,7 +2263,7 @@ export default class VelociousConfiguration {
    * connection message / channel dispatch. The wrapper receives the
    * session and a `next` callback; it must call `next()` to run the
    * handler. Use it to set up AsyncLocalStorage per request.
-   * @param {((session: import("./http-server/client/websocket-session.js").default, next: () => Promise<void>) => Promise<void>) | null} wrapper - Wrapper callback.
+   * @param {((session: import("./http-server/client/websocket-session.js").default, next: () => Promise<void>) => Promise<void>) | null} wrapper - Per-message session-context wrapper, or null to disable it.
    * @returns {void}
    */
   setWebsocketAroundRequest(wrapper) {
@@ -2283,7 +2283,7 @@ export default class VelociousConfiguration {
    * HTTP and WS-borne. Receives `{request, response, next}` and must
    * call `next()` to run the action. Use it for per-request context
    * like AsyncLocalStorage-scoped locale or tracing.
-   * @param {((context: {request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, response: import("./http-server/client/response.js").default, next: () => Promise<void>}) => Promise<void>) | null} wrapper - Wrapper callback.
+   * @param {((context: {request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, response: import("./http-server/client/response.js").default, next: () => Promise<void>}) => Promise<void>) | null} wrapper - Per-action request-context wrapper, or null to disable it.
    * @returns {void}
    */
   setAroundAction(wrapper) {
@@ -2311,7 +2311,7 @@ export default class VelociousConfiguration {
    *
    * Return `null`/`undefined` to mean "no identity" — resumes still
    * succeed if pause and resume both resolve to a nullish value.
-   * @param {((session: import("./http-server/client/websocket-session.js").default) => ? | Promise<?>) | null} resolver - Tenant resolver.
+   * @param {((session: import("./http-server/client/websocket-session.js").default) => ? | Promise<?>) | null} resolver - Authenticated-caller identity resolver, or null to disable identity checks.
    * @returns {void}
    */
   setWebsocketSessionIdentityResolver(resolver) {
@@ -2328,7 +2328,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs set websocket session grace seconds.
-   * @param {number} seconds - Duration in seconds.
+   * @param {number} seconds - Grace period before a paused session expires.
    * @returns {void}
    */
   setWebsocketSessionGraceSeconds(seconds) {
@@ -2338,7 +2338,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs set websocket session heartbeat seconds.
-   * @param {number} seconds - Duration in seconds.
+   * @param {number} seconds - Heartbeat interval, with zero disabling reaping.
    * @returns {void}
    */
   setWebsocketSessionHeartbeatSeconds(seconds) {
@@ -2351,7 +2351,7 @@ export default class VelociousConfiguration {
    * timer. When the timer fires, the session's permanent teardown
    * hook is invoked. Called by the session itself from `_handleClose`
    * when there is resumable state (live Connections / Channel subs).
-   * @param {import("./http-server/client/websocket-session.js").default} session - Websocket session.
+   * @param {import("./http-server/client/websocket-session.js").default} session - Resumable session to retain during its grace period.
    * @returns {void}
    */
   _pauseWebsocketSession(session) {
@@ -2374,8 +2374,8 @@ export default class VelociousConfiguration {
   /**
    * Looks up a paused session by id (does NOT remove it — caller is
    * expected to call `_resumeWebsocketSession` to complete the handoff).
-   * @param {string} sessionId - Websocket session identifier.
-   * @returns {import("./http-server/client/websocket-session.js").default | null} - Websocket session when registered.
+   * @param {string} sessionId - Paused session identifier to look up.
+   * @returns {import("./http-server/client/websocket-session.js").default | null} - Paused session with the requested identifier, if present.
    */
   _findPausedWebsocketSession(sessionId) {
     return this._pausedWebsocketSessions.get(sessionId)?.session || null
@@ -2385,7 +2385,7 @@ export default class VelociousConfiguration {
    * Removes a paused session from the registry and cancels its grace
    * timer. Called on successful resume handoff and on explicit
    * expiry.
-   * @param {string} sessionId - Websocket session identifier.
+   * @param {string} sessionId - Paused session identifier to remove and cancel.
    * @returns {void}
    */
   _clearPausedWebsocketSession(sessionId) {
@@ -2400,7 +2400,7 @@ export default class VelociousConfiguration {
   /**
    * Grace-timer callback. Calls the session's permanent-teardown
    * hook and drops it from the registry.
-   * @param {string} sessionId - Websocket session identifier.
+   * @param {string} sessionId - Paused session identifier whose grace period expired.
    * @returns {void}
    */
   _expireWebsocketSession(sessionId) {
@@ -2418,9 +2418,9 @@ export default class VelociousConfiguration {
 
   /**
    * Runs broadcast to channel.
-   * @param {string} name - Registered name.
-   * @param {Record<string, ?>} broadcastParams - Broadcast parameters.
-   * @param {?} body - Message body.
+   * @param {string} name - Channel type receiving the broadcast.
+   * @param {Record<string, ?>} broadcastParams - Values used to match eligible subscriptions.
+   * @param {?} body - Broadcast payload delivered to matching subscriptions.
    * @returns {void}
    */
   broadcastToChannel(name, broadcastParams, body) {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2056,7 +2056,8 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get translator.
-   * @returns {(msgID: string, args?: Record<string, ?>) => string} */
+   * @returns {(msgID: string, args?: Record<string, ?>) => string} - The configured translator.
+   */
   getTranslator() {
     if (this._translator) return this._translator
 
@@ -2156,8 +2157,8 @@ export default class VelociousConfiguration {
    * Registers a `VelociousWebsocketConnection` subclass under a name.
    * Clients that send `{type: "connection-open", connectionType: name}`
    * will have this class instantiated for their connection.
-   * @param {string} name
-   * @param {typeof import("./http-server/websocket-connection.js").default} ConnectionClass
+   * @param {string} name - Registered name.
+   * @param {typeof import("./http-server/websocket-connection.js").default} ConnectionClass - Websocket connection class.
    * @returns {void}
    */
   registerWebsocketConnection(name, ConnectionClass) {
@@ -2168,8 +2169,8 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get websocket connection class.
-   * @param {string} name
-   * @returns {typeof import("./http-server/websocket-connection.js").default | undefined}
+   * @param {string} name - Registered name.
+   * @returns {typeof import("./http-server/websocket-connection.js").default | undefined} - Registered websocket connection class.
    */
   getWebsocketConnectionClass(name) {
     return this._websocketConnectionClasses.get(name)
@@ -2178,8 +2179,8 @@ export default class VelociousConfiguration {
   /**
    * Registers a `VelociousWebsocketChannel` subclass under a name.
    * Clients subscribe via `{type: "channel-subscribe", channelType: name, ...}`.
-   * @param {string} name
-   * @param {typeof import("./http-server/websocket-channel.js").default} ChannelClass
+   * @param {string} name - Registered name.
+   * @param {typeof import("./http-server/websocket-channel.js").default} ChannelClass - Websocket channel class.
    * @returns {void}
    */
   registerWebsocketChannel(name, ChannelClass) {
@@ -2190,8 +2191,8 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get websocket channel class.
-   * @param {string} name
-   * @returns {typeof import("./http-server/websocket-channel.js").default | undefined}
+   * @param {string} name - Registered name.
+   * @returns {typeof import("./http-server/websocket-channel.js").default | undefined} - Registered websocket channel class.
    */
   getWebsocketChannelClass(name) {
     return this._websocketChannelClasses.get(name)
@@ -2201,8 +2202,8 @@ export default class VelociousConfiguration {
    * Tracks a live channel subscription in the global routing registry.
    * Called by the session when `canSubscribe()` resolves truthy; the
    * session calls `_unregisterWebsocketChannelSubscription` on unsubscribe.
-   * @param {string} name
-   * @param {import("./http-server/websocket-channel.js").default} subscription
+   * @param {string} name - Registered name.
+   * @param {import("./http-server/websocket-channel.js").default} subscription - Subscription callback.
    * @returns {void}
    */
   _registerWebsocketChannelSubscription(name, subscription) {
@@ -2218,8 +2219,8 @@ export default class VelociousConfiguration {
 
   /**
    * Runs unregister websocket channel subscription.
-   * @param {string} name
-   * @param {import("./http-server/websocket-channel.js").default} subscription
+   * @param {string} name - Registered name.
+   * @param {import("./http-server/websocket-channel.js").default} subscription - Subscription callback.
    * @returns {void}
    */
   _unregisterWebsocketChannelSubscription(name, subscription) {
@@ -2262,7 +2263,7 @@ export default class VelociousConfiguration {
    * connection message / channel dispatch. The wrapper receives the
    * session and a `next` callback; it must call `next()` to run the
    * handler. Use it to set up AsyncLocalStorage per request.
-   * @param {((session: import("./http-server/client/websocket-session.js").default, next: () => Promise<void>) => Promise<void>) | null} wrapper
+   * @param {((session: import("./http-server/client/websocket-session.js").default, next: () => Promise<void>) => Promise<void>) | null} wrapper - Wrapper callback.
    * @returns {void}
    */
   setWebsocketAroundRequest(wrapper) {
@@ -2271,7 +2272,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get websocket around request.
-   * @returns {((session: import("./http-server/client/websocket-session.js").default, next: () => Promise<void>) => Promise<void>) | null}
+   * @returns {((session: import("./http-server/client/websocket-session.js").default, next: () => Promise<void>) => Promise<void>) | null} - Websocket session wrapper.
    */
   getWebsocketAroundRequest() {
     return this._websocketAroundRequest
@@ -2282,7 +2283,7 @@ export default class VelociousConfiguration {
    * HTTP and WS-borne. Receives `{request, response, next}` and must
    * call `next()` to run the action. Use it for per-request context
    * like AsyncLocalStorage-scoped locale or tracing.
-   * @param {((context: {request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, response: import("./http-server/client/response.js").default, next: () => Promise<void>}) => Promise<void>) | null} wrapper
+   * @param {((context: {request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, response: import("./http-server/client/response.js").default, next: () => Promise<void>}) => Promise<void>) | null} wrapper - Wrapper callback.
    * @returns {void}
    */
   setAroundAction(wrapper) {
@@ -2291,7 +2292,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get around action.
-   * @returns {((context: {request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, response: import("./http-server/client/response.js").default, next: () => Promise<void>}) => Promise<void>) | null}
+   * @returns {((context: {request: import("./http-server/client/request.js").default | import("./http-server/client/websocket-request.js").default, response: import("./http-server/client/response.js").default, next: () => Promise<void>}) => Promise<void>) | null} - HTTP request wrapper.
    */
   getAroundAction() {
     return this._aroundAction
@@ -2310,7 +2311,7 @@ export default class VelociousConfiguration {
    *
    * Return `null`/`undefined` to mean "no identity" — resumes still
    * succeed if pause and resume both resolve to a nullish value.
-   * @param {((session: import("./http-server/client/websocket-session.js").default) => ? | Promise<?>) | null} resolver
+   * @param {((session: import("./http-server/client/websocket-session.js").default) => ? | Promise<?>) | null} resolver - Tenant resolver.
    * @returns {void}
    */
   setWebsocketSessionIdentityResolver(resolver) {
@@ -2319,14 +2320,15 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get websocket session identity resolver.
-   * @returns {((session: import("./http-server/client/websocket-session.js").default) => ? | Promise<?>) | null} */
+   * @returns {((session: import("./http-server/client/websocket-session.js").default) => ? | Promise<?>) | null} - The configured identity resolver.
+   */
   getWebsocketSessionIdentityResolver() {
     return this._websocketSessionIdentityResolver
   }
 
   /**
    * Runs set websocket session grace seconds.
-   * @param {number} seconds
+   * @param {number} seconds - Duration in seconds.
    * @returns {void}
    */
   setWebsocketSessionGraceSeconds(seconds) {
@@ -2336,7 +2338,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs set websocket session heartbeat seconds.
-   * @param {number} seconds
+   * @param {number} seconds - Duration in seconds.
    * @returns {void}
    */
   setWebsocketSessionHeartbeatSeconds(seconds) {
@@ -2349,7 +2351,7 @@ export default class VelociousConfiguration {
    * timer. When the timer fires, the session's permanent teardown
    * hook is invoked. Called by the session itself from `_handleClose`
    * when there is resumable state (live Connections / Channel subs).
-   * @param {import("./http-server/client/websocket-session.js").default} session
+   * @param {import("./http-server/client/websocket-session.js").default} session - Websocket session.
    * @returns {void}
    */
   _pauseWebsocketSession(session) {
@@ -2372,8 +2374,8 @@ export default class VelociousConfiguration {
   /**
    * Looks up a paused session by id (does NOT remove it — caller is
    * expected to call `_resumeWebsocketSession` to complete the handoff).
-   * @param {string} sessionId
-   * @returns {import("./http-server/client/websocket-session.js").default | null}
+   * @param {string} sessionId - Websocket session identifier.
+   * @returns {import("./http-server/client/websocket-session.js").default | null} - Websocket session when registered.
    */
   _findPausedWebsocketSession(sessionId) {
     return this._pausedWebsocketSessions.get(sessionId)?.session || null
@@ -2383,7 +2385,7 @@ export default class VelociousConfiguration {
    * Removes a paused session from the registry and cancels its grace
    * timer. Called on successful resume handoff and on explicit
    * expiry.
-   * @param {string} sessionId
+   * @param {string} sessionId - Websocket session identifier.
    * @returns {void}
    */
   _clearPausedWebsocketSession(sessionId) {
@@ -2398,7 +2400,7 @@ export default class VelociousConfiguration {
   /**
    * Grace-timer callback. Calls the session's permanent-teardown
    * hook and drops it from the registry.
-   * @param {string} sessionId
+   * @param {string} sessionId - Websocket session identifier.
    * @returns {void}
    */
   _expireWebsocketSession(sessionId) {
@@ -2416,9 +2418,9 @@ export default class VelociousConfiguration {
 
   /**
    * Runs broadcast to channel.
-   * @param {string} name
-   * @param {Record<string, ?>} broadcastParams
-   * @param {?} body
+   * @param {string} name - Registered name.
+   * @param {Record<string, ?>} broadcastParams - Broadcast parameters.
+   * @param {?} body - Message body.
    * @returns {void}
    */
   broadcastToChannel(name, broadcastParams, body) {

--- a/src/controller.js
+++ b/src/controller.js
@@ -339,16 +339,21 @@ export default class VelociousController {
    * @param {object} [args] - Options object.
    * @param {string} [args.contentType] - Content type.
    * @param {number | string} [args.status] - Status.
+   * @param {(result: "completed" | "aborted") => void | Promise<void>} [args.onFinished] - Called once after file delivery completes or aborts.
    * @returns {void} - No return value.
    */
   sendFile(filePath, args = {}) {
     this._measureViewRender(() => {
-      const {contentType, status, ...restArgs} = args
+      const {contentType, onFinished, status, ...restArgs} = args
 
       restArgsError(restArgs)
 
       if (typeof filePath !== "string" || filePath.length < 1) {
         throw new Error(`Expected file path to be a non-empty string, got: ${String(filePath)}`)
+      }
+
+      if (onFinished !== undefined && typeof onFinished !== "function") {
+        throw new Error(`Expected onFinished to be a function, got: ${typeof onFinished}`)
       }
 
       const detectedContentType = contentType || this.sendFileContentType(filePath)
@@ -361,7 +366,7 @@ export default class VelociousController {
         this._response.setStatus(status)
       }
 
-      this._response.setFilePath(filePath)
+      this._response.setFilePath(filePath, onFinished || null)
     })
   }
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -169,7 +169,7 @@ export default class VelociousController {
       const beforeActions = currentControllerClass._beforeActions
 
       if (beforeActions) {
-        const controllerPrototype = /** @type {Record<string, Function | undefined>} */ (/** @type {?} */ (currentControllerClass.prototype))
+        const controllerPrototype = /** @type {Record<string, ((...args: Array<?>) => ?) | undefined>} */ (/** @type {?} */ (currentControllerClass.prototype))
 
         for (const beforeActionName of beforeActions) {
           const beforeAction = controllerPrototype[beforeActionName]
@@ -266,6 +266,7 @@ export default class VelociousController {
   /**
    * Runs render json arg.
    * @param {object} json - JSON payload.
+   * @returns {void} - No return value.
    */
   renderJsonArg(json) {
     return this._measureViewRender(() => {

--- a/src/controller.js
+++ b/src/controller.js
@@ -266,7 +266,7 @@ export default class VelociousController {
   /**
    * Runs render json arg.
    * @param {object} json - JSON payload.
-   * @returns {void} - No return value.
+   * @returns {void} - Sets the response JSON payload.
    */
   renderJsonArg(json) {
     return this._measureViewRender(() => {

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -401,7 +401,7 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
         const waiters = state.waitersByName.get(name) || []
         /**
          * Timeout handle.
-         * @type {NodeJS.Timeout | null} */
+         * @type {ReturnType<typeof setTimeout> | null} */
         let timeoutHandle = null
         /**
          * Remove and resolve.

--- a/src/database/drivers/sqlite/index.js
+++ b/src/database/drivers/sqlite/index.js
@@ -93,7 +93,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * (create and remove) per critical section.
    * @param {string} name - Lock name.
    * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null`, `undefined`, or negative blocks forever.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory lock was acquired.
    */
   async acquireAdvisoryLock(name, {timeoutMs} = {}) {
     const deadline = typeof timeoutMs === "number" && timeoutMs >= 0 ? Date.now() + timeoutMs : null
@@ -121,7 +121,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
   /**
    * Runs try acquire advisory lock.
    * @param {string} name - Lock name.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory lock was acquired immediately.
    */
   async tryAcquireAdvisoryLock(name) {
     const inProcessAcquired = await super.tryAcquireAdvisoryLock(name)
@@ -151,7 +151,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * and the filesystem state is left alone so we never delete somebody
    * else's lock directory.
    * @param {string} name - Lock name.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory lock was released.
    */
   async releaseAdvisoryLock(name) {
     const inProcessReleased = await super.releaseAdvisoryLock(name)
@@ -166,7 +166,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
   /**
    * Runs is advisory lock held.
    * @param {string} name - Lock name.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory lock is held.
    */
   async isAdvisoryLockHeld(name) {
     if (await super.isAdvisoryLockHeld(name)) return true
@@ -176,7 +176,8 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
 
   /**
    * Runs resolve advisory lock directory.
-   * @returns {string} */
+   * @returns {string} - The advisory-lock directory.
+   */
   _resolveAdvisoryLockDirectory() {
     if (!this._advisoryLockDirectory) {
       // Fall back to deriving the directory for callers that invoked
@@ -192,7 +193,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
   /**
    * Runs advisory lock path.
    * @param {string} name - Lock name.
-   * @returns {string}
+   * @returns {string} - Filesystem path for the advisory lock.
    */
   _advisoryLockPath(name) {
     const hash = createHash("sha256").update(name).digest("hex").slice(0, 16)
@@ -228,7 +229,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * Runs acquire advisory lock file.
    * @param {string} name - Lock name.
    * @param {{timeoutMs?: number | null}} args - Timeout args.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory-lock file was acquired.
    */
   async _acquireAdvisoryLockFile(name, {timeoutMs}) {
     await this._ensureAdvisoryLockDirectory()
@@ -247,7 +248,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
 
         return true
       } catch (error) {
-        if (/** @type {NodeJS.ErrnoException} */ (error)?.code !== "EEXIST") throw error
+        if (/** @type {Error & {code?: string}} */ (error)?.code !== "EEXIST") throw error
 
         if (await this._isAdvisoryLockStale(lockPath)) {
           await fs.rm(lockPath, {recursive: true, force: true})
@@ -270,7 +271,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
   /**
    * Runs try acquire advisory lock file.
    * @param {string} name - Lock name.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory-lock file was acquired immediately.
    */
   async _tryAcquireAdvisoryLockFile(name) {
     await this._ensureAdvisoryLockDirectory()
@@ -283,7 +284,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
 
       return true
     } catch (error) {
-      if (/** @type {NodeJS.ErrnoException} */ (error)?.code !== "EEXIST") throw error
+      if (/** @type {Error & {code?: string}} */ (error)?.code !== "EEXIST") throw error
 
       if (await this._isAdvisoryLockStale(lockPath)) {
         await fs.rm(lockPath, {recursive: true, force: true})
@@ -294,7 +295,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
 
           return true
         } catch (retryError) {
-          if (/** @type {NodeJS.ErrnoException} */ (retryError)?.code === "EEXIST") return false
+          if (/** @type {Error & {code?: string}} */ (retryError)?.code === "EEXIST") return false
 
           throw retryError
         }
@@ -324,7 +325,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
   /**
    * Runs is advisory lock file held.
    * @param {string} name - Lock name.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory-lock file exists and is active.
    */
   async _isAdvisoryLockFileHeld(name) {
     const lockPath = this._advisoryLockPath(name)
@@ -345,7 +346,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * probe a PID on another machine; operators in that situation should
    * remove stale lock directories by hand if they linger.
    * @param {string} lockPath - Absolute path of the lock directory.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the advisory-lock file is stale.
    */
   async _isAdvisoryLockStale(lockPath) {
     /**
@@ -382,7 +383,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
 
       return false
     } catch (error) {
-      return /** @type {NodeJS.ErrnoException} */ (error)?.code === "ESRCH"
+      return /** @type {Error & {code?: string}} */ (error)?.code === "ESRCH"
     }
   }
 }

--- a/src/database/migrations-ledger.js
+++ b/src/database/migrations-ledger.js
@@ -26,7 +26,7 @@ export default class MigrationsLedger {
 
   /**
    * Whether the ledger table exists on the given database.
-   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {import("./drivers/base.js").default} db - Database whose migration ledger is inspected.
    * @returns {Promise<boolean>} - Whether the ledger table exists.
    */
   static async tableExists(db) {
@@ -38,7 +38,7 @@ export default class MigrationsLedger {
   /**
    * Creates the ledger table if it does not exist. This is the single definition of
    * the `schema_migrations` table shape.
-   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {import("./drivers/base.js").default} db - Database that should contain the ledger table.
    * @returns {Promise<void>}
    */
   static async ensureTable(db) {
@@ -57,7 +57,7 @@ export default class MigrationsLedger {
 
   /**
    * Every applied migration version recorded in the ledger.
-   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {import("./drivers/base.js").default} db - Database whose applied versions are loaded.
    * @returns {Promise<string[]>} - Applied migration versions.
    */
   static async appliedVersions(db) {
@@ -68,8 +68,8 @@ export default class MigrationsLedger {
 
   /**
    * Whether the given version is recorded as applied.
-   * @param {import("./drivers/base.js").default} db - Database connection.
-   * @param {string} version - Migration version.
+   * @param {import("./drivers/base.js").default} db - Database whose ledger is queried.
+   * @param {string} version - Migration version to look up.
    * @returns {Promise<boolean>} - Whether the migration version is applied.
    */
   static async hasVersion(db, version) {
@@ -84,8 +84,8 @@ export default class MigrationsLedger {
   /**
    * Records a single version as applied. The targeted existence check keeps the
    * migrator's per-migration hot path cheap (no full-table load per migration).
-   * @param {import("./drivers/base.js").default} db - Database connection.
-   * @param {string} version - Migration version.
+   * @param {import("./drivers/base.js").default} db - Database whose ledger receives the version.
+   * @param {string} version - Migration version to record as applied.
    * @returns {Promise<void>}
    */
   static async recordVersion(db, version) {
@@ -96,8 +96,8 @@ export default class MigrationsLedger {
 
   /**
    * Removes a version from the ledger (used when migrating down).
-   * @param {import("./drivers/base.js").default} db - Database connection.
-   * @param {string} version - Migration version.
+   * @param {import("./drivers/base.js").default} db - Database whose ledger loses the version.
+   * @param {string} version - Migration version to mark as unapplied.
    * @returns {Promise<void>}
    */
   static async removeVersion(db, version) {
@@ -108,8 +108,8 @@ export default class MigrationsLedger {
    * Baselines a database's ledger: records each version as applied without running
    * its migration. Idempotent — already-recorded versions are skipped. Ensures the
    * ledger table exists first, then loads the existing set once for the whole batch.
-   * @param {import("./drivers/base.js").default} db - Database connection.
-   * @param {string[]} versions - Migration versions.
+   * @param {import("./drivers/base.js").default} db - Database whose ledger should be baselined.
+   * @param {string[]} versions - Migration versions to record without running them.
    * @returns {Promise<string[]>} The versions that were newly recorded.
    */
   static async markApplied(db, versions) {
@@ -136,7 +136,7 @@ export default class MigrationsLedger {
    * provisioning path advanced `targetDb`'s schema to match `sourceDb` out of band
    * (e.g. cloning table structure between databases): the migrations are, by
    * construction, already applied on the target, so record them without re-running.
-   * @param {{sourceDb: import("./drivers/base.js").default, targetDb: import("./drivers/base.js").default}} args - Options.
+   * @param {{sourceDb: import("./drivers/base.js").default, targetDb: import("./drivers/base.js").default}} args - Source ledger and target database to baseline.
    * @returns {Promise<string[]>} The versions that were newly recorded on the target.
    */
   static async baselineFromDatabase({sourceDb, targetDb}) {

--- a/src/database/migrations-ledger.js
+++ b/src/database/migrations-ledger.js
@@ -18,7 +18,7 @@ const TABLE_NAME = "schema_migrations"
 export default class MigrationsLedger {
   /**
    * The ledger table name.
-   * @returns {string}
+   * @returns {string} - Ledger table name.
    */
   static tableName() {
     return TABLE_NAME
@@ -26,8 +26,8 @@ export default class MigrationsLedger {
 
   /**
    * Whether the ledger table exists on the given database.
-   * @param {import("./drivers/base.js").default} db
-   * @returns {Promise<boolean>}
+   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @returns {Promise<boolean>} - Whether the ledger table exists.
    */
   static async tableExists(db) {
     const table = await db.getTableByName(TABLE_NAME, {throwError: false})
@@ -38,7 +38,7 @@ export default class MigrationsLedger {
   /**
    * Creates the ledger table if it does not exist. This is the single definition of
    * the `schema_migrations` table shape.
-   * @param {import("./drivers/base.js").default} db
+   * @param {import("./drivers/base.js").default} db - Database connection.
    * @returns {Promise<void>}
    */
   static async ensureTable(db) {
@@ -57,8 +57,8 @@ export default class MigrationsLedger {
 
   /**
    * Every applied migration version recorded in the ledger.
-   * @param {import("./drivers/base.js").default} db
-   * @returns {Promise<string[]>}
+   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @returns {Promise<string[]>} - Applied migration versions.
    */
   static async appliedVersions(db) {
     const rows = await db.select(TABLE_NAME)
@@ -68,9 +68,9 @@ export default class MigrationsLedger {
 
   /**
    * Whether the given version is recorded as applied.
-   * @param {import("./drivers/base.js").default} db
-   * @param {string} version
-   * @returns {Promise<boolean>}
+   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {string} version - Migration version.
+   * @returns {Promise<boolean>} - Whether the migration version is applied.
    */
   static async hasVersion(db, version) {
     const rows = await db.newQuery()
@@ -84,8 +84,8 @@ export default class MigrationsLedger {
   /**
    * Records a single version as applied. The targeted existence check keeps the
    * migrator's per-migration hot path cheap (no full-table load per migration).
-   * @param {import("./drivers/base.js").default} db
-   * @param {string} version
+   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {string} version - Migration version.
    * @returns {Promise<void>}
    */
   static async recordVersion(db, version) {
@@ -96,8 +96,8 @@ export default class MigrationsLedger {
 
   /**
    * Removes a version from the ledger (used when migrating down).
-   * @param {import("./drivers/base.js").default} db
-   * @param {string} version
+   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {string} version - Migration version.
    * @returns {Promise<void>}
    */
   static async removeVersion(db, version) {
@@ -108,8 +108,8 @@ export default class MigrationsLedger {
    * Baselines a database's ledger: records each version as applied without running
    * its migration. Idempotent — already-recorded versions are skipped. Ensures the
    * ledger table exists first, then loads the existing set once for the whole batch.
-   * @param {import("./drivers/base.js").default} db
-   * @param {string[]} versions
+   * @param {import("./drivers/base.js").default} db - Database connection.
+   * @param {string[]} versions - Migration versions.
    * @returns {Promise<string[]>} The versions that were newly recorded.
    */
   static async markApplied(db, versions) {
@@ -136,7 +136,7 @@ export default class MigrationsLedger {
    * provisioning path advanced `targetDb`'s schema to match `sourceDb` out of band
    * (e.g. cloning table structure between databases): the migrations are, by
    * construction, already applied on the target, so record them without re-running.
-   * @param {{sourceDb: import("./drivers/base.js").default, targetDb: import("./drivers/base.js").default}} args
+   * @param {{sourceDb: import("./drivers/base.js").default, targetDb: import("./drivers/base.js").default}} args - Options.
    * @returns {Promise<string[]>} The versions that were newly recorded on the target.
    */
   static async baselineFromDatabase({sourceDb, targetDb}) {

--- a/src/database/query/where-model-class-hash.js
+++ b/src/database/query/where-model-class-hash.js
@@ -316,7 +316,7 @@ export default class VelociousDatabaseQueryWhereModelClassHash extends WhereBase
     /**
      * Normalize.
      * @param {?} entry - Value to normalize.
-     * @returns {?} - Normalized value.
+     * @returns {?} - SQLite predicate value with booleans encoded as 1 or 0.
      */
     const normalize = (entry) => {
       if (entry === true) return 1
@@ -354,7 +354,7 @@ export default class VelociousDatabaseQueryWhereModelClassHash extends WhereBase
     /**
      * Normalize.
      * @param {?} entry - Value to normalize.
-     * @returns {?} - Normalized value.
+     * @returns {?} - Column-compatible predicate value, or the no-match sentinel for numeric UUIDs.
      */
     const normalize = (entry) => {
       if (isUuidType && typeof entry === "number") return NO_MATCH

--- a/src/database/query/where-model-class-hash.js
+++ b/src/database/query/where-model-class-hash.js
@@ -316,6 +316,7 @@ export default class VelociousDatabaseQueryWhereModelClassHash extends WhereBase
     /**
      * Normalize.
      * @param {?} entry - Value to normalize.
+     * @returns {?} - Normalized value.
      */
     const normalize = (entry) => {
       if (entry === true) return 1
@@ -353,6 +354,7 @@ export default class VelociousDatabaseQueryWhereModelClassHash extends WhereBase
     /**
      * Normalize.
      * @param {?} entry - Value to normalize.
+     * @returns {?} - Normalized value.
      */
     const normalize = (entry) => {
       if (isUuidType && typeof entry === "number") return NO_MATCH

--- a/src/database/query/with-count.js
+++ b/src/database/query/with-count.js
@@ -85,7 +85,7 @@ export function normalizeWithCount(spec) {
 /**
  * Runs entry from name.
  * @param {string} name - Relationship name (attribute name is derived by appending "Count").
- * @returns {WithCountEntry}
+ * @returns {WithCountEntry} - Normalized association-count entry.
  */
 function entryFromName(name) {
   return {

--- a/src/database/record/acts-as-list.js
+++ b/src/database/record/acts-as-list.js
@@ -21,7 +21,7 @@ function setShiftingFlag(record, value) {
 /**
  * Runs is shifting.
  * @param {import("./index.js").default} record - Model instance.
- * @returns {boolean}
+ * @returns {boolean} - Whether list positions are currently shifting.
  */
 function isShifting(record) {
   // @ts-ignore - Symbol indexing on Record instances
@@ -341,7 +341,7 @@ async function highestPositionInScope({record, positionColumn, scope, scopeValue
  * _belongsToChanges.
  * @param {import("./index.js").default} record - Model instance.
  * @param {string} scope - camelCase scope attribute name (e.g. "projectId").
- * @returns {string | number | null}
+ * @returns {string | number | null} - Current list position value.
  */
 function resolveScopeValue(record, scope) {
   const attrValue = record.readAttribute(scope)

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -76,9 +76,9 @@ let globalEventConnections = {}
 const AuditEvents = {
   /**
    * Fire all registered callbacks for a model type and action.
-   * @param {string} type - Model type.
-   * @param {string} action - Audit action name.
-   * @param {AuditEventPayload} args - Audit event payload.
+   * @param {string} type - Audited model type whose listeners should fire.
+   * @param {string} action - Audit action whose listeners should fire.
+   * @param {AuditEventPayload} args - Audit event delivered to matching listeners.
    */
   call(type, action, args) {
     const actions = globalEventConnections[type] || {}
@@ -91,9 +91,9 @@ const AuditEvents = {
 
   /**
    * Register a callback for a model type and action.
-   * @param {string} type - Model type.
-   * @param {string} action - Audit action name.
-   * @param {(args: AuditEventPayload) => void} callback - Callback to register.
+   * @param {string} type - Audited model type to observe.
+   * @param {string} action - Audit action to observe.
+   * @param {(args: AuditEventPayload) => void} callback - Listener invoked for matching audit events.
    * @returns {() => void} - Callback that removes the registration.
    */
   connect(type, action, callback) {
@@ -257,7 +257,7 @@ function sharedAuditClass(modelClass) {
   class Audit extends dbRecordClass {
     /**
      * Returns the backing table name.
-     * @returns {string} - The backing table name.
+     * @returns {string} - Shared `audits` table name.
      */
     static tableName() {
       return "audits"
@@ -307,7 +307,7 @@ function dedicatedAuditClass(modelClass, tableName) {
   class ModelAudit extends dbRecordClass {
     /**
      * Returns the backing table name.
-     * @returns {string} - The backing table name.
+     * @returns {string} - Dedicated audit table supplied for this model class.
      */
     static tableName() {
       return tableName
@@ -923,7 +923,7 @@ function normalizeAction(action) {
  * Creates the shared audit tables migration up/down callbacks for use inside
  * a Migration class. The `table` parameter is a Migration instance.
  * @param {{id?: {type: string}}} [options] - ID column options.
- * @returns {{down: (table: import("../migration/index.js").default) => Promise<void>, up: (table: import("../migration/index.js").default) => Promise<void>}} - Migration callbacks.
+ * @returns {{down: (table: import("../migration/index.js").default) => Promise<void>, up: (table: import("../migration/index.js").default) => Promise<void>}} - Up/down callbacks for the shared audit tables.
  */
 function createSharedAuditTablesMigration(options = {}) {
   const opts = /** @type {{id?: {type: string}}} */ (options)

--- a/src/database/record/auditing.js
+++ b/src/database/record/auditing.js
@@ -74,7 +74,12 @@ let globalEventConnections = {}
 
 /** @type {AuditEventsType} */
 const AuditEvents = {
-  /** Fire all registered callbacks for a model type + action. @param {string} type @param {string} action @param {AuditEventPayload} args */
+  /**
+   * Fire all registered callbacks for a model type and action.
+   * @param {string} type - Model type.
+   * @param {string} action - Audit action name.
+   * @param {AuditEventPayload} args - Audit event payload.
+   */
   call(type, action, args) {
     const actions = globalEventConnections[type] || {}
     const callbacks = actions[action] || []
@@ -84,7 +89,13 @@ const AuditEvents = {
     }
   },
 
-  /** Register a callback for a model type + action. Returns an unsubscribe function. @param {string} type @param {string} action @param {(args: AuditEventPayload) => void} callback @returns {() => void} */
+  /**
+   * Register a callback for a model type and action.
+   * @param {string} type - Model type.
+   * @param {string} action - Audit action name.
+   * @param {(args: AuditEventPayload) => void} callback - Callback to register.
+   * @returns {() => void} - Callback that removes the registration.
+   */
   connect(type, action, callback) {
     if (!globalEventConnections[type]) {
       globalEventConnections[type] = {}
@@ -109,7 +120,7 @@ const AuditEvents = {
     }
   },
 
-  /** Clear all registered callbacks. @returns {void} */
+  /** Clear all registered callbacks. */
   reset() {
     globalEventConnections = {}
   }
@@ -244,7 +255,10 @@ function sharedAuditClass(modelClass) {
    * Framework-owned Audit model for the shared `audits` table.
    */
   class Audit extends dbRecordClass {
-    /** Returns the backing table name. @returns {string} */
+    /**
+     * Returns the backing table name.
+     * @returns {string} - The backing table name.
+     */
     static tableName() {
       return "audits"
     }
@@ -291,7 +305,10 @@ function dedicatedAuditClass(modelClass, tableName) {
    * Framework-owned per-model Audit class.
    */
   class ModelAudit extends dbRecordClass {
-    /** Returns the backing table name. @returns {string} */
+    /**
+     * Returns the backing table name.
+     * @returns {string} - The backing table name.
+     */
     static tableName() {
       return tableName
     }
@@ -906,7 +923,7 @@ function normalizeAction(action) {
  * Creates the shared audit tables migration up/down callbacks for use inside
  * a Migration class. The `table` parameter is a Migration instance.
  * @param {{id?: {type: string}}} [options] - ID column options.
- * @returns {{down: (table: import("../migration/index.js").default) => Promise<void>, up: (table: import("../migration/index.js").default) => Promise<void>}}
+ * @returns {{down: (table: import("../migration/index.js").default) => Promise<void>, up: (table: import("../migration/index.js").default) => Promise<void>}} - Migration callbacks.
  */
 function createSharedAuditTablesMigration(options = {}) {
   const opts = /** @type {{id?: {type: string}}} */ (options)

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -2688,7 +2688,7 @@ class VelociousDatabaseRecord {
    * @param {string} name - Lock name (for the error message).
    * @param {() => Promise<T>} callback - Callback holding the lock.
    * @param {number | null} [holdTimeoutMs] - Max hold time; falsy disables the timeout.
-   * @returns {Promise<T>}
+   * @returns {Promise<T>} - Callback result after the lock-protected operation.
    */
   static async runWithAdvisoryLockHoldTimeout(name, callback, holdTimeoutMs) {
     return await AdvisoryLockRunner.runWithAdvisoryLockHoldTimeout(name, callback, holdTimeoutMs)
@@ -3816,7 +3816,7 @@ class VelociousDatabaseRecord {
    * column of the same name. Returns the attached number, or 0 when
    * `.withCount(...)` wasn't requested for this attribute.
    * @param {string} attributeName - Attribute name, e.g. `"tasksCount"` or a custom `"activeMembersCount"` from `.withCount({activeMembersCount: {...}})`.
-   * @returns {number}
+   * @returns {number} - Attached association count, or zero when absent.
    */
   readCount(attributeName) {
     return readPayloadAssociationCount(/** @type {import("../../record-payload-values.js").RecordPayloadValuesTarget} */ (/** @type {?} */ (this)), attributeName)
@@ -3837,7 +3837,7 @@ class VelociousDatabaseRecord {
    * All attached association counts as a plain object. Used by the
    * frontend-model serializer to ship counts alongside the record
    * attributes on the wire.
-   * @returns {Record<string, number>}
+   * @returns {Record<string, number>} - Association counts keyed by attribute name.
    */
   associationCounts() {
     /**
@@ -3864,7 +3864,7 @@ class VelociousDatabaseRecord {
    * registered fn for this record (e.g. no child rows matched the
    * aggregate).
    * @param {string} name - queryData attribute name (matches a SELECT alias from the registered fn).
-   * @returns {?}
+   * @returns {?} - Attached query-data value.
    */
   queryData(name) {
     return readPayloadQueryData(/** @type {import("../../record-payload-values.js").RecordPayloadValuesTarget} */ (/** @type {?} */ (this)), name)
@@ -3886,7 +3886,7 @@ class VelociousDatabaseRecord {
    * All attached queryData values as a plain object. Used by the
    * frontend-model serializer to ship queryData alongside the record
    * attributes on the wire.
-   * @returns {Record<string, ?>}
+   * @returns {Record<string, ?>} - Query-data values keyed by name.
    */
   queryDataValues() {
     /**
@@ -3914,7 +3914,7 @@ class VelociousDatabaseRecord {
    * `record.can("update")` without first checking whether the ability
    * was loaded.
    * @param {string} action - Ability action name, e.g. `"update"`.
-   * @returns {boolean}
+   * @returns {boolean} - Whether the requested ability is allowed.
    */
   can(action) {
     return readPayloadComputedAbility(/** @type {import("../../record-payload-values.js").RecordPayloadValuesTarget} */ (/** @type {?} */ (this)), action)
@@ -3936,7 +3936,7 @@ class VelociousDatabaseRecord {
    * All attached per-record ability results as a plain object. Used
    * by the frontend-model serializer to ship results alongside the
    * record attributes on the wire.
-   * @returns {Record<string, boolean>}
+   * @returns {Record<string, boolean>} - Ability results keyed by action.
    */
   computedAbilities() {
     /**

--- a/src/database/record/validators/uniqueness.js
+++ b/src/database/record/validators/uniqueness.js
@@ -74,7 +74,7 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
    * `new Task({project})`, the FK (`projectId`) is only flushed onto
    * the attribute store during save — but the relationship object is
    * already loaded and carries the id we need for the WHERE clause.
-   * @param {import("../index.js").default} model - Model instance.
+   * @param {import("../index.js").default} model - Record whose loaded relationship may supply the scope value.
    * @param {string} scopeColumn - camelCase attribute name (e.g. `"projectId"`).
    * @returns {string | number | null} - Value normalized for comparison.
    */

--- a/src/database/record/validators/uniqueness.js
+++ b/src/database/record/validators/uniqueness.js
@@ -74,9 +74,9 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
    * `new Task({project})`, the FK (`projectId`) is only flushed onto
    * the attribute store during save — but the relationship object is
    * already loaded and carries the id we need for the WHERE clause.
-   * @param {import("../index.js").default} model
+   * @param {import("../index.js").default} model - Model instance.
    * @param {string} scopeColumn - camelCase attribute name (e.g. `"projectId"`).
-   * @returns {string | number | null}
+   * @returns {string | number | null} - Value normalized for comparison.
    */
   _resolveScopeValueFromRelationship(model, scopeColumn) {
     const modelClass = /** @type {typeof import("../index.js").default} */ (model.constructor)
@@ -106,7 +106,7 @@ export default class VelociousDatabaseRecordValidatorsUniqueness extends Base {
    * Normalize the `scope` option into an array of attribute names.
    * Supports string (`"userId"`), array of strings (`["userId", "projectId"]`),
    * or absent (empty array — no scope, original single-column behavior).
-   * @returns {string[]}
+   * @returns {string[]} - Columns participating in the uniqueness check.
    */
   _normalizeScopeColumns() {
     const scope = this.args?.scope

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -6,9 +6,9 @@ const DEFAULT_QUERY_CHUNK_SIZE = 500
 /**
  * Splits an array into chunks of at most `chunkSize` items.
  * @template T
- * @param {T[]} values - Values to process.
- * @param {number} chunkSize - Maximum chunk size.
- * @returns {T[][]} - Values divided into bounded chunks.
+ * @param {T[]} values - Ordered items to partition.
+ * @param {number} chunkSize - Maximum items per chunk.
+ * @returns {T[][]} - Consecutive chunks preserving input order.
  */
 function chunks(values, chunkSize) {
   const chunkedValues = []
@@ -22,8 +22,8 @@ function chunks(values, chunkSize) {
 
 /**
  * Stringifies values and returns the distinct, non-blank ones, preserving first-seen order.
- * @param {unknown[]} values - Values to process.
- * @returns {string[]} - Deduplicated string values.
+ * @param {unknown[]} values - Candidate database identifiers to stringify and deduplicate.
+ * @returns {string[]} - Distinct non-blank identifiers in first-seen order.
  */
 function uniqueStrings(values) {
   return Array.from(new Set(values.map((value) => String(value)).filter((value) => value.trim())))
@@ -60,7 +60,7 @@ export default class DataCopier {
    *   insertChunkSize?: number,
    *   queryChunkSize?: number,
    *   onProgress?: (message: string) => void
-   * }} args - Options.
+   * }} args - Source, target, traversal plan, chunk limits, and progress handler.
    */
   constructor({sourceDb, targetDb, tablePlan, idColumn = "id", insertChunkSize = DEFAULT_INSERT_CHUNK_SIZE, queryChunkSize = DEFAULT_QUERY_CHUNK_SIZE, onProgress}) {
     this.sourceDb = sourceDb
@@ -77,7 +77,7 @@ export default class DataCopier {
    * returns the copied source rows keyed by table name. The target's current tenant rows
    * are deleted (children first) and the source rows inserted (parents first) in a single
    * target transaction with foreign keys disabled.
-   * @param {string} keyValue - Key value.
+   * @param {string} keyValue - Tenant key selecting the rows to copy.
    * @returns {Promise<Map<string, Record<string, unknown>[]>>} - Copied source rows grouped by table name.
    */
   async copy(keyValue) {
@@ -125,8 +125,8 @@ export default class DataCopier {
    * Loads the rows for `keyValue` for every table in the plan from `db`, resolving
    * parent-scoped tables from the ids already selected for their parent table. Used for
    * both the source rows to copy and the target's current tenant rows to delete.
-   * @param {import("../drivers/base.js").default} db - Database connection.
-   * @param {string} keyValue - Key value.
+   * @param {import("../drivers/base.js").default} db - Source or target database to traverse.
+   * @param {string} keyValue - Tenant key selecting the root plan rows.
    * @returns {Promise<Map<string, Record<string, unknown>[]>>} - Loaded rows grouped by table name.
    */
   async loadRows(db, keyValue) {
@@ -175,7 +175,7 @@ export default class DataCopier {
 
   /**
    * Selects all rows of `tableName` in `db` whose `columnName` is in `values`, chunked.
-   * @param {{columnName: string, db: import("../drivers/base.js").default, tableName: string, values: string[]}} args - Options.
+   * @param {{columnName: string, db: import("../drivers/base.js").default, tableName: string, values: string[]}} args - Table, column, database, and values for the chunked lookup.
    * @returns {Promise<Record<string, unknown>[]>} - Rows matching the supplied column values.
    */
   async queryRowsByColumn({columnName, db, tableName, values}) {
@@ -256,8 +256,8 @@ export default class DataCopier {
 
   /**
    * Quotes and comma-joins values for an SQL `IN (...)` list against the given database.
-   * @param {import("../drivers/base.js").default} db - Database connection.
-   * @param {string[]} values - Values to process.
+   * @param {import("../drivers/base.js").default} db - Database whose quoting rules format the values.
+   * @param {string[]} values - Values to quote for the `IN` list.
    * @returns {string} - Quoted SQL value list.
    */
   quotedValuesSql(db, values) {
@@ -266,8 +266,8 @@ export default class DataCopier {
 
   /**
    * Runs a query without per-query logging, used for the high-volume copy statements.
-   * @param {import("../drivers/base.js").default} db - Database connection.
-   * @param {string} sql - SQL statement.
+   * @param {import("../drivers/base.js").default} db - Database on which to execute the copy query.
+   * @param {string} sql - Copy-related SQL statement to execute quietly.
    * @returns {Promise<Record<string, unknown>[]>} - Query result rows.
    */
   async executeQuietQuery(db, sql) {
@@ -276,7 +276,7 @@ export default class DataCopier {
 
   /**
    * Inserts column-aligned row tuples into a table without per-query logging.
-   * @param {{columns: string[], db: import("../drivers/base.js").default, rows: Array<Array<unknown>>, tableName: string}} args - Options.
+   * @param {{columns: string[], db: import("../drivers/base.js").default, rows: Array<Array<unknown>>, tableName: string}} args - Destination table and column-aligned row values to insert.
    * @returns {Promise<void>}
    */
   async insertRowsQuietly({columns, db, rows, tableName}) {
@@ -285,7 +285,7 @@ export default class DataCopier {
 
   /**
    * Forwards a progress message to the optional `onProgress` callback when one was given.
-   * @param {string} message - Message to process.
+   * @param {string} message - Copy progress message to forward when reporting is enabled.
    * @returns {void}
    */
   reportProgress(message) {

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -6,9 +6,9 @@ const DEFAULT_QUERY_CHUNK_SIZE = 500
 /**
  * Splits an array into chunks of at most `chunkSize` items.
  * @template T
- * @param {T[]} values
- * @param {number} chunkSize
- * @returns {T[][]}
+ * @param {T[]} values - Values to process.
+ * @param {number} chunkSize - Maximum chunk size.
+ * @returns {T[][]} - Values divided into bounded chunks.
  */
 function chunks(values, chunkSize) {
   const chunkedValues = []
@@ -22,8 +22,8 @@ function chunks(values, chunkSize) {
 
 /**
  * Stringifies values and returns the distinct, non-blank ones, preserving first-seen order.
- * @param {unknown[]} values
- * @returns {string[]}
+ * @param {unknown[]} values - Values to process.
+ * @returns {string[]} - Deduplicated string values.
  */
 function uniqueStrings(values) {
   return Array.from(new Set(values.map((value) => String(value)).filter((value) => value.trim())))
@@ -60,7 +60,7 @@ export default class DataCopier {
    *   insertChunkSize?: number,
    *   queryChunkSize?: number,
    *   onProgress?: (message: string) => void
-   * }} args
+   * }} args - Options.
    */
   constructor({sourceDb, targetDb, tablePlan, idColumn = "id", insertChunkSize = DEFAULT_INSERT_CHUNK_SIZE, queryChunkSize = DEFAULT_QUERY_CHUNK_SIZE, onProgress}) {
     this.sourceDb = sourceDb
@@ -77,8 +77,8 @@ export default class DataCopier {
    * returns the copied source rows keyed by table name. The target's current tenant rows
    * are deleted (children first) and the source rows inserted (parents first) in a single
    * target transaction with foreign keys disabled.
-   * @param {string} keyValue
-   * @returns {Promise<Map<string, Record<string, unknown>[]>>}
+   * @param {string} keyValue - Key value.
+   * @returns {Promise<Map<string, Record<string, unknown>[]>>} - Copied source rows grouped by table name.
    */
   async copy(keyValue) {
     const sourceRowsByTableName = await this.loadRows(this.sourceDb, keyValue)
@@ -125,9 +125,9 @@ export default class DataCopier {
    * Loads the rows for `keyValue` for every table in the plan from `db`, resolving
    * parent-scoped tables from the ids already selected for their parent table. Used for
    * both the source rows to copy and the target's current tenant rows to delete.
-   * @param {import("../drivers/base.js").default} db
-   * @param {string} keyValue
-   * @returns {Promise<Map<string, Record<string, unknown>[]>>}
+   * @param {import("../drivers/base.js").default} db - Database connection.
+   * @param {string} keyValue - Key value.
+   * @returns {Promise<Map<string, Record<string, unknown>[]>>} - Loaded rows grouped by table name.
    */
   async loadRows(db, keyValue) {
     /** @type {Map<string, string[]>} */
@@ -175,8 +175,8 @@ export default class DataCopier {
 
   /**
    * Selects all rows of `tableName` in `db` whose `columnName` is in `values`, chunked.
-   * @param {{columnName: string, db: import("../drivers/base.js").default, tableName: string, values: string[]}} args
-   * @returns {Promise<Record<string, unknown>[]>}
+   * @param {{columnName: string, db: import("../drivers/base.js").default, tableName: string, values: string[]}} args - Options.
+   * @returns {Promise<Record<string, unknown>[]>} - Rows matching the supplied column values.
    */
   async queryRowsByColumn({columnName, db, tableName, values}) {
     const normalizedValues = uniqueStrings(values)
@@ -201,7 +201,7 @@ export default class DataCopier {
   /**
    * Deletes the matching target rows for every plan table, children before parents, so the
    * reinsert that follows starts from a clean slate without violating foreign keys.
-   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName
+   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName - Rows grouped by table name.
    * @returns {Promise<void>}
    */
   async deleteTargetRows(rowsByTableName) {
@@ -227,7 +227,7 @@ export default class DataCopier {
   /**
    * Inserts the loaded source rows into the target for every plan table, parents before
    * children, chunked to bound statement size.
-   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName
+   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName - Rows grouped by table name.
    * @returns {Promise<void>}
    */
   async insertTargetRows(rowsByTableName) {
@@ -256,9 +256,9 @@ export default class DataCopier {
 
   /**
    * Quotes and comma-joins values for an SQL `IN (...)` list against the given database.
-   * @param {import("../drivers/base.js").default} db
-   * @param {string[]} values
-   * @returns {string}
+   * @param {import("../drivers/base.js").default} db - Database connection.
+   * @param {string[]} values - Values to process.
+   * @returns {string} - Quoted SQL value list.
    */
   quotedValuesSql(db, values) {
     return values.map((value) => db.quote(value)).join(", ")
@@ -266,9 +266,9 @@ export default class DataCopier {
 
   /**
    * Runs a query without per-query logging, used for the high-volume copy statements.
-   * @param {import("../drivers/base.js").default} db
-   * @param {string} sql
-   * @returns {Promise<Record<string, unknown>[]>}
+   * @param {import("../drivers/base.js").default} db - Database connection.
+   * @param {string} sql - SQL statement.
+   * @returns {Promise<Record<string, unknown>[]>} - Query result rows.
    */
   async executeQuietQuery(db, sql) {
     return await db.query(sql, {logQuery: false})
@@ -276,7 +276,7 @@ export default class DataCopier {
 
   /**
    * Inserts column-aligned row tuples into a table without per-query logging.
-   * @param {{columns: string[], db: import("../drivers/base.js").default, rows: Array<Array<unknown>>, tableName: string}} args
+   * @param {{columns: string[], db: import("../drivers/base.js").default, rows: Array<Array<unknown>>, tableName: string}} args - Options.
    * @returns {Promise<void>}
    */
   async insertRowsQuietly({columns, db, rows, tableName}) {
@@ -285,7 +285,7 @@ export default class DataCopier {
 
   /**
    * Forwards a progress message to the optional `onProgress` callback when one was given.
-   * @param {string} message
+   * @param {string} message - Message to process.
    * @returns {void}
    */
   reportProgress(message) {

--- a/src/database/tenants/schema-cloner.js
+++ b/src/database/tenants/schema-cloner.js
@@ -31,7 +31,7 @@ const TEXT_TYPE_RANKS = {
 export default class SchemaCloner {
   /**
    * Creates a cloner that copies table structure from `sourceDb` into `targetDb`.
-   * @param {{sourceDb: import("../drivers/base.js").default, targetDb: import("../drivers/base.js").default}} args - Options.
+   * @param {{sourceDb: import("../drivers/base.js").default, targetDb: import("../drivers/base.js").default}} args - Databases to clone structure from and into.
    */
   constructor({sourceDb, targetDb}) {
     this.sourceDb = sourceDb
@@ -41,7 +41,7 @@ export default class SchemaCloner {
   /**
    * Clones every given table from the source into the target, then baselines the
    * target's ledger so the cloned schema is recorded as already-migrated.
-   * @param {string[]} tableNames - Table names.
+   * @param {string[]} tableNames - Source tables whose structure should be cloned.
    * @returns {Promise<void>}
    */
   async syncTables(tableNames) {
@@ -55,7 +55,7 @@ export default class SchemaCloner {
   /**
    * Clones a single table from the source into the target, creating it or adding and
    * widening columns and indexes as needed.
-   * @param {string} tableName - Table name.
+   * @param {string} tableName - Source table to synchronize with the target.
    * @returns {Promise<void>}
    */
   async syncTable(tableName) {
@@ -82,7 +82,7 @@ export default class SchemaCloner {
   /**
    * Creates the table in the target from the source table's columns and its
    * non-primary-key indexes.
-   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Options.
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Source table metadata and target table name.
    * @returns {Promise<void>}
    */
   async createTargetTable({sourceTable, tableName}) {
@@ -105,7 +105,7 @@ export default class SchemaCloner {
   /**
    * Adds columns present on the source but missing from the target, and widens
    * too-narrow target text columns.
-   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Options.
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Source table metadata and target table name.
    * @returns {Promise<boolean>} Whether any column was added or widened.
    */
   async ensureTargetColumns({sourceTable, tableName}) {
@@ -154,7 +154,7 @@ export default class SchemaCloner {
    * Creates non-primary-key indexes present on the source but missing from the target,
    * and replaces target indexes whose definition (columns or uniqueness) drifted from
    * the source.
-   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Options.
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Source table metadata and target table name.
    * @returns {Promise<void>}
    */
   async ensureTargetIndexes({sourceTable, tableName}) {
@@ -230,7 +230,7 @@ export default class SchemaCloner {
 
   /**
    * Drops an index on the target database.
-   * @param {{tableName: string, targetIndex: import("../drivers/base-columns-index.js").default}} args - Options.
+   * @param {{tableName: string, targetIndex: import("../drivers/base-columns-index.js").default}} args - Target table and index to remove.
    * @returns {Promise<void>}
    */
   async dropTargetIndex({tableName, targetIndex}) {
@@ -289,7 +289,7 @@ export default class SchemaCloner {
   /**
    * Builds driver create-index args from a source index (the index name is omitted on
    * SQLite, where index names are unique per-database rather than per-table).
-   * @param {{sourceIndex: import("../drivers/base-columns-index.js").default, tableName: string}} args - Options.
+   * @param {{sourceIndex: import("../drivers/base-columns-index.js").default, tableName: string}} args - Source index and target table receiving it.
    * @returns {{columns: string[], name?: string, tableName: string, unique: boolean}} - Arguments for creating the target index.
    */
   createIndexArgsFromSourceIndex({sourceIndex, tableName}) {
@@ -384,7 +384,7 @@ export default class SchemaCloner {
    * Builds TableData column args from a source column, copying type, nullability,
    * length, notes, simple defaults and (for full clones) primary-key flag.
    * @param {import("../drivers/base-column.js").default} sourceColumn - Source column definition.
-   * @param {{isNewColumn: boolean}} args - Options.
+   * @param {{isNewColumn: boolean}} args - Whether the column is being added instead of cloned with its table.
    * @returns {Record<string, unknown>} - Arguments for altering the target column.
    */
   columnArgsFromSourceColumn(sourceColumn, {isNewColumn}) {

--- a/src/database/tenants/schema-cloner.js
+++ b/src/database/tenants/schema-cloner.js
@@ -31,7 +31,7 @@ const TEXT_TYPE_RANKS = {
 export default class SchemaCloner {
   /**
    * Creates a cloner that copies table structure from `sourceDb` into `targetDb`.
-   * @param {{sourceDb: import("../drivers/base.js").default, targetDb: import("../drivers/base.js").default}} args
+   * @param {{sourceDb: import("../drivers/base.js").default, targetDb: import("../drivers/base.js").default}} args - Options.
    */
   constructor({sourceDb, targetDb}) {
     this.sourceDb = sourceDb
@@ -41,7 +41,7 @@ export default class SchemaCloner {
   /**
    * Clones every given table from the source into the target, then baselines the
    * target's ledger so the cloned schema is recorded as already-migrated.
-   * @param {string[]} tableNames
+   * @param {string[]} tableNames - Table names.
    * @returns {Promise<void>}
    */
   async syncTables(tableNames) {
@@ -55,7 +55,7 @@ export default class SchemaCloner {
   /**
    * Clones a single table from the source into the target, creating it or adding and
    * widening columns and indexes as needed.
-   * @param {string} tableName
+   * @param {string} tableName - Table name.
    * @returns {Promise<void>}
    */
   async syncTable(tableName) {
@@ -82,7 +82,7 @@ export default class SchemaCloner {
   /**
    * Creates the table in the target from the source table's columns and its
    * non-primary-key indexes.
-   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Options.
    * @returns {Promise<void>}
    */
   async createTargetTable({sourceTable, tableName}) {
@@ -105,7 +105,7 @@ export default class SchemaCloner {
   /**
    * Adds columns present on the source but missing from the target, and widens
    * too-narrow target text columns.
-   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Options.
    * @returns {Promise<boolean>} Whether any column was added or widened.
    */
   async ensureTargetColumns({sourceTable, tableName}) {
@@ -154,7 +154,7 @@ export default class SchemaCloner {
    * Creates non-primary-key indexes present on the source but missing from the target,
    * and replaces target indexes whose definition (columns or uniqueness) drifted from
    * the source.
-   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args
+   * @param {{sourceTable: import("../drivers/base-table.js").default, tableName: string}} args - Options.
    * @returns {Promise<void>}
    */
   async ensureTargetIndexes({sourceTable, tableName}) {
@@ -230,7 +230,7 @@ export default class SchemaCloner {
 
   /**
    * Drops an index on the target database.
-   * @param {{tableName: string, targetIndex: import("../drivers/base-columns-index.js").default}} args
+   * @param {{tableName: string, targetIndex: import("../drivers/base-columns-index.js").default}} args - Options.
    * @returns {Promise<void>}
    */
   async dropTargetIndex({tableName, targetIndex}) {
@@ -252,7 +252,7 @@ export default class SchemaCloner {
   /**
    * Whether the target ledger is missing any version applied on the source — i.e. the
    * target schema may have been advanced out of band without recording it.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} - Whether the target ledger differs from the source.
    */
   async ledgerDriftsFromSource() {
     if (!await MigrationsLedger.tableExists(this.targetDb)) {
@@ -268,8 +268,8 @@ export default class SchemaCloner {
   /**
    * Maps a source index into a TableData index for table creation (SQLite omits the
    * index name so the driver can generate a unique one).
-   * @param {import("../drivers/base-columns-index.js").default} sourceIndex
-   * @returns {TableIndex}
+   * @param {import("../drivers/base-columns-index.js").default} sourceIndex - Source index definition.
+   * @returns {TableIndex} - Framework-independent index definition.
    */
   tableDataIndexFromSourceIndex(sourceIndex) {
     /** @type {{name?: string, unique: boolean}} */
@@ -289,8 +289,8 @@ export default class SchemaCloner {
   /**
    * Builds driver create-index args from a source index (the index name is omitted on
    * SQLite, where index names are unique per-database rather than per-table).
-   * @param {{sourceIndex: import("../drivers/base-columns-index.js").default, tableName: string}} args
-   * @returns {{columns: string[], name?: string, tableName: string, unique: boolean}}
+   * @param {{sourceIndex: import("../drivers/base-columns-index.js").default, tableName: string}} args - Options.
+   * @returns {{columns: string[], name?: string, tableName: string, unique: boolean}} - Arguments for creating the target index.
    */
   createIndexArgsFromSourceIndex({sourceIndex, tableName}) {
     /** @type {{columns: string[], name?: string, tableName: string, unique: boolean}} */
@@ -309,9 +309,9 @@ export default class SchemaCloner {
 
   /**
    * Whether two indexes have the same uniqueness and ordered column list.
-   * @param {import("../drivers/base-columns-index.js").default} sourceIndex
-   * @param {import("../drivers/base-columns-index.js").default} targetIndex
-   * @returns {boolean}
+   * @param {import("../drivers/base-columns-index.js").default} sourceIndex - Source index definition.
+   * @param {import("../drivers/base-columns-index.js").default} targetIndex - Target index definition.
+   * @returns {boolean} - Whether both indexes have the same shape.
    */
   indexesMatch(sourceIndex, targetIndex) {
     const sourceColumnNames = sourceIndex.getColumnNames()
@@ -336,8 +336,8 @@ export default class SchemaCloner {
 
   /**
    * A stable signature for an index, used to match cloned indexes by shape.
-   * @param {import("../drivers/base-columns-index.js").default} index
-   * @returns {string}
+   * @param {import("../drivers/base-columns-index.js").default} index - Index definition.
+   * @returns {string} - Stable index-shape signature.
    */
   indexSignature(index) {
     return `${index.isUnique() ? "unique" : "index"}:${index.getColumnNames().join(",")}`
@@ -345,8 +345,8 @@ export default class SchemaCloner {
 
   /**
    * Normalizes a column type to its canonical lowercase form (`int` becomes `integer`).
-   * @param {string} columnType
-   * @returns {string}
+   * @param {string} columnType - Database column type.
+   * @returns {string} - Canonical lowercase column type.
    */
   normalizedColumnType(columnType) {
     const normalizedType = columnType.toLowerCase()
@@ -360,8 +360,8 @@ export default class SchemaCloner {
 
   /**
    * The widening rank of a text column type (0 when not a text type).
-   * @param {string} columnType
-   * @returns {number}
+   * @param {string} columnType - Database column type.
+   * @returns {number} - Text-type widening rank.
    */
   textTypeRank(columnType) {
     return TEXT_TYPE_RANKS[this.normalizedColumnType(columnType)] || 0
@@ -369,9 +369,9 @@ export default class SchemaCloner {
 
   /**
    * Whether the target's text column is narrower than the source's and must be widened.
-   * @param {import("../drivers/base-column.js").default} sourceColumn
-   * @param {import("../drivers/base-column.js").default} targetColumn
-   * @returns {boolean}
+   * @param {import("../drivers/base-column.js").default} sourceColumn - Source column definition.
+   * @param {import("../drivers/base-column.js").default} targetColumn - Target column definition.
+   * @returns {boolean} - Whether the target text column must be widened.
    */
   columnNeedsWidening(sourceColumn, targetColumn) {
     const sourceRank = this.textTypeRank(sourceColumn.getType())
@@ -383,9 +383,9 @@ export default class SchemaCloner {
   /**
    * Builds TableData column args from a source column, copying type, nullability,
    * length, notes, simple defaults and (for full clones) primary-key flag.
-   * @param {import("../drivers/base-column.js").default} sourceColumn
-   * @param {{isNewColumn: boolean}} args
-   * @returns {Record<string, unknown>}
+   * @param {import("../drivers/base-column.js").default} sourceColumn - Source column definition.
+   * @param {{isNewColumn: boolean}} args - Options.
+   * @returns {Record<string, unknown>} - Arguments for altering the target column.
    */
   columnArgsFromSourceColumn(sourceColumn, {isNewColumn}) {
     /** @type {{autoIncrement?: boolean, default?: unknown, isNewColumn: boolean, maxLength?: number, notes?: string, null: boolean, primaryKey?: boolean, type: string}} */

--- a/src/environment-handlers/browser.js
+++ b/src/environment-handlers/browser.js
@@ -290,7 +290,6 @@ export default class VelociousEnvironmentsHandlerBrowser extends Base {
    * Runs after migrations.
    * @param {object} args - Options object.
    * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs.
-   * @param {"migration" | "schemaDump"} [args.reason] - Why the structure hook is running.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async afterMigrations({dbs}) {

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -860,7 +860,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         files.push({file, fullPath, date, migrationClassName})
       }
     } catch (error) {
-      if (/** @type {NodeJS.ErrnoException} */ (error)?.code !== "ENOENT") {
+      if (/** @type {Error & {code?: string}} */ (error)?.code !== "ENOENT") {
         throw error
       }
     }

--- a/src/environment-handlers/node/cli/commands/lint/relationships.js
+++ b/src/environment-handlers/node/cli/commands/lint/relationships.js
@@ -124,7 +124,7 @@ export default class VelociousCliCommandsLintRelationships extends BaseCommand {
 
       if (!stats.isDirectory()) return false
     } catch (error) {
-      if (/** @type {NodeJS.ErrnoException} */ (error).code == "ENOENT") return false
+      if (/** @type {Error & {code?: string}} */ (error).code == "ENOENT") return false
 
       throw error
     }
@@ -213,7 +213,7 @@ export default class VelociousCliCommandsLintRelationships extends BaseCommand {
     try {
       configContent = await fs.readFile(configPath, "utf8")
     } catch (error) {
-      if (!explicitConfigPath && /** @type {NodeJS.ErrnoException} */ (error).code == "ENOENT") {
+      if (!explicitConfigPath && /** @type {Error & {code?: string}} */ (error).code == "ENOENT") {
         return new Set()
       }
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -20,6 +20,8 @@ import isDate from "./utils/is-date.js"
 import isPlainObject from "./utils/plain-object.js"
 import {RansackQueryError, normalizeRansackGroup, parseRansackSort} from "./utils/ransack.js"
 
+/** @typedef {import("./database/query/model-class-query.js").default & Record<symbol, Set<string> | undefined>} FrontendModelQueryMetadata */
+
 /**
  * Runs normalize frontend model preload.
  * @param {import("./database/query/index.js").NestedPreloadRecord | string | string[] | boolean | undefined | null} preload - Preload shorthand.
@@ -31,7 +33,7 @@ function normalizeFrontendModelPreload(preload) {
   try {
     return normalizeQueryPreload(preload)
   } catch (error) {
-    throwFrontendModelQueryErrorForParserError(error)
+    return throwFrontendModelQueryErrorForParserError(error)
   }
 }
 
@@ -46,7 +48,7 @@ function normalizeFrontendModelJoins(joins) {
   try {
     return normalizeQueryJoins(joins)
   } catch (error) {
-    throwFrontendModelQueryErrorForParserError(error)
+    return throwFrontendModelQueryErrorForParserError(error)
   }
 }
 
@@ -190,10 +192,10 @@ function frontendSyncReplaySafeError(message, cause) {
 /**
  * Runs frontend model query metadata.
  * @param {import("./database/query/model-class-query.js").default} query - Query instance.
- * @returns {import("./database/query/model-class-query.js").default & {[frontendModelJoinedPathsSymbol]?: Set<string>, [frontendModelGroupedColumnsSymbol]?: Set<string>}} - Query metadata access helper.
+ * @returns {FrontendModelQueryMetadata} - Query metadata access helper.
  */
 function frontendModelQueryMetadata(query) {
-  return /** @type {import("./database/query/model-class-query.js").default & {[frontendModelJoinedPathsSymbol]?: Set<string>, [frontendModelGroupedColumnsSymbol]?: Set<string>}} */ (query)
+  return /** @type {FrontendModelQueryMetadata} */ (query)
 }
 
 /**
@@ -1253,7 +1255,7 @@ export default class FrontendModelController extends Controller {
     try {
       return normalizeQuerySort(this.frontendModelParams().sort)
     } catch (error) {
-      throwFrontendModelQueryErrorForParserError(error)
+      return throwFrontendModelQueryErrorForParserError(error)
     }
   }
 
@@ -1265,7 +1267,7 @@ export default class FrontendModelController extends Controller {
     try {
       return normalizeQueryGroup(this.frontendModelParams().group)
     } catch (error) {
-      throwFrontendModelQueryErrorForParserError(error)
+      return throwFrontendModelQueryErrorForParserError(error)
     }
   }
 
@@ -1304,7 +1306,7 @@ export default class FrontendModelController extends Controller {
 
       return pluck
     } catch (error) {
-      throwFrontendModelQueryErrorForParserError(error)
+      return throwFrontendModelQueryErrorForParserError(error)
     }
   }
 
@@ -1351,8 +1353,8 @@ export default class FrontendModelController extends Controller {
    * its backend model class by looking up the resource by modelName
    * across all configured backend projects. Returns null when no
    * resource matches the user-provided ability entry.
-   * @param {string} modelName
-   * @returns {typeof import("./database/record/index.js").default | null}
+   * @param {string} modelName - Model name.
+   * @returns {typeof import("./database/record/index.js").default | null} - Matching root model when present.
    */
   _frontendModelClassForAbilities(modelName) {
     if (typeof modelName !== "string" || modelName.length === 0) return null
@@ -1383,9 +1385,9 @@ export default class FrontendModelController extends Controller {
    * preloaded relationships at any depth. Used to evaluate per-record
    * abilities against nested preloaded children with a single batched
    * query per (modelClass, action) pair.
-   * @param {import("./database/record/index.js").default[]} rootModels
-   * @param {string} modelName
-   * @returns {import("./database/record/index.js").default[]}
+   * @param {import("./database/record/index.js").default[]} rootModels - Root model collection.
+   * @param {string} modelName - Model name.
+   * @returns {import("./database/record/index.js").default[]} - Root models reachable from the record.
    */
   _frontendModelCollectRecordsForName(rootModels, modelName) {
     /**
@@ -1399,7 +1401,8 @@ export default class FrontendModelController extends Controller {
 
     /**
      * Walk.
-     * @param {import("./database/record/index.js").default | null | undefined} record */
+     * @param {import("./database/record/index.js").default | null | undefined} record - Record to process.
+     */
     const walk = (record) => {
       if (!record || typeof record !== "object") return
       if (seen.has(record)) return
@@ -1437,7 +1440,7 @@ export default class FrontendModelController extends Controller {
    * `_setComputedAbility`. Runs one batched `authorized query + pluck`
    * per (modelClass, action) pair, regardless of how many records
    * were loaded.
-   * @param {import("./database/record/index.js").default[]} rootModels
+   * @param {import("./database/record/index.js").default[]} rootModels - Root model collection.
    * @returns {Promise<void>}
    */
   async frontendModelComputeAbilities(rootModels) {
@@ -1491,7 +1494,7 @@ export default class FrontendModelController extends Controller {
    * Unknown entries are silently skipped — downstream code resolves
    * model names to classes when applying the check, so unresolved
    * names naturally become no-ops.
-   * @returns {Array<{modelName: string, actions: string[]}>}
+   * @returns {Array<{modelName: string, actions: string[]}>} - Normalized model ability requests.
    */
   frontendModelAbilities() {
     const raw = this.frontendModelParams().abilities
@@ -1529,7 +1532,7 @@ export default class FrontendModelController extends Controller {
    *
    * Returns the raw nested-record spec (shape validated by the
    * normalizer inside `Query.queryData`) or `null` when not requested.
-   * @returns {import("./database/query/query-data.js").QueryDataSpec | null}
+   * @returns {import("./database/query/query-data.js").QueryDataSpec | null} - Normalized query-data specification.
    */
   frontendModelQueryData() {
     const raw = this.frontendModelParams().queryData
@@ -1853,7 +1856,7 @@ export default class FrontendModelController extends Controller {
     try {
       return normalizeRansackGroup(this.frontendModelClass(), filterParams)
     } catch (error) {
-      throwFrontendModelQueryErrorForParserError(error)
+      return throwFrontendModelQueryErrorForParserError(error)
     }
   }
 
@@ -1866,7 +1869,7 @@ export default class FrontendModelController extends Controller {
     try {
       return parseRansackSort(this.frontendModelClass(), sortString)
     } catch (error) {
-      throwFrontendModelQueryErrorForParserError(error)
+      return throwFrontendModelQueryErrorForParserError(error)
     }
   }
 
@@ -2698,12 +2701,14 @@ export default class FrontendModelController extends Controller {
     /**
      * Resource attribute method name.
      * @param {string} attributeName - Attribute name.
+     * @returns {string} - Resource attribute method name.
      */
     const resourceAttributeMethodName = (attributeName) => `${attributeName}Attribute`
 
     /**
      * Resource has attribute.
      * @param {string} attributeName - Attribute name.
+     * @returns {ReturnType<FrontendModelBaseResource["resourceMethod"]>} - Resource attribute method details.
      */
     const resourceAttributeMethod = (attributeName) => {
       const methodName = resourceAttributeMethodName(attributeName)
@@ -2714,6 +2719,7 @@ export default class FrontendModelController extends Controller {
     /**
      * Prototype attribute method.
      * @param {string} attributeName - Attribute name.
+     * @returns {{method: (...args: Array<?>) => ?, ownerName: string} | undefined} - Prototype method details when present.
      */
     const prototypeAttributeMethod = (attributeName) => {
       let currentPrototype = Object.getPrototypeOf(model)
@@ -2735,6 +2741,7 @@ export default class FrontendModelController extends Controller {
     /**
      * Serialized attribute value.
      * @param {string} attributeName - Attribute name.
+     * @returns {Promise<?>} - Serialized attribute value.
      */
     const serializedAttributeValue = async (attributeName) => {
       // Check resource instance first (virtual/computed attributes via ${name}Attribute convention)
@@ -2758,6 +2765,7 @@ export default class FrontendModelController extends Controller {
     /**
      * Attribute exists.
      * @param {string} attributeName - Attribute name.
+     * @returns {boolean} - Whether the attribute exists.
      */
     const attributeExists = (attributeName) => {
       return (attributeName in modelAttributes) || (attributeName in /** @type {Record<string, ?>} */ (model)) || Boolean(resourceAttributeMethod(attributeName))

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -1353,8 +1353,8 @@ export default class FrontendModelController extends Controller {
    * its backend model class by looking up the resource by modelName
    * across all configured backend projects. Returns null when no
    * resource matches the user-provided ability entry.
-   * @param {string} modelName - Model name.
-   * @returns {typeof import("./database/record/index.js").default | null} - Matching root model when present.
+   * @param {string} modelName - Frontend model name from an ability request.
+   * @returns {typeof import("./database/record/index.js").default | null} - Backend model class exposed under that frontend name, if present.
    */
   _frontendModelClassForAbilities(modelName) {
     if (typeof modelName !== "string" || modelName.length === 0) return null
@@ -1385,9 +1385,9 @@ export default class FrontendModelController extends Controller {
    * preloaded relationships at any depth. Used to evaluate per-record
    * abilities against nested preloaded children with a single batched
    * query per (modelClass, action) pair.
-   * @param {import("./database/record/index.js").default[]} rootModels - Root model collection.
-   * @param {string} modelName - Model name.
-   * @returns {import("./database/record/index.js").default[]} - Root models reachable from the record.
+   * @param {import("./database/record/index.js").default[]} rootModels - Loaded roots whose relationship graphs should be traversed.
+   * @param {string} modelName - Model name records must match.
+   * @returns {import("./database/record/index.js").default[]} - Matching records reachable from the loaded roots.
    */
   _frontendModelCollectRecordsForName(rootModels, modelName) {
     /**
@@ -1401,7 +1401,7 @@ export default class FrontendModelController extends Controller {
 
     /**
      * Walk.
-     * @param {import("./database/record/index.js").default | null | undefined} record - Record to process.
+     * @param {import("./database/record/index.js").default | null | undefined} record - Loaded record whose relationship graph should be visited.
      */
     const walk = (record) => {
       if (!record || typeof record !== "object") return
@@ -1440,7 +1440,7 @@ export default class FrontendModelController extends Controller {
    * `_setComputedAbility`. Runs one batched `authorized query + pluck`
    * per (modelClass, action) pair, regardless of how many records
    * were loaded.
-   * @param {import("./database/record/index.js").default[]} rootModels - Root model collection.
+   * @param {import("./database/record/index.js").default[]} rootModels - Loaded roots that receive computed ability results.
    * @returns {Promise<void>}
    */
   async frontendModelComputeAbilities(rootModels) {

--- a/src/frontend-models/base.js
+++ b/src/frontend-models/base.js
@@ -104,7 +104,7 @@ import {readPayloadAssociationCount, readPayloadComputedAbility, readPayloadQuer
  * frontend models passed model classes into relationship helpers, while newer
  * generated models pass instance types.
  * @template {FrontendModelBase<any, any, any> | typeof FrontendModelBase} T
- * @typedef {T extends new (...args: any[]) => infer Instance ? Instance : T} FrontendModelRelationshipModel
+ * @typedef {T extends typeof FrontendModelBase ? InstanceType<T> : T} FrontendModelRelationshipModel
  */
 /**
  * FrontendModelTransportConfig type.
@@ -1799,7 +1799,7 @@ async function performSharedFrontendModelApiRequest(requestPayload) {
 /**
  * Throws a frontend-model HTTP error with backend-provided envelope details when available.
  * @param {{commandLabel: string, response: Response, responseText: string}} args - Error response details.
- * @returns {never}
+ * @returns {never} - Always throws an unknown-attribute error.
  */
 function throwFrontendModelHttpError({commandLabel, response, responseText}) {
   // Surface the backend's friendly errorMessage envelope (the
@@ -2612,7 +2612,7 @@ export default class FrontendModelBase {
    * column of the same name. Returns the attached value, or 0 when
    * `.withCount(...)` wasn't requested for this attribute.
    * @param {string} attributeName - Attribute name, e.g. `"tasksCount"` or a custom name from `.withCount({customName: {...}})`.
-   * @returns {number}
+   * @returns {number} - Attached association count, or zero when absent.
    */
   readCount(attributeName) {
     return readPayloadAssociationCount(/** @type {import("../record-payload-values.js").RecordPayloadValuesTarget} */ (/** @type {?} */ (this)), attributeName)
@@ -2638,7 +2638,7 @@ export default class FrontendModelBase {
    * on `record.can("update")` without first checking whether the
    * ability was loaded.
    * @param {string} action - Ability action name, e.g. `"update"`.
-   * @returns {boolean}
+   * @returns {boolean} - Whether the requested ability is allowed.
    */
   can(action) {
     return readPayloadComputedAbility(/** @type {import("../record-payload-values.js").RecordPayloadValuesTarget} */ (/** @type {?} */ (this)), action)
@@ -2663,7 +2663,7 @@ export default class FrontendModelBase {
    * name. Returns `null` when no registered fn produced that alias for
    * this record (e.g. no child rows matched the aggregate).
    * @param {string} name - queryData alias name.
-   * @returns {?}
+   * @returns {?} - Attached query-data value.
    */
   queryData(name) {
     return readPayloadQueryData(/** @type {import("../record-payload-values.js").RecordPayloadValuesTarget} */ (/** @type {?} */ (this)), name)

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -166,8 +166,8 @@ export function normalizePreload(preload) {
  * query API into the strict internal entries used in the transport
  * payload. Shares the shape semantics with the backend normalizer in
  * `database/query/with-count.js`.
- * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec
- * @returns {Array<{attributeName: string, relationshipName: string, where?: Record<string, ?>}>}
+ * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec - Query specification.
+ * @returns {Array<{attributeName: string, relationshipName: string, where?: Record<string, ?>}>} - Normalized association-count requests.
  */
 function normalizeWithCountFrontend(spec) {
   if (spec == null) return []
@@ -222,9 +222,9 @@ function normalizeWithCountFrontend(spec) {
  * shorthand (applies to the query's own model class) and the keyed
  * `{ModelName: [action, ...]}` form (applies to records of that model
  * class, useful for preloaded children).
- * @param {string[] | Record<string, string[]>} spec
- * @param {{getModelName: () => string}} rootModelClass
- * @returns {Array<{modelName: string, actions: string[]}>}
+ * @param {string[] | Record<string, string[]>} spec - Query specification.
+ * @param {{getModelName: () => string}} rootModelClass - Root model class.
+ * @returns {Array<{modelName: string, actions: string[]}>} - Normalized model ability requests.
  */
 function normalizeAbilitiesSpec(spec, rootModelClass) {
   if (spec == null) return []
@@ -1181,8 +1181,8 @@ export default class FrontendModelQuery {
    * strings — typically `"update"` / `"destroy"` / `"create"` /
    * `"read"`, but any custom action registered on the resource's
    * authorization ability is accepted.
-   * @param {string[] | Record<string, string[]>} spec
-   * @returns {this}
+   * @param {string[] | Record<string, string[]>} spec - Query specification.
+   * @returns {this} - This query for chaining.
    */
   abilities(spec) {
     for (const entry of normalizeAbilitiesSpec(spec, this.modelClass)) {
@@ -1194,7 +1194,7 @@ export default class FrontendModelQuery {
 
   /**
    * Runs merge ability entry.
-   * @param {{modelName: string, actions: string[]}} entry
+   * @param {{modelName: string, actions: string[]}} entry - Query entry.
    * @returns {void}
    */
   _mergeAbilityEntry(entry) {
@@ -1215,8 +1215,8 @@ export default class FrontendModelQuery {
    * counts to each returned record. Parses the same shapes as the
    * backend `ModelClassQuery#withCount`, then ships the normalized
    * entries as part of the `index` command payload.
-   * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec
-   * @returns {this}
+   * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec - Query specification.
+   * @returns {this} - This query for chaining.
    */
   withCount(spec) {
     for (const entry of normalizeWithCountFrontend(spec)) {
@@ -1233,8 +1233,8 @@ export default class FrontendModelQuery {
    * frontend ships only these names; the SQL fragments stay server-
    * side. All resulting aliases are attached to the root record and
    * read back with `record.queryData(aliasName)`.
-   * @param {string | Array<string | Record<string, ?>> | Record<string, ?>} spec
-   * @returns {this}
+   * @param {string | Array<string | Record<string, ?>> | Record<string, ?>} spec - Query specification.
+   * @returns {this} - This query for chaining.
    */
   queryData(spec) {
     if (spec == null) return this

--- a/src/frontend-models/query.js
+++ b/src/frontend-models/query.js
@@ -166,7 +166,7 @@ export function normalizePreload(preload) {
  * query API into the strict internal entries used in the transport
  * payload. Shares the shape semantics with the backend normalizer in
  * `database/query/with-count.js`.
- * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec - Query specification.
+ * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec - Association-count shorthand to normalize.
  * @returns {Array<{attributeName: string, relationshipName: string, where?: Record<string, ?>}>} - Normalized association-count requests.
  */
 function normalizeWithCountFrontend(spec) {
@@ -222,8 +222,8 @@ function normalizeWithCountFrontend(spec) {
  * shorthand (applies to the query's own model class) and the keyed
  * `{ModelName: [action, ...]}` form (applies to records of that model
  * class, useful for preloaded children).
- * @param {string[] | Record<string, string[]>} spec - Query specification.
- * @param {{getModelName: () => string}} rootModelClass - Root model class.
+ * @param {string[] | Record<string, string[]>} spec - Ability actions grouped by model, or root-model action shorthand.
+ * @param {{getModelName: () => string}} rootModelClass - Query root used by the flat action shorthand.
  * @returns {Array<{modelName: string, actions: string[]}>} - Normalized model ability requests.
  */
 function normalizeAbilitiesSpec(spec, rootModelClass) {
@@ -1181,7 +1181,7 @@ export default class FrontendModelQuery {
    * strings — typically `"update"` / `"destroy"` / `"create"` /
    * `"read"`, but any custom action registered on the resource's
    * authorization ability is accepted.
-   * @param {string[] | Record<string, string[]>} spec - Query specification.
+   * @param {string[] | Record<string, string[]>} spec - Ability actions to request for root or named models.
    * @returns {this} - This query for chaining.
    */
   abilities(spec) {
@@ -1194,7 +1194,7 @@ export default class FrontendModelQuery {
 
   /**
    * Runs merge ability entry.
-   * @param {{modelName: string, actions: string[]}} entry - Query entry.
+   * @param {{modelName: string, actions: string[]}} entry - Normalized model ability request to append.
    * @returns {void}
    */
   _mergeAbilityEntry(entry) {
@@ -1215,7 +1215,7 @@ export default class FrontendModelQuery {
    * counts to each returned record. Parses the same shapes as the
    * backend `ModelClassQuery#withCount`, then ships the normalized
    * entries as part of the `index` command payload.
-   * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec - Query specification.
+   * @param {string | string[] | Record<string, boolean | {relationship?: string, where?: Record<string, ?>}>} spec - Relationships whose counts should be serialized.
    * @returns {this} - This query for chaining.
    */
   withCount(spec) {
@@ -1233,7 +1233,7 @@ export default class FrontendModelQuery {
    * frontend ships only these names; the SQL fragments stay server-
    * side. All resulting aliases are attached to the root record and
    * read back with `record.queryData(aliasName)`.
-   * @param {string | Array<string | Record<string, ?>> | Record<string, ?>} spec - Query specification.
+   * @param {string | Array<string | Record<string, ?>> | Record<string, ?>} spec - Backend query-data names and arguments to serialize.
    * @returns {this} - This query for chaining.
    */
   queryData(spec) {

--- a/src/http-server/client/index.js
+++ b/src/http-server/client/index.js
@@ -2,7 +2,6 @@
 
 import crypto from "crypto"
 import fs from "node:fs/promises"
-import {createReadStream} from "node:fs"
 import {digg} from "diggerize"
 import {ensureError} from "typanic"
 import EventEmitter from "../../utils/event-emitter.js"
@@ -58,6 +57,9 @@ export default class VeoliciousHttpServerClient {
      * Narrows the runtime value to the documented type.
      * @type {RequestRunner[]} */
     this.requestRunners = []
+
+    /** @type {Set<(result: "completed" | "aborted") => Promise<void>>} */
+    this.pendingFileResponses = new Set()
   }
 
   /**
@@ -355,6 +357,7 @@ export default class VeoliciousHttpServerClient {
     const response = digg(requestRunner, "response")
     const request = requestRunner.getRequest()
     const filePath = response.getFilePath()
+    const fileOnFinished = response.getFileOnFinished()
     const date = new Date()
     const connectionHeader = request.header("connection")?.toLowerCase()?.trim()
     const httpVersion = request.httpVersion()
@@ -423,8 +426,9 @@ export default class VeoliciousHttpServerClient {
 
     if (isBodylessStatus) {
       this.logger.debug(() => ["sendResponse body suppressed for no-body status", {clientCount: this.clientCount, statusCode: response.getStatusCode()}])
+      if (hasFilePath) await this.sendFileOutput(filePath, false, fileOnFinished)
     } else if (hasFilePath) {
-      await this.sendFileOutput(filePath)
+      await this.sendFileOutput(filePath, true, fileOnFinished)
     } else {
       this.events.emit("output", body)
       this.logger.debug(() => ["sendResponse body emitted", {clientCount: this.clientCount, bodyLength: bodyIsString ? body.length : body.byteLength}])
@@ -441,25 +445,67 @@ export default class VeoliciousHttpServerClient {
   /**
    * Runs send file output.
    * @param {string} filePath - File path.
+   * @param {boolean} sendBody - Whether the file body should be sent.
+   * @param {((result: "completed" | "aborted") => void | Promise<void>) | null} onFinished - Completion callback.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async sendFileOutput(filePath) {
+  async sendFileOutput(filePath, sendBody, onFinished) {
     this.logger.debug(() => ["sendFileOutput start", {clientCount: this.clientCount, filePath}])
-    let totalBytes = 0
-    let chunkCount = 0
+
+    const result = await new Promise((resolve) => {
+      /** @type {Promise<void> | null} */
+      let settlement = null
+      const settle = (/** @type {"completed" | "aborted"} */ transferResult) => {
+        if (settlement) return settlement
+
+        this.pendingFileResponses.delete(settle)
+        settlement = this.runFileOnFinished({filePath, onFinished, result: transferResult})
+          .finally(() => resolve(transferResult))
+
+        return settlement
+      }
+
+      this.pendingFileResponses.add(settle)
+      this.events.emit("file", {filePath, sendBody, settle})
+    })
+
+    this.logger.debug(() => ["sendFileOutput done", {clientCount: this.clientCount, filePath, result}])
+  }
+
+  /**
+   * Runs a file completion callback without allowing cleanup failures to replace the committed response.
+   * @param {object} args - Completion details.
+   * @param {string} args.filePath - File path.
+   * @param {((result: "completed" | "aborted") => void | Promise<void>) | null} args.onFinished - Completion callback.
+   * @param {"completed" | "aborted"} args.result - Transfer result.
+   * @returns {Promise<void>} - Resolves after callback cleanup and error reporting finish.
+   */
+  async runFileOnFinished({filePath, onFinished, result}) {
+    if (!onFinished) return
 
     try {
-      for await (const chunk of createReadStream(filePath)) {
-        chunkCount += 1
-        totalBytes += chunk.length
-        this.logger.debug(() => ["sendFileOutput chunk", {clientCount: this.clientCount, chunkCount, chunkLength: chunk.length, totalBytes}])
-        this.events.emit("output", chunk)
+      await onFinished(result)
+    } catch (caughtError) {
+      const error = ensureError(caughtError)
+
+      await this.logger.error(() => ["File response onFinished callback failed", {clientCount: this.clientCount, filePath, result}, error])
+
+      const errorPayload = {
+        context: {clientCount: this.clientCount, filePath, result, stage: "send-file-on-finished"},
+        error
       }
-      this.logger.debug(() => ["sendFileOutput done", {clientCount: this.clientCount, chunkCount, totalBytes}])
-    } catch (error) {
-      this.logger.error(() => [`Velocious client ${this.clientCount} failed while streaming file output: ${filePath}`, error])
-      throw error
+
+      this.configuration.getErrorEvents().emit("framework-error", errorPayload)
+      this.configuration.getErrorEvents().emit("all-error", {...errorPayload, errorType: "framework-error"})
     }
+  }
+
+  /**
+   * Aborts all file responses awaiting transport acknowledgement.
+   * @returns {Promise<void>} - Resolves after pending callbacks settle.
+   */
+  async abortPendingFileResponses() {
+    await Promise.all([...this.pendingFileResponses].map((settle) => settle("aborted")))
   }
 
   /**

--- a/src/http-server/client/index.js
+++ b/src/http-server/client/index.js
@@ -534,7 +534,7 @@ export default class VeoliciousHttpServerClient {
  * cannot carry a message body: every 1xx informational, 204 No
  * Content, and 304 Not Modified.
  * @param {number} statusCode - HTTP status code.
- * @returns {boolean}
+ * @returns {boolean} - Whether the status code forbids a response body.
  */
 function isNoBodyStatusCode(statusCode) {
   return (statusCode >= 100 && statusCode < 200) || statusCode === 204 || statusCode === 304

--- a/src/http-server/client/response.js
+++ b/src/http-server/client/response.js
@@ -89,6 +89,11 @@ export default class VelociousHttpServerClientResponse {
   filePath = null
 
   /**
+   * File response completion callback.
+   * @type {((result: "completed" | "aborted") => void | Promise<void>) | null} */
+  fileOnFinished = null
+
+  /**
    * Headers.
    * @type {Record<string, string[]>} */
   headers = {}
@@ -163,6 +168,7 @@ export default class VelociousHttpServerClientResponse {
    */
   setBody(value) {
     this.filePath = null
+    this.fileOnFinished = null
     this.body = value
   }
 
@@ -175,12 +181,22 @@ export default class VelociousHttpServerClientResponse {
   }
 
   /**
+   * Gets the file response completion callback.
+   * @returns {((result: "completed" | "aborted") => void | Promise<void>) | null} - File response completion callback.
+   */
+  getFileOnFinished() {
+    return this.fileOnFinished
+  }
+
+  /**
    * Runs set file path.
    * @param {string} path - File path.
+   * @param {((result: "completed" | "aborted") => void | Promise<void>) | null} [onFinished] - Completion callback.
    * @returns {void} - No return value.
    */
-  setFilePath(path) {
+  setFilePath(path, onFinished = null) {
     this.filePath = path
+    this.fileOnFinished = onFinished
     this.body = null
   }
 

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -239,7 +239,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Removes a closed connection from the session registry. Called by
    * `VelociousWebsocketConnection.close()` after it sends the final
    * `connection-closed` frame.
-   * @param {string} connectionId - Connection identifier.
+   * @param {string} connectionId - Closed connection identifier to remove.
    * @returns {void}
    */
   _removeConnection(connectionId) {
@@ -450,7 +450,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * The actual message dispatch, extracted so
    * `configuration.getWebsocketAroundRequest()` can wrap it in any
    * per-request context (AsyncLocalStorage, tracing, etc.).
-   * @param {WebsocketSessionMessage} message - Message to process.
+   * @param {WebsocketSessionMessage} message - Decoded client frame to dispatch by message type.
    * @returns {Promise<void>}
    */
   async _handleMessageInner(message) {
@@ -731,7 +731,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * fragmented message. Returns true when the fragment was accepted
    * and false when the per-message cap was hit and the socket has
    * been closed.
-   * @param {Buffer} payload - Message payload.
+   * @param {Buffer} payload - Continuation-frame bytes to append.
    * @returns {boolean} - Whether the fragment was accepted.
    */
   _appendFragment(payload) {
@@ -1087,7 +1087,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * created one whose socket just connected) transfers state from
    * the paused session and instructs the client via
    * `session-resumed` or `session-gone`.
-   * @param {Record<string, ?>} message - Message to process.
+   * @param {Record<string, ?>} message - Session-resume frame containing the paused session identifier.
    * @returns {Promise<void>}
    */
   async _handleSessionResume(message) {
@@ -1168,7 +1168,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Fires `onClose(reason)` on every live app-defined connection, then
    * drops them from the registry. No network frame is sent — the
    * socket is already going away.
-   * @param {"session_destroyed" | "grace_expired" | "error"} reason - Close reason.
+   * @param {"session_destroyed" | "grace_expired" | "error"} reason - Permanent teardown reason passed to each connection.
    * @returns {Promise<void>}
    */
   async _teardownConnections(reason) {
@@ -1194,7 +1194,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * registered connection class, stores it on `_connections`, and
    * fires `onConnect()`. Sends `connection-opened` on success or
    * `connection-error` on failure.
-   * @param {Record<string, ?>} message - Message to process.
+   * @param {Record<string, ?>} message - Connection-open frame naming the connection type and identifier.
    * @returns {Promise<void>}
    */
   async _handleConnectionOpen(message) {
@@ -1242,7 +1242,7 @@ export default class VelociousHttpServerClientWebsocketSession {
 
   /**
    * Handles a `{type: "connection-message"}` from the client.
-   * @param {Record<string, ?>} message - Message to process.
+   * @param {Record<string, ?>} message - Connection-message frame containing the target identifier and body.
    * @returns {Promise<void>}
    */
   async _handleConnectionMessage(message) {
@@ -1267,7 +1267,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   /**
    * Handles a `{type: "connection-close"}` from the client — fires
    * `onClose("client_close")` and confirms with `connection-closed`.
-   * @param {Record<string, ?>} message - Message to process.
+   * @param {Record<string, ?>} message - Connection-close frame containing the target identifier.
    * @returns {Promise<void>}
    */
   async _handleConnectionClose(message) {
@@ -1296,7 +1296,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Handles `{type: "channel-subscribe"}` — runs `canSubscribe()`,
    * registers with the Configuration's global routing registry on
    * success, and sends `channel-subscribed` or `channel-error`.
-   * @param {Record<string, ?>} message - Message to process.
+   * @param {Record<string, ?>} message - Channel-subscribe frame describing the requested subscription.
    * @returns {Promise<void>}
    */
   async _handleChannelSubscribe(message) {
@@ -1421,7 +1421,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   /**
    * Handles `{type: "channel-unsubscribe"}` from the client — calls
    * `unsubscribed()` and sends `channel-unsubscribed`.
-   * @param {Record<string, ?>} message - Message to process.
+   * @param {Record<string, ?>} message - Channel-unsubscribe frame containing the subscription identifier.
    * @returns {Promise<void>}
    */
   async _handleChannelUnsubscribe(message) {

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -239,7 +239,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Removes a closed connection from the session registry. Called by
    * `VelociousWebsocketConnection.close()` after it sends the final
    * `connection-closed` frame.
-   * @param {string} connectionId
+   * @param {string} connectionId - Connection identifier.
    * @returns {void}
    */
   _removeConnection(connectionId) {
@@ -450,7 +450,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * The actual message dispatch, extracted so
    * `configuration.getWebsocketAroundRequest()` can wrap it in any
    * per-request context (AsyncLocalStorage, tracing, etc.).
-   * @param {WebsocketSessionMessage} message
+   * @param {WebsocketSessionMessage} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleMessageInner(message) {
@@ -731,8 +731,8 @@ export default class VelociousHttpServerClientWebsocketSession {
    * fragmented message. Returns true when the fragment was accepted
    * and false when the per-message cap was hit and the socket has
    * been closed.
-   * @param {Buffer} payload
-   * @returns {boolean}
+   * @param {Buffer} payload - Message payload.
+   * @returns {boolean} - Whether the fragment was accepted.
    */
   _appendFragment(payload) {
     // Guard pushing first so `_enforceFragmentLimits` sees the final
@@ -750,7 +750,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * close frame, and tears the session down. Returns true when the
    * caller can continue processing, false when the session is being
    * closed.
-   * @returns {boolean}
+   * @returns {boolean} - Whether fragment processing may continue.
    */
   _enforceFragmentLimits() {
     if (this._fragmentedPayloads === null) return true
@@ -1024,7 +1024,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * The returned promise is stored at pause time and awaited at
    * resume time so we can reject resume attempts from a different
    * authenticated caller (signed out, swapped user, expired cookie).
-   * @returns {Promise<?>}
+   * @returns {Promise<?>} - Captured authenticated identity for resume validation.
    */
   async _captureResumeIdentity() {
     const resolver = this.configuration.getWebsocketSessionIdentityResolver?.()
@@ -1087,7 +1087,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * created one whose socket just connected) transfers state from
    * the paused session and instructs the client via
    * `session-resumed` or `session-gone`.
-   * @param {Record<string, ?>} message
+   * @param {Record<string, ?>} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleSessionResume(message) {
@@ -1168,7 +1168,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Fires `onClose(reason)` on every live app-defined connection, then
    * drops them from the registry. No network frame is sent — the
    * socket is already going away.
-   * @param {"session_destroyed" | "grace_expired" | "error"} reason
+   * @param {"session_destroyed" | "grace_expired" | "error"} reason - Close reason.
    * @returns {Promise<void>}
    */
   async _teardownConnections(reason) {
@@ -1194,7 +1194,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * registered connection class, stores it on `_connections`, and
    * fires `onConnect()`. Sends `connection-opened` on success or
    * `connection-error` on failure.
-   * @param {Record<string, ?>} message
+   * @param {Record<string, ?>} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleConnectionOpen(message) {
@@ -1242,7 +1242,7 @@ export default class VelociousHttpServerClientWebsocketSession {
 
   /**
    * Handles a `{type: "connection-message"}` from the client.
-   * @param {Record<string, ?>} message
+   * @param {Record<string, ?>} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleConnectionMessage(message) {
@@ -1267,7 +1267,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   /**
    * Handles a `{type: "connection-close"}` from the client — fires
    * `onClose("client_close")` and confirms with `connection-closed`.
-   * @param {Record<string, ?>} message
+   * @param {Record<string, ?>} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleConnectionClose(message) {
@@ -1296,7 +1296,7 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Handles `{type: "channel-subscribe"}` — runs `canSubscribe()`,
    * registers with the Configuration's global routing registry on
    * success, and sends `channel-subscribed` or `channel-error`.
-   * @param {Record<string, ?>} message
+   * @param {Record<string, ?>} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleChannelSubscribe(message) {
@@ -1421,7 +1421,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   /**
    * Handles `{type: "channel-unsubscribe"}` from the client — calls
    * `unsubscribed()` and sends `channel-unsubscribed`.
-   * @param {Record<string, ?>} message
+   * @param {Record<string, ?>} message - Message to process.
    * @returns {Promise<void>}
    */
   async _handleChannelUnsubscribe(message) {

--- a/src/http-server/server-client.js
+++ b/src/http-server/server-client.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import EventEmitter from "../utils/event-emitter.js"
+import {createReadStream} from "node:fs"
 import Logger from "../logger.js"
 
 /**
@@ -202,6 +203,99 @@ export default class ServerClient {
 
         finish()
       })
+    })
+  }
+
+  /**
+   * Streams a file to the socket while respecting socket write backpressure.
+   * @param {string} filePath - File path.
+   * @param {boolean} [sendBody] - Whether to read and send the file body.
+   * @returns {Promise<"completed" | "aborted">} - Transfer result.
+   */
+  async sendFile(filePath, sendBody = true) {
+    if (this.socket.destroyed || this.socket.writableEnded || this.socket.writable === false) return "aborted"
+    if (!sendBody) return "completed"
+
+    const readStream = createReadStream(filePath)
+    let aborted = false
+    const abort = () => {
+      aborted = true
+      readStream.destroy()
+    }
+
+    this.socket.once("close", abort)
+    this.socket.once("error", abort)
+
+    try {
+      for await (const chunk of readStream) {
+        if (aborted || !await this.writeFileChunk(chunk)) return "aborted"
+      }
+
+      return aborted ? "aborted" : "completed"
+    } catch (error) {
+      this.logger.error(() => [`Socket ${this.clientCount} file response failed`, filePath, error])
+      return "aborted"
+    } finally {
+      this.socket.off("close", abort)
+      this.socket.off("error", abort)
+      readStream.destroy()
+    }
+  }
+
+  /**
+   * Writes one file chunk and waits for both write acceptance and drain when required.
+   * @param {Buffer | Uint8Array} chunk - File chunk.
+   * @returns {Promise<boolean>} - Whether the chunk was accepted before the socket aborted.
+   */
+  writeFileChunk(chunk) {
+    return new Promise((resolve) => {
+      let callbackCompleted = false
+      let drained = false
+      let settled = false
+
+      const cleanup = () => {
+        this.socket.off("close", onAbort)
+        this.socket.off("error", onAbort)
+        this.socket.off("drain", onDrain)
+      }
+      const finish = (/** @type {boolean} */ result) => {
+        if (settled) return
+
+        settled = true
+        cleanup()
+        resolve(result)
+      }
+      const finishIfReady = () => {
+        if (callbackCompleted && drained) finish(true)
+      }
+      const onAbort = () => finish(false)
+      const onDrain = () => {
+        drained = true
+        finishIfReady()
+      }
+
+      this.socket.once("close", onAbort)
+      this.socket.once("error", onAbort)
+      this.socket.once("drain", onDrain)
+
+      try {
+        const accepted = this.socket.write(chunk, (error) => {
+          if (error) {
+            finish(false)
+            return
+          }
+
+          callbackCompleted = true
+          finishIfReady()
+        })
+
+        drained = accepted
+        if (accepted) this.socket.off("drain", onDrain)
+        finishIfReady()
+      } catch (error) {
+        this.logger.error(() => [`Socket ${this.clientCount} file write failed`, error])
+        finish(false)
+      }
     })
   }
 

--- a/src/http-server/server-client.js
+++ b/src/http-server/server-client.js
@@ -234,6 +234,8 @@ export default class ServerClient {
       return aborted ? "aborted" : "completed"
     } catch (error) {
       this.logger.error(() => [`Socket ${this.clientCount} file response failed`, filePath, error])
+      if (!this.socket.destroyed) this.socket.destroy()
+
       return "aborted"
     } finally {
       this.socket.off("close", abort)

--- a/src/http-server/websocket-channel.js
+++ b/src/http-server/websocket-channel.js
@@ -20,7 +20,7 @@
 export default class VelociousWebsocketChannel {
   /**
    * Runs constructor.
-   * @param {object} args
+   * @param {object} args - Options.
    * @param {string} args.subscriptionId - Client-assigned id, unique within the session.
    * @param {WebsocketParams} args.params - Subscribe params.
    * @param {import("./client/websocket-session.js").default} args.session - Owning session.
@@ -36,7 +36,7 @@ export default class VelociousWebsocketChannel {
    * Subscribe-time auth. Default is `false` (deny). Channel authors
    * MUST override to allow subscriptions. Returning a Promise defers
    * the `channel-subscribed` confirmation until it resolves.
-   * @returns {boolean | Promise<boolean>}
+   * @returns {boolean | Promise<boolean>} - Whether the subscription is authorized.
    */
   canSubscribe() { return false }
 
@@ -44,14 +44,14 @@ export default class VelociousWebsocketChannel {
    * Optional — called once after `canSubscribe` resolves truthy and
    * before `channel-subscribed` is sent to the client. Use for
    * initial snapshot delivery.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after subscription setup.
    */
   subscribed() {}
 
   /**
    * Optional — called once when the subscription ends. Fires on
    * client-initiated `channel-unsubscribe` or on session teardown.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after subscription teardown.
    */
   unsubscribed() {}
 
@@ -60,14 +60,14 @@ export default class VelociousWebsocketChannel {
    * moved into the paused/grace registry. Either `onResume` fires
    * on successful client reconnect, or `unsubscribed()` fires when
    * the grace window expires.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after disconnect handling.
    */
   onDisconnect() {}
 
   /**
    * Called after a client reconnect + `session-resume` rebinds this
    * subscription to a new socket.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after resume handling.
    */
   onResume() {}
 
@@ -76,7 +76,7 @@ export default class VelociousWebsocketChannel {
    * sign-in / locale change). Override to react to session-level
    * metadata updates.
    * @param {WebsocketParams} _metadata - Updated metadata.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after metadata-change handling.
    */
   onMetadataChanged(_metadata) {}
 
@@ -101,9 +101,9 @@ export default class VelociousWebsocketChannel {
    * Delivers a matched broadcast to this subscriber. Subclasses can
    * override when the outbound body must be tailored to subscription
    * params before sending.
-   * @param {WebsocketJsonValue} body
+   * @param {WebsocketJsonValue} body - Message body.
    * @param {{eventId?: string}} [meta] - Optional event metadata.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after broadcast delivery.
    */
   deliverBroadcast(body, meta) {
     this.sendMessage(body, meta)
@@ -113,7 +113,7 @@ export default class VelociousWebsocketChannel {
    * Sends a `channel-message` frame to THIS subscriber only.
    * When `meta.eventId` is provided, the client receives it so it
    * can track its checkpoint for `lastEventId` replay on reconnect.
-   * @param {WebsocketJsonValue} body
+   * @param {WebsocketJsonValue} body - Message body.
    * @param {{eventId?: string}} [meta] - Optional event metadata.
    * @returns {void}
    */
@@ -132,6 +132,7 @@ export default class VelociousWebsocketChannel {
 
   /**
    * Runs is closed.
-   * @returns {boolean} */
+   * @returns {boolean} - Whether the channel is closed.
+   */
   isClosed() { return this._closed }
 }

--- a/src/http-server/websocket-channel.js
+++ b/src/http-server/websocket-channel.js
@@ -20,7 +20,7 @@
 export default class VelociousWebsocketChannel {
   /**
    * Runs constructor.
-   * @param {object} args - Options.
+   * @param {object} args - Session, channel parameters, and client subscription identifier.
    * @param {string} args.subscriptionId - Client-assigned id, unique within the session.
    * @param {WebsocketParams} args.params - Subscribe params.
    * @param {import("./client/websocket-session.js").default} args.session - Owning session.
@@ -101,7 +101,7 @@ export default class VelociousWebsocketChannel {
    * Delivers a matched broadcast to this subscriber. Subclasses can
    * override when the outbound body must be tailored to subscription
    * params before sending.
-   * @param {WebsocketJsonValue} body - Message body.
+   * @param {WebsocketJsonValue} body - Broadcast payload offered to this subscription.
    * @param {{eventId?: string}} [meta] - Optional event metadata.
    * @returns {void | Promise<void>} - Completes after broadcast delivery.
    */
@@ -113,7 +113,7 @@ export default class VelociousWebsocketChannel {
    * Sends a `channel-message` frame to THIS subscriber only.
    * When `meta.eventId` is provided, the client receives it so it
    * can track its checkpoint for `lastEventId` replay on reconnect.
-   * @param {WebsocketJsonValue} body - Message body.
+   * @param {WebsocketJsonValue} body - Channel payload to send to the subscribed client.
    * @param {{eventId?: string}} [meta] - Optional event metadata.
    * @returns {void}
    */

--- a/src/http-server/websocket-connection.js
+++ b/src/http-server/websocket-connection.js
@@ -12,7 +12,7 @@
 export default class VelociousWebsocketConnection {
   /**
    * Runs constructor.
-   * @param {object} args
+   * @param {object} args - Options.
    * @param {string} args.connectionId - Client-assigned id, unique within the session.
    * @param {Record<string, ?>} args.params - Opaque params from the `connection-open` message.
    * @param {import("./client/websocket-session.js").default} args.session - Owning session.
@@ -28,7 +28,7 @@ export default class VelociousWebsocketConnection {
    * Called once after the session registers this connection and before
    * any `onMessage` fires. Returning a Promise defers the first
    * `connection-opened` message to the client until it resolves.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after connection setup.
    */
   onConnect() {}
 
@@ -36,8 +36,8 @@ export default class VelociousWebsocketConnection {
    * Called for each `connection-message` the client sends to this
    * specific connection. Messages arriving before `onConnect` has
    * resolved are queued and delivered in order once it finishes.
-   * @param {?} body
-   * @returns {void | Promise<void>}
+   * @param {?} body - Message body.
+   * @returns {void | Promise<void>} - Completes after message handling.
    */
   onMessage(body) { void body }
 
@@ -47,14 +47,14 @@ export default class VelociousWebsocketConnection {
    * itself survives; either `onResume` fires on a successful
    * client reconnect, or `onClose("grace_expired")` fires when the
    * grace window expires.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after disconnect handling.
    */
   onDisconnect() {}
 
   /**
    * Called after a client reconnect + `session-resume` rebinds this
    * connection to a new socket.
-   * @returns {void | Promise<void>}
+   * @returns {void | Promise<void>} - Completes after resume handling.
    */
   onResume() {}
 
@@ -64,15 +64,15 @@ export default class VelociousWebsocketConnection {
    * (server-initiated `close()`), `session_destroyed` (socket dropped
    * and nothing to resume; grace path did not apply), `grace_expired`
    * (paused session's grace window ran out without resume), `error`.
-   * @param {"client_close" | "server_close" | "session_destroyed" | "grace_expired" | "error"} reason
-   * @returns {void | Promise<void>}
+   * @param {"client_close" | "server_close" | "session_destroyed" | "grace_expired" | "error"} reason - Close reason.
+   * @returns {void | Promise<void>} - Completes after close handling.
    */
   onClose(reason) { void reason }
 
   /**
    * Sends a `connection-message` frame to the client side of this
    * connection. Throws if the connection has already been closed.
-   * @param {?} body
+   * @param {?} body - Message body.
    * @returns {void}
    */
   sendMessage(body) {
@@ -90,7 +90,7 @@ export default class VelociousWebsocketConnection {
   /**
    * Closes this connection from the server side. Fires `onClose`
    * locally and notifies the client with `{type: "connection-closed"}`.
-   * @param {"server_close" | "error"} [reason]
+   * @param {"server_close" | "error"} [reason] - Close reason.
    * @returns {Promise<void>}
    */
   async close(reason = "server_close") {
@@ -111,7 +111,8 @@ export default class VelociousWebsocketConnection {
 
   /**
    * Runs is closed.
-   * @returns {boolean} */
+   * @returns {boolean} - Whether the connection is closed.
+   */
   isClosed() {
     return this._closed
   }

--- a/src/http-server/websocket-connection.js
+++ b/src/http-server/websocket-connection.js
@@ -12,7 +12,7 @@
 export default class VelociousWebsocketConnection {
   /**
    * Runs constructor.
-   * @param {object} args - Options.
+   * @param {object} args - Owning session, connection parameters, and client identifier.
    * @param {string} args.connectionId - Client-assigned id, unique within the session.
    * @param {Record<string, ?>} args.params - Opaque params from the `connection-open` message.
    * @param {import("./client/websocket-session.js").default} args.session - Owning session.
@@ -36,7 +36,7 @@ export default class VelociousWebsocketConnection {
    * Called for each `connection-message` the client sends to this
    * specific connection. Messages arriving before `onConnect` has
    * resolved are queued and delivered in order once it finishes.
-   * @param {?} body - Message body.
+   * @param {?} body - Client-sent payload for this connection.
    * @returns {void | Promise<void>} - Completes after message handling.
    */
   onMessage(body) { void body }
@@ -64,7 +64,7 @@ export default class VelociousWebsocketConnection {
    * (server-initiated `close()`), `session_destroyed` (socket dropped
    * and nothing to resume; grace path did not apply), `grace_expired`
    * (paused session's grace window ran out without resume), `error`.
-   * @param {"client_close" | "server_close" | "session_destroyed" | "grace_expired" | "error"} reason - Close reason.
+   * @param {"client_close" | "server_close" | "session_destroyed" | "grace_expired" | "error"} reason - Lifecycle reason for permanent connection teardown.
    * @returns {void | Promise<void>} - Completes after close handling.
    */
   onClose(reason) { void reason }
@@ -72,7 +72,7 @@ export default class VelociousWebsocketConnection {
   /**
    * Sends a `connection-message` frame to the client side of this
    * connection. Throws if the connection has already been closed.
-   * @param {?} body - Message body.
+   * @param {?} body - Connection payload to send to the client.
    * @returns {void}
    */
   sendMessage(body) {
@@ -90,7 +90,7 @@ export default class VelociousWebsocketConnection {
   /**
    * Closes this connection from the server side. Fires `onClose`
    * locally and notifies the client with `{type: "connection-closed"}`.
-   * @param {"server_close" | "error"} [reason] - Close reason.
+   * @param {"server_close" | "error"} [reason] - Reason reported to the close hook and client.
    * @returns {Promise<void>}
    */
   async close(reason = "server_close") {

--- a/src/http-server/websocket-events-host.js
+++ b/src/http-server/websocket-events-host.js
@@ -120,7 +120,7 @@ export class VelociousHttpServerWebsocketEventsHost {
    * @param {object} args - Options.
    * @param {?} args.body - Event body.
    * @param {string} args.channel - Channel name.
-   * @returns {Promise<{createdAt: string, id: string} | null>}
+   * @returns {Promise<{createdAt: string, id: string} | null>} - Persisted event metadata when storage is enabled.
    */
   async _persistV2EventIfNeeded({body, channel}) {
     return await this._persistChannelEventIfNeeded({channel, payload: body})

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -53,16 +53,39 @@ export default class VelociousHttpServerInProcessHandler {
       remoteAddress: serverClient.remoteAddress
     })
 
+    let deliveryQueue = Promise.resolve()
+    const enqueueDelivery = (/** @type {() => Promise<void>} */ delivery) => {
+      deliveryQueue = deliveryQueue
+        .catch(() => {})
+        .then(delivery)
+
+      return deliveryQueue
+    }
+
     httpClient.events.on("output", (output) => {
       if (output !== null && output !== undefined) {
-        void serverClient.send(output).catch((error) => {
+        void enqueueDelivery(() => serverClient.send(output)).catch((error) => {
           this.logger.error(() => ["Failed to deliver client output", {clientCount}, error])
         })
       }
     })
 
+    httpClient.events.on("file", ({filePath, sendBody, settle}) => {
+      void enqueueDelivery(async () => {
+        await settle(await serverClient.sendFile(filePath, sendBody))
+      }).catch((error) => {
+        this.logger.error(() => ["Failed to deliver file response", {clientCount, filePath}, error])
+        void settle("aborted")
+      })
+    })
+
     httpClient.events.on("close", () => {
-      void serverClient.end()
+      void enqueueDelivery(() => serverClient.end())
+        .finally(() => delete this.clients[clientCount])
+    })
+
+    serverClient.events.on("close", () => {
+      void httpClient.abortPendingFileResponses()
       delete this.clients[clientCount]
     })
 
@@ -92,6 +115,7 @@ export default class VelociousHttpServerInProcessHandler {
 
     for (const {serverClient} of Object.values(this.clients)) {
       try {
+        void this.clients[serverClient.clientCount]?.httpClient.abortPendingFileResponses()
         void serverClient.end()
       } catch (error) {
         this.logger.warn("Failed to close client during shutdown", error)

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -26,6 +26,9 @@ export default class VelociousHttpServerInProcessHandler {
      * @type {Record<number, {httpClient: Client, serverClient: import("../server-client.js").default}>} */
     this.clients = {}
 
+    /** @type {Set<Promise<void>>} */
+    this.pendingClientCloseCleanups = new Set()
+
     this.logger = new Logger(this)
     this.workerCount = workerCount
     this.unregisterFromEventsHost = websocketEventsHost.register(/** @type {?} */ (this))
@@ -85,8 +88,16 @@ export default class VelociousHttpServerInProcessHandler {
     })
 
     serverClient.events.on("close", () => {
-      void httpClient.abortPendingFileResponses()
-      delete this.clients[clientCount]
+      const cleanup = httpClient.abortPendingFileResponses()
+        .catch((error) => {
+          this.logger.warn("Failed to abort file responses after client close", error)
+        })
+        .finally(() => {
+          this.pendingClientCloseCleanups.delete(cleanup)
+          delete this.clients[clientCount]
+        })
+
+      this.pendingClientCloseCleanups.add(cleanup)
     })
 
     this.clients[clientCount] = {httpClient, serverClient}
@@ -113,14 +124,18 @@ export default class VelociousHttpServerInProcessHandler {
   async stop() {
     this._stopping = true
 
-    for (const {serverClient} of Object.values(this.clients)) {
-      try {
-        void this.clients[serverClient.clientCount]?.httpClient.abortPendingFileResponses()
-        void serverClient.end()
-      } catch (error) {
-        this.logger.warn("Failed to close client during shutdown", error)
-      }
+    for (const {httpClient, serverClient} of Object.values(this.clients)) {
+      await Promise.all([
+        httpClient.abortPendingFileResponses().catch((error) => {
+          this.logger.warn("Failed to abort file responses during shutdown", error)
+        }),
+        serverClient.end().catch((error) => {
+          this.logger.warn("Failed to close client during shutdown", error)
+        })
+      ])
     }
+
+    await Promise.all(this.pendingClientCloseCleanups)
 
     this.clients = {}
     this.unregisterFromEventsHost?.()

--- a/src/http-server/worker-handler/index.js
+++ b/src/http-server/worker-handler/index.js
@@ -58,6 +58,9 @@ export default class VelociousHttpServerWorker {
      * Narrows the runtime value to the documented type.
      * @type {Map<number, {resolve: (snapshot: Record<string, ?>) => void}>} */
     this._debugSnapshotRequests = new Map()
+
+    /** @type {Map<number, Promise<void>>} */
+    this._clientDeliveryQueues = new Map()
   }
 
   start() {
@@ -99,7 +102,23 @@ export default class VelociousHttpServerWorker {
     client.listen()
 
     this.clients[clientCount] = client
+    client.events.on("close", () => {
+      this.handleClientAbort(clientCount)
+    })
     this.worker.postMessage({command: "newClient", clientCount, remoteAddress: client.remoteAddress})
+  }
+
+  /**
+   * Propagates a parent-side socket close and clears all parent state for the client.
+   * @param {number} clientCount - Client count.
+   * @returns {void}
+   */
+  handleClientAbort(clientCount) {
+    if (!this.clients[clientCount] && !this._clientDeliveryQueues.has(clientCount)) return
+
+    delete this.clients[clientCount]
+    this._clientDeliveryQueues.delete(clientCount)
+    this.worker?.postMessage({command: "clientAbort", clientCount})
   }
 
   /**
@@ -121,10 +140,10 @@ export default class VelociousHttpServerWorker {
   onWorkerExit = (code) => {
     this._hasExited = true
     this.workerStarted = false
+    this._closeAllClients()
 
     if (code !== 0 && !this._stopping) {
       this.logger.error(`Velocious worker ${this.workerCount} exited unexpectedly with code ${code}`)
-      void this._closeAllClients()
       throw new Error(`Client worker stopped with exit code ${code}`)
     } else {
       this.logger.debug(() => `Client worker stopped with exit code ${code}`)
@@ -160,6 +179,9 @@ export default class VelociousHttpServerWorker {
    * @param {string} data.command - Command.
    * @param {number} [data.clientCount] - Client count.
    * @param {string | Uint8Array} [data.output] - Output.
+   * @param {string} [data.filePath] - File path.
+   * @param {boolean} [data.sendBody] - Whether to send the file body.
+   * @param {number} [data.transferId] - File transfer id.
    * @param {string} [data.channel] - Channel name.
    * @param {number} [data.requestId] - Debug request id.
    * @param {Record<string, ?>} [data.snapshot] - Worker debug snapshot.
@@ -197,7 +219,7 @@ export default class VelociousHttpServerWorker {
       if (output !== null && output !== undefined) {
         const outputLength = typeof output === "string" ? output.length : output.byteLength
 
-        void client.send(output).then(() => {
+        void this.enqueueClientDelivery(client.clientCount, () => client.send(output)).then(() => {
           this.logger.debug(() => ["Client output delivered", {
             clientCount,
             outputLength,
@@ -210,6 +232,25 @@ export default class VelociousHttpServerWorker {
           }, error])
         })
       }
+    } else if (command == "clientFile") {
+      const {clientCount, filePath, sendBody, transferId} = data
+      const client = typeof clientCount === "number" ? this.clients[clientCount] : undefined
+
+      if (typeof transferId !== "number") throw new Error("clientFile transferId must be a number")
+
+      if (!client || typeof filePath !== "string") {
+        this.worker?.postMessage({command: "clientFileResult", result: "aborted", transferId})
+        return
+      }
+
+      void this.enqueueClientDelivery(client.clientCount, async () => {
+        const result = await client.sendFile(filePath, sendBody !== false)
+
+        this.worker?.postMessage({command: "clientFileResult", result, transferId})
+      }).catch((error) => {
+        this.logger.error(() => ["Failed to deliver file response", {clientCount: client.clientCount, filePath}, error])
+        this.worker?.postMessage({command: "clientFileResult", result: "aborted", transferId})
+      })
     } else if (command == "clientClose") {
       const {clientCount} = data
       const client = typeof clientCount === "number" ? this.clients[clientCount] : undefined
@@ -219,11 +260,8 @@ export default class VelociousHttpServerWorker {
         return
       }
 
-      void client.end()
-
-      if (typeof clientCount === "number") {
-        delete this.clients[clientCount]
-      }
+      void this.enqueueClientDelivery(client.clientCount, () => client.end())
+        .finally(() => delete this.clients[client.clientCount])
     } else if (command == "debugSnapshot") {
       const {requestId, snapshot} = data
       if (typeof requestId !== "number") throw new Error("debugSnapshot requestId must be a number")
@@ -255,6 +293,28 @@ export default class VelociousHttpServerWorker {
     } else {
       throw new Error(`Unknown command: ${command}`)
     }
+  }
+
+  /**
+   * Preserves socket output ordering for one client.
+   * @param {number} clientCount - Client count.
+   * @param {() => Promise<void>} delivery - Delivery operation.
+   * @returns {Promise<void>} - Queued delivery.
+   */
+  enqueueClientDelivery(clientCount, delivery) {
+    const previous = this._clientDeliveryQueues.get(clientCount) || Promise.resolve()
+    const queued = previous
+      .catch(() => {})
+      .then(delivery)
+
+    this._clientDeliveryQueues.set(clientCount, queued)
+    const clearQueue = () => {
+      if (this._clientDeliveryQueues.get(clientCount) === queued) this._clientDeliveryQueues.delete(clientCount)
+    }
+
+    void queued.then(clearQueue, clearQueue)
+
+    return queued
   }
 
   /**

--- a/src/http-server/worker-handler/worker-thread.js
+++ b/src/http-server/worker-handler/worker-thread.js
@@ -42,6 +42,10 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
     this.parentPort = parentPort
     this.workerData = workerData
     this.workerCount = workerCount
+    this.fileTransferCount = 0
+
+    /** @type {Map<number, {clientCount: number, settle: (result: "completed" | "aborted") => Promise<void>}>} */
+    this.fileTransfers = new Map()
 
     parentPort.on("message", errorLogger(this.onCommand))
 
@@ -98,6 +102,8 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
    * @param {string} [data.createdAt] - Event creation time.
    * @param {string} [data.eventId] - Event identifier.
    * @param {number} [data.requestId] - Debug request id.
+   * @param {number} [data.transferId] - File transfer id.
+   * @param {"completed" | "aborted"} [data.result] - File transfer result.
    * @param {?} [data.payload] - Payload data.
    * @param {Record<string, ?>} [data.broadcastParams] - V2 broadcast filter params.
    * @param {?} [data.body] - V2 broadcast body.
@@ -111,6 +117,10 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
       this.handleNewClient(data)
     } else if (command == "clientWrite") {
       await this.handleClientWrite(data)
+    } else if (command == "clientFileResult") {
+      await this.handleClientFileResult(data)
+    } else if (command == "clientAbort") {
+      await this.handleClientAbort(data)
     } else if (command == "websocketEvent") {
       await this.handleWebsocketEvent(data)
     } else if (command == "websocketV2Broadcast") {
@@ -148,12 +158,67 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
       this.parentPort.postMessage({command: "clientOutput", clientCount, output})
     })
 
+    client.events.on("file", ({filePath, sendBody, settle}) => {
+      const transferId = ++this.fileTransferCount
+
+      this.fileTransfers.set(transferId, {clientCount, settle})
+      this.parentPort.postMessage({command: "clientFile", clientCount, filePath, sendBody, transferId})
+    })
+
     client.events.on("close", (output) => {
       this.logger.debugLowLevel(() => "Close received from client in worker - forwarding to worker parent")
       this.parentPort.postMessage({command: "clientClose", clientCount, output})
     })
 
     this.clients[clientCount] = client
+  }
+
+  /**
+   * Settles a file response after the parent finishes socket delivery.
+   * @param {object} data - File result message.
+   * @param {number} [data.transferId] - File transfer id.
+   * @param {"completed" | "aborted"} [data.result] - File transfer result.
+   * @returns {Promise<void>} - Resolves after the worker-side completion callback settles.
+   */
+  async handleClientFileResult(data) {
+    const {result, transferId} = data
+
+    if (typeof transferId !== "number") throw new Error("transferId must be a number")
+    if (result !== "completed" && result !== "aborted") throw new Error(`Unknown file transfer result: ${result}`)
+
+    const transfer = this.fileTransfers.get(transferId)
+
+    if (!transfer) return
+
+    this.fileTransfers.delete(transferId)
+    await transfer.settle(result)
+  }
+
+  /**
+   * Aborts file responses belonging to a closed parent-side socket.
+   * @param {object} data - Client abort message.
+   * @param {number} [data.clientCount] - Client count.
+   * @returns {Promise<void>} - Resolves after pending completion callbacks settle.
+   */
+  async handleClientAbort(data) {
+    const {clientCount} = data
+
+    if (typeof clientCount !== "number") throw new Error("clientCount must be a number")
+
+    const settlements = []
+    const client = this.clients[clientCount]
+
+    if (client) settlements.push(client.abortPendingFileResponses())
+
+    for (const [transferId, transfer] of this.fileTransfers) {
+      if (transfer.clientCount !== clientCount) continue
+
+      this.fileTransfers.delete(transferId)
+      settlements.push(transfer.settle("aborted"))
+    }
+
+    delete this.clients[clientCount]
+    await Promise.all(settlements)
   }
 
   /**
@@ -238,6 +303,9 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
    * @returns {Promise<void>} Resolves after worker shutdown has been requested.
    */
   async handleShutdown() {
+    await Promise.all(Object.values(this.clients).map((client) => client.abortPendingFileResponses()))
+    this.fileTransfers.clear()
+
     if (this.configuration?.closeDatabaseConnections) {
       await this.configuration.closeDatabaseConnections()
     }

--- a/src/sync/device-identity.js
+++ b/src/sync/device-identity.js
@@ -5,7 +5,7 @@ const ECDSA_P256_SHA256_SIGNATURE_PREFIX = "ecdsa-p256-sha256-"
 
 /**
  * JSON Web Key used by the sync signing helpers.
- * @typedef {JsonWebKey} SyncJsonWebKey
+ * @typedef {import("node:crypto").webcrypto.JsonWebKey} SyncJsonWebKey
  */
 
 /**
@@ -223,7 +223,7 @@ function signedMutationSignatureValue({deviceCertificate, mutation}) {
  */
 async function signStableJson({privateKey, value}) {
   const key = await cryptoSubtle().importKey("jwk", privateKey, {name: "ECDSA", namedCurve: "P-256"}, false, ["sign"])
-  const signature = await cryptoSubtle().sign({hash: "SHA-256", name: "ECDSA"}, key, /** @type {BufferSource} */ (utf8(stableJsonStringify(value))))
+  const signature = await cryptoSubtle().sign({hash: "SHA-256", name: "ECDSA"}, key, /** @type {Uint8Array<ArrayBuffer>} */ (utf8(stableJsonStringify(value))))
 
   return `${ECDSA_P256_SHA256_SIGNATURE_PREFIX}${base64UrlEncode(new Uint8Array(signature))}`
 }
@@ -240,7 +240,7 @@ async function verifyStableJsonSignature({publicKey, signature, value}) {
   const key = await cryptoSubtle().importKey("jwk", publicKey, {name: "ECDSA", namedCurve: "P-256"}, false, ["verify"])
   const signatureBytes = base64UrlDecode(signatureWithoutPrefix(signature))
 
-  return await cryptoSubtle().verify({hash: "SHA-256", name: "ECDSA"}, key, /** @type {BufferSource} */ (signatureBytes), /** @type {BufferSource} */ (utf8(stableJsonStringify(value))))
+  return await cryptoSubtle().verify({hash: "SHA-256", name: "ECDSA"}, key, /** @type {Uint8Array<ArrayBuffer>} */ (signatureBytes), /** @type {Uint8Array<ArrayBuffer>} */ (utf8(stableJsonStringify(value))))
 }
 
 /**

--- a/src/sync/local-mutation-log.js
+++ b/src/sync/local-mutation-log.js
@@ -20,7 +20,6 @@ const STORAGE_KEY_LOCKS = new Map()
  * Implementations should store each mutation log record as its own row/entry.
  * Native apps should back this with SQLite and indexes on storage key, status,
  * and sequence. Avoid storing the whole log as one JSON blob.
- *
  * @typedef {object} LocalMutationLogStorage
  * @property {(storageKey: string, record: LocalMutationLogRecord) => Promise<void> | void} appendRecord - Appends one log record.
  * @property {(storageKey: string, ids: string[]) => Promise<void> | void} deleteRecords - Deletes log records by id.

--- a/src/tenants/tenant-iterator.js
+++ b/src/tenants/tenant-iterator.js
@@ -7,12 +7,12 @@
  * against the wrong connection. When iterating in parallel the per-tenant failures are
  * collected and rethrown together as an `AggregateError` so one bad tenant does not hide the
  * others. This is the iteration engine shared by the `db:tenants:*` CLI commands and the
- * runtime {@link Tenant} façade; the caller is responsible for producing the tenant list.
+ * runtime tenant façade; the caller is responsible for producing the tenant list.
  */
 export default class TenantIterator {
   /**
    * Creates an iterator bound to a configuration and tenant database identifier.
-   * @param {{configuration: import("../configuration.js").default, identifier: string, parallelCount?: number}} args
+   * @param {{configuration: import("../configuration.js").default, identifier: string, parallelCount?: number}} args - Options.
    */
   constructor({configuration, identifier, parallelCount = 1}) {
     this.configuration = configuration
@@ -22,9 +22,9 @@ export default class TenantIterator {
 
   /**
    * Runs `callback` within each tenant's context and returns how many tenants were processed.
-   * @param {Array<?>} tenants
-   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>} callback
-   * @returns {Promise<number>}
+   * @param {Array<?>} tenants - Tenant instances.
+   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>} callback - Callback to invoke.
+   * @returns {Promise<number>} - Number of processed tenants.
    */
   async run(tenants, callback) {
     if (this.parallelCount <= 1) {
@@ -76,7 +76,7 @@ export default class TenantIterator {
 
   /**
    * Enters one tenant's context and runs the callback, asserting the database is active first.
-   * @param {{callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, tenant: ?}} args
+   * @param {{callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, tenant: ?}} args - Options.
    * @returns {Promise<void>}
    */
   async runTenantCallback({callback, tenant}) {
@@ -94,8 +94,8 @@ export default class TenantIterator {
 
   /**
    * Builds a human-readable label for a tenant for use in error messages.
-   * @param {?} tenant
-   * @returns {string}
+   * @param {?} tenant - Tenant instance.
+   * @returns {string} - Human-readable tenant label.
    */
   static tenantLabel(tenant) {
     if (tenant && typeof tenant === "object") {

--- a/src/tenants/tenant-iterator.js
+++ b/src/tenants/tenant-iterator.js
@@ -12,7 +12,7 @@
 export default class TenantIterator {
   /**
    * Creates an iterator bound to a configuration and tenant database identifier.
-   * @param {{configuration: import("../configuration.js").default, identifier: string, parallelCount?: number}} args - Options.
+   * @param {{configuration: import("../configuration.js").default, identifier: string, parallelCount?: number}} args - Tenant configuration, database identifier, and concurrency limit.
    */
   constructor({configuration, identifier, parallelCount = 1}) {
     this.configuration = configuration
@@ -22,8 +22,8 @@ export default class TenantIterator {
 
   /**
    * Runs `callback` within each tenant's context and returns how many tenants were processed.
-   * @param {Array<?>} tenants - Tenant instances.
-   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>} callback - Callback to invoke.
+   * @param {Array<?>} tenants - Tenant descriptors to enter and process.
+   * @param {function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>} callback - Per-tenant operation receiving the active database configuration.
    * @returns {Promise<number>} - Number of processed tenants.
    */
   async run(tenants, callback) {
@@ -76,7 +76,7 @@ export default class TenantIterator {
 
   /**
    * Enters one tenant's context and runs the callback, asserting the database is active first.
-   * @param {{callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, tenant: ?}} args - Options.
+   * @param {{callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, tenant: ?}} args - Tenant descriptor and operation to run in its context.
    * @returns {Promise<void>}
    */
   async runTenantCallback({callback, tenant}) {
@@ -94,7 +94,7 @@ export default class TenantIterator {
 
   /**
    * Builds a human-readable label for a tenant for use in error messages.
-   * @param {?} tenant - Tenant instance.
+   * @param {?} tenant - Tenant descriptor to identify in an error.
    * @returns {string} - Human-readable tenant label.
    */
   static tenantLabel(tenant) {

--- a/src/tenants/tenant.js
+++ b/src/tenants/tenant.js
@@ -26,8 +26,8 @@ export default class Tenant {
    * connections keyed by identifier, the same as `ensureConnections`.
    * @template T
    * @param {object} tenant Descriptor understood by the app's tenantDatabaseResolver.
-   * @param {(connections: Record<string, import("../database/drivers/base.js").default>) => Promise<T>} callback
-   * @returns {Promise<T>}
+   * @param {(connections: Record<string, import("../database/drivers/base.js").default>) => Promise<T>} callback - Callback to invoke.
+   * @returns {Promise<T>} - Callback result from within the tenant context.
    */
   static async with(tenant, callback) {
     const configuration = Current.configuration()
@@ -37,7 +37,7 @@ export default class Tenant {
 
   /**
    * The current tenant descriptor, or undefined when running outside any tenant context.
-   * @returns {Record<string, unknown> | undefined}
+   * @returns {Record<string, unknown> | undefined} - Tenant metadata when configured.
    */
   static current() {
     return Current.tenant()
@@ -49,8 +49,8 @@ export default class Tenant {
    * {@link Tenant.with}, the callback runs inside `ensureConnections` so each tenant's
    * database is queryable without the caller wiring up connections. Returns how many tenants
    * the callback ran for (after filtering).
-   * @param {{identifier: string, callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, parallel?: number, filter?: (tenant: ?) => boolean, configuration?: import("../configuration.js").default}} args
-   * @returns {Promise<number>}
+   * @param {{identifier: string, callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, parallel?: number, filter?: (tenant: ?) => boolean, configuration?: import("../configuration.js").default}} args - Options.
+   * @returns {Promise<number>} - Number of processed tenants.
    */
   static async each({identifier, callback, parallel = 1, filter, configuration = Current.configuration()}) {
     const provider = configuration.getTenantDatabaseProvider(identifier)
@@ -76,7 +76,7 @@ export default class Tenant {
 
   /**
    * Drops one tenant's database/schema through the provider's `dropDatabase` hook.
-   * @param {{identifier: string, tenant: object, configuration?: import("../configuration.js").default}} args
+   * @param {{identifier: string, tenant: object, configuration?: import("../configuration.js").default}} args - Options.
    * @returns {Promise<void>}
    */
   static async drop({identifier, tenant, configuration = Current.configuration()}) {

--- a/src/tenants/tenant.js
+++ b/src/tenants/tenant.js
@@ -26,7 +26,7 @@ export default class Tenant {
    * connections keyed by identifier, the same as `ensureConnections`.
    * @template T
    * @param {object} tenant Descriptor understood by the app's tenantDatabaseResolver.
-   * @param {(connections: Record<string, import("../database/drivers/base.js").default>) => Promise<T>} callback - Callback to invoke.
+   * @param {(connections: Record<string, import("../database/drivers/base.js").default>) => Promise<T>} callback - Operation to run with the tenant's active connections.
    * @returns {Promise<T>} - Callback result from within the tenant context.
    */
   static async with(tenant, callback) {
@@ -37,7 +37,7 @@ export default class Tenant {
 
   /**
    * The current tenant descriptor, or undefined when running outside any tenant context.
-   * @returns {Record<string, unknown> | undefined} - Tenant metadata when configured.
+   * @returns {Record<string, unknown> | undefined} - Current async-context tenant descriptor, if any.
    */
   static current() {
     return Current.tenant()
@@ -49,7 +49,7 @@ export default class Tenant {
    * {@link Tenant.with}, the callback runs inside `ensureConnections` so each tenant's
    * database is queryable without the caller wiring up connections. Returns how many tenants
    * the callback ran for (after filtering).
-   * @param {{identifier: string, callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, parallel?: number, filter?: (tenant: ?) => boolean, configuration?: import("../configuration.js").default}} args - Options.
+   * @param {{identifier: string, callback: function({databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}) : Promise<void>, parallel?: number, filter?: (tenant: ?) => boolean, configuration?: import("../configuration.js").default}} args - Tenant database identifier, per-tenant operation, filtering, and concurrency settings.
    * @returns {Promise<number>} - Number of processed tenants.
    */
   static async each({identifier, callback, parallel = 1, filter, configuration = Current.configuration()}) {
@@ -76,7 +76,7 @@ export default class Tenant {
 
   /**
    * Drops one tenant's database/schema through the provider's `dropDatabase` hook.
-   * @param {{identifier: string, tenant: object, configuration?: import("../configuration.js").default}} args - Options.
+   * @param {{identifier: string, tenant: object, configuration?: import("../configuration.js").default}} args - Tenant descriptor and database identifier to drop.
    * @returns {Promise<void>}
    */
   static async drop({identifier, tenant, configuration = Current.configuration()}) {


### PR DESCRIPTION
## Summary
- move file bytes out of worker IPC and stream from the main-thread socket owner with drain-aware backpressure
- add ordered per-client delivery, abort propagation, and descriptor completion acknowledgements
- add async `sendFile(..., {onFinished})` cleanup callbacks that are exactly-once and error-isolated

## Verification
- `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npx velocious test ../http-server/response-spec.js` (7 passed)
- `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npx velocious test ../http-server/server-client-spec.js` (5 passed)
- `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npx velocious test ../http-server/worker-handler-spec.js` (16 passed)
- `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npx velocious test ../plugins/sqljs-wasm-route-spec.js` (7 passed)
- `npm run eslint` passed with existing warnings; `npm run typecheck` passed.
- `npm run fallow` exits 1 because its health report flags 10 pre-existing dev dependencies; this change does not touch dependency files.
- `git diff --check` passed.