### PR TITLE
fix(background-jobs): recover disconnected worker handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2108,7 +2108,7 @@ Each job must define exactly one of `every` or `cron`. Cron times are evaluated 
 
 ## Persistence and retries
 
-Jobs are persisted in the configured database (`backgroundJobs.databaseIdentifier`) in an internal `background_jobs` table. When a worker picks a job, the job is marked as handed off and the worker reports completion or failure back to the main process.
+Jobs are persisted in the configured database (`backgroundJobs.databaseIdentifier`) in an internal `background_jobs` table. When a worker picks a job, the job is marked as handed off with a unique lease id and the worker reports completion or failure back to the main process. If that worker socket disconnects unexpectedly, only the leases handed to that exact socket are immediately returned to the queue; late reports are fenced by lease id so they cannot mutate a newer attempt. This recovery is at-least-once and may repeat application side effects if the disconnected attempt had already started them. Gracefully draining workers keep their leases while they finish. For rolling upgrades, upgrade workers before the main process: a lease-aware main keeps legacy workers connected for old reports but dispatches new jobs only to workers advertising lease-reporting support. See [docs/background-jobs.md](docs/background-jobs.md#worker-disconnect-recovery).
 
 Failed jobs are re-queued with backoff and retried up to 10 times by default (10s, 1m, 10m, 1h, then +1h per retry). You can override the retry limit per job:
 

--- a/changelog.d/20260713174530-fence-disconnected-job-handoffs.md
+++ b/changelog.d/20260713174530-fence-disconnected-job-handoffs.md
@@ -1,0 +1,1 @@
+Immediately requeue durable background jobs when their worker socket disconnects, fence late completion or failure reports with a unique handoff lease id, and dispatch fenced jobs only to workers that advertise lease-reporting support.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -2,6 +2,16 @@
 
 Velocious background jobs are documented in the main README. This page covers behavior that applications usually need when operating background jobs in production.
 
+## Worker Disconnect Recovery
+
+Each durable worker handoff has a unique lease id. If a worker socket disconnects unexpectedly, `background-jobs-main` immediately returns only the jobs handed to that exact socket to the queue and makes them available to another connected worker. Two connections that advertise the same worker id remain isolated from each other.
+
+Disconnect recovery provides at-least-once delivery: a disconnected worker may already have started external side effects before the replacement attempt begins. Completion and failure reports carry the lease id and update the database only while that exact handoff is still active, so a late report from the disconnected attempt cannot complete or fail a newer attempt.
+
+Graceful draining is unchanged. A worker that announces `draining` keeps its socket open while its in-flight jobs finish, and those jobs are not reclaimed unless that socket is subsequently lost before their reports are accepted.
+
+The fenced protocol uses an explicit worker handshake capability. A main process that creates lease ids dispatches new jobs only to workers advertising handoff-id reporting; older workers remain connected so they can report legacy handoffs that have no lease id. During a rolling upgrade, upgrade workers before the main process to avoid pausing new dispatch while only legacy workers are connected.
+
 ## Failure Events
 
 `background-jobs-main` emits a `background-job-failed` error event after it accepts a worker failure report and records the updated job state. Duplicate or stale worker reports do not emit this event because they are rejected before the job row changes.
@@ -34,6 +44,7 @@ The `background-job-failed` payload has:
 
 - `error`: the job failure as an `Error`. String failure reports are normalized to an `Error`, with the original string preserved as `error.stack` when available.
 - `context.attempts`: the updated failed-attempt count after this report.
+- `context.handoffId`: the unique handoff lease id included in the accepted report.
 - `context.handedOffAtMs`: the worker handoff timestamp included in the accepted report.
 - `context.jobArgs`: the serialized arguments for the job.
 - `context.jobId`: the background job id.

--- a/spec/background-jobs/basic-spec.js
+++ b/spec/background-jobs/basic-spec.js
@@ -3,13 +3,165 @@
 import net from "net"
 import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
+import JsonSocket from "../../src/background-jobs/json-socket.js"
 import BackgroundJobsMain from "../../src/background-jobs/main.js"
-import {outputPathFor, startBackgroundJobs, waitForJobCompleted, waitForOutputJson} from "../helpers/background-jobs-helper.js"
+import BackgroundJobsStatusReporter from "../../src/background-jobs/status-reporter.js"
+import { outputPathFor, startBackgroundJobs, startBackgroundJobsMain, waitForJobCompleted, waitForOutputJson } from "../helpers/background-jobs-helper.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import SlowTestJob from "../dummy/src/jobs/slow-test-job.js"
 import TestJob from "../dummy/src/jobs/test-job.js"
 
+/**
+ * @param {object} args - Options.
+ * @param {number} args.port - Background jobs main port.
+ * @param {boolean} [args.supportsHandoffIdReporting] - Whether the worker advertises handoff-id reporting.
+ * @param {string} args.workerId - Worker id.
+ * @returns {Promise<{jsonSocket: JsonSocket, nextJob: () => Promise<import("../../src/background-jobs/types.js").BackgroundJobPayload>, receivedJobs: import("../../src/background-jobs/types.js").BackgroundJobPayload[]}>} - Connected controllable worker.
+ */
+async function connectControllableWorker({port, supportsHandoffIdReporting = true, workerId}) {
+  const socket = net.createConnection({host: "127.0.0.1", port})
+  const jsonSocket = new JsonSocket(socket)
+  /** @type {import("../../src/background-jobs/types.js").BackgroundJobPayload[]} */
+  const jobs = []
+
+  jsonSocket.on("message", (message) => {
+    if (message?.type === "job") jobs.push(message.payload)
+  })
+
+  await new Promise((resolve, reject) => {
+    socket.once("error", reject)
+    socket.once("connect", resolve)
+  })
+
+  if (supportsHandoffIdReporting) {
+    jsonSocket.send({type: "hello", role: "worker", supportsHandoffIdReporting: true, workerId})
+  } else {
+    jsonSocket.send({type: "hello", role: "worker", workerId})
+  }
+  jsonSocket.send({type: "ready", acceptsForked: true, acceptsInline: true, acceptsSpawned: true})
+
+  return {
+    jsonSocket,
+    nextJob: async () => await timeout({timeout: 2000}, async () => {
+      while (jobs.length === 0) await wait(0.01)
+
+      const payload = jobs.shift()
+
+      if (!payload) throw new Error("Expected a background job payload")
+
+      return payload
+    }),
+    receivedJobs: jobs
+  }
+}
+
 describe("Background jobs", {databaseCleaning: {truncate: true}}, () => {
+  it("dispatches fenced handoffs only to workers that advertise handoff-id reporting", async () => {
+    const {main, store} = await startBackgroundJobsMain()
+    const legacyWorker = await connectControllableWorker({
+      port: main.getPort(),
+      supportsHandoffIdReporting: false,
+      workerId: "legacy-worker"
+    })
+    const capableWorker = await connectControllableWorker({port: main.getPort(), workerId: "capable-worker"})
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false}})
+
+    await main._drain()
+
+    const payload = await capableWorker.nextJob()
+
+    expect(payload.id).toEqual(jobId)
+    expect(payload.handoffId).toBeTruthy()
+    expect(legacyWorker.receivedJobs).toEqual([])
+
+    const reporter = new BackgroundJobsStatusReporter({
+      configuration: dummyConfiguration,
+      host: "127.0.0.1",
+      port: main.getPort()
+    })
+
+    await reporter.report({
+      jobId,
+      status: "completed",
+      handoffId: payload.handoffId,
+      handedOffAtMs: payload.handedOffAtMs,
+      workerId: payload.workerId
+    })
+
+    const job = await store.getJob(jobId)
+
+    expect(job?.status).toEqual("completed")
+
+    legacyWorker.jsonSocket.close()
+    capableWorker.jsonSocket.close()
+    await main.stop()
+  })
+
+  it("immediately requeues a disconnected worker's exact handoff to another socket", async () => {
+    const {main, store} = await startBackgroundJobsMain()
+    const firstWorker = await connectControllableWorker({port: main.getPort(), workerId: "shared-worker-id"})
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false}})
+
+    await main._drain()
+
+    const firstPayload = await firstWorker.nextJob()
+
+    expect(firstPayload.id).toEqual(jobId)
+    expect(firstPayload.handoffId).toBeTruthy()
+
+    const secondWorker = await connectControllableWorker({port: main.getPort(), workerId: "shared-worker-id"})
+
+    firstWorker.jsonSocket.close()
+
+    const secondPayload = await secondWorker.nextJob()
+
+    expect(secondPayload.id).toEqual(jobId)
+    expect(secondPayload.handoffId).toBeTruthy()
+    expect(secondPayload.handoffId).not.toEqual(firstPayload.handoffId)
+
+    const reporter = new BackgroundJobsStatusReporter({
+      configuration: dummyConfiguration,
+      host: "127.0.0.1",
+      port: main.getPort()
+    })
+
+    await reporter.report({
+      jobId,
+      status: "completed",
+      handoffId: firstPayload.handoffId,
+      handedOffAtMs: firstPayload.handedOffAtMs,
+      workerId: firstPayload.workerId
+    })
+    await reporter.report({
+      jobId,
+      status: "failed",
+      error: "late failure",
+      handoffId: firstPayload.handoffId,
+      handedOffAtMs: firstPayload.handedOffAtMs,
+      workerId: firstPayload.workerId
+    })
+
+    let job = await store.getJob(jobId)
+
+    expect(job?.status).toEqual("handed_off")
+    expect(job?.handoffId).toEqual(secondPayload.handoffId)
+    expect(job?.attempts).toEqual(0)
+
+    await reporter.report({
+      jobId,
+      status: "completed",
+      handoffId: secondPayload.handoffId,
+      handedOffAtMs: secondPayload.handedOffAtMs,
+      workerId: secondPayload.workerId
+    })
+
+    job = await store.getJob(jobId)
+    expect(job?.status).toEqual("completed")
+
+    secondWorker.jsonSocket.close()
+    await main.stop()
+  })
+
   it("enqueues and runs a job in a worker", async () => {
     const {main, store, worker} = await startBackgroundJobs()
     const outputPath = await outputPathFor("job")

--- a/spec/background-jobs/dispatch-strategy-spec.js
+++ b/spec/background-jobs/dispatch-strategy-spec.js
@@ -59,8 +59,9 @@ describe("Background jobs - dispatch strategy", {databaseCleaning: {truncate: tr
     // Pre-create a future-scheduled job so the dispatcher's initial drain
     // calls `_armScheduledTimer` against a real future timestamp.
     const futureJobId = await store.enqueue({jobName: "TestJob", args: ["future"], options: {forked: false, maxRetries: 5}})
-    const handedOffAtMs = await store.markHandedOff({jobId: futureJobId, workerId: "worker-z"})
-    await store.markFailed({jobId: futureJobId, error: "transient", workerId: "worker-z", handedOffAtMs})
+    const handoff = await store.markHandedOff({jobId: futureJobId, workerId: "worker-z"})
+    if (!handoff) throw new Error("Expected the future job to be handed off")
+    await store.markFailed({jobId: futureJobId, error: "transient", workerId: "worker-z", ...handoff})
 
     const main = new BackgroundJobsMain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
     await main.start()
@@ -90,7 +91,11 @@ describe("Background jobs - dispatch strategy", {databaseCleaning: {truncate: tr
       // Make the store look like it has a ready worker so the drain
       // actually calls `nextAvailableJob()` — the loop is gated on
       // `readyWorkers.size > 0`.
-      const fakeWorker = /** @type {any} */ ({workerId: "fake", send: () => {}})
+      const fakeWorker = /** @type {any} */ ({
+        workerId: "fake",
+        send: () => {},
+        supportsHandoffIdReporting: true
+      })
       main.readyWorkers.add(fakeWorker)
 
       await main._drain()

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -132,6 +132,41 @@ async function createStoreWithLegacyJobsSchema() {
 }
 
 describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => {
+  it("fences stale completion and failure reports after a handoff is requeued", async () => {
+    const store = await createClearedStore()
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false}})
+    const firstHandoff = await store.markHandedOff({jobId, workerId: "shared-worker-id"})
+
+    if (!firstHandoff) throw new Error("Expected the first handoff to be claimed")
+
+    await store.markReturnedToQueue({jobId, handoffId: firstHandoff.handoffId})
+
+    const secondHandoff = await store.markHandedOff({jobId, workerId: "shared-worker-id"})
+
+    if (!secondHandoff) throw new Error("Expected the second handoff to be claimed")
+
+    await store.markCompleted({
+      jobId,
+      handoffId: firstHandoff.handoffId,
+      workerId: "shared-worker-id",
+      handedOffAtMs: firstHandoff.handedOffAtMs
+    })
+    await store.markFailed({
+      jobId,
+      error: "late failure",
+      handoffId: firstHandoff.handoffId,
+      workerId: "shared-worker-id",
+      handedOffAtMs: firstHandoff.handedOffAtMs
+    })
+
+    const job = await getJobOrFail({jobId, store})
+
+    expect(job.status).toEqual("handed_off")
+    expect(job.handoffId).toEqual(secondHandoff.handoffId)
+    expect(job.attempts).toEqual(0)
+    expect(job.lastError).toBeNull()
+  })
+
   it("requeues failed jobs and honors max retries", async () => {
     const store = await createClearedStore()
 
@@ -144,10 +179,12 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
       }
     })
 
-    let handedOffAtMs = await store.markHandedOff({jobId, workerId: "worker-1"})
+    let handoff = await store.markHandedOff({jobId, workerId: "worker-1"})
+
+    if (!handoff) throw new Error("Expected the job to be handed off")
 
     const before = Date.now()
-    await store.markFailed({jobId, error: "boom", workerId: "worker-1", handedOffAtMs})
+    await store.markFailed({jobId, error: "boom", workerId: "worker-1", ...handoff})
 
     let job = await store.getJob(jobId)
 
@@ -155,8 +192,9 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(job?.attempts).toEqual(1)
     expect(job?.scheduledAtMs).toBeGreaterThan(before + 9000)
 
-    handedOffAtMs = await store.markHandedOff({jobId, workerId: "worker-1"})
-    await store.markFailed({jobId, error: "boom again", workerId: "worker-1", handedOffAtMs})
+    handoff = await store.markHandedOff({jobId, workerId: "worker-1"})
+    if (!handoff) throw new Error("Expected the retried job to be handed off")
+    await store.markFailed({jobId, error: "boom again", workerId: "worker-1", ...handoff})
 
     job = await store.getJob(jobId)
 
@@ -192,8 +230,9 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
 
     // Job 2: build a future-scheduled job by re-queueing a failed job with backoff.
     const futureJobId = await store.enqueue({jobName: "TestJob", args: ["later"], options: {forked: false, maxRetries: 5}})
-    const handedOffAtMs = await store.markHandedOff({jobId: futureJobId, workerId: "worker-x"})
-    await store.markFailed({jobId: futureJobId, error: "transient", workerId: "worker-x", handedOffAtMs})
+    const handoff = await store.markHandedOff({jobId: futureJobId, workerId: "worker-x"})
+    if (!handoff) throw new Error("Expected the future job to be handed off")
+    await store.markFailed({jobId: futureJobId, error: "transient", workerId: "worker-x", ...handoff})
 
     const next = await store.nextScheduledJob()
 

--- a/spec/background-jobs/web/api-spec.js
+++ b/spec/background-jobs/web/api-spec.js
@@ -30,9 +30,10 @@ async function seedJobs() {
   await store.enqueue({jobName: "TestJob", args: ["beta"], options: {forked: false}})
 
   const failedId = await store.enqueue({jobName: "FailingJob", args: ["b"], options: {forked: false, maxRetries: 0}})
-  const handedOffAtMs = await store.markHandedOff({jobId: failedId, workerId: "worker-1"})
+  const handoff = await store.markHandedOff({jobId: failedId, workerId: "worker-1"})
+  if (!handoff) throw new Error("Expected the failed job to be handed off")
 
-  await store.markFailed({error: "boom", handedOffAtMs, jobId: failedId, workerId: "worker-1"})
+  await store.markFailed({error: "boom", jobId: failedId, workerId: "worker-1", ...handoff})
 
   return {failedId}
 }

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -78,6 +78,7 @@ export default async function runJobPayload(payload) {
         await reporter.reportWithRetry({
           jobId: payload.id,
           status: "completed",
+          handoffId: payload.handoffId,
           workerId: payload.workerId,
           handedOffAtMs: payload.handedOffAtMs,
           maxDurationMs: 30000
@@ -89,6 +90,7 @@ export default async function runJobPayload(payload) {
           jobId: payload.id,
           status: "failed",
           error,
+          handoffId: payload.handoffId,
           workerId: payload.workerId,
           handedOffAtMs: payload.handedOffAtMs,
           maxDurationMs: 30000

--- a/src/background-jobs/json-socket.js
+++ b/src/background-jobs/json-socket.js
@@ -17,6 +17,10 @@ export default class JsonSocket extends EventEmitter {
     /**
      * Narrows the runtime value to the documented type.
      * @type {boolean} */
+    this.supportsHandoffIdReporting = false
+    /**
+     * Narrows the runtime value to the documented type.
+     * @type {boolean} */
     this.acceptsSpawnedJobs = true
     /**
      * Narrows the runtime value to the documented type.

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -65,6 +65,10 @@ export default class BackgroundJobsMain {
      * @type {Set<JsonSocket>} */
     this.readyWorkers = new Set()
     /**
+     * Active durable handoffs keyed by the exact worker socket that received them.
+     * @type {Map<JsonSocket, Map<string, string>>} */
+    this.workerHandoffs = new Map()
+    /**
      * Narrows the runtime value to the documented type.
      * @type {net.Server | undefined} */
     this.server = undefined
@@ -270,7 +274,7 @@ export default class BackgroundJobsMain {
   _setupDispatchTriggers() {
     if (this.dispatchStrategy === "polling") {
       this._pollTimer = setInterval(() => {
-        void this._drain()
+        void this._retryAfterError()
       }, this.pollIntervalMs)
       return
     }
@@ -330,11 +334,12 @@ export default class BackgroundJobsMain {
      * @type {import("./types.js").BackgroundJobSocketRole | null} */
     let role = null
 
+    let cleanedUp = false
     const cleanup = () => {
-      if (role === "worker") {
-        this.workers.delete(jsonSocket)
-        this.readyWorkers.delete(jsonSocket)
-      }
+      if (cleanedUp) return
+      cleanedUp = true
+
+      if (role === "worker") void this._handleWorkerSocketClosed(jsonSocket)
     }
 
     jsonSocket.on("close", cleanup)
@@ -377,7 +382,9 @@ export default class BackgroundJobsMain {
 
     if (message.role === "worker") {
       jsonSocket.workerId = message.workerId
+      jsonSocket.supportsHandoffIdReporting = message.supportsHandoffIdReporting === true
       this.workers.add(jsonSocket)
+      this.workerHandoffs.set(jsonSocket, new Map())
     }
 
     return message.role
@@ -446,7 +453,11 @@ export default class BackgroundJobsMain {
     jsonSocket.acceptsSpawnedJobs = message.acceptsSpawned !== false && message.acceptsForked !== false
     jsonSocket.acceptsForkedJobs = message.acceptsForked !== false
     jsonSocket.acceptsInlineJobs = message.acceptsInline !== false
-    this.readyWorkers.add(jsonSocket)
+    if (jsonSocket.supportsHandoffIdReporting) {
+      this.readyWorkers.add(jsonSocket)
+    } else {
+      this.readyWorkers.delete(jsonSocket)
+    }
     void this._drain()
   }
 
@@ -461,6 +472,98 @@ export default class BackgroundJobsMain {
     // to it but keep the connection in `workers` so any in-flight job
     // it's still draining can report its result.
     this.readyWorkers.delete(jsonSocket)
+  }
+
+  /**
+   * Removes a lost worker socket and releases only leases dispatched through it.
+   * @param {JsonSocket} worker - Disconnected worker socket.
+   * @returns {Promise<void>} - Resolves after its active leases are released.
+   */
+  async _handleWorkerSocketClosed(worker) {
+    this.workers.delete(worker)
+    this.readyWorkers.delete(worker)
+
+    if (this._stopped) {
+      this.workerHandoffs.delete(worker)
+      return
+    }
+
+    try {
+      await this._releaseWorkerHandoffs(worker)
+    } catch (error) {
+      this._reportHandoffReleaseError(error)
+      this._scheduleErrorRetry()
+    }
+  }
+
+  /**
+   * Releases all leases still owned by one exact worker socket.
+   * @param {JsonSocket} worker - Worker socket.
+   * @returns {Promise<void>} - Resolves after fenced releases and dispatch wake-up.
+   */
+  async _releaseWorkerHandoffs(worker) {
+    const handoffs = this.workerHandoffs.get(worker)
+
+    if (!handoffs || handoffs.size === 0) {
+      this.workerHandoffs.delete(worker)
+      return
+    }
+
+    for (const [jobId, handoffId] of handoffs) {
+      await this._releaseHandoff({handoffId, jobId, worker})
+    }
+
+    this.workerHandoffs.delete(worker)
+    this._notifyEnqueued()
+    await this._drain()
+  }
+
+  /**
+   * Runs one idempotent conditional lease release.
+   * @param {object} args - Options.
+   * @param {string} args.handoffId - Handoff lease id.
+   * @param {string} args.jobId - Job id.
+   * @param {JsonSocket} args.worker - Socket that received the lease.
+   * @returns {Promise<void>} - Resolves after the fenced transition.
+   */
+  async _releaseHandoff({handoffId, jobId, worker}) {
+    await this.store.markReturnedToQueue({handoffId, jobId})
+
+    const handoffs = this.workerHandoffs.get(worker)
+
+    if (handoffs?.get(jobId) === handoffId) handoffs.delete(jobId)
+  }
+
+  /**
+   * Forgets a successfully reported lease without relying on worker ids.
+   * @param {object} args - Options.
+   * @param {string} args.handoffId - Handoff lease id.
+   * @param {string} args.jobId - Job id.
+   * @returns {void}
+   */
+  _forgetHandoff({handoffId, jobId}) {
+    for (const [worker, handoffs] of this.workerHandoffs) {
+      if (handoffs.get(jobId) !== handoffId) continue
+
+      handoffs.delete(jobId)
+      if (handoffs.size === 0 && !this.workers.has(worker)) this.workerHandoffs.delete(worker)
+      return
+    }
+  }
+
+  /**
+   * Reports an unexpected lease-release failure on framework error channels.
+   * @param {?} error - Release failure.
+   * @returns {void}
+   */
+  _reportHandoffReleaseError(error) {
+    const normalizedError = error instanceof Error ? error : new Error(String(error))
+    const payload = {context: {stage: "background-job-handoff-release"}, error: normalizedError}
+    const errorEvents = this.configuration.getErrorEvents()
+
+    this.logger.error(() => ["Failed to release disconnected worker handoffs:", normalizedError])
+    errorEvents.emit("framework-error", payload)
+    errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
   }
 
   /**
@@ -496,11 +599,15 @@ export default class BackgroundJobsMain {
    */
   async _handleJobComplete({jsonSocket, message}) {
     try {
-      await this.store.markCompleted({
+      const accepted = await this.store.markCompleted({
         jobId: message.jobId,
+        handoffId: message.handoffId,
         workerId: message.workerId,
         handedOffAtMs: message.handedOffAtMs
       })
+      if (accepted && message.handoffId) {
+        this._forgetHandoff({handoffId: message.handoffId, jobId: message.jobId})
+      }
       jsonSocket.send({type: "job-updated", jobId: message.jobId})
     } catch (error) {
       this.logger.error(() => ["Failed to update job completion:", error])
@@ -520,13 +627,18 @@ export default class BackgroundJobsMain {
       const failedJob = await this.store.markFailed({
         jobId: message.jobId,
         error: message.error,
+        handoffId: message.handoffId,
         workerId: message.workerId,
         handedOffAtMs: message.handedOffAtMs
       })
 
       if (failedJob) {
+        if (message.handoffId) {
+          this._forgetHandoff({handoffId: message.handoffId, jobId: message.jobId})
+        }
         this._emitBackgroundJobFailed({
           error: message.error,
+          handoffId: message.handoffId,
           handedOffAtMs: message.handedOffAtMs,
           job: failedJob,
           workerId: message.workerId
@@ -546,14 +658,15 @@ export default class BackgroundJobsMain {
 
   /**
    * Runs emit background job failed.
-   * @param {{error: ?, handedOffAtMs?: number, job: import("./types.js").BackgroundJobRow, workerId?: string}} args - Failure event data.
+   * @param {{error: ?, handoffId?: string, handedOffAtMs?: number, job: import("./types.js").BackgroundJobRow, workerId?: string}} args - Failure event data.
    * @returns {void}
    */
-  _emitBackgroundJobFailed({error, handedOffAtMs, job, workerId}) {
+  _emitBackgroundJobFailed({error, handoffId, handedOffAtMs, job, workerId}) {
     const normalizedError = this._normalizeFailureError(error)
     const payload = {
       context: {
         attempts: job.attempts,
+        handoffId,
         handedOffAtMs,
         jobArgs: job.args,
         jobId: job.id,
@@ -699,6 +812,10 @@ export default class BackgroundJobsMain {
    * Runs clear error retry timer.
    * @returns {void} */
   _clearErrorRetryTimer() {
+    for (const worker of this.workerHandoffs.keys()) {
+      if (!this.workers.has(worker)) return
+    }
+
     if (this._errorRetryTimer) {
       clearTimeout(this._errorRetryTimer)
       this._errorRetryTimer = undefined
@@ -771,8 +888,28 @@ export default class BackgroundJobsMain {
 
     this._errorRetryTimer = setTimeout(() => {
       this._errorRetryTimer = undefined
-      void this._drain()
+      void this._retryAfterError()
     }, this.pollIntervalMs)
+  }
+
+  /**
+   * Retries failed disconnected-socket releases before draining queued work.
+   * @returns {Promise<void>} - Resolves after retry work.
+   */
+  async _retryAfterError() {
+    if (this._stopped) return
+
+    try {
+      for (const worker of this.workerHandoffs.keys()) {
+        if (!this.workers.has(worker)) await this._releaseWorkerHandoffs(worker)
+      }
+    } catch (error) {
+      this._reportHandoffReleaseError(error)
+      this._scheduleErrorRetry()
+      return
+    }
+
+    await this._drain()
   }
 
   /**
@@ -790,7 +927,23 @@ export default class BackgroundJobsMain {
 
       this.readyWorkers.delete(worker)
 
-      const handedOffAtMs = await this.store.markHandedOff({jobId: job.id, workerId: worker.workerId})
+      const handoff = await this.store.markHandedOff({jobId: job.id, workerId: worker.workerId})
+
+      if (!handoff) {
+        if (this.workers.has(worker)) this.readyWorkers.add(worker)
+        continue
+      }
+
+      const handoffs = this.workerHandoffs.get(worker)
+
+      if (!handoffs || !this.workers.has(worker)) {
+        await this.store.markReturnedToQueue({handoffId: handoff.handoffId, jobId: job.id})
+        this._notifyEnqueued()
+        await this._drain()
+        continue
+      }
+
+      handoffs.set(job.id, handoff.handoffId)
 
       try {
         worker.send({
@@ -799,8 +952,9 @@ export default class BackgroundJobsMain {
             id: job.id,
             jobName: job.jobName,
             args: job.args,
+            handoffId: handoff.handoffId,
             workerId: worker.workerId,
-            handedOffAtMs,
+            handedOffAtMs: handoff.handedOffAtMs,
             options: {
               executionMode: job.executionMode,
               forked: job.forked
@@ -809,8 +963,12 @@ export default class BackgroundJobsMain {
         })
       } catch (error) {
         this.logger.warn(() => ["Failed to send job to worker, re-queueing:", error])
-        await this.store.markReturnedToQueue({jobId: job.id})
-        this.readyWorkers.add(worker)
+        try {
+          worker.close()
+        } catch (closeError) {
+          this.logger.warn(() => ["Failed to close worker after job send failure:", closeError])
+        }
+        await this._handleWorkerSocketClosed(worker)
       }
     }
   }
@@ -850,6 +1008,8 @@ export default class BackgroundJobsMain {
    * @returns {void}
    */
   _addAcceptedExecutionModes({executionModes, worker}) {
+    if (!worker.supportsHandoffIdReporting) return
+
     for (const capability of WORKER_EXECUTION_MODE_CAPABILITIES) {
       if (capability.accepts(worker)) executionModes.add(capability.executionMode)
     }
@@ -874,6 +1034,8 @@ export default class BackgroundJobsMain {
    * @returns {boolean} - Whether the worker accepts the job mode.
    */
   _workerAcceptsJob({job, worker}) {
+    if (!worker.supportsHandoffIdReporting) return false
+
     const capability = WORKER_EXECUTION_MODE_CAPABILITIES_BY_MODE.get(job.executionMode)
 
     if (!capability) return false

--- a/src/background-jobs/status-reporter.js
+++ b/src/background-jobs/status-reporter.js
@@ -27,11 +27,12 @@ export default class BackgroundJobsStatusReporter {
    * @param {string} args.jobId - Job id.
    * @param {"completed" | "failed"} args.status - Status.
    * @param {?} [args.error] - Error.
+   * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @param {string} [args.workerId] - Worker id.
    * @returns {Promise<void>} - Resolves when reported.
    */
-  async report({jobId, status, error, handedOffAtMs, workerId}) {
+  async report({jobId, status, error, handoffId, handedOffAtMs, workerId}) {
     const config = this.configuration.getBackgroundJobsConfig()
     const host = this.host || config.host
     const port = typeof this.port === "number" ? this.port : config.port
@@ -44,6 +45,7 @@ export default class BackgroundJobsStatusReporter {
           jsonSocket.send({
             type: status === "completed" ? "job-complete" : "job-failed",
             jobId,
+            handoffId,
             workerId,
             handedOffAtMs,
             error: error ? normalizeBackgroundJobError(error) : undefined
@@ -69,18 +71,19 @@ export default class BackgroundJobsStatusReporter {
    * @param {string} args.jobId - Job id.
    * @param {"completed" | "failed"} args.status - Status.
    * @param {?} [args.error] - Error.
+   * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @param {string} [args.workerId] - Worker id.
    * @param {number} [args.maxDurationMs] - Max duration for retries.
    * @returns {Promise<void>} - Resolves when reported.
    */
-  async reportWithRetry({jobId, status, error, handedOffAtMs, workerId, maxDurationMs}) {
+  async reportWithRetry({jobId, status, error, handoffId, handedOffAtMs, workerId, maxDurationMs}) {
     let attempt = 0
     const startTime = Date.now()
 
     while (true) {
       try {
-        await this.report({jobId, status, error, handedOffAtMs, workerId})
+        await this.report({jobId, status, error, handoffId, handedOffAtMs, workerId})
         return
       } catch (error) {
         attempt += 1

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -306,44 +306,51 @@ export default class BackgroundJobsStore {
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
    * @param {string} [args.workerId] - Worker id.
-   * @returns {Promise<number>} - Resolves with handed off timestamp.
+   * @returns {Promise<import("./types.js").BackgroundJobHandoff | null>} - Claimed handoff lease, or null when no longer queued.
    */
   async markHandedOff({jobId, workerId}) {
     await this.ensureReady()
 
     const handedOffAtMs = Date.now()
+    const handoffId = randomUUID()
 
-    await this._withDb(async (db) => {
+    return await this._withDb(async (db) => {
       await db.update({
         tableName: JOBS_TABLE,
         data: {
           status: "handed_off",
           handed_off_at_ms: handedOffAtMs,
+          handoff_id: handoffId,
           worker_id: workerId || null
         },
-        conditions: {id: jobId}
+        conditions: {id: jobId, status: "queued"}
       })
-    })
 
-    return handedOffAtMs
+      const job = await this._getJobRowById(db, jobId)
+
+      if (job?.status !== "handed_off" || job.handoffId !== handoffId) return null
+
+      return {handedOffAtMs, handoffId}
+    })
   }
 
   /**
    * Runs mark completed.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
+   * @param {string} [args.handoffId] - Handoff lease id.
    * @param {string} [args.workerId] - Worker id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
-   * @returns {Promise<void>} - Resolves when updated.
+   * @returns {Promise<boolean>} - Whether the fenced report was accepted.
    */
-  async markCompleted({jobId, workerId, handedOffAtMs}) {
+  async markCompleted({jobId, handoffId, workerId, handedOffAtMs}) {
     await this.ensureReady()
 
-    await this._withDb(async (db) => {
+    return await this._withDb(async (db) => await this._withHandoffLock({db, jobId}, async () => {
       const job = await this._getJobRowById(db, jobId)
 
-      if (!job) return
-      if (!this._shouldAcceptReport({job, workerId, handedOffAtMs})) return
+      if (!job) return false
+      if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return false
 
       await db.update({
         tableName: JOBS_TABLE,
@@ -351,18 +358,23 @@ export default class BackgroundJobsStore {
           status: "completed",
           completed_at_ms: Date.now()
         },
-        conditions: {id: jobId}
+        conditions: this._activeHandoffConditions(job)
       })
-    })
+
+      const updatedJob = await this._getJobRowById(db, jobId)
+
+      return updatedJob?.status === "completed" && updatedJob.handoffId === job.handoffId
+    }))
   }
 
   /**
    * Runs mark returned to queue.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
+   * @param {string} args.handoffId - Handoff lease id.
    * @returns {Promise<void>} - Resolves when updated.
    */
-  async markReturnedToQueue({jobId}) {
+  async markReturnedToQueue({jobId, handoffId}) {
     await this.ensureReady()
 
     await this._withDb(async (db) => {
@@ -372,9 +384,10 @@ export default class BackgroundJobsStore {
           status: "queued",
           scheduled_at_ms: Date.now(),
           handed_off_at_ms: null,
+          handoff_id: null,
           worker_id: null
         },
-        conditions: {id: jobId}
+        conditions: {handoff_id: handoffId, id: jobId, status: "handed_off"}
       })
     })
   }
@@ -384,21 +397,22 @@ export default class BackgroundJobsStore {
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
    * @param {?} args.error - Error.
+   * @param {string} [args.handoffId] - Handoff lease id.
    * @param {string} [args.workerId] - Worker id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Updated job row when the report was accepted.
    */
-  async markFailed({jobId, error, workerId, handedOffAtMs}) {
+  async markFailed({jobId, error, handoffId, workerId, handedOffAtMs}) {
     await this.ensureReady()
 
-    return await this._withDb(async (db) => {
+    return await this._withDb(async (db) => await this._withHandoffLock({db, jobId}, async () => {
       const job = await this._getJobRowById(db, jobId)
 
       if (!job) return null
-      if (!this._shouldAcceptReport({job, workerId, handedOffAtMs})) return null
+      if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return null
 
       return await this._applyFailure({db, job, error, markOrphaned: false})
-    })
+    }))
   }
 
   /**
@@ -420,18 +434,22 @@ export default class BackgroundJobsStore {
 
       const rows = await query.results()
 
+      let orphanedCount = 0
+
       for (const row of rows) {
         const job = this._normalizeJobRow(row)
 
-        await this._applyFailure({
+        const orphanedJob = await this._applyFailure({
           db,
           job,
           error: "Job orphaned after timeout",
           markOrphaned: true
         })
+
+        if (orphanedJob) orphanedCount += 1
       }
 
-      return rows.length
+      return orphanedCount
     })
   }
 
@@ -562,6 +580,7 @@ export default class BackgroundJobsStore {
     table.bigint("scheduled_at_ms", {null: false, index: true})
     table.bigint("created_at_ms", {null: false, index: true})
     table.bigint("handed_off_at_ms", {null: true, index: true})
+    table.string("handoff_id", {null: true})
     table.bigint("completed_at_ms", {null: true})
     table.bigint("failed_at_ms", {null: true})
     table.bigint("orphaned_at_ms", {null: true, index: true})
@@ -592,6 +611,35 @@ export default class BackgroundJobsStore {
       }
 
       db.clearSchemaCache()
+    }
+
+    const refreshedTable = await db.getTableByNameOrFail(JOBS_TABLE)
+    const handoffIdColumn = await refreshedTable.getColumnByName("handoff_id")
+
+    if (!handoffIdColumn) {
+      const lockName = `${MIGRATION_SCOPE}:handoff_id_column`
+      const acquired = await db.acquireAdvisoryLock(lockName)
+
+      if (!acquired) throw new Error("Failed to acquire background jobs handoff schema lock")
+
+      try {
+        db.clearSchemaCache()
+        const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
+
+        if (!(await lockedTable.getColumnByName("handoff_id"))) {
+          const tableData = new TableData(JOBS_TABLE)
+          tableData.string("handoff_id", {null: true})
+          const sqls = await db.alterTableSQLs(tableData)
+
+          for (const sql of sqls) {
+            await db.query(sql)
+          }
+
+          db.clearSchemaCache()
+        }
+      } finally {
+        await db.releaseAdvisoryLock(lockName)
+      }
     }
 
     await this._backfillExecutionModesOnce(db)
@@ -639,14 +687,16 @@ export default class BackgroundJobsStore {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async _recordMigration(db, version) {
-    await db.insert({
+    await db.upsert({
       tableName: MIGRATIONS_TABLE,
       data: {
         key: this._migrationKey(version),
         scope: MIGRATION_SCOPE,
         version,
         applied_at_ms: Date.now()
-      }
+      },
+      conflictColumns: ["key"],
+      updateColumns: ["scope", "version", "applied_at_ms"]
     })
   }
 
@@ -689,7 +739,7 @@ export default class BackgroundJobsStore {
    * @param {import("./types.js").BackgroundJobRow} args.job - Job row.
    * @param {?} args.error - Error.
    * @param {boolean} args.markOrphaned - Whether marking orphaned.
-   * @returns {Promise<import("./types.js").BackgroundJobRow>} - Updated job row.
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Updated job row when the lease transition won.
    */
   async _applyFailure({db, job, error, markOrphaned}) {
     const now = Date.now()
@@ -710,10 +760,17 @@ export default class BackgroundJobsStore {
     await db.update({
       tableName: JOBS_TABLE,
       data: update,
-      conditions: {id: job.id}
+      conditions: this._activeHandoffConditions(job)
     })
 
-    return this._jobWithFailureUpdate({failureMessage, job, nextAttempt, update})
+    const updatedJob = await this._getJobRowById(db, job.id)
+
+    if (!updatedJob) return null
+    if (updatedJob.handoffId !== job.handoffId) return null
+    if (updatedJob.attempts !== nextAttempt) return null
+    if (updatedJob.status !== update.status) return null
+
+    return updatedJob
   }
 
   /**
@@ -783,29 +840,6 @@ export default class BackgroundJobsStore {
   }
 
   /**
-   * Runs job with failure update.
-   * @param {object} args - Options.
-   * @param {string} args.failureMessage - Last failure message.
-   * @param {import("./types.js").BackgroundJobRow} args.job - Job row.
-   * @param {number} args.nextAttempt - Next attempt count.
-   * @param {Record<string, ?>} args.update - Database update data.
-   * @returns {import("./types.js").BackgroundJobRow} - Updated job row.
-   */
-  _jobWithFailureUpdate({failureMessage, job, nextAttempt, update}) {
-    return {
-      ...job,
-      attempts: nextAttempt,
-      failedAtMs: update.failed_at_ms ?? job.failedAtMs,
-      handedOffAtMs: null,
-      lastError: failureMessage,
-      orphanedAtMs: update.orphaned_at_ms ?? job.orphanedAtMs,
-      scheduledAtMs: update.scheduled_at_ms ?? job.scheduledAtMs,
-      status: update.status,
-      workerId: null
-    }
-  }
-
-  /**
    * Runs normalize job row.
    * @param {Record<string, ?>} row - Raw database row.
    * @returns {import("./types.js").BackgroundJobRow} - Normalized job row.
@@ -827,6 +861,7 @@ export default class BackgroundJobsStore {
       scheduledAtMs: this._normalizeNumber(row.scheduled_at_ms),
       createdAtMs: this._normalizeNumber(row.created_at_ms),
       handedOffAtMs: this._normalizeNumber(row.handed_off_at_ms),
+      handoffId: row.handoff_id ? String(row.handoff_id) : null,
       completedAtMs: this._normalizeNumber(row.completed_at_ms),
       failedAtMs: this._normalizeNumber(row.failed_at_ms),
       orphanedAtMs: this._normalizeNumber(row.orphaned_at_ms),
@@ -938,17 +973,64 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Serializes reports for one job so duplicate reports cannot both appear accepted.
+   * @template T
+   * @param {object} args - Options.
+   * @param {import("../database/drivers/base.js").default} args.db - Database connection.
+   * @param {string} args.jobId - Job id.
+   * @param {() => Promise<T>} callback - Locked callback.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async _withHandoffLock({db, jobId}, callback) {
+    const lockName = `background-job:${jobId}`
+    const acquired = await db.acquireAdvisoryLock(lockName)
+
+    if (!acquired) throw new Error(`Failed to acquire background job handoff lock: ${jobId}`)
+
+    try {
+      return await callback()
+    } finally {
+      await db.releaseAdvisoryLock(lockName)
+    }
+  }
+
+  /**
    * Runs should accept report.
    * @param {object} args - Options.
    * @param {import("./types.js").BackgroundJobRow} args.job - Job row.
+   * @param {string | null | undefined} args.handoffId - Handoff lease id from report.
    * @param {string | null | undefined} args.workerId - Worker id from report.
    * @param {number | null | undefined} args.handedOffAtMs - Handed off timestamp from report.
    * @returns {boolean} - Whether to accept the report.
    */
-  _shouldAcceptReport({job, workerId, handedOffAtMs}) {
+  _shouldAcceptReport({job, handoffId, workerId, handedOffAtMs}) {
     if (job.status !== "handed_off") return false
 
-    return this._workerReportMatches({job, workerId}) && this._handoffReportMatches({handedOffAtMs, job})
+    return this._handoffIdReportMatches({handoffId, job})
+      && this._workerReportMatches({job, workerId})
+      && this._handoffReportMatches({handedOffAtMs, job})
+  }
+
+  /**
+   * Runs active handoff conditions.
+   * @param {import("./types.js").BackgroundJobRow} job - Job row.
+   * @returns {Record<string, string | null>} - Conditional transition fence.
+   */
+  _activeHandoffConditions(job) {
+    return {handoff_id: job.handoffId, id: job.id, status: "handed_off"}
+  }
+
+  /**
+   * Runs handoff id report matches.
+   * @param {object} args - Options.
+   * @param {string | null | undefined} args.handoffId - Handoff lease id from report.
+   * @param {import("./types.js").BackgroundJobRow} args.job - Job row.
+   * @returns {boolean} - Whether the handoff lease matches.
+   */
+  _handoffIdReportMatches({handoffId, job}) {
+    if (!job.handoffId) return true
+
+    return handoffId === job.handoffId
   }
 
   /**

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -4,6 +4,11 @@
  * @typedef {"inline" | "forked" | "spawned"} BackgroundJobExecutionMode
  */
 /**
+ * @typedef {object} BackgroundJobHandoff
+ * @property {string} handoffId - Unique handoff lease id.
+ * @property {number} handedOffAtMs - Time handed to a worker in ms.
+ */
+/**
  * @typedef {object} BackgroundJobOptions
  * @property {BackgroundJobExecutionMode} [executionMode] - How the job should run. Defaults to `"forked"`.
  * @property {boolean} [forked] - Compatibility alias: `false` maps to `"inline"` and `true` maps to `"forked"`.
@@ -14,6 +19,7 @@
  * @property {string} [id] - Job id.
  * @property {string} jobName - Job class name.
  * @property {Array<?>} [args] - Serialized job arguments.
+ * @property {string} [handoffId] - Unique handoff lease id.
  * @property {string} [workerId] - Worker id handling the job.
  * @property {number} [handedOffAtMs] - Time handed to a worker in ms.
  * @property {BackgroundJobOptions} [options] - Runtime options.
@@ -31,6 +37,7 @@
  * @property {number | null} scheduledAtMs - Next scheduled time in ms.
  * @property {number | null} createdAtMs - Creation time in ms.
  * @property {number | null} handedOffAtMs - Time handed to worker in ms.
+ * @property {string | null} handoffId - Unique latest handoff lease id.
  * @property {number | null} completedAtMs - Completion time in ms.
  * @property {number | null} failedAtMs - Failure time in ms.
  * @property {number | null} orphanedAtMs - Orphaned time in ms.
@@ -44,6 +51,7 @@
  * @property {number | null} attempts - Updated failure attempts count.
  * @property {boolean} terminal - Whether this failure ended the job.
  * @property {boolean} willRetry - Whether the job was returned to the queue.
+ * @property {string | undefined} handoffId - Handoff lease id from the worker report.
  * @property {number | undefined} handedOffAtMs - Handoff timestamp from the worker report.
  * @property {string | undefined} workerId - Worker id from the worker report.
  */
@@ -51,15 +59,15 @@
  * @typedef {"worker" | "client" | "reporter"} BackgroundJobSocketRole
  */
 /**
- * @typedef {{type: "hello", role: BackgroundJobSocketRole, workerId?: string}} BackgroundJobHelloMessage
+ * @typedef {{type: "hello", role: BackgroundJobSocketRole, supportsHandoffIdReporting?: boolean, workerId?: string}} BackgroundJobHelloMessage
  * @typedef {{type: "ready", acceptsForked?: boolean, acceptsInline?: boolean, acceptsSpawned?: boolean}} BackgroundJobReadyMessage
  * @typedef {{type: "draining"}} BackgroundJobDrainingMessage
  * @typedef {{type: "enqueue", jobName: string, args?: Array<?>, options?: BackgroundJobOptions}} BackgroundJobEnqueueMessage
  * @typedef {{type: "enqueued", jobId: string}} BackgroundJobEnqueuedMessage
  * @typedef {{type: "enqueue-error", error?: string}} BackgroundJobEnqueueErrorMessage
  * @typedef {{type: "job", payload: BackgroundJobPayload}} BackgroundJobJobMessage
- * @typedef {{type: "job-complete", jobId: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobCompleteMessage
- * @typedef {{type: "job-failed", jobId: string, error?: ?, workerId?: string, handedOffAtMs?: number}} BackgroundJobFailedMessage
+ * @typedef {{type: "job-complete", jobId: string, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobCompleteMessage
+ * @typedef {{type: "job-failed", jobId: string, error?: ?, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobFailedMessage
  * @typedef {{type: "job-updated", jobId: string}} BackgroundJobUpdatedMessage
  * @typedef {{type: "job-update-error", jobId: string, error?: string}} BackgroundJobUpdateErrorMessage
  */

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -261,7 +261,7 @@ export default class BackgroundJobsWorker {
     })
 
     socket.on("connect", () => {
-      jsonSocket.send({type: "hello", role: "worker", workerId: this.workerId})
+      jsonSocket.send({type: "hello", role: "worker", supportsHandoffIdReporting: true, workerId: this.workerId})
       this._sendReadyIfRunning()
     })
   }
@@ -399,6 +399,7 @@ export default class BackgroundJobsWorker {
       await this._reportJobResult({
         jobId: payload.id,
         status: "completed",
+        handoffId: payload.handoffId,
         handedOffAtMs: payload.handedOffAtMs,
         workerId: payload.workerId || this.workerId
       })
@@ -407,6 +408,7 @@ export default class BackgroundJobsWorker {
         jobId: payload.id,
         status: "failed",
         error,
+        handoffId: payload.handoffId,
         handedOffAtMs: payload.handedOffAtMs,
         workerId: payload.workerId || this.workerId
       })
@@ -609,6 +611,7 @@ export default class BackgroundJobsWorker {
       jobId: payload.id,
       status: "failed",
       error,
+      handoffId: payload.handoffId,
       handedOffAtMs: payload.handedOffAtMs,
       workerId: payload.workerId || this.workerId
     })
@@ -665,15 +668,16 @@ export default class BackgroundJobsWorker {
    * @param {string} args.jobId - Job id.
    * @param {"completed" | "failed"} args.status - Status.
    * @param {?} [args.error] - Error.
+   * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @param {string} [args.workerId] - Worker id.
    * @returns {Promise<void>} - Resolves when reported.
    */
-  async _reportJobResult({jobId, status, error, handedOffAtMs, workerId}) {
+  async _reportJobResult({jobId, status, error, handoffId, handedOffAtMs, workerId}) {
     if (!this.statusReporter) return
 
     try {
-      await this.statusReporter.reportWithRetry({jobId, status, error, handedOffAtMs, workerId})
+      await this.statusReporter.reportWithRetry({jobId, status, error, handoffId, handedOffAtMs, workerId})
     } catch (reportError) {
       console.error("Background job status reporting failed:", reportError)
     }


### PR DESCRIPTION
## Summary
- Fence durable background-job handoffs with a UUID lease token.
- Immediately return only the exact handoffs owned by an unexpectedly disconnected worker socket.
- Gate new handoffs on a worker capability handshake, preserving safe rolling upgrades and accepting legacy reports for existing unfenced work.

## Validation
- `VELOCIOUS_DISABLE_MSSQL=1 npm test -- spec/background-jobs/basic-spec.js spec/background-jobs/dispatch-strategy-spec.js spec/background-jobs/store-spec.js spec/background-jobs/web/api-spec.js` — 32 passing
- `npm run lint`, `npm run typecheck`, `npm run fallow` in a clean Node 22 Trixie container
- Independent final protocol/concurrency review: no findings

Note: the repository lint command exits successfully but reports pre-existing JSDoc warnings outside this change; this PR does not introduce lint warnings.