### PR TITLE
fix(generator): emit TypeScript-compatible JSON JSDoc

### DIFF
--- a/spec/cli/commands/generate/base-models-jsdoc-types-spec.js
+++ b/spec/cli/commands/generate/base-models-jsdoc-types-spec.js
@@ -74,4 +74,11 @@ describe("Base-models JSDoc types", () => {
 
     expect(command.jsDocTypeFromColumn(column, modelClass)).toEqual("number")
   })
+
+  it("maps pgsql json to Record<string, unknown>", async () => {
+    const command = buildCommand()
+    const {column, modelClass} = buildColumnAndModelClass("json")
+
+    expect(command.jsDocTypeFromColumn(column, modelClass)).toEqual("Record<string, unknown>")
+  })
 })

--- a/src/environment-handlers/node/cli/commands/generate/base-models.js
+++ b/src/environment-handlers/node/cli/commands/generate/base-models.js
@@ -24,7 +24,7 @@ const jsDocTypeByColumnType = {
   float: "number",
   int: "number",
   integer: "number",
-  json: "Record<string, ?>",
+  json: "Record<string, unknown>",
   longtext: "string",
   mediumtext: "string",
   numeric: "number",


### PR DESCRIPTION
## Summary
- emit `Record<string, unknown>` for JSON columns instead of Closure-style wildcard syntax rejected by TypeScript 7
- add a generator regression spec

## Validation
- `npm run lint` (Docker, Node 24 Trixie)
- focused BaseModelsCommand JSON contract executed in Docker

The full project test command is currently blocked in the isolated Docker runner: the Node MSSQL driver rejects the configured dummy SA login while `sqlcmd` accepts it against the same disposable server. The generator regression itself is database-independent and was executed directly.