### PR TITLE
feat(background-jobs): add durable concurrency limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1930,6 +1930,8 @@ Create the file `src/routes/testing/another-action.ejs` and so something like th
 
 Velocious includes a simple background jobs system inspired by Sidekiq.
 
+Jobs can opt into cross-worker durable concurrency limits by pairing a non-empty `concurrencyKey` with a positive-integer `maxConcurrency` in their background-job options. The first cap registered for a key is stable; conflicting caps are rejected. See [durable concurrency limits](docs/background-jobs.md#durable-concurrency-limits).
+
 Production apps can listen for `background-job-failed` or its `all-error` mirror to report accepted failed attempts, including retry and terminal state metadata. See [docs/background-jobs.md](docs/background-jobs.md#failure-events).
 
 ## Setup

--- a/changelog.d/20260715120000-background-job-concurrency.md
+++ b/changelog.d/20260715120000-background-job-concurrency.md
@@ -1,0 +1,1 @@
+Add portable, durable per-key concurrency limits for background jobs, including atomic cross-worker claims, stable cap validation, lifecycle release, orphan reconciliation, and saturated-key queue skipping.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -2,6 +2,12 @@
 
 Velocious background jobs are documented in the main README. This page covers behavior that applications usually need when operating background jobs in production.
 
+## Durable concurrency limits
+
+Pass `concurrencyKey` and `maxConcurrency` together in `jobOptions` (or in `performLaterWithOptions`). The key is an opaque, non-empty string shared by jobs that use the same limit, and the cap is a positive integer. Omitting both preserves unlimited behavior. Once a key is registered, every enqueue for that key must use the same cap; a conflicting cap is rejected.
+
+Limits are enforced by durable database reservations shared by every main/worker process. Saturated keys do not prevent unrelated queued jobs from being dispatched. Reservations are released when work completes, fails terminally, is requeued for retry, is cancelled, or is recovered as orphaned; startup reconciliation repairs reservation counts after an unclean scheduler stop.
+
 ## Worker Disconnect Recovery
 
 Each durable worker handoff has a unique lease id. If a worker socket disconnects unexpectedly, `background-jobs-main` immediately returns only the jobs handed to that exact socket to the queue and makes them available to another connected worker. Two connections that advertise the same worker id remain isolated from each other.

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -49,6 +49,63 @@ async function createOrphanedJob({maxRetries, store}) {
   return await getJobOrFail({jobId, store})
 }
 
+class ScriptedBackgroundJobsStore extends BackgroundJobsStore {
+  /**
+   * @param {object} args - Options.
+   * @param {import("../../src/database/drivers/base.js").default} args.db - Scripted database connection.
+   * @param {import("../../src/background-jobs/types.js").BackgroundJobRow} args.job - Scripted job row.
+   */
+  constructor({db, job}) {
+    super({configuration: dummyConfiguration})
+    this.scriptedDb = db
+    this.scriptedJob = job
+  }
+
+  /** @returns {Promise<void>} - Resolves immediately. */
+  async ensureReady() {}
+
+  /** @param {Function} callback - Database callback. */
+  async _withDb(callback) {
+    return await callback(this.scriptedDb)
+  }
+
+  /** @param {import("../../src/database/drivers/base.js").default} db - Database connection. @param {Function} callback - Transaction callback. */
+  async _transactionResult(db, callback) {
+    void db
+    return await callback()
+  }
+
+  /** @returns {Promise<import("../../src/background-jobs/types.js").BackgroundJobRow>} - Scripted job. */
+  async _getJobRowById() {
+    return this.scriptedJob
+  }
+}
+
+/** @returns {import("../../src/background-jobs/types.js").BackgroundJobRow} - Active concurrency-limited job. */
+function activeConcurrencyJob() {
+  return {
+    id: "concurrent-job",
+    jobName: "TestJob",
+    args: [],
+    executionMode: "inline",
+    forked: false,
+    status: "handed_off",
+    attempts: 0,
+    maxRetries: 0,
+    scheduledAtMs: 1,
+    createdAtMs: 1,
+    handedOffAtMs: 2,
+    handoffId: "handoff-1",
+    completedAtMs: null,
+    failedAtMs: null,
+    orphanedAtMs: null,
+    workerId: "worker-1",
+    lastError: null,
+    concurrencyKey: "shared-key",
+    maxConcurrency: 2
+  }
+}
+
 /** @returns {Promise<BackgroundJobsStore>} - Store with a legacy jobs table missing execution_mode. */
 async function createStoreWithLegacyJobsSchema() {
   dummyConfiguration.setCurrent()
@@ -164,6 +221,75 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     const claimedIndex = claims.findIndex(Boolean)
     expect(await store.cancel(ids[claimedIndex])).toEqual(true)
     expect(await store.markHandedOff({jobId: ids[1 - claimedIndex], workerId: "replacement"})).not.toBeNull()
+  })
+
+  it("releases a concurrency reservation when a competing queued claim loses", async () => {
+    let activeCount = 0
+    const db = {
+      affectedRows: async (sql) => {
+        if (sql.includes("active_count + 1")) {
+          activeCount += 1
+          return 1
+        }
+
+        return 0
+      },
+      query: async (sql) => {
+        if (sql.includes("active_count - 1")) activeCount -= 1
+        return []
+      },
+      quoteColumn: (value) => value,
+      quoteTable: (value) => value,
+      quote: (value) => `'${value}'`,
+      updateSql: () => "UPDATE background_jobs SET status = 'handed_off' WHERE status = 'queued'"
+    }
+    const queuedJob = activeConcurrencyJob()
+    queuedJob.status = "queued"
+    queuedJob.handoffId = null
+    queuedJob.handedOffAtMs = null
+    const scriptedDb = /** @type {import("../../src/database/drivers/base.js").default} */ (db)
+    const store = new ScriptedBackgroundJobsStore({db: scriptedDb, job: queuedJob})
+
+    expect(await store.markHandedOff({jobId: queuedJob.id, workerId: "claim-loser"})).toBeNull()
+    expect(activeCount).toEqual(0)
+  })
+
+  it("releases capacity only for the competing terminal transition that wins", async () => {
+    let activeCount = 1
+    let terminalUpdates = 0
+    let releases = 0
+    const db = {
+      affectedRows: async (sql) => {
+        if (sql.includes("active_count + 1")) {
+          activeCount += 1
+          return 1
+        }
+
+        terminalUpdates += 1
+        return terminalUpdates === 1 ? 1 : 0
+      },
+      query: async (sql) => {
+        if (sql.includes("active_count - 1")) {
+          activeCount -= 1
+          releases += 1
+        }
+        return []
+      },
+      quoteColumn: (value) => value,
+      quoteTable: (value) => value,
+      quote: (value) => `'${value}'`,
+      updateSql: () => "UPDATE background_jobs SET status = 'completed' WHERE status = 'handed_off'"
+    }
+    const job = activeConcurrencyJob()
+    const scriptedDb = /** @type {import("../../src/database/drivers/base.js").default} */ (db)
+    const store = new ScriptedBackgroundJobsStore({db: scriptedDb, job})
+    const report = {jobId: job.id, handoffId: job.handoffId || undefined, workerId: job.workerId || undefined, handedOffAtMs: job.handedOffAtMs || undefined}
+
+    expect(await Promise.all([store.markCompleted(report), store.markCompleted(report)])).toEqual([true, false])
+    expect(releases).toEqual(1)
+
+    expect(await store._reserveConcurrency(scriptedDb, job.concurrencyKey || "")).toEqual(true)
+    expect(activeCount).toEqual(1)
   })
 
   it("uses each conditional update result instead of a shared claim token", async () => {
@@ -388,6 +514,29 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
       expect(await jobsTable.getColumnByName("concurrency_key")).not.toBeNull()
       expect(await jobsTable.getColumnByName("max_concurrency")).not.toBeNull()
       expect(await concurrencyTable.getColumnByName("reservation_token")).toEqual(undefined)
+    })
+  })
+
+  it("serializes and rechecks concurrent legacy concurrency-column migrations", async () => {
+    const firstStore = await createStoreWithLegacyJobsSchema()
+    const pool = dummyConfiguration.getDatabasePool(firstStore.getDatabaseIdentifier())
+
+    await pool.withConnection({name: "Background jobs prepare concurrency-only legacy schema"}, async (db) => {
+      const tableData = new TableData("background_jobs")
+      tableData.string("execution_mode", {null: true})
+      tableData.string("handoff_id", {null: true})
+      for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+      db.clearSchemaCache()
+    })
+
+    const secondStore = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+    await Promise.all([firstStore.ensureReady(), secondStore.ensureReady()])
+
+    await pool.withConnection({name: "Background jobs verify concurrent concurrency migration"}, async (db) => {
+      const jobsTable = await db.getTableByNameOrFail("background_jobs")
+      expect(await jobsTable.getColumnByName("concurrency_key")).not.toBeNull()
+      expect(await jobsTable.getColumnByName("max_concurrency")).not.toBeNull()
     })
   })
 

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -132,6 +132,89 @@ async function createStoreWithLegacyJobsSchema() {
 }
 
 describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => {
+  it("validates paired concurrency options and rejects conflicting caps", async () => {
+    const store = await createClearedStore()
+    await expect(async () => await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: "account:1"}})).toThrow(/must be paired/)
+    await expect(async () => await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: "", maxConcurrency: 1}})).toThrow(/must be paired/)
+    await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: "account:1", maxConcurrency: 2}})
+    await expect(async () => await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: "account:1", maxConcurrency: 3}})).toThrow(/Conflicting maxConcurrency/)
+  })
+
+  it("claims atomically, skips saturated keys, and releases reservations", async () => {
+    const store = await createClearedStore()
+    const firstId = await store.enqueue({jobName: "TestJob", args: ["first"], options: {concurrencyKey: "serial", maxConcurrency: 1}})
+    const blockedId = await store.enqueue({jobName: "TestJob", args: ["blocked"], options: {concurrencyKey: "serial", maxConcurrency: 1}})
+    const freeId = await store.enqueue({jobName: "TestJob", args: ["free"], options: {concurrencyKey: "other", maxConcurrency: 1}})
+    const firstHandoff = await store.markHandedOff({jobId: firstId, workerId: "worker-1"})
+    if (!firstHandoff) throw new Error("Expected first job claim")
+
+    expect((await store.nextAvailableJob())?.id).toEqual(freeId)
+    expect(await store.markHandedOff({jobId: blockedId, workerId: "worker-2"})).toBeNull()
+
+    await store.markCompleted({jobId: firstId, workerId: "worker-1", ...firstHandoff})
+    expect((await store.nextAvailableJob())?.id).toEqual(blockedId)
+  })
+
+  it("allows only the cap across workers and releases on cancellation", async () => {
+    const store = await createClearedStore()
+    const ids = await Promise.all([1, 2].map(async (number) => await store.enqueue({jobName: "TestJob", args: [number], options: {concurrencyKey: "one-at-a-time", maxConcurrency: 1}})))
+    const claims = []
+    for (const [index, jobId] of ids.entries()) claims.push(await store.markHandedOff({jobId, workerId: `worker-${index}`}))
+    expect(claims.filter(Boolean)).toHaveLength(1)
+    const claimedIndex = claims.findIndex(Boolean)
+    expect(await store.cancel(ids[claimedIndex])).toEqual(true)
+    expect(await store.markHandedOff({jobId: ids[1 - claimedIndex], workerId: "replacement"})).not.toBeNull()
+  })
+
+  it("uses each conditional update result instead of a shared claim token", async () => {
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    let updateCount = 0
+    let sharedToken = null
+    let secondUpdateFinished
+    const secondUpdate = new Promise((resolve) => { secondUpdateFinished = resolve })
+    const db = {
+      affectedRows: async () => 1,
+      query: async (sql) => {
+        updateCount += 1
+        sharedToken = sql.match(/reservation_token = '([^']+)'/)?.[1] || null
+        if (updateCount === 1) await secondUpdate
+        else secondUpdateFinished()
+        return []
+      },
+      newQuery: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => ({results: async () => [{reservation_token: sharedToken}]})
+          })
+        })
+      }),
+      quoteColumn: (value) => value,
+      quoteTable: (value) => value,
+      quote: (value) => `'${value}'`
+    }
+
+    const claims = await Promise.all([
+      store._reserveConcurrency(/** @type {import("../../src/database/drivers/base.js").default} */ (db), "two-at-a-time"),
+      store._reserveConcurrency(/** @type {import("../../src/database/drivers/base.js").default} */ (db), "two-at-a-time")
+    ])
+
+    expect(claims).toEqual([true, true])
+  })
+
+  it("releases concurrency capacity for retries and orphan recovery", async () => {
+    const store = await createClearedStore()
+    const retryId = await store.enqueue({jobName: "TestJob", args: ["retry"], options: {concurrencyKey: "lifecycle", maxConcurrency: 1, maxRetries: 1}})
+    const waitingId = await store.enqueue({jobName: "TestJob", args: ["waiting"], options: {concurrencyKey: "lifecycle", maxConcurrency: 1}})
+    const retryHandoff = await store.markHandedOff({jobId: retryId, workerId: "worker-1"})
+    if (!retryHandoff) throw new Error("Expected retry job claim")
+    await store.markFailed({jobId: retryId, error: "retry", workerId: "worker-1", ...retryHandoff})
+    const waitingHandoff = await store.markHandedOff({jobId: waitingId, workerId: "worker-2"})
+    if (!waitingHandoff) throw new Error("Expected waiting job claim")
+    await store.markOrphanedJobs({orphanedAfterMs: 0})
+
+    expect(await store.markHandedOff({jobId: retryId, workerId: "worker-3"})).not.toBeNull()
+  })
+
   it("fences stale completion and failure reports after a handoff is requeued", async () => {
     const store = await createClearedStore()
     const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false}})
@@ -297,6 +380,15 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
 
     const nextInline = await store.nextAvailableJob({executionMode: "inline"})
     expect(nextInline?.id).toEqual("legacy-inline-job")
+
+    const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
+    await pool.withConnection({name: "Background jobs verify concurrency migration"}, async (db) => {
+      const jobsTable = await db.getTableByNameOrFail("background_jobs")
+      const concurrencyTable = await db.getTableByNameOrFail("background_job_concurrency")
+      expect(await jobsTable.getColumnByName("concurrency_key")).not.toBeNull()
+      expect(await jobsTable.getColumnByName("max_concurrency")).not.toBeNull()
+      expect(await concurrencyTable.getColumnByName("reservation_token")).toEqual(undefined)
+    })
   })
 
   it("records legacy execution mode backfill as a one-time migration", async () => {

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -522,10 +522,12 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     const pool = dummyConfiguration.getDatabasePool(firstStore.getDatabaseIdentifier())
 
     await pool.withConnection({name: "Background jobs prepare concurrency-only legacy schema"}, async (db) => {
-      const tableData = new TableData("background_jobs")
-      tableData.string("execution_mode", {null: true})
-      tableData.string("handoff_id", {null: true})
-      for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+      for (const columnName of ["execution_mode", "handoff_id"]) {
+        const tableData = new TableData("background_jobs")
+        tableData.string(columnName, {null: true})
+        for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+      }
+
       db.clearSchemaCache()
     })
 

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -42,6 +42,7 @@ describe("Cli - Commands - db:migrate", () => {
     /** @type {string[]} */
     const tablesResult = []
     const internalTables = new Set([
+      "background_job_concurrency",
       "background_jobs",
       "velocious_attachments",
       "velocious_internal_migrations",

--- a/spec/cli/commands/db/rollback-spec.js
+++ b/spec/cli/commands/db/rollback-spec.js
@@ -6,6 +6,7 @@ import uniqunize from "uniqunize"
 
 describe("Cli - Commands - db:rollback", () => {
   const internalTables = new Set([
+    "background_job_concurrency",
     "background_jobs",
     "velocious_attachments",
     "velocious_internal_migrations",

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -335,7 +335,7 @@ export default class BackgroundJobsStore {
       if (!queuedJob || queuedJob.status !== "queued") return null
       if (queuedJob.concurrencyKey && !(await this._reserveConcurrency(db, queuedJob.concurrencyKey))) return null
 
-      await db.update({
+      const affectedRows = await this._updateAffectedRows(db, {
         tableName: JOBS_TABLE,
         data: {
           status: "handed_off",
@@ -346,9 +346,10 @@ export default class BackgroundJobsStore {
         conditions: {id: jobId, status: "queued"}
       })
 
-      const job = await this._getJobRowById(db, jobId)
-
-      if (job?.status !== "handed_off" || job.handoffId !== handoffId) return null
+      if (affectedRows !== 1) {
+        await this._releaseConcurrency(db, queuedJob.concurrencyKey)
+        return null
+      }
 
       return {handedOffAtMs, handoffId}
     }))
@@ -372,7 +373,7 @@ export default class BackgroundJobsStore {
       if (!job) return false
       if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return false
 
-      await db.update({
+      const affectedRows = await this._updateAffectedRows(db, {
         tableName: JOBS_TABLE,
         data: {
           status: "completed",
@@ -381,11 +382,9 @@ export default class BackgroundJobsStore {
         conditions: this._activeHandoffConditions(job)
       })
 
-      const updatedJob = await this._getJobRowById(db, jobId)
-
-      if (updatedJob?.status === "completed") await this._releaseConcurrency(db, job.concurrencyKey)
-
-      return updatedJob?.status === "completed" && updatedJob.handoffId === job.handoffId
+      if (affectedRows !== 1) return false
+      await this._releaseConcurrency(db, job.concurrencyKey)
+      return true
     }))
   }
 
@@ -402,7 +401,7 @@ export default class BackgroundJobsStore {
     await this._withDb(async (db) => await db.transaction(async () => {
       const job = await this._getJobRowById(db, jobId)
       if (!job || job.handoffId !== handoffId || job.status !== "handed_off") return
-      await db.update({
+      const affectedRows = await this._updateAffectedRows(db, {
         tableName: JOBS_TABLE,
         data: {
           status: "queued",
@@ -413,8 +412,7 @@ export default class BackgroundJobsStore {
         },
         conditions: {handoff_id: handoffId, id: jobId, status: "handed_off"}
       })
-      const updatedJob = await this._getJobRowById(db, jobId)
-      if (updatedJob?.status === "queued") await this._releaseConcurrency(db, job.concurrencyKey)
+      if (affectedRows === 1) await this._releaseConcurrency(db, job.concurrencyKey)
     }))
   }
 
@@ -438,7 +436,6 @@ export default class BackgroundJobsStore {
       if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return null
 
       const updatedJob = await this._applyFailure({db, job, error, markOrphaned: false})
-      if (updatedJob) await this._releaseConcurrency(db, job.concurrencyKey)
       return updatedJob
     }))
   }
@@ -475,7 +472,6 @@ export default class BackgroundJobsStore {
         })
 
         if (orphanedJob) orphanedCount += 1
-        if (orphanedJob) await this._releaseConcurrency(db, job.concurrencyKey)
       }
 
       return orphanedCount
@@ -505,9 +501,8 @@ export default class BackgroundJobsStore {
     return await this._withDb(async (db) => await this._transactionResult(db, async () => {
       const job = await this._getJobRowById(db, jobId)
       if (!job || (job.status !== "queued" && job.status !== "handed_off")) return false
-      await db.update({tableName: JOBS_TABLE, data: {status: "cancelled"}, conditions: {id: job.id, status: job.status}})
-      const updatedJob = await this._getJobRowById(db, jobId)
-      if (updatedJob?.status !== "cancelled") return false
+      const affectedRows = await this._updateAffectedRows(db, {tableName: JOBS_TABLE, data: {status: "cancelled"}, conditions: {id: job.id, status: job.status}})
+      if (affectedRows !== 1) return false
       if (job.status === "handed_off") await this._releaseConcurrency(db, job.concurrencyKey)
       return true
     }))
@@ -699,12 +694,28 @@ export default class BackgroundJobsStore {
     await this._backfillExecutionModesOnce(db)
 
     const concurrencyTable = await db.getTableByNameOrFail(JOBS_TABLE)
-    if (!(await concurrencyTable.getColumnByName("concurrency_key"))) {
-      const tableData = new TableData(JOBS_TABLE)
-      tableData.string("concurrency_key", {null: true, index: true})
-      tableData.integer("max_concurrency", {null: true})
-      for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
-      db.clearSchemaCache()
+    const hasConcurrencyKey = await concurrencyTable.getColumnByName("concurrency_key")
+    const hasMaxConcurrency = await concurrencyTable.getColumnByName("max_concurrency")
+
+    if (!hasConcurrencyKey || !hasMaxConcurrency) {
+      const lockName = `${MIGRATION_SCOPE}:concurrency_columns`
+      const acquired = await db.acquireAdvisoryLock(lockName)
+
+      if (!acquired) throw new Error("Failed to acquire background jobs concurrency schema lock")
+
+      try {
+        db.clearSchemaCache()
+        const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
+        const tableData = new TableData(JOBS_TABLE)
+
+        if (!(await lockedTable.getColumnByName("concurrency_key"))) tableData.string("concurrency_key", {null: true, index: true})
+        if (!(await lockedTable.getColumnByName("max_concurrency"))) tableData.integer("max_concurrency", {null: true})
+
+        for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+        db.clearSchemaCache()
+      } finally {
+        await db.releaseAdvisoryLock(lockName)
+      }
     }
   }
 
@@ -820,19 +831,18 @@ export default class BackgroundJobsStore {
       shouldRetry
     })
 
-    await db.update({
+    const affectedRows = await this._updateAffectedRows(db, {
       tableName: JOBS_TABLE,
       data: update,
       conditions: this._activeHandoffConditions(job)
     })
 
+    if (affectedRows !== 1) return null
+    await this._releaseConcurrency(db, job.concurrencyKey)
+
     const updatedJob = await this._getJobRowById(db, job.id)
 
     if (!updatedJob) return null
-    if (updatedJob.handoffId !== job.handoffId) return null
-    if (updatedJob.attempts !== nextAttempt) return null
-    if (updatedJob.status !== update.status) return null
-
     return updatedJob
   }
 
@@ -999,6 +1009,16 @@ export default class BackgroundJobsStore {
     const count = db.quoteColumn("active_count")
     const affectedRows = await db.affectedRows(`UPDATE ${table} SET ${count} = ${count} + 1 WHERE ${db.quoteColumn("concurrency_key")} = ${db.quote(concurrencyKey)} AND ${count} < ${db.quoteColumn("max_concurrency")}`)
     return affectedRows === 1
+  }
+
+  /**
+   * Runs a portable update and returns its affected-row count.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {import("../database/drivers/base.js").UpdateSqlArgsType} args - Update options.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _updateAffectedRows(db, args) {
+    return await db.affectedRows(db.updateSql(args))
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -693,38 +693,35 @@ export default class BackgroundJobsStore {
 
     await this._backfillExecutionModesOnce(db)
 
-    const concurrencyTable = await db.getTableByNameOrFail(JOBS_TABLE)
-    const hasConcurrencyKey = await concurrencyTable.getColumnByName("concurrency_key")
-    const hasMaxConcurrency = await concurrencyTable.getColumnByName("max_concurrency")
+    const lockName = `${MIGRATION_SCOPE}:concurrency_columns`
+    const acquired = await db.acquireAdvisoryLock(lockName)
 
-    if (!hasConcurrencyKey || !hasMaxConcurrency) {
-      const lockName = `${MIGRATION_SCOPE}:concurrency_columns`
-      const acquired = await db.acquireAdvisoryLock(lockName)
+    if (!acquired) throw new Error("Failed to acquire background jobs concurrency schema lock")
 
-      if (!acquired) throw new Error("Failed to acquire background jobs concurrency schema lock")
+    try {
+      // SQL Server schema reads can deadlock with a concurrent ALTER TABLE, so
+      // acquire the lock before inspecting either column rather than only
+      // protecting the mutation.
+      db.clearSchemaCache()
+      const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
+      const concurrencyColumnNames = ["concurrency_key", "max_concurrency"]
 
-      try {
-        db.clearSchemaCache()
-        const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
-        const concurrencyColumnNames = ["concurrency_key", "max_concurrency"]
+      for (const concurrencyColumnName of concurrencyColumnNames) {
+        if (await lockedTable.getColumnByName(concurrencyColumnName)) continue
 
-        for (const concurrencyColumnName of concurrencyColumnNames) {
-          if (await lockedTable.getColumnByName(concurrencyColumnName)) continue
-
-          const tableData = new TableData(JOBS_TABLE)
-          if (concurrencyColumnName == "concurrency_key") {
-            tableData.string("concurrency_key", {null: true, index: true})
-          } else {
-            tableData.integer("max_concurrency", {null: true})
-          }
-
-          for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+        const tableData = new TableData(JOBS_TABLE)
+        if (concurrencyColumnName == "concurrency_key") {
+          tableData.string("concurrency_key", {null: true, index: true})
+        } else {
+          tableData.integer("max_concurrency", {null: true})
         }
 
-        db.clearSchemaCache()
-      } finally {
-        await db.releaseAdvisoryLock(lockName)
+        for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
       }
+
+      db.clearSchemaCache()
+    } finally {
+      await db.releaseAdvisoryLock(lockName)
     }
   }
 

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -11,6 +11,7 @@ const MIGRATION_SCOPE = "background_jobs"
 const MIGRATION_VERSION = "20250215000000"
 const EXECUTION_MODE_BACKFILL_MIGRATION_VERSION = "20260607131010"
 const JOBS_TABLE = "background_jobs"
+const CONCURRENCY_TABLE = "background_job_concurrency"
 const DEFAULT_MAX_RETRIES = 10
 const ORPHANED_AFTER_MS = 2 * 60 * 60 * 1000
 /**
@@ -94,8 +95,10 @@ export default class BackgroundJobsStore {
     const executionMode = this._normalizeExecutionMode(options)
     const maxRetries = this._normalizeMaxRetries(options?.maxRetries)
     const argsJson = JSON.stringify(args || [])
+    const concurrency = this._normalizeConcurrencyOptions(options)
 
     await this._withDb(async (db) => {
+      if (concurrency) await this._ensureConcurrencyKey(db, concurrency)
       await db.insert({
         tableName: JOBS_TABLE,
         data: {
@@ -108,7 +111,9 @@ export default class BackgroundJobsStore {
           attempts: 0,
           status: "queued",
           scheduled_at_ms: now,
-          created_at_ms: now
+          created_at_ms: now,
+          concurrency_key: concurrency?.concurrencyKey || null,
+          max_concurrency: concurrency?.maxConcurrency || null
         }
       })
     })
@@ -168,6 +173,17 @@ export default class BackgroundJobsStore {
       .from(JOBS_TABLE)
       .where({status: "queued"})
       .where(`scheduled_at_ms ${scheduledAtOperator} ${db.quote(now)}`)
+
+    if (scheduledAtOperator === "<=") {
+      const jobsTable = db.quoteTable(JOBS_TABLE)
+      const concurrencyTable = db.quoteTable(CONCURRENCY_TABLE)
+      query = query.where(
+        `(${jobsTable}.${db.quoteColumn("concurrency_key")} IS NULL OR EXISTS (` +
+        `SELECT 1 FROM ${concurrencyTable} WHERE ` +
+        `${concurrencyTable}.${db.quoteColumn("concurrency_key")} = ${jobsTable}.${db.quoteColumn("concurrency_key")} AND ` +
+        `${concurrencyTable}.${db.quoteColumn("active_count")} < ${concurrencyTable}.${db.quoteColumn("max_concurrency")}))`
+      )
+    }
 
     if (typeof forked === "boolean") {
       query = query.where({forked})
@@ -314,7 +330,11 @@ export default class BackgroundJobsStore {
     const handedOffAtMs = Date.now()
     const handoffId = randomUUID()
 
-    return await this._withDb(async (db) => {
+    return await this._withDb(async (db) => await this._transactionResult(db, async () => {
+      const queuedJob = await this._getJobRowById(db, jobId)
+      if (!queuedJob || queuedJob.status !== "queued") return null
+      if (queuedJob.concurrencyKey && !(await this._reserveConcurrency(db, queuedJob.concurrencyKey))) return null
+
       await db.update({
         tableName: JOBS_TABLE,
         data: {
@@ -331,7 +351,7 @@ export default class BackgroundJobsStore {
       if (job?.status !== "handed_off" || job.handoffId !== handoffId) return null
 
       return {handedOffAtMs, handoffId}
-    })
+    }))
   }
 
   /**
@@ -346,7 +366,7 @@ export default class BackgroundJobsStore {
   async markCompleted({jobId, handoffId, workerId, handedOffAtMs}) {
     await this.ensureReady()
 
-    return await this._withDb(async (db) => await this._withHandoffLock({db, jobId}, async () => {
+    return await this._withDb(async (db) => await this._transactionResult(db, async () => {
       const job = await this._getJobRowById(db, jobId)
 
       if (!job) return false
@@ -363,6 +383,8 @@ export default class BackgroundJobsStore {
 
       const updatedJob = await this._getJobRowById(db, jobId)
 
+      if (updatedJob?.status === "completed") await this._releaseConcurrency(db, job.concurrencyKey)
+
       return updatedJob?.status === "completed" && updatedJob.handoffId === job.handoffId
     }))
   }
@@ -377,7 +399,9 @@ export default class BackgroundJobsStore {
   async markReturnedToQueue({jobId, handoffId}) {
     await this.ensureReady()
 
-    await this._withDb(async (db) => {
+    await this._withDb(async (db) => await db.transaction(async () => {
+      const job = await this._getJobRowById(db, jobId)
+      if (!job || job.handoffId !== handoffId || job.status !== "handed_off") return
       await db.update({
         tableName: JOBS_TABLE,
         data: {
@@ -389,7 +413,9 @@ export default class BackgroundJobsStore {
         },
         conditions: {handoff_id: handoffId, id: jobId, status: "handed_off"}
       })
-    })
+      const updatedJob = await this._getJobRowById(db, jobId)
+      if (updatedJob?.status === "queued") await this._releaseConcurrency(db, job.concurrencyKey)
+    }))
   }
 
   /**
@@ -405,13 +431,15 @@ export default class BackgroundJobsStore {
   async markFailed({jobId, error, handoffId, workerId, handedOffAtMs}) {
     await this.ensureReady()
 
-    return await this._withDb(async (db) => await this._withHandoffLock({db, jobId}, async () => {
+    return await this._withDb(async (db) => await this._transactionResult(db, async () => {
       const job = await this._getJobRowById(db, jobId)
 
       if (!job) return null
       if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return null
 
-      return await this._applyFailure({db, job, error, markOrphaned: false})
+      const updatedJob = await this._applyFailure({db, job, error, markOrphaned: false})
+      if (updatedJob) await this._releaseConcurrency(db, job.concurrencyKey)
+      return updatedJob
     }))
   }
 
@@ -447,6 +475,7 @@ export default class BackgroundJobsStore {
         })
 
         if (orphanedJob) orphanedCount += 1
+        if (orphanedJob) await this._releaseConcurrency(db, job.concurrencyKey)
       }
 
       return orphanedCount
@@ -462,7 +491,26 @@ export default class BackgroundJobsStore {
 
     await this._withDb(async (db) => {
       await db.query(`DELETE FROM ${db.quoteTable(JOBS_TABLE)}`)
+      if (await db.tableExists(CONCURRENCY_TABLE)) await db.query(`DELETE FROM ${db.quoteTable(CONCURRENCY_TABLE)}`)
     })
+  }
+
+  /**
+   * Cancels a queued or handed-off job and releases any durable concurrency reservation.
+   * @param {string} jobId - Job id.
+   * @returns {Promise<boolean>} - Whether the job was cancelled.
+   */
+  async cancel(jobId) {
+    await this.ensureReady()
+    return await this._withDb(async (db) => await this._transactionResult(db, async () => {
+      const job = await this._getJobRowById(db, jobId)
+      if (!job || (job.status !== "queued" && job.status !== "handed_off")) return false
+      await db.update({tableName: JOBS_TABLE, data: {status: "cancelled"}, conditions: {id: job.id, status: job.status}})
+      const updatedJob = await this._getJobRowById(db, jobId)
+      if (updatedJob?.status !== "cancelled") return false
+      if (job.status === "handed_off") await this._releaseConcurrency(db, job.concurrencyKey)
+      return true
+    }))
   }
 
   /**
@@ -506,11 +554,15 @@ export default class BackgroundJobsStore {
       // row alone, otherwise later callers fail with "no such table".
       if (alreadyApplied && await db.tableExists(JOBS_TABLE)) {
         await this._ensureJobsTableColumns(db)
+        await this._ensureConcurrencyTable(db)
+        await this._reconcileConcurrency(db)
         return
       }
 
       await this._applyMigrations(db)
       await this._ensureJobsTableColumns(db)
+      await this._ensureConcurrencyTable(db)
+      await this._reconcileConcurrency(db)
 
       if (alreadyApplied) return
 
@@ -586,6 +638,8 @@ export default class BackgroundJobsStore {
     table.bigint("orphaned_at_ms", {null: true, index: true})
     table.string("worker_id", {null: true})
     table.text("last_error", {null: true})
+    table.string("concurrency_key", {null: true, index: true})
+    table.integer("max_concurrency", {null: true})
 
     await db.createTable(table)
   }
@@ -643,6 +697,15 @@ export default class BackgroundJobsStore {
     }
 
     await this._backfillExecutionModesOnce(db)
+
+    const concurrencyTable = await db.getTableByNameOrFail(JOBS_TABLE)
+    if (!(await concurrencyTable.getColumnByName("concurrency_key"))) {
+      const tableData = new TableData(JOBS_TABLE)
+      tableData.string("concurrency_key", {null: true, index: true})
+      tableData.integer("max_concurrency", {null: true})
+      for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+      db.clearSchemaCache()
+    }
   }
 
   /**
@@ -866,8 +929,105 @@ export default class BackgroundJobsStore {
       failedAtMs: this._normalizeNumber(row.failed_at_ms),
       orphanedAtMs: this._normalizeNumber(row.orphaned_at_ms),
       workerId: row.worker_id ? String(row.worker_id) : null,
-      lastError: row.last_error ? String(row.last_error) : null
+      lastError: row.last_error ? String(row.last_error) : null,
+      concurrencyKey: row.concurrency_key ? String(row.concurrency_key) : null,
+      maxConcurrency: this._normalizeNumber(row.max_concurrency)
     }
+  }
+
+  /**
+   * Validates concurrency options.
+   * @param {import("./types.js").BackgroundJobOptions | undefined} options - Job options.
+   * @returns {{concurrencyKey: string, maxConcurrency: number} | null} - Normalized configuration.
+   */
+  _normalizeConcurrencyOptions(options) {
+    const key = options?.concurrencyKey
+    const cap = options?.maxConcurrency
+    if (key === undefined && cap === undefined) return null
+    if (typeof key !== "string" || key.length === 0 || !Number.isInteger(cap) || Number(cap) <= 0) {
+      throw new Error("background job concurrencyKey and maxConcurrency must be paired; concurrencyKey must be non-empty and maxConcurrency must be a positive integer")
+    }
+    return {concurrencyKey: key, maxConcurrency: Number(cap)}
+  }
+
+  /**
+   * Ensures the concurrency state table exists.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when ready.
+   */
+  async _ensureConcurrencyTable(db) {
+    if (await db.tableExists(CONCURRENCY_TABLE)) return
+    const table = new TableData(CONCURRENCY_TABLE, {ifNotExists: true})
+    table.string("concurrency_key", {primaryKey: true})
+    table.integer("max_concurrency", {null: false})
+    table.integer("active_count", {null: false})
+    await db.createTable(table)
+  }
+
+  /**
+   * Registers or verifies a stable key configuration.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {object} concurrency - Concurrency configuration.
+   * @param {string} concurrency.concurrencyKey - Concurrency key.
+   * @param {number} concurrency.maxConcurrency - Stable cap.
+   * @returns {Promise<void>} - Resolves when verified.
+   */
+  async _ensureConcurrencyKey(db, {concurrencyKey, maxConcurrency}) {
+    const rows = await db.newQuery().from(CONCURRENCY_TABLE).where({concurrency_key: concurrencyKey}).limit(1).results()
+    if (!rows[0]) {
+      try {
+        await db.insert({tableName: CONCURRENCY_TABLE, data: {active_count: 0, concurrency_key: concurrencyKey, max_concurrency: maxConcurrency}})
+        return
+      } catch (error) {
+        const racedRows = await db.newQuery().from(CONCURRENCY_TABLE).where({concurrency_key: concurrencyKey}).limit(1).results()
+        if (!racedRows[0]) throw error
+        rows[0] = racedRows[0]
+      }
+    }
+    const configured = /** @type {{max_concurrency?: number | string}} */ (rows[0])
+    if (this._normalizeNumber(configured.max_concurrency) !== maxConcurrency) throw new Error(`Conflicting maxConcurrency for background job concurrencyKey: ${concurrencyKey}`)
+  }
+
+  /**
+   * Atomically reserves capacity for a key.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {string} concurrencyKey - Concurrency key.
+   * @returns {Promise<boolean>} - Whether capacity was reserved.
+   */
+  async _reserveConcurrency(db, concurrencyKey) {
+    const table = db.quoteTable(CONCURRENCY_TABLE)
+    const count = db.quoteColumn("active_count")
+    const affectedRows = await db.affectedRows(`UPDATE ${table} SET ${count} = ${count} + 1 WHERE ${db.quoteColumn("concurrency_key")} = ${db.quote(concurrencyKey)} AND ${count} < ${db.quoteColumn("max_concurrency")}`)
+    return affectedRows === 1
+  }
+
+  /**
+   * Releases capacity for a key.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {string | null} concurrencyKey - Concurrency key.
+   * @returns {Promise<void>} - Resolves when released.
+   */
+  async _releaseConcurrency(db, concurrencyKey) {
+    if (!concurrencyKey) return
+    const table = db.quoteTable(CONCURRENCY_TABLE)
+    const count = db.quoteColumn("active_count")
+    await db.query(`UPDATE ${table} SET ${count} = ${count} - 1 WHERE ${db.quoteColumn("concurrency_key")} = ${db.quote(concurrencyKey)} AND ${count} > 0`)
+  }
+
+  /**
+   * Rebuilds durable counts from active handoffs after startup.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when reconciled.
+   */
+  async _reconcileConcurrency(db) {
+    if (!(await db.tableExists(CONCURRENCY_TABLE))) return
+    const concurrencyTable = db.quoteTable(CONCURRENCY_TABLE)
+    const jobsTable = db.quoteTable(JOBS_TABLE)
+    await db.query(
+      `UPDATE ${concurrencyTable} SET ${db.quoteColumn("active_count")} = (` +
+      `SELECT COUNT(*) FROM ${jobsTable} WHERE ${jobsTable}.${db.quoteColumn("status")} = ${db.quote("handed_off")} AND ` +
+      `${jobsTable}.${db.quoteColumn("concurrency_key")} = ${concurrencyTable}.${db.quoteColumn("concurrency_key")})`
+    )
   }
 
   /**
@@ -973,25 +1133,22 @@ export default class BackgroundJobsStore {
   }
 
   /**
-   * Serializes reports for one job so duplicate reports cannot both appear accepted.
+   * Runs a value-returning callback inside the driver's void-typed transaction API.
    * @template T
-   * @param {object} args - Options.
-   * @param {import("../database/drivers/base.js").default} args.db - Database connection.
-   * @param {string} args.jobId - Job id.
-   * @param {() => Promise<T>} callback - Locked callback.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {() => Promise<T>} callback - Transaction callback.
    * @returns {Promise<T>} - Callback result.
    */
-  async _withHandoffLock({db, jobId}, callback) {
-    const lockName = `background-job:${jobId}`
-    const acquired = await db.acquireAdvisoryLock(lockName)
-
-    if (!acquired) throw new Error(`Failed to acquire background job handoff lock: ${jobId}`)
-
-    try {
-      return await callback()
-    } finally {
-      await db.releaseAdvisoryLock(lockName)
-    }
+  async _transactionResult(db, callback) {
+    let completed = false
+    /** @type {T | undefined} */
+    let result
+    await db.transaction(async () => {
+      result = await callback()
+      completed = true
+    })
+    if (!completed) throw new Error("Background jobs transaction callback was not invoked")
+    return /** @type {T} */ (result)
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -706,12 +706,21 @@ export default class BackgroundJobsStore {
       try {
         db.clearSchemaCache()
         const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
-        const tableData = new TableData(JOBS_TABLE)
+        const concurrencyColumnNames = ["concurrency_key", "max_concurrency"]
 
-        if (!(await lockedTable.getColumnByName("concurrency_key"))) tableData.string("concurrency_key", {null: true, index: true})
-        if (!(await lockedTable.getColumnByName("max_concurrency"))) tableData.integer("max_concurrency", {null: true})
+        for (const concurrencyColumnName of concurrencyColumnNames) {
+          if (await lockedTable.getColumnByName(concurrencyColumnName)) continue
 
-        for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+          const tableData = new TableData(JOBS_TABLE)
+          if (concurrencyColumnName == "concurrency_key") {
+            tableData.string("concurrency_key", {null: true, index: true})
+          } else {
+            tableData.integer("max_concurrency", {null: true})
+          }
+
+          for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+        }
+
         db.clearSchemaCache()
       } finally {
         await db.releaseAdvisoryLock(lockName)

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -13,6 +13,8 @@
  * @property {BackgroundJobExecutionMode} [executionMode] - How the job should run. Defaults to `"forked"`.
  * @property {boolean} [forked] - Compatibility alias: `false` maps to `"inline"` and `true` maps to `"forked"`.
  * @property {number} [maxRetries] - Max retries for a failed job before it is marked failed.
+ * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap.
+ * @property {number} [maxConcurrency] - Positive integer cap; must be paired with `concurrencyKey`.
  */
 /**
  * @typedef {object} BackgroundJobPayload
@@ -43,6 +45,8 @@
  * @property {number | null} orphanedAtMs - Orphaned time in ms.
  * @property {string | null} workerId - Worker id handling the job.
  * @property {string | null} lastError - Last failure message.
+ * @property {string | null} concurrencyKey - Durable concurrency key.
+ * @property {number | null} maxConcurrency - Durable per-key cap.
  */
 /**
  * @typedef {object} BackgroundJobFailureEvent

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -1051,6 +1051,22 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Executes a mutation and returns the number of rows changed by that statement.
+   * @param {string} sql - Mutation SQL string.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async affectedRows(sql) {
+    this._assertWritableQuery(sql)
+    await this.beforeQuery(sql, {})
+
+    try {
+      return await this._affectedRowsActual(sql)
+    } finally {
+      await this.afterQuery(sql, {})
+    }
+  }
+
+  /**
    * Runs query actual with logging.
    * @param {object} args - Options object.
    * @param {string} args.originalSql - Original SQL string before process-list comments.
@@ -1306,6 +1322,16 @@ export default class VelociousDatabaseDriversBase {
    */
   _queryActual(sql) { // eslint-disable-line no-unused-vars
     throw new Error(`queryActual not implemented`)
+  }
+
+  /**
+   * Executes a mutation and returns its affected row count.
+   * @abstract
+   * @param {string} sql - Mutation SQL string.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  _affectedRowsActual(sql) { // eslint-disable-line no-unused-vars
+    throw new Error(`affectedRowsActual not implemented`)
   }
 
   /**

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -329,6 +329,19 @@ export default class VelociousDatabaseDriversMssql extends Base{
   }
 
   /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _affectedRowsActual(sql) {
+    const request = this._currentTransaction
+      ? new mssql.Request(this._currentTransaction)
+      : new mssql.Request(this.connection)
+    const result = await request.query(sql)
+    return result.rowsAffected.reduce((total, count) => total + count, 0)
+  }
+
+  /**
    * Runs query to sql.
    * @param {import("../../query/index.js").default} query - Query instance.
    * @returns {string} - SQL string.

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -345,6 +345,24 @@ export default class VelociousDatabaseDriversMysql extends Base{
   }
 
   /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _affectedRowsActual(sql) {
+    if (!this.pool) await this.connect()
+    if (!this.pool) throw new Error("MySQL pool failed to initialize")
+    const pool = this.pool
+
+    return await new Promise((resolve, reject) => {
+      pool.query(sql, (error, result) => {
+        if (error) reject(error)
+        else resolve("affectedRows" in result ? result.affectedRows : 0)
+      })
+    })
+  }
+
+  /**
    * Runs query to sql.
    * @param {import("../../query/index.js").default} query - Query instance.
    * @returns {string} - SQL string.

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -228,6 +228,18 @@ export default class VelociousDatabaseDriversPgsql extends Base{
   }
 
   /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _affectedRowsActual(sql) {
+    if (!this.connection) await this.connect()
+    if (!this.connection) throw new Error("PostgreSQL connection failed to initialize")
+    const response = await this.connection.query(sql)
+    return response.rowCount || 0
+  }
+
+  /**
    * Runs query to sql.
    * @param {import("../../query/index.js").default} query - Query instance.
    * @returns {string} - SQL string.

--- a/src/database/drivers/sqlite/connection-sql-js.js
+++ b/src/database/drivers/sqlite/connection-sql-js.js
@@ -47,6 +47,17 @@ export default class VelociousDatabaseDriversSqliteConnectionSqlJs {
     return result
   }
 
+  /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async affectedRows(sql) {
+    await this.query(sql)
+    const connection = /** @type {import("sql.js").Database & {getRowsModified: () => number}} */ (this.connection)
+    return connection.getRowsModified()
+  }
+
   saveDatabase = async () => {
     const databaseContent = this.connection.export()
 

--- a/src/database/drivers/sqlite/index.js
+++ b/src/database/drivers/sqlite/index.js
@@ -15,7 +15,7 @@ import fileExists from "../../../utils/file-exists.js"
 export default class VelociousDatabaseDriversSqliteNode extends Base {
   /**
    * Connection.
-   * @type {import("sqlite3").Database | undefined} */
+   * @type {import("sqlite").Database | undefined} */
   connection = undefined
 
   /**
@@ -39,11 +39,10 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
     this._advisoryLockDirectory = path.join(databaseDir, `${this.localStorageName()}.velocious-advisory-locks`)
 
     try {
-      // @ts-expect-error
-      this.connection = /** @type {import("sqlite3").Database} */ (await open({
+      this.connection = await open({
         filename: databasePath,
         driver: sqlite3.Database
-      }))
+      })
     } catch (error) {
       if (error instanceof Error) {
         throw new Error(`Couldn't open database ${databasePath} because of ${error.constructor.name}: ${error.message}`, {cause: error})
@@ -77,6 +76,17 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
     if (!this.connection) throw new Error("No connection")
 
     return await query(this.connection, sql)
+  }
+
+  /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _affectedRowsActual(sql) {
+    if (!this.connection) throw new Error("No connection")
+    const result = await this.connection.run(sql)
+    return result.changes || 0
   }
 
   /**

--- a/src/database/drivers/sqlite/index.native.js
+++ b/src/database/drivers/sqlite/index.native.js
@@ -81,4 +81,17 @@ export default class VelociousDatabaseDriversSqliteNative extends Base {
       return query(this.connection, sql)
     })
   }
+
+  /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _affectedRowsActual(sql) {
+    return await this._queryMutex.sync(async () => {
+      if (!this.connection) throw new Error("Not connected yet")
+      const result = await this.connection.runAsync(sql)
+      return result.changes
+    })
+  }
 }

--- a/src/database/drivers/sqlite/index.web.js
+++ b/src/database/drivers/sqlite/index.web.js
@@ -8,7 +8,7 @@ import Base from "./base.js"
 
 /**
  * VelociousDatabaseDriversSqliteWeb class.
- * @typedef {{query: (sql: string) => Promise<Record<string, ?>[]>, close: () => Promise<void>}} SqliteWebConnection
+ * @typedef {{query: (sql: string) => Promise<Record<string, ?>[]>, affectedRows: (sql: string) => Promise<number>, close: () => Promise<void>}} SqliteWebConnection
  */
 
 export default class VelociousDatabaseDriversSqliteWeb extends Base {
@@ -109,5 +109,15 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
     }
 
     return result
+  }
+
+  /**
+   * Executes a mutation with affected-row metadata.
+   * @param {string} sql - Mutation SQL.
+   * @returns {Promise<number>} - Affected row count.
+   */
+  async _affectedRowsActual(sql) {
+    const connection = this.getConnection()
+    return await connection.affectedRows(sql)
   }
 }

--- a/src/database/drivers/sqlite/query.js
+++ b/src/database/drivers/sqlite/query.js
@@ -2,7 +2,7 @@
 
 /**
  * Runs query.
- * @param {import("sqlite3").Database} connection - Connection.
+ * @param {import("sqlite").Database} connection - Connection.
  * @param {string} sql - SQL string.
  * @returns {Promise<Record<string, ?>[]>} - Resolves with string value.
  */
@@ -13,7 +13,6 @@ export default async function query(connection, sql) {
      * @type {Record<string, ?>[]} */
     let result
 
-    // @ts-expect-error
     result = await connection.all(sql)
 
     return result


### PR DESCRIPTION
## Summary
- Adds optional `concurrencyKey` and `maxConcurrency` scheduling options for durable per-key active-job limits.
- Atomically reserves/release capacity through portable conditional updates; no advisory locks, in-memory state, PostgreSQL-specific `RETURNING`, or `ON CONFLICT`.
- Skips saturated keys during dispatch so unrelated queued jobs remain eligible.
- Enforces stable per-key caps and reconciles active counts from handed-off jobs on startup.
- Adds a small cross-driver affected-row primitive required to determine whether a conditional reservation succeeded.

## Lifecycle coverage
- completion, retry, cancellation, disconnect requeue, and orphan recovery release capacity
- legacy schema migration and conflicting-cap validation
- saturation/fairness and the prior competing-reservation race regression

## Validation
- `npx velocious test spec/background-jobs/store-spec.js` — 16 passed (disposable container)
- `npm run lint` (SQLite Peakflow config) — passed
- `npm run typecheck` — passed
- `npm run fallow` — passed
- `git diff --check` — passed
