### PR TITLE
fix(background-jobs): require durable completion acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1987,7 +1987,7 @@ VELOCIOUS_BACKGROUND_JOBS_WORKER_SHUTDOWN_TIMEOUT_MS=indefinite
 
 `maxConcurrentInlineJobs` (default: `4`) caps how many `executionMode: "inline"` jobs a single `background-jobs-worker` process runs in parallel. Concurrency is at the JS event-loop level: every job in flight shares the worker's process and DB connection pool, so the cap should fit the pool, not the CPU count. Forking remains the right tool when you need memory isolation across long-running jobs or want to use more cores. The older `forked: false` option still maps to inline mode.
 
-`maxConcurrentForkedJobs` (default: `4`) caps how many out-of-process `executionMode: "forked"` or `executionMode: "spawned"` jobs one worker may keep in flight. Forked jobs use `child_process.fork()` with an attached IPC channel and exit after the job runner closes its framework resources. Spawned jobs use the legacy `background-jobs-runner` CLI process via `child_process.spawn()` and are only for callers that intentionally want that spawned behavior.
+`maxConcurrentForkedJobs` (default: `4`) caps how many out-of-process `executionMode: "forked"` or `executionMode: "spawned"` jobs one worker may keep in flight. Forked jobs use `child_process.fork()` with an attached IPC channel. After the main process acknowledges their durable status report, forked and spawned one-shot runners exit without waiting for graceful Beacon/database teardown; the OS closes their process-owned resources. A missing or rejected status acknowledgement makes the runner exit as failed instead of reporting clean success. Spawned jobs use the legacy `background-jobs-runner` CLI process via `child_process.spawn()` and are only for callers that intentionally want that spawned behavior.
 
 ### Dispatch strategy
 

--- a/changelog.d/20260714070000-exit-completed-forked-runners.md
+++ b/changelog.d/20260714070000-exit-completed-forked-runners.md
@@ -1,0 +1,1 @@
+Fix forked and spawned background-job runners lingering after their durable completion report when graceful connection teardown stalls, while ensuring a missing or rejected durable acknowledgement exits as failed.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -70,6 +70,15 @@ then `SIGKILL` after a short grace) so they are not orphaned across a deploy —
 an orphaned runner keeps running against deleted release code and holds its
 database connections open.
 
+After a forked or spawned one-shot runner receives the main process's durable
+status acknowledgement, it exits without waiting for graceful Beacon/database
+teardown; the operating system closes those process-owned resources. This keeps
+a completed runner from lingering when a graceful socket close stalls. Inline
+and long-lived worker shutdown still performs graceful framework cleanup. If
+the acknowledgement is missing or rejected through `job-update-error`, the
+one-shot runner exits as failed and does not reinterpret the transport failure
+as a failed job-performance report.
+
 The drain window is controlled by `VELOCIOUS_BACKGROUND_JOBS_WORKER_SHUTDOWN_TIMEOUT_MS`:
 
 - unset, `"indefinite"`, or `"0"` (default): wait for in-flight jobs to finish

--- a/spec/background-jobs/worker-shutdown-spec.js
+++ b/spec/background-jobs/worker-shutdown-spec.js
@@ -1,11 +1,66 @@
 // @ts-check
 
+import fs from "node:fs/promises"
+import net from "node:net"
+import path from "node:path"
 import {fileURLToPath} from "node:url"
-import {fork} from "node:child_process"
+import {fork, spawn} from "node:child_process"
+import timeout from "awaitery/build/timeout.js"
 import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
 import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import JsonSocket from "../../src/background-jobs/json-socket.js"
 
 const FORKED_RUNNER_ENTRY_PATH = fileURLToPath(new URL("../../src/background-jobs/forked-runner-child.js", import.meta.url))
+const VELOCIOUS_CLI_ENTRY_PATH = fileURLToPath(new URL("../../bin/velocious.js", import.meta.url))
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+
+/**
+ * @returns {Promise<{cleanup: () => Promise<void>, directory: string}>} - Temporary runner project.
+ */
+async function createStalledTeardownProject() {
+  const directory = path.join(REPOSITORY_ROOT, "tmp", `forked-runner-exit-${process.pid}-${Date.now()}`)
+  const configurationPath = path.join(directory, "src", "config", "configuration.js")
+  const jobsDirectory = path.join(directory, "src", "jobs")
+  const frameworkConfigurationPath = new URL("../../src/configuration.js", import.meta.url).href
+  const environmentHandlerPath = new URL("../../src/environment-handlers/node.js", import.meta.url).href
+  const jobPath = new URL("../../src/background-jobs/job.js", import.meta.url).href
+
+  await fs.mkdir(path.dirname(configurationPath), {recursive: true})
+  await fs.mkdir(jobsDirectory, {recursive: true})
+  await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+  await fs.writeFile(configurationPath, `
+import Configuration from ${JSON.stringify(frameworkConfigurationPath)}
+import EnvironmentHandlerNode from ${JSON.stringify(environmentHandlerPath)}
+
+class StalledTeardownConfiguration extends Configuration {
+  async initialize() {}
+  async connectBeacon() {}
+  async withConnections(_args, callback) { await callback() }
+  async disconnectBeacon() { await new Promise(() => {}) }
+  async closeDatabaseConnections() { await new Promise(() => {}) }
+}
+
+export default new StalledTeardownConfiguration({
+  database: {test: {}},
+  directory: ${JSON.stringify(directory)},
+  environment: "test",
+  environmentHandler: new EnvironmentHandlerNode(),
+  initializeModels: async () => {},
+  locale: "en",
+  localeFallbacks: {en: ["en"]},
+  locales: ["en"]
+})
+`)
+  await fs.writeFile(path.join(jobsDirectory, "exit-after-completion-job.js"), `
+import Job from ${JSON.stringify(jobPath)}
+export default class ExitAfterCompletionJob extends Job { async perform() {} }
+`)
+
+  return {
+    cleanup: async () => await fs.rm(directory, {recursive: true, force: true}),
+    directory
+  }
+}
 
 /**
  * Builds a worker with a tracked fake process-runner child whose `kill()` signals
@@ -31,14 +86,14 @@ function workerWithTrackedChild() {
 
 /**
  * @param {import("node:child_process").ChildProcess} child - Child process.
+ * @param {number} [timeoutMs] - Maximum exit wait.
  * @returns {Promise<{code: number | null, signal: NodeJS.Signals | null}>} - Exit result.
  */
-async function waitForChildExit(child) {
+async function waitForChildExit(child, timeoutMs = 2000) {
   return await new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
-      child.kill("SIGKILL")
       reject(new Error("Timed out waiting for forked runner child to exit"))
-    }, 2000)
+    }, timeoutMs)
 
     child.once("exit", (code, signal) => {
       clearTimeout(timeout)
@@ -104,6 +159,292 @@ describe("Background jobs worker - shutdown", () => {
     const exit = await exitPromise
 
     expect(exit.code === 0 && !exit.signal).toBeFalse()
+  })
+
+  it("exits after durable completion without waiting for graceful teardown", async () => {
+    const {cleanup, directory} = await createStalledTeardownProject()
+    const server = net.createServer()
+    const jobId = `job-${Date.now()}`
+    let durableReportReceived = false
+    /** @type {import("node:child_process").ChildProcess | undefined} */
+    let child
+
+    try {
+      server.on("connection", (socket) => {
+        const jsonSocket = new JsonSocket(socket)
+        jsonSocket.on("message", (message) => {
+          if (message?.type !== "job-complete" || message.jobId !== jobId) return
+
+          durableReportReceived = true
+          jsonSocket.send({type: "job-updated", jobId})
+        })
+      })
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Runner status server did not bind to a TCP port")
+      child = fork(FORKED_RUNNER_ENTRY_PATH, [], {
+        cwd: directory,
+        execArgv: [],
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+        env: {
+          ...process.env,
+          VELOCIOUS_ENV: "test",
+          VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+          VELOCIOUS_BACKGROUND_JOBS_PORT: `${address.port}`
+        }
+      })
+
+      child.send({type: "job", payload: {id: jobId, jobName: "ExitAfterCompletionJob", args: []}})
+      const exit = await timeout({timeout: 2000}, async () => await waitForChildExit(child))
+
+      expect(durableReportReceived).toBe(true)
+      expect(exit).toEqual({code: 0, signal: null})
+    } finally {
+      if (child && !child.killed && child.exitCode === null) child.kill("SIGKILL")
+      await new Promise((resolve) => server.close(resolve))
+      await cleanup()
+    }
+  })
+
+  it("exits a spawned CLI runner after durable completion without waiting for outer cleanup", async () => {
+    const {cleanup, directory} = await createStalledTeardownProject()
+    const server = net.createServer()
+    const jobId = `spawned-job-${Date.now()}`
+    let durableReportReceived = false
+    /** @type {import("node:child_process").ChildProcess | undefined} */
+    let child
+
+    try {
+      server.on("connection", (socket) => {
+        const jsonSocket = new JsonSocket(socket)
+        jsonSocket.on("message", (message) => {
+          if (message?.type !== "job-complete" || message.jobId !== jobId) return
+
+          durableReportReceived = true
+          jsonSocket.send({type: "job-updated", jobId})
+        })
+      })
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Runner status server did not bind to a TCP port")
+      const jobPayload = Buffer.from(JSON.stringify({
+        id: jobId,
+        jobName: "ExitAfterCompletionJob",
+        args: []
+      })).toString("base64")
+      child = spawn(process.execPath, [VELOCIOUS_CLI_ENTRY_PATH, "background-jobs-runner"], {
+        cwd: directory,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          VELOCIOUS_ENV: "test",
+          VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+          VELOCIOUS_BACKGROUND_JOBS_PORT: `${address.port}`,
+          VELOCIOUS_JOB_PAYLOAD: jobPayload
+        }
+      })
+
+      const exit = await timeout({timeout: 2000}, async () => await waitForChildExit(child))
+
+      expect(durableReportReceived).toBe(true)
+      expect(exit).toEqual({code: 0, signal: null})
+    } finally {
+      if (child && !child.killed && child.exitCode === null) child.kill("SIGKILL")
+      await new Promise((resolve) => server.close(resolve))
+      await cleanup()
+    }
+  })
+
+  it("does not exit a forked runner cleanly without a durable completion acknowledgement", async () => {
+    const {cleanup, directory} = await createStalledTeardownProject()
+    const server = net.createServer()
+    const jobId = `unacknowledged-job-${Date.now()}`
+    let completionReports = 0
+    /** @type {import("node:child_process").ChildProcess | undefined} */
+    let child
+
+    try {
+      server.on("connection", (socket) => {
+        const jsonSocket = new JsonSocket(socket)
+        jsonSocket.on("message", (message) => {
+          if (message?.type !== "job-complete" || message.jobId !== jobId) return
+
+          completionReports += 1
+          socket.destroy()
+        })
+      })
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Runner status server did not bind to a TCP port")
+      child = fork(FORKED_RUNNER_ENTRY_PATH, [], {
+        cwd: directory,
+        execArgv: [],
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+        env: {
+          ...process.env,
+          VELOCIOUS_ENV: "test",
+          VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+          VELOCIOUS_BACKGROUND_JOBS_PORT: `${address.port}`
+        }
+      })
+
+      child.send({type: "job", payload: {id: jobId, jobName: "ExitAfterCompletionJob", args: []}})
+      const exit = await waitForChildExit(child, 40000)
+
+      expect(completionReports).toBeGreaterThan(0)
+      expect(exit.signal).toBe(null)
+      expect(exit.code).toBeGreaterThan(0)
+    } finally {
+      if (child && !child.killed && child.exitCode === null) child.kill("SIGKILL")
+      await new Promise((resolve) => server.close(resolve))
+      await cleanup()
+    }
+  })
+
+  it("does not exit a spawned CLI runner cleanly without a durable completion acknowledgement", async () => {
+    const {cleanup, directory} = await createStalledTeardownProject()
+    const server = net.createServer()
+    const jobId = `unacknowledged-spawned-job-${Date.now()}`
+    let completionReports = 0
+    /** @type {import("node:child_process").ChildProcess | undefined} */
+    let child
+
+    try {
+      server.on("connection", (socket) => {
+        const jsonSocket = new JsonSocket(socket)
+        jsonSocket.on("message", (message) => {
+          if (message?.type !== "job-complete" || message.jobId !== jobId) return
+
+          completionReports += 1
+          socket.destroy()
+        })
+      })
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Runner status server did not bind to a TCP port")
+      const jobPayload = Buffer.from(JSON.stringify({
+        id: jobId,
+        jobName: "ExitAfterCompletionJob",
+        args: []
+      })).toString("base64")
+      child = spawn(process.execPath, [VELOCIOUS_CLI_ENTRY_PATH, "background-jobs-runner"], {
+        cwd: directory,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          VELOCIOUS_ENV: "test",
+          VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+          VELOCIOUS_BACKGROUND_JOBS_PORT: `${address.port}`,
+          VELOCIOUS_JOB_PAYLOAD: jobPayload
+        }
+      })
+
+      const exit = await waitForChildExit(child, 40000)
+
+      expect(completionReports).toBeGreaterThan(0)
+      expect(exit.signal).toBe(null)
+      expect(exit.code).toBeGreaterThan(0)
+    } finally {
+      if (child && !child.killed && child.exitCode === null) child.kill("SIGKILL")
+      await new Promise((resolve) => server.close(resolve))
+      await cleanup()
+    }
+  })
+
+  it("exits a forked runner nonzero when durable completion is rejected", async () => {
+    const {cleanup, directory} = await createStalledTeardownProject()
+    const server = net.createServer()
+    const jobId = `rejected-job-${Date.now()}`
+    let completionReports = 0
+    /** @type {import("node:child_process").ChildProcess | undefined} */
+    let child
+
+    try {
+      server.on("connection", (socket) => {
+        const jsonSocket = new JsonSocket(socket)
+        jsonSocket.on("message", (message) => {
+          if (message?.type !== "job-complete" || message.jobId !== jobId) return
+
+          completionReports += 1
+          jsonSocket.send({type: "job-update-error", jobId, error: "Completion update rejected"})
+        })
+      })
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Runner status server did not bind to a TCP port")
+      child = fork(FORKED_RUNNER_ENTRY_PATH, [], {
+        cwd: directory,
+        execArgv: [],
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+        env: {
+          ...process.env,
+          VELOCIOUS_ENV: "test",
+          VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+          VELOCIOUS_BACKGROUND_JOBS_PORT: `${address.port}`
+        }
+      })
+
+      child.send({type: "job", payload: {id: jobId, jobName: "ExitAfterCompletionJob", args: []}})
+      const exit = await waitForChildExit(child, 5000)
+
+      expect(completionReports).toBe(1)
+      expect(exit.signal).toBe(null)
+      expect(exit.code).toBeGreaterThan(0)
+    } finally {
+      if (child && !child.killed && child.exitCode === null) child.kill("SIGKILL")
+      await new Promise((resolve) => server.close(resolve))
+      await cleanup()
+    }
+  })
+
+  it("exits a spawned CLI runner nonzero when durable completion is rejected", async () => {
+    const {cleanup, directory} = await createStalledTeardownProject()
+    const server = net.createServer()
+    const jobId = `rejected-spawned-job-${Date.now()}`
+    let completionReports = 0
+    /** @type {import("node:child_process").ChildProcess | undefined} */
+    let child
+
+    try {
+      server.on("connection", (socket) => {
+        const jsonSocket = new JsonSocket(socket)
+        jsonSocket.on("message", (message) => {
+          if (message?.type !== "job-complete" || message.jobId !== jobId) return
+
+          completionReports += 1
+          jsonSocket.send({type: "job-update-error", jobId, error: "Completion update rejected"})
+        })
+      })
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Runner status server did not bind to a TCP port")
+      const jobPayload = Buffer.from(JSON.stringify({
+        id: jobId,
+        jobName: "ExitAfterCompletionJob",
+        args: []
+      })).toString("base64")
+      child = spawn(process.execPath, [VELOCIOUS_CLI_ENTRY_PATH, "background-jobs-runner"], {
+        cwd: directory,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          VELOCIOUS_ENV: "test",
+          VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+          VELOCIOUS_BACKGROUND_JOBS_PORT: `${address.port}`,
+          VELOCIOUS_JOB_PAYLOAD: jobPayload
+        }
+      })
+
+      const exit = await waitForChildExit(child, 5000)
+
+      expect(completionReports).toBe(1)
+      expect(exit.signal).toBe(null)
+      expect(exit.code).toBeGreaterThan(0)
+    } finally {
+      if (child && !child.killed && child.exitCode === null) child.kill("SIGKILL")
+      await new Promise((resolve) => server.close(resolve))
+      await cleanup()
+    }
   })
 })
 

--- a/spec/beacon/client-spec.js
+++ b/spec/beacon/client-spec.js
@@ -2,6 +2,7 @@
 
 import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
+import EventEmitter from "node:events"
 
 import BeaconClient from "../../src/beacon/client.js"
 import BeaconServer from "../../src/beacon/server.js"
@@ -25,6 +26,23 @@ function buildConfiguration() {
 }
 
 describe("BeaconClient", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("force-destroys sockets that do not close within the graceful bound", async () => {
+    class StalledSocket extends EventEmitter {
+      destroyed = false
+      end() {}
+      destroySoon() {}
+      destroy() { this.destroyed = true }
+    }
+
+    const socket = new StalledSocket()
+    const client = new BeaconClient({host: "127.0.0.1", port: 1, closeTimeoutMs: 10})
+    client._socket = /** @type {import("net").Socket} */ (/** @type {never} */ (socket))
+
+    await client.close()
+
+    expect(socket.destroyed).toBe(true)
+  })
+
   it("returns false from publish before the connection is established", async () => {
     const beacon = new BeaconServer({configuration: buildConfiguration(), host: "127.0.0.1", port: 0})
     await beacon.start()

--- a/src/background-jobs/forked-runner-child.js
+++ b/src/background-jobs/forked-runner-child.js
@@ -51,7 +51,7 @@ async function runJobMessage(message) {
     throw new Error("Forked background job runner received invalid payload")
   }
 
-  await runJobPayload(message.payload)
+  await runJobPayload(message.payload, {closeConnections: false})
 }
 
 /**

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -50,9 +50,11 @@ async function connectBeacon(configuration) {
 /**
  * Runs run job payload.
  * @param {import("./types.js").BackgroundJobPayload} payload - Payload.
+ * @param {object} [options] - Runner options.
+ * @param {boolean} [options.closeConnections] - Whether to gracefully close framework connections after the job.
  * @returns {Promise<void>} - Resolves when complete.
  */
-export default async function runJobPayload(payload) {
+export default async function runJobPayload(payload, {closeConnections = true} = {}) {
   const configuration = await configurationResolver()
   configuration.setCurrent()
   await configuration.initialize({type: "background-jobs-runner"})
@@ -73,17 +75,6 @@ export default async function runJobPayload(payload) {
       await configuration.withConnections({name: `Background job runner: ${payload.jobName}`}, async () => {
         await perform.apply(jobInstance, payload.args || [])
       })
-
-      if (payload.id) {
-        await reporter.reportWithRetry({
-          jobId: payload.id,
-          status: "completed",
-          handoffId: payload.handoffId,
-          workerId: payload.workerId,
-          handedOffAtMs: payload.handedOffAtMs,
-          maxDurationMs: 30000
-        })
-      }
     } catch (error) {
       if (payload.id) {
         await reporter.reportWithRetry({
@@ -99,11 +90,24 @@ export default async function runJobPayload(payload) {
 
       throw error
     }
+
+    if (payload.id) {
+      await reporter.reportWithRetry({
+        jobId: payload.id,
+        status: "completed",
+        handoffId: payload.handoffId,
+        workerId: payload.workerId,
+        handedOffAtMs: payload.handedOffAtMs,
+        maxDurationMs: 30000
+      })
+    }
   } finally {
-    try {
-      await configuration.disconnectBeacon()
-    } finally {
-      await configuration.closeDatabaseConnections()
+    if (closeConnections) {
+      try {
+        await configuration.disconnectBeacon()
+      } finally {
+        await configuration.closeDatabaseConnections()
+      }
     }
   }
 }

--- a/src/background-jobs/status-reporter.js
+++ b/src/background-jobs/status-reporter.js
@@ -6,6 +6,8 @@ import Logger from "../logger.js"
 import normalizeBackgroundJobError from "./normalize-error.js"
 import BackgroundJobsSocketRequest from "./socket-request.js"
 
+class BackgroundJobUpdateError extends Error {}
+
 export default class BackgroundJobsStatusReporter {
   /**
    * Runs constructor.
@@ -58,7 +60,7 @@ export default class BackgroundJobsStatusReporter {
           }
 
           if (message?.type === "job-update-error" && message.jobId === jobId) {
-            reject(new Error(message.error || "Job update failed"))
+            reject(new BackgroundJobUpdateError(message.error || "Job update failed"))
           }
         }
       })
@@ -86,6 +88,8 @@ export default class BackgroundJobsStatusReporter {
         await this.report({jobId, status, error, handoffId, handedOffAtMs, workerId})
         return
       } catch (error) {
+        if (error instanceof BackgroundJobUpdateError) throw error
+
         attempt += 1
         const delaySeconds = Math.min(30, 0.5 * attempt)
 
@@ -93,7 +97,7 @@ export default class BackgroundJobsStatusReporter {
 
         if (maxDurationMs && Date.now() - startTime >= maxDurationMs) {
           this.logger.warn(() => ["Background job status report timed out, giving up", error])
-          return
+          throw error
         }
 
         await wait(delaySeconds)

--- a/src/beacon/client.js
+++ b/src/beacon/client.js
@@ -9,6 +9,7 @@ import EventEmitter from "../utils/event-emitter.js"
 
 const DEFAULT_RECONNECT_DELAY_MS = 1000
 const MAX_RECONNECT_DELAY_MS = 30_000
+const DEFAULT_CLOSE_TIMEOUT_MS = 1000
 
 /**
  * BeaconBroadcastHandler type.
@@ -43,8 +44,9 @@ export default class BeaconClient extends EventEmitter {
    * @param {string} [args.peerId] - Optional explicit peer id (defaults to a random UUID).
    * @param {number} [args.reconnectDelayMs] - Starting reconnect delay in ms.
    * @param {number} [args.maxReconnectDelayMs] - Maximum reconnect delay in ms.
+   * @param {number} [args.closeTimeoutMs] - Maximum graceful socket close wait in ms.
    */
-  constructor({host, port, peerType, peerId, reconnectDelayMs, maxReconnectDelayMs}) {
+  constructor({host, port, peerType, peerId, reconnectDelayMs, maxReconnectDelayMs, closeTimeoutMs}) {
     super()
     this.host = host
     this.port = port
@@ -53,6 +55,7 @@ export default class BeaconClient extends EventEmitter {
     this._initialReconnectDelayMs = reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS
     this._maxReconnectDelayMs = maxReconnectDelayMs ?? MAX_RECONNECT_DELAY_MS
     this._reconnectDelayMs = this._initialReconnectDelayMs
+    this._closeTimeoutMs = closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS
     /**
      * Narrows the runtime value to the documented type.
      * @type {JsonSocket | undefined} */
@@ -66,7 +69,7 @@ export default class BeaconClient extends EventEmitter {
     this._closed = false
     /**
      * Narrows the runtime value to the documented type.
-     * @type {NodeJS.Timeout | undefined} */
+     * @type {ReturnType<typeof setTimeout> | undefined} */
     this._reconnectTimer = undefined
     /**
      * Narrows the runtime value to the documented type.
@@ -235,10 +238,14 @@ export default class BeaconClient extends EventEmitter {
 
     if (socket.destroyed) return
 
-    await new Promise((resolve) => {
-      socket.once("close", () => resolve(undefined))
-      socket.end()
-      socket.destroySoon()
+    await timeout({timeout: this._closeTimeoutMs}, async () => {
+      await new Promise((resolve) => {
+        socket.once("close", () => resolve(undefined))
+        socket.end()
+        socket.destroySoon()
+      })
+    }).catch(() => {
+      socket.destroy()
     })
   }
 

--- a/src/environment-handlers/node/cli/commands/background-jobs-runner.js
+++ b/src/environment-handlers/node/cli/commands/background-jobs-runner.js
@@ -19,6 +19,7 @@ export default class BackgroundJobsRunnerCommand extends BaseCommand {
     const decoded = Buffer.from(payload, "base64").toString("utf8")
     const jobPayload = JSON.parse(decoded)
 
-    await runJobPayload(jobPayload)
+    await runJobPayload(jobPayload, {closeConnections: false})
+    process.exit(0)
   }
 }


### PR DESCRIPTION
## Summary

- require a durable `job-updated` acknowledgement before a completed forked/spawned background runner is considered successful
- make acknowledgement timeout and explicit `job-update-error` terminal failures rather than false successes
- allow only acknowledged one-shot runners to bypass generic framework teardown, while preserving normal cleanup/error paths
- bound Beacon client shutdown and force-drain lingering worker subprocesses

## Regression coverage

- forked and spawned runner exit `0` only after durable acknowledgement
- forked and spawned runner exit nonzero when acknowledgement is absent
- forked and spawned runner exit nonzero when the durable update is rejected
- graceful shutdown retains bounded cleanup behavior

## Local validation

- `VELOCIOUS_DISABLE_MSSQL=1 npm test -- spec/background-jobs/worker-shutdown-spec.js` — 11 passing
- `npm run lint` — passing
- `npm run typecheck` — passing
- `npm run fallow` — passing
- `npm run build` — passing
- `git diff --check` — passing

The focused test was independently rerun inside the Docker validation container after matching worktree/container source hashes.
