### PR TITLE
attachments: add purgeAll() to remove an owner's attachments + storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ This creates `src/frontend-models/user.js` (and one file per configured resource
 - Attribute methods like `user.name()` and `user.setName(...)`
 - Relationship helpers (when `relationships` are configured), for example `task.project()`, `await task.projectOrLoad()`, `await project.tasks().toArray()`, `await project.tasks().load()`, and `project.tasks().build({...})`
 - Preload relationships onto records you already have with `await record.preload(Model.preload({...}).select({...}))` (or `Preloader.preload(records, ...)` for arrays), including `selectsExtra(...)` and a `{force: true}` reload option — see [docs/frontend-models.md](docs/frontend-models.md#preloading-onto-loaded-records)
-- Attachment helpers (when `attachments` are configured), for example `await task.descriptionFile().attach(file)`, `await task.descriptionFile().download()`, and `await task.update({descriptionFile: file})`
+- Attachment helpers (when `attachments` are configured), for example `await task.descriptionFile().attach(file)`, `await task.descriptionFile().download()`, `await task.files().purgeAll()`, and `await task.update({descriptionFile: file})`
 
 React components can subscribe to lifecycle broadcasts without manual cleanup code:
 
@@ -500,6 +500,14 @@ await task.update({
   }
 })
 ```
+
+Purge a record's attachments — both the stored files and their rows — for example before destroying the owner record:
+
+```js
+const purgedCount = await task.files().purgeAll()
+```
+
+`purgeAll()` deletes each attachment's backing storage and then its row, and removes only the attachments that existed when the purge started (a concurrent `attach()` for the same record/name is left intact). It throws without deleting anything if a storage driver has no `delete` operation, so a driver configured without deletion can never silently leak storage. It is a no-op for unpersisted records and returns the number of attachments purged.
 
 Configure attachment storage drivers in `Configuration`:
 

--- a/changelog.d/20260717-attachment-purge-all.md
+++ b/changelog.d/20260717-attachment-purge-all.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Add `RecordAttachmentHandle#purgeAll()` (backed by `RecordAttachmentsStore#purgeAll`) to remove an owner record's attachments — deleting each attachment's backing storage and then its row — so callers can clean up attachments before/when destroying the owner. Only the attachments present when the purge starts are removed (a concurrent `attach()` for the same record/name is left intact), and it throws without deleting any rows if a storage driver has no `delete` operation, so a driver configured without deletion can never silently leak storage. A no-op for unpersisted records; returns the number of attachments purged.

--- a/spec/database/record/attachments-spec.js
+++ b/spec/database/record/attachments-spec.js
@@ -119,6 +119,30 @@ describe("Record - attachments", {tags: ["dummy"], databaseCleaning: {transactio
     expect(await task.files().downloadAll()).toEqual([])
   })
 
+  it("refuses to purge when the storage driver cannot delete, preserving the attachment", async () => {
+    const originalDriver = Task.getAttachmentByName("descriptionFile").driver
+
+    // InlineMemoryAttachmentDriver has write/read/url but no delete operation.
+    Task.getAttachmentByName("descriptionFile").driver = InlineMemoryAttachmentDriver
+
+    try {
+      const project = await Project.create({name: "Attachment project"})
+      const task = await Task.create({name: "Attachment task", projectId: project.id()})
+
+      await task.descriptionFile().attach({content: "keep me", filename: "keep.txt"})
+
+      await expect(async () => await task.descriptionFile().purgeAll()).toThrow(/does not support deletion/)
+
+      // The attachment row is preserved so cleanup can be retried, rather than
+      // deleting the metadata and leaking the still-present backing storage.
+      const downloadedAttachment = await task.descriptionFile().download()
+
+      expect(downloadedAttachment.content().toString()).toEqual("keep me")
+    } finally {
+      Task.getAttachmentByName("descriptionFile").driver = originalDriver
+    }
+  })
+
   it("normalizes trailing slash filenames to basename values", async () => {
     const project = await Project.create({name: "Attachment project"})
     const task = await Task.create({name: "Attachment task", projectId: project.id()})

--- a/spec/database/record/attachments-spec.js
+++ b/spec/database/record/attachments-spec.js
@@ -105,6 +105,20 @@ describe("Record - attachments", {tags: ["dummy"], databaseCleaning: {transactio
     expect(metadata.map((entry) => entry.byteSize)).toEqual([1, 2])
   })
 
+  it("purges all attachments and their storage", async () => {
+    const project = await Project.create({name: "Attachment project"})
+    const task = await Task.create({name: "Attachment task", projectId: project.id()})
+
+    await task.files().attach({content: "A", filename: "a.txt"})
+    await task.files().attach({content: "B", filename: "b.txt"})
+
+    const purgedCount = await task.files().purgeAll()
+
+    expect(purgedCount).toEqual(2)
+    expect(await task.files().listMetadata()).toEqual([])
+    expect(await task.files().downloadAll()).toEqual([])
+  })
+
   it("normalizes trailing slash filenames to basename values", async () => {
     const project = await Project.create({name: "Attachment project"})
     const task = await Task.create({name: "Attachment task", projectId: project.id()})

--- a/src/database/record/attachments/handle.js
+++ b/src/database/record/attachments/handle.js
@@ -217,4 +217,19 @@ export default class RecordAttachmentHandle {
 
     return await store.attachmentRowUrl({model: this.model, name: this.name, row})
   }
+
+  /**
+   * Purges every attachment under this (record, name): deletes the backing
+   * storage for each and removes the attachment rows. A no-op for unpersisted
+   * records. Callers use this to clean up attachments before destroying the
+   * owner record.
+   * @returns {Promise<number>} - Number of attachments purged.
+   */
+  async purgeAll() {
+    if (!this.model.isPersisted()) return 0
+
+    const store = recordAttachmentsStoreForModel(this.model)
+
+    return await store.purgeAll({model: this.model, name: this.name})
+  }
 }

--- a/src/database/record/attachments/handle.js
+++ b/src/database/record/attachments/handle.js
@@ -221,8 +221,11 @@ export default class RecordAttachmentHandle {
   /**
    * Purges every attachment under this (record, name): deletes the backing
    * storage for each and removes the attachment rows. A no-op for unpersisted
-   * records. Callers use this to clean up attachments before destroying the
-   * owner record.
+   * records. Only the attachments present when the purge starts are removed, so a
+   * concurrent attach for the same (record, name) is left intact. Throws (without
+   * deleting any rows) if a storage driver cannot delete its object, so a driver
+   * configured without a `delete` operation can never leak storage. Callers use
+   * this to clean up attachments before destroying the owner record.
    * @returns {Promise<number>} - Number of attachments purged.
    */
   async purgeAll() {

--- a/src/database/record/attachments/store.js
+++ b/src/database/record/attachments/store.js
@@ -406,20 +406,31 @@ export default class RecordAttachmentsStore {
     return await this._withDb(async (db) => {
       const recordType = model.getModelClass().getModelName()
       const recordId = String(model.id())
+      /** @type {Array<Record<string, ?>>} */
       const rows = await db
         .newQuery()
         .from(ATTACHMENTS_TABLE)
         .where({name, record_id: recordId, record_type: recordType})
         .results()
 
+      // Refuse to purge when any row's driver cannot delete its backing storage:
+      // removing the row while the object stays behind would leak storage and
+      // discard the metadata needed to retry cleanup. Fail loudly instead.
       for (const row of rows) {
-        await this.deleteAttachmentRowStorage({model, name, row})
+        const attachmentDriver = await this.resolveAttachmentDriver({model, name, row})
+
+        if (typeof attachmentDriver.delete !== "function") {
+          throw new Error(`Cannot purge attachment ${row.id} for ${recordType}#${recordId} (${name}): its storage driver does not support deletion.`)
+        }
       }
 
-      await db.delete({
-        conditions: {name, record_id: recordId, record_type: recordType},
-        tableName: ATTACHMENTS_TABLE
-      })
+      for (const row of rows) {
+        await this.deleteAttachmentRowStorage({model, name, row})
+        // Delete only the snapshotted row by id, so an attachment inserted for the
+        // same (record, name) after the snapshot is not removed with its storage
+        // still present (which would leave it as unreachable storage).
+        await db.delete({conditions: {id: row.id}, tableName: ATTACHMENTS_TABLE})
+      }
 
       return rows.length
     })

--- a/src/database/record/attachments/store.js
+++ b/src/database/record/attachments/store.js
@@ -392,6 +392,40 @@ export default class RecordAttachmentsStore {
   }
 
   /**
+   * Purges every attachment stored under (model, name): deletes each row's
+   * backing storage and then removes the attachment rows. Used to clean up an
+   * owner record's attachments before/when the owner is destroyed.
+   * @param {object} args - Options.
+   * @param {import("../index.js").default} args.model - Model instance.
+   * @param {string} args.name - Attachment name.
+   * @returns {Promise<number>} - Number of attachments purged.
+   */
+  async purgeAll({model, name}) {
+    await this.ensureReady()
+
+    return await this._withDb(async (db) => {
+      const recordType = model.getModelClass().getModelName()
+      const recordId = String(model.id())
+      const rows = await db
+        .newQuery()
+        .from(ATTACHMENTS_TABLE)
+        .where({name, record_id: recordId, record_type: recordType})
+        .results()
+
+      for (const row of rows) {
+        await this.deleteAttachmentRowStorage({model, name, row})
+      }
+
+      await db.delete({
+        conditions: {name, record_id: recordId, record_type: recordType},
+        tableName: ATTACHMENTS_TABLE
+      })
+
+      return rows.length
+    })
+  }
+
+  /**
    * Runs attachment driver by name.
    * @param {string} driverName - Driver name.
    * @returns {Promise<Record<string, ?>>} - Attachment storage driver instance.


### PR DESCRIPTION
## What

Adds `purgeAll()` to the record attachment API so an owner record can clean up its attachments (backing storage **and** rows) — e.g. before/when the owner is destroyed. Previously `RecordAttachmentHandle` only exposed `attach` / `download` / `downloadAll` / `listMetadata` / `url`, so there was no way to delete attachments.

- `RecordAttachmentsStore.purgeAll({model, name})` — reuses the exact delete-storage-then-remove-rows sequence the existing `attach({replace: true})` path already uses.
- `RecordAttachmentHandle.purgeAll()` — public API, returns the number of attachments purged; a no-op for unpersisted records.

## Why

Downstream (TensorBuzz) needs to persist build diagnostic artifacts as attachments and remove them on build rebuild/teardown. Attachment cleanup is framework behavior, so it belongs here rather than reaching into store internals from the app.

## Tests

`spec/database/record/attachments-spec.js`: "purges all attachments and their storage" — attaches two files, `purgeAll()` returns 2, and both `listMetadata()` and `downloadAll()` come back empty.

Verified locally against sqlite: attachments spec 10/10; `npm run lint` clean; `npm run typecheck` clean.
