### PR TITLE
background-jobs: per-queue concurrency caps (Sidekiq-style)

### DIFF
--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -223,6 +223,88 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(await store.markHandedOff({jobId: ids[1 - claimedIndex], workerId: "replacement"})).not.toBeNull()
   })
 
+  it("routes queue-configured jobs onto a cluster-wide per-queue concurrency cap", async () => {
+    dummyConfiguration.setBackgroundJobsConfig({queues: {builds: {maxConcurrent: 2}}})
+
+    try {
+      const store = await createClearedStore()
+      const first = await store.enqueue({jobName: "TestJob", args: [1], options: {queue: "builds"}})
+      const second = await store.enqueue({jobName: "TestJob", args: [2], options: {queue: "builds"}})
+      const third = await store.enqueue({jobName: "TestJob", args: [3], options: {queue: "builds"}})
+      const firstRow = await getJobOrFail({jobId: first, store})
+
+      expect(firstRow.queue).toEqual("builds")
+      expect(firstRow.concurrencyKey).toEqual("queue:builds")
+      expect(firstRow.maxConcurrency).toEqual(2)
+
+      const claim1 = await store.markHandedOff({jobId: first, workerId: "w1"})
+      const claim2 = await store.markHandedOff({jobId: second, workerId: "w2"})
+
+      if (!claim1 || !claim2) throw new Error("Expected the first two queued jobs to claim")
+
+      expect(await store.markHandedOff({jobId: third, workerId: "w3"})).toBeNull()
+
+      await store.markCompleted({jobId: first, workerId: "w1", ...claim1})
+
+      expect(await store.markHandedOff({jobId: third, workerId: "w3"})).not.toBeNull()
+    } finally {
+      dummyConfiguration.setBackgroundJobsConfig({queues: {}})
+    }
+  })
+
+  it("lets an explicit concurrencyKey override the queue-derived cap", async () => {
+    dummyConfiguration.setBackgroundJobsConfig({queues: {builds: {maxConcurrent: 5}}})
+
+    try {
+      const store = await createClearedStore()
+      const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {queue: "builds", concurrencyKey: "account:1", maxConcurrency: 1}})
+      const row = await getJobOrFail({jobId, store})
+
+      expect(row.queue).toEqual("builds")
+      expect(row.concurrencyKey).toEqual("account:1")
+      expect(row.maxConcurrency).toEqual(1)
+    } finally {
+      dummyConfiguration.setBackgroundJobsConfig({queues: {}})
+    }
+  })
+
+  it("leaves jobs on unconfigured queues uncapped", async () => {
+    const store = await createClearedStore()
+    const first = await store.enqueue({jobName: "TestJob", args: [1], options: {queue: "adhoc"}})
+    const second = await store.enqueue({jobName: "TestJob", args: [2], options: {queue: "adhoc"}})
+    const firstRow = await getJobOrFail({jobId: first, store})
+
+    expect(firstRow.queue).toEqual("adhoc")
+    expect(firstRow.concurrencyKey).toBeNull()
+    expect(await store.markHandedOff({jobId: first, workerId: "w1"})).not.toBeNull()
+    expect(await store.markHandedOff({jobId: second, workerId: "w2"})).not.toBeNull()
+  })
+
+  it("updates a queue's stored cap when the configured cap changes instead of throwing", async () => {
+    dummyConfiguration.setBackgroundJobsConfig({queues: {builds: {maxConcurrent: 1}}})
+
+    try {
+      const store = await createClearedStore()
+
+      await store.enqueue({jobName: "TestJob", args: [1], options: {queue: "builds"}})
+      dummyConfiguration.setBackgroundJobsConfig({queues: {builds: {maxConcurrent: 3}}})
+      const jobId = await store.enqueue({jobName: "TestJob", args: [2], options: {queue: "builds"}})
+      const row = await getJobOrFail({jobId, store})
+
+      expect(row.maxConcurrency).toEqual(3)
+    } finally {
+      dummyConfiguration.setBackgroundJobsConfig({queues: {}})
+    }
+  })
+
+  it("defaults an unspecified queue to \"default\"", async () => {
+    const store = await createClearedStore()
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false}})
+    const row = await getJobOrFail({jobId, store})
+
+    expect(row.queue).toEqual("default")
+  })
+
   it("releases a concurrency reservation when a competing queued claim loses", async () => {
     let activeCount = 0
     const db = {

--- a/src/background-jobs/job.js
+++ b/src/background-jobs/job.js
@@ -14,11 +14,36 @@ import BackgroundJobsClient from "./client.js"
  */
 export default class VelociousJob {
   /**
+   * Queue this job class runs on. Subclasses set e.g. `static queue = "builds"`
+   * to route onto a queue with its own cluster-wide concurrency cap (configured
+   * via `backgroundJobs.queues`). The `{queue}` enqueue option overrides it.
+   * Left undefined, jobs run on the `"default"` queue.
+   * @type {string | undefined}
+   */
+  static queue = undefined
+
+  /**
    * Runs job name.
    * @returns {string} - Job name.
    */
   static jobName() {
     return this.name
+  }
+
+  /**
+   * Folds this job class's static `queue` into the enqueue options unless the
+   * caller already specified one.
+   * @param {import("./types.js").BackgroundJobOptions | undefined} options - Job options.
+   * @returns {import("./types.js").BackgroundJobOptions} - Options including the resolved queue.
+   */
+  static _withQueue(options) {
+    const merged = options ? {...options} : {}
+
+    if (merged.queue === undefined && typeof this.queue === "string" && this.queue.length > 0) {
+      merged.queue = this.queue
+    }
+
+    return merged
   }
 
   /**
@@ -33,7 +58,7 @@ export default class VelociousJob {
     return await client.enqueue({
       jobName: this.jobName(),
       args: jobArgs,
-      options: jobOptions
+      options: this._withQueue(jobOptions)
     })
   }
 
@@ -50,7 +75,7 @@ export default class VelociousJob {
     return await client.enqueue({
       jobName: this.jobName(),
       args,
-      options
+      options: this._withQueue(options)
     })
   }
 

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -19,6 +19,10 @@ const ORPHANED_AFTER_MS = 2 * 60 * 60 * 1000
  * @type {import("./types.js").BackgroundJobExecutionMode[]} */
 const EXECUTION_MODES = ["inline", "forked", "spawned"]
 const DEFAULT_EXECUTION_MODE = "forked"
+const DEFAULT_QUEUE = "default"
+// Queue-derived durable concurrency keys are namespaced so they can't collide
+// with explicit caller-supplied concurrencyKeys.
+const QUEUE_CONCURRENCY_KEY_PREFIX = "queue:"
 
 /**
  * Columns the dashboard is allowed to sort job listings by, mapped to their
@@ -95,10 +99,17 @@ export default class BackgroundJobsStore {
     const executionMode = this._normalizeExecutionMode(options)
     const maxRetries = this._normalizeMaxRetries(options?.maxRetries)
     const argsJson = JSON.stringify(args || [])
-    const concurrency = this._normalizeConcurrencyOptions(options)
+    const queue = this._normalizeQueue(options)
+    const concurrency = this._resolveConcurrency(options, queue)
 
     await this._withDb(async (db) => {
-      if (concurrency) await this._ensureConcurrencyKey(db, concurrency)
+      if (concurrency) {
+        if (concurrency.queueDerived) {
+          await this._ensureQueueConcurrencyKey(db, concurrency)
+        } else {
+          await this._ensureConcurrencyKey(db, concurrency)
+        }
+      }
       await db.insert({
         tableName: JOBS_TABLE,
         data: {
@@ -107,6 +118,7 @@ export default class BackgroundJobsStore {
           args_json: argsJson,
           forked: executionMode !== "inline",
           execution_mode: executionMode,
+          queue,
           max_retries: maxRetries,
           attempts: 0,
           status: "queued",
@@ -621,6 +633,7 @@ export default class BackgroundJobsStore {
     table.text("args_json", {null: false})
     table.boolean("forked", {null: false})
     table.string("execution_mode", {null: false})
+    table.string("queue", {null: true, index: true})
     table.integer("max_retries", {null: false})
     table.integer("attempts", {null: false})
     table.string("status", {null: false, index: true})
@@ -720,6 +733,43 @@ export default class BackgroundJobsStore {
       }
 
       db.clearSchemaCache()
+    } finally {
+      await db.releaseAdvisoryLock(lockName)
+    }
+
+    await this._ensureQueueColumn(db)
+  }
+
+  /**
+   * Idempotently adds the `queue` column to an existing jobs table. Existing
+   * rows read back as the default queue (see {@link _normalizeJobRow}), so no
+   * data backfill is required.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when ensured.
+   */
+  async _ensureQueueColumn(db) {
+    const table = await db.getTableByNameOrFail(JOBS_TABLE)
+
+    if (await table.getColumnByName("queue")) return
+
+    const lockName = `${MIGRATION_SCOPE}:queue_column`
+    const acquired = await db.acquireAdvisoryLock(lockName)
+
+    if (!acquired) throw new Error("Failed to acquire background jobs queue schema lock")
+
+    try {
+      db.clearSchemaCache()
+      const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
+
+      if (!(await lockedTable.getColumnByName("queue"))) {
+        const tableData = new TableData(JOBS_TABLE)
+
+        tableData.string("queue", {null: true, index: true})
+
+        for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+
+        db.clearSchemaCache()
+      }
     } finally {
       await db.releaseAdvisoryLock(lockName)
     }
@@ -934,6 +984,7 @@ export default class BackgroundJobsStore {
       args: this._parseArgs(row.args_json),
       executionMode,
       forked: executionMode !== "inline",
+      queue: row.queue ? String(row.queue) : DEFAULT_QUEUE,
       status: row.status ? String(row.status) : "queued",
       attempts: this._normalizeNumber(row.attempts),
       maxRetries: this._normalizeNumber(row.max_retries),
@@ -964,6 +1015,89 @@ export default class BackgroundJobsStore {
       throw new Error("background job concurrencyKey and maxConcurrency must be paired; concurrencyKey must be non-empty and maxConcurrency must be a positive integer")
     }
     return {concurrencyKey: key, maxConcurrency: Number(cap)}
+  }
+
+  /**
+   * Normalizes a job's queue name, defaulting to "default".
+   * @param {import("./types.js").BackgroundJobOptions | undefined} options - Job options.
+   * @returns {string} - Queue name.
+   */
+  _normalizeQueue(options) {
+    const queue = options?.queue
+
+    if (typeof queue === "string" && queue.trim().length > 0) return queue.trim()
+
+    return DEFAULT_QUEUE
+  }
+
+  /**
+   * Resolves a job's durable concurrency. An explicit concurrencyKey/maxConcurrency
+   * pair always wins. Otherwise, when the job's queue has a configured cap
+   * (`backgroundJobs.queues[queue].maxConcurrent`), derive a queue-scoped
+   * concurrency key so the queue cap is enforced cluster-wide through the
+   * existing durable concurrency mechanism.
+   * @param {import("./types.js").BackgroundJobOptions | undefined} options - Job options.
+   * @param {string} queue - Normalized queue name.
+   * @returns {{concurrencyKey: string, maxConcurrency: number, queueDerived: boolean} | null} - Resolved concurrency.
+   */
+  _resolveConcurrency(options, queue) {
+    const explicit = this._normalizeConcurrencyOptions(options)
+
+    if (explicit) return {...explicit, queueDerived: false}
+
+    const cap = this._queueMaxConcurrency(queue)
+
+    if (cap === null) return null
+
+    return {concurrencyKey: `${QUEUE_CONCURRENCY_KEY_PREFIX}${queue}`, maxConcurrency: cap, queueDerived: true}
+  }
+
+  /**
+   * Reads the configured max concurrency for a queue from the background-jobs config.
+   * @param {string} queue - Queue name.
+   * @returns {number | null} - Positive integer cap, or null when the queue has no configured cap.
+   */
+  _queueMaxConcurrency(queue) {
+    const queues = this.configuration.getBackgroundJobsConfig().queues
+    const cap = queues?.[queue]?.maxConcurrent
+
+    if (Number.isInteger(cap) && Number(cap) > 0) return Number(cap)
+
+    return null
+  }
+
+  /**
+   * Like {@link _ensureConcurrencyKey}, but for queue-derived keys the configured
+   * queue cap is the source of truth: if it changed, update the stored cap
+   * instead of throwing on conflict (config-driven caps must be tunable).
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {{concurrencyKey: string, maxConcurrency: number}} concurrency - Concurrency configuration.
+   * @returns {Promise<void>} - Resolves when ensured.
+   */
+  async _ensureQueueConcurrencyKey(db, {concurrencyKey, maxConcurrency}) {
+    const rows = await db.newQuery().from(CONCURRENCY_TABLE).where({concurrency_key: concurrencyKey}).limit(1).results()
+
+    if (!rows[0]) {
+      try {
+        await db.insert({tableName: CONCURRENCY_TABLE, data: {active_count: 0, concurrency_key: concurrencyKey, max_concurrency: maxConcurrency}})
+
+        return
+      } catch (error) {
+        const racedRows = await db.newQuery().from(CONCURRENCY_TABLE).where({concurrency_key: concurrencyKey}).limit(1).results()
+
+        if (!racedRows[0]) throw error
+
+        rows[0] = racedRows[0]
+      }
+    }
+
+    const configured = /** @type {{max_concurrency?: number | string}} */ (rows[0])
+
+    if (this._normalizeNumber(configured.max_concurrency) !== maxConcurrency) {
+      const table = db.quoteTable(CONCURRENCY_TABLE)
+
+      await db.query(`UPDATE ${table} SET ${db.quoteColumn("max_concurrency")} = ${Number(maxConcurrency)} WHERE ${db.quoteColumn("concurrency_key")} = ${db.quote(concurrencyKey)}`)
+    }
   }
 
   /**

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -13,7 +13,8 @@
  * @property {BackgroundJobExecutionMode} [executionMode] - How the job should run. Defaults to `"forked"`.
  * @property {boolean} [forked] - Compatibility alias: `false` maps to `"inline"` and `true` maps to `"forked"`.
  * @property {number} [maxRetries] - Max retries for a failed job before it is marked failed.
- * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap.
+ * @property {string} [queue] - Queue name. Defaults to `"default"`. When the queue has a configured cap in `backgroundJobs.queues`, that cap is enforced cluster-wide.
+ * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap. Overrides any queue-derived cap.
  * @property {number} [maxConcurrency] - Positive integer cap; must be paired with `concurrencyKey`.
  */
 /**
@@ -33,6 +34,7 @@
  * @property {Array<?>} args - Serialized job arguments.
  * @property {BackgroundJobExecutionMode} executionMode - How the job should run.
  * @property {boolean} forked - Compatibility flag; true for non-inline execution.
+ * @property {string} queue - Queue name (defaults to `"default"`).
  * @property {string} status - Current job status.
  * @property {number | null} attempts - Failure attempts count.
  * @property {number | null} maxRetries - Max retry attempts.

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -161,7 +161,18 @@
  *   long-running jobs and for using more cores. Default: `4`.
  * @property {number} [maxConcurrentForkedJobs] - How many out-of-process
  *   `"forked"` or `"spawned"` jobs a single `background-jobs-worker` is
- *   allowed to keep in flight. Default: `4`.
+ *   allowed to keep in flight. Default: `4`. This is a per-worker safety cap;
+ *   for workload-shaped limits use per-queue caps (`queues`) instead, which are
+ *   enforced cluster-wide and are immune to duplicate worker processes.
+ * @property {Record<string, {maxConcurrent?: number}>} [queues] - Per-queue
+ *   concurrency caps, Sidekiq-style. A job declares its queue (static `queue` on
+ *   the job class, or the `queue` enqueue option; defaults to `"default"`), and
+ *   `queues[name].maxConcurrent` bounds how many jobs from that queue may be
+ *   in flight across the whole cluster (enforced via durable per-key
+ *   concurrency, so it holds regardless of how many worker processes run).
+ *   Size each queue to its workload: I/O-bound queues (e.g. build runners
+ *   waiting on remote Docker servers) can run far above the core count, while
+ *   CPU-bound queues should stay near it. Default: `{}` (no queue caps).
  * @property {BackgroundJobsDispatchStrategy} [dispatchStrategy] - How the main process
  *   detects new work. Defaults to `"beacon"` (event-driven). Set to `"polling"`
  *   to restore the legacy fixed-interval poll.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1291,8 +1291,9 @@ export default class VelociousConfiguration {
     const pollIntervalMs = typeof configured.pollIntervalMs === "number" && configured.pollIntervalMs >= 1
       ? configured.pollIntervalMs
       : (typeof envPollInterval === "number" && Number.isFinite(envPollInterval) && envPollInterval >= 1 ? envPollInterval : 1000)
+    const queues = configured.queues && typeof configured.queues === "object" ? configured.queues : {}
 
-    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, dispatchStrategy, pollIntervalMs}
+    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, dispatchStrategy, pollIntervalMs, queues}
   }
 
   /**


### PR DESCRIPTION
## What

Adds a **queue** concept to background jobs. A job declares its queue — a static `queue` on the job class (`static queue = "builds"`) or the `queue` enqueue option (default `"default"`) — and `backgroundJobs.queues[name].maxConcurrent` bounds how many jobs from that queue may be in flight **across the whole cluster**.

## Why

A single global `maxConcurrentForkedJobs` can't be right for mixed workloads: build-runner jobs are I/O-bound (they mostly wait on remote Docker servers) so they can safely run ~100 concurrent, while CPU-bound jobs must stay near the core count. Sizing the one cap for either starves or melts the other. Per-queue caps let each queue be sized to its workload.

## How (small + reuses existing enforcement)

Implemented over the existing durable per-key concurrency mechanism rather than a new per-worker protocol:

- An enqueue resolves the job's queue to a namespaced concurrency key (`queue:<name>`) with the configured cap. Enforcement then rides the **existing** `nextAvailableJob()` concurrency filter + `markHandedOff()` reservation — **no `main.js`/`worker.js` changes**.
- Because the cap is durable and cluster-wide, it holds regardless of how many worker processes run — unlike the per-worker `maxConcurrentForkedJobs`, it's immune to duplicate/stale workers.
- Queue caps are config-driven and tunable: a changed cap **updates** the stored value instead of throwing (config is the source of truth for queue caps; explicit caller `concurrencyKey`s still throw on conflict).
- Adds a nullable, idempotently-migrated `queue` column (fresh-table + additive alter, mirroring `concurrency_key`) for visibility; existing rows read back as `"default"`, so no data backfill.

## Files
- `src/background-jobs/store.js` — queue normalization, queue→concurrency resolution, `_ensureQueueConcurrencyKey` (upsert), `queue` column migration, row normalization.
- `src/background-jobs/job.js` — static `queue` + threading into enqueue options.
- `src/background-jobs/types.js`, `src/configuration-types.js`, `src/configuration.js` — `queue` option/row + `queues` config (defaulted to `{}`).

## Tests
Store specs cover: queue routing enforces a cluster-wide cap, explicit `concurrencyKey` overrides the queue cap, unconfigured queues stay uncapped, cap changes update instead of throwing, and the default queue. `npm run lint` (eslint + tsc + fallow) and the background-jobs store + end-to-end specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)