### PR TITLE
background-jobs: reclaim null-handoff orphans + prune terminal-row retention

### DIFF
--- a/changelog.d/20260717000000-background-jobs-null-handoff-reclaim-and-retention.md
+++ b/changelog.d/20260717000000-background-jobs-null-handoff-reclaim-and-retention.md
@@ -1,0 +1,4 @@
+# Changelog
+
+- Fix background-job orphan recovery so it reclaims handed-off rows whose `handoff_id` is null (for example rows handed off by an older velocious before handoff-id fencing existed); the sweep previously fenced its update on `handoff_id = NULL`, which matches nothing, leaving such rows stranded in `handed_off` forever. Reclamation now fences on the selected handoff's `handed_off_at_ms`, which is null-safe and still race-safe against a job that is re-handed-off between selection and update.
+- Add background-job retention: the main process periodically prunes terminal rows (`completed` older than `retention.completedTtlMs`, default 7 days; `failed`/`orphaned` older than `retention.failedTtlMs`, default 30 days) in id-batched deletes so the jobs table does not grow unbounded. Configurable under `backgroundJobs.retention` (`completedTtlMs`, `failedTtlMs`, `batchSize`, `sweepIntervalMs`).

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -535,6 +535,61 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(job.orphanedAtMs).toBeGreaterThan(0)
   })
 
+  it("fences orphan reclamation to the selected handoff timestamp so a re-handed-off lease is not clobbered", async () => {
+    // A handed-off row the sweep selected at an old cutoff-era timestamp.
+    const rawRow = {
+      id: "stranded-1",
+      job_name: "TestJob",
+      args_json: "[]",
+      execution_mode: "forked",
+      forked: true,
+      max_retries: 10,
+      attempts: 0,
+      status: "handed_off",
+      scheduled_at_ms: 1,
+      created_at_ms: 1,
+      handed_off_at_ms: 1000,
+      handoff_id: null,
+      worker_id: "dead-worker",
+      completed_at_ms: null,
+      failed_at_ms: null,
+      orphaned_at_ms: null,
+      last_error: null,
+      concurrency_key: null,
+      max_concurrency: null,
+      queue: "default"
+    }
+    let capturedConditions = null
+    let releaseCalls = 0
+    const db = {
+      newQuery: () => ({from: () => ({where: () => ({where: () => ({results: async () => [rawRow]})})})}),
+      updateSql: (/** @type {{conditions: Record<string, ?>}} */ args) => {
+        capturedConditions = args.conditions
+
+        return "UPDATE background_jobs SET status = 'orphaned' WHERE fenced"
+      },
+      // Simulate the row having been re-handed-off after the SELECT: the stale
+      // cutoff-era timestamp fence now matches no rows.
+      affectedRows: async () => 0,
+      query: async (/** @type {string} */ sql) => {
+        if (sql.includes("active_count - 1")) releaseCalls += 1
+
+        return []
+      },
+      quote: (/** @type {?} */ value) => (value === null ? "NULL" : `'${value}'`),
+      quoteColumn: (/** @type {string} */ value) => value,
+      quoteTable: (/** @type {string} */ value) => value
+    }
+    const scriptedDb = /** @type {import("../../src/database/drivers/base.js").default} */ (db)
+    const store = new ScriptedBackgroundJobsStore({db: scriptedDb, job: /** @type {?} */ (rawRow)})
+
+    const count = await store.markOrphanedJobs({orphanedAfterMs: 0})
+
+    expect(count).toEqual(0)
+    expect(capturedConditions).toEqual({id: "stranded-1", status: "handed_off", handed_off_at_ms: 1000})
+    expect(releaseCalls).toEqual(0)
+  })
+
   it("prunes completed rows past the retention window and keeps recent and non-terminal rows", async () => {
     const store = await createClearedStore()
 

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -513,6 +513,28 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(job.orphanedAtMs).toBeGreaterThan(0)
   })
 
+  it("reclaims handed-off jobs whose handoff_id is null (older-velocious legacy rows)", async () => {
+    const store = await createClearedStore()
+
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false, maxRetries: 1}})
+    await store.markHandedOff({jobId, workerId: "worker-1"})
+
+    // Simulate a row handed off by an older velocious that never populated
+    // handoff_id. The old orphan sweep matched `{handoff_id: null}`, which
+    // renders as `handoff_id = NULL` and strands such rows forever.
+    await store._withDb(async (db) => {
+      await db.query(`UPDATE background_jobs SET handoff_id = NULL WHERE id = ${db.quote(jobId)}`)
+    })
+
+    const orphanedCount = await store.markOrphanedJobs({orphanedAfterMs: 0})
+    const job = await getJobOrFail({jobId, store})
+
+    expect(orphanedCount).toEqual(1)
+    expect(job.status).toEqual("queued")
+    expect(job.attempts).toEqual(1)
+    expect(job.orphanedAtMs).toBeGreaterThan(0)
+  })
+
   it("returns the soonest future-scheduled queued job from nextScheduledJob", async () => {
     const store = await createClearedStore()
 

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -535,6 +535,58 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(job.orphanedAtMs).toBeGreaterThan(0)
   })
 
+  it("prunes completed rows past the retention window and keeps recent and non-terminal rows", async () => {
+    const store = await createClearedStore()
+
+    const oldCompletedId = await store.enqueue({jobName: "TestJob", args: ["old"], options: {forked: false}})
+    const oldHandoff = await store.markHandedOff({jobId: oldCompletedId, workerId: "w"})
+    if (!oldHandoff) throw new Error("Expected the old job to be handed off")
+    await store.markCompleted({jobId: oldCompletedId, workerId: "w", ...oldHandoff})
+
+    const recentCompletedId = await store.enqueue({jobName: "TestJob", args: ["recent"], options: {forked: false}})
+    const recentHandoff = await store.markHandedOff({jobId: recentCompletedId, workerId: "w"})
+    if (!recentHandoff) throw new Error("Expected the recent job to be handed off")
+    await store.markCompleted({jobId: recentCompletedId, workerId: "w", ...recentHandoff})
+
+    const queuedId = await store.enqueue({jobName: "TestJob", args: ["queued"], options: {forked: false}})
+
+    // Age the old row's completion 10 days into the past.
+    await store._withDb(async (db) => {
+      await db.query(`UPDATE background_jobs SET completed_at_ms = ${db.quote(Date.now() - 10 * 24 * 60 * 60 * 1000)} WHERE id = ${db.quote(oldCompletedId)}`)
+    })
+
+    const deleted = await store.pruneTerminalJobs({completedTtlMs: 7 * 24 * 60 * 60 * 1000, batchSize: 100})
+
+    expect(deleted).toEqual(1)
+    expect(await store.getJob(oldCompletedId)).toEqual(null)
+    expect((await getJobOrFail({jobId: recentCompletedId, store})).status).toEqual("completed")
+    expect((await getJobOrFail({jobId: queuedId, store})).status).toEqual("queued")
+  })
+
+  it("prunes failed and orphaned rows past the failed retention window", async () => {
+    const store = await createClearedStore()
+
+    const orphaned = await createOrphanedJob({maxRetries: 0, store})
+
+    const failedId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false, maxRetries: 0}})
+    const failedHandoff = await store.markHandedOff({jobId: failedId, workerId: "w"})
+    if (!failedHandoff) throw new Error("Expected the failing job to be handed off")
+    await store.markFailed({jobId: failedId, error: "boom", workerId: "w", ...failedHandoff})
+
+    // Age both terminal timestamps 60 days into the past.
+    await store._withDb(async (db) => {
+      const past = db.quote(Date.now() - 60 * 24 * 60 * 60 * 1000)
+      await db.query(`UPDATE background_jobs SET orphaned_at_ms = ${past} WHERE id = ${db.quote(orphaned.id)}`)
+      await db.query(`UPDATE background_jobs SET failed_at_ms = ${past} WHERE id = ${db.quote(failedId)}`)
+    })
+
+    const deleted = await store.pruneTerminalJobs({failedTtlMs: 30 * 24 * 60 * 60 * 1000, batchSize: 100})
+
+    expect(deleted).toEqual(2)
+    expect(await store.getJob(orphaned.id)).toEqual(null)
+    expect(await store.getJob(failedId)).toEqual(null)
+  })
+
   it("returns the soonest future-scheduled queued job from nextScheduledJob", async () => {
     const store = await createClearedStore()
 

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -54,6 +54,7 @@ export default class BackgroundJobsMain {
     this.port = typeof port === "number" ? port : config.port
     this.dispatchStrategy = config.dispatchStrategy
     this.pollIntervalMs = config.pollIntervalMs
+    this.retention = config.retention
     this.store = new BackgroundJobsStore({configuration, databaseIdentifier: config.databaseIdentifier})
     this.logger = new Logger(this)
     /**
@@ -88,6 +89,10 @@ export default class BackgroundJobsMain {
      * Narrows the runtime value to the documented type.
      * @type {ReturnType<typeof setTimeout> | undefined} */
     this._orphanTimer = undefined
+    /**
+     * Narrows the runtime value to the documented type.
+     * @type {ReturnType<typeof setTimeout> | undefined} */
+    this._retentionTimer = undefined
     /**
      * Narrows the runtime value to the documented type.
      * @type {BackgroundJobsScheduler | undefined} */
@@ -138,6 +143,10 @@ export default class BackgroundJobsMain {
       this._orphanTimer = setInterval(() => {
         void this._sweepOrphans()
       }, 60000)
+
+      this._retentionTimer = setInterval(() => {
+        void this._sweepRetention()
+      }, this.retention.sweepIntervalMs)
 
       this.scheduler = new BackgroundJobsScheduler({
         configuration: this.configuration,
@@ -197,10 +206,12 @@ export default class BackgroundJobsMain {
     if (this._scheduledTimer) clearTimeout(this._scheduledTimer)
     if (this._errorRetryTimer) clearTimeout(this._errorRetryTimer)
     if (this._orphanTimer) clearInterval(this._orphanTimer)
+    if (this._retentionTimer) clearInterval(this._retentionTimer)
     this._pollTimer = undefined
     this._scheduledTimer = undefined
     this._errorRetryTimer = undefined
     this._orphanTimer = undefined
+    this._retentionTimer = undefined
   }
 
   /**
@@ -1083,6 +1094,26 @@ export default class BackgroundJobsMain {
       }
     } catch (error) {
       this.logger.error(() => ["Failed to mark orphaned jobs:", error])
+    }
+  }
+
+  /**
+   * Deletes terminal job rows past their retention window so the jobs table
+   * does not grow unbounded. Runs on its own interval; failures are logged and
+   * retried on the next tick.
+   * @returns {Promise<void>} - Resolves after one retention sweep.
+   */
+  async _sweepRetention() {
+    try {
+      const deleted = await this.store.pruneTerminalJobs({
+        completedTtlMs: this.retention.completedTtlMs,
+        failedTtlMs: this.retention.failedTtlMs,
+        batchSize: this.retention.batchSize
+      })
+
+      if (deleted > 0) this.logger.warn(() => ["Pruned terminal background jobs", deleted])
+    } catch (error) {
+      this.logger.error(() => ["Failed to prune terminal jobs:", error])
     }
   }
 }

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -476,11 +476,18 @@ export default class BackgroundJobsStore {
       for (const row of rows) {
         const job = this._normalizeJobRow(row)
 
+        // Reclaim by id/status, not by handoff-id lease: this is a time-based
+        // sweep of rows already read as handed-off past the cutoff, and some
+        // rows have a null `handoff_id` (handed off by an older velocious
+        // before handoff-id fencing). Matching `{handoff_id: null}` renders as
+        // `handoff_id = NULL` in SQL, which matches nothing, so those rows
+        // would be stranded in `handed_off` forever.
         const orphanedJob = await this._applyFailure({
           db,
           job,
           error: "Job orphaned after timeout",
-          markOrphaned: true
+          markOrphaned: true,
+          conditions: {id: job.id, status: "handed_off"}
         })
 
         if (orphanedJob) orphanedCount += 1
@@ -869,9 +876,10 @@ export default class BackgroundJobsStore {
    * @param {import("./types.js").BackgroundJobRow} args.job - Job row.
    * @param {?} args.error - Error.
    * @param {boolean} args.markOrphaned - Whether marking orphaned.
+   * @param {Record<string, ?>} [args.conditions] - Update fencing conditions. Defaults to the active-handoff lease match; the time-based orphan sweep overrides this with an id/status match so it can reclaim rows whose `handoff_id` is null (e.g. handed off by an older velocious before handoff-id fencing existed).
    * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Updated job row when the lease transition won.
    */
-  async _applyFailure({db, job, error, markOrphaned}) {
+  async _applyFailure({db, job, error, markOrphaned, conditions}) {
     const now = Date.now()
     const nextAttempt = (job.attempts || 0) + 1
     const maxRetries = this._normalizeMaxRetries(job.maxRetries)
@@ -890,7 +898,7 @@ export default class BackgroundJobsStore {
     const affectedRows = await this._updateAffectedRows(db, {
       tableName: JOBS_TABLE,
       data: update,
-      conditions: this._activeHandoffConditions(job)
+      conditions: conditions ?? this._activeHandoffConditions(job)
     })
 
     if (affectedRows !== 1) return null

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -498,6 +498,78 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Deletes terminal job rows past their retention window so the jobs table
+   * does not grow unbounded (completed rows in particular accumulate forever
+   * otherwise). Batched by id — SELECT a page of ids, then
+   * `DELETE ... WHERE id IN (...)` — rather than `DELETE ... LIMIT`, which not
+   * every driver supports; each batch runs on its own connection so the sweep
+   * yields between batches instead of holding one long transaction.
+   * @param {object} [args] - Options.
+   * @param {number | null} [args.completedTtlMs] - Delete `completed` jobs whose `completed_at_ms` is older than this many ms. Falsy or `<= 0` disables completed pruning.
+   * @param {number | null} [args.failedTtlMs] - Delete terminal `failed`/`orphaned` jobs older than this many ms (by `failed_at_ms`/`orphaned_at_ms`). Falsy or `<= 0` disables.
+   * @param {number} [args.batchSize] - Max rows deleted per batch. Default `1000`.
+   * @returns {Promise<number>} - Total rows deleted.
+   */
+  async pruneTerminalJobs({completedTtlMs = null, failedTtlMs = null, batchSize = 1000} = {}) {
+    await this.ensureReady()
+
+    const now = Date.now()
+    const size = batchSize > 0 ? batchSize : 1000
+    let deleted = 0
+
+    if (completedTtlMs && completedTtlMs > 0) {
+      deleted += await this._pruneStatusBatches({status: "completed", column: "completed_at_ms", cutoff: now - completedTtlMs, batchSize: size})
+    }
+
+    if (failedTtlMs && failedTtlMs > 0) {
+      deleted += await this._pruneStatusBatches({status: "failed", column: "failed_at_ms", cutoff: now - failedTtlMs, batchSize: size})
+      deleted += await this._pruneStatusBatches({status: "orphaned", column: "orphaned_at_ms", cutoff: now - failedTtlMs, batchSize: size})
+    }
+
+    return deleted
+  }
+
+  /**
+   * Deletes rows of one terminal status older than a cutoff, batch by batch,
+   * until a page returns fewer than `batchSize` rows.
+   * @param {object} args - Options.
+   * @param {string} args.status - Terminal status to prune.
+   * @param {string} args.column - Timestamp column compared against the cutoff.
+   * @param {number} args.cutoff - Delete rows whose column value is `<= cutoff`.
+   * @param {number} args.batchSize - Max rows per batch.
+   * @returns {Promise<number>} - Rows deleted for this status.
+   */
+  async _pruneStatusBatches({status, column, cutoff, batchSize}) {
+    let deleted = 0
+
+    for (;;) {
+      const removed = await this._withDb(async (db) => {
+        const rows = await db
+          .newQuery()
+          .from(JOBS_TABLE)
+          .select("id")
+          .where({status})
+          .where(`${db.quoteColumn(column)} <= ${db.quote(cutoff)}`)
+          .limit(batchSize)
+          .results()
+
+        if (rows.length === 0) return 0
+
+        const ids = rows.map((/** @type {Record<string, ?>} */ row) => db.quote(String(row.id))).join(", ")
+
+        await db.query(`DELETE FROM ${db.quoteTable(JOBS_TABLE)} WHERE ${db.quoteColumn("id")} IN (${ids})`)
+
+        return rows.length
+      })
+
+      deleted += removed
+      if (removed < batchSize) break
+    }
+
+    return deleted
+  }
+
+  /**
    * Runs clear all.
    * @returns {Promise<void>} - Resolves when cleared.
    */

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -476,18 +476,25 @@ export default class BackgroundJobsStore {
       for (const row of rows) {
         const job = this._normalizeJobRow(row)
 
-        // Reclaim by id/status, not by handoff-id lease: this is a time-based
-        // sweep of rows already read as handed-off past the cutoff, and some
-        // rows have a null `handoff_id` (handed off by an older velocious
-        // before handoff-id fencing). Matching `{handoff_id: null}` renders as
-        // `handoff_id = NULL` in SQL, which matches nothing, so those rows
-        // would be stranded in `handed_off` forever.
+        // Fence the reclaim on the exact handoff this sweep selected, using its
+        // `handed_off_at_ms` rather than its `handoff_id`. Two reasons:
+        //   1. Null-safe. Some rows have a null `handoff_id` (handed off by an
+        //      older velocious before handoff-id fencing). `{handoff_id: null}`
+        //      renders as `handoff_id = NULL`, which matches nothing, so those
+        //      rows would be stranded in `handed_off` forever.
+        //   2. Race-safe. If the row is returned to the queue and re-handed-off
+        //      between the SELECT above and this update, it gets a fresh
+        //      `handed_off_at_ms` (always "now"), so this stale cutoff-era
+        //      timestamp no longer matches and we won't fail/orphan — or
+        //      wrongly release the concurrency reservation of — that new lease.
+        // `handed_off_at_ms` is always set on a handed-off row (and the SELECT
+        // required it `<= cutoff`), so it is a reliable null-safe lease pin.
         const orphanedJob = await this._applyFailure({
           db,
           job,
           error: "Job orphaned after timeout",
           markOrphaned: true,
-          conditions: {id: job.id, status: "handed_off"}
+          conditions: {id: job.id, status: "handed_off", handed_off_at_ms: job.handedOffAtMs}
         })
 
         if (orphanedJob) orphanedCount += 1

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -178,6 +178,24 @@
  *   to restore the legacy fixed-interval poll.
  * @property {number} [pollIntervalMs] - Poll interval in milliseconds. Only used
  *   when `dispatchStrategy === "polling"`. Default: `1000`.
+ * @property {BackgroundJobsRetentionConfiguration} [retention] - Retention/pruning
+ *   of terminal job rows. Without pruning the jobs table grows unbounded
+ *   (completed rows accumulate forever), which bloats storage and indexes and
+ *   eventually slows dispatch. The main process sweeps terminal rows past their
+ *   window on an interval.
+ */
+
+/**
+ * @typedef {object} BackgroundJobsRetentionConfiguration
+ * @property {number | null} [completedTtlMs] - Delete `completed` jobs whose
+ *   `completed_at_ms` is older than this many ms. `null` or `<= 0` disables
+ *   completed pruning. Default: `604800000` (7 days).
+ * @property {number | null} [failedTtlMs] - Delete terminal `failed`/`orphaned`
+ *   jobs older than this many ms. `null` or `<= 0` disables (keeps them for
+ *   debugging). Default: `2592000000` (30 days).
+ * @property {number} [batchSize] - Rows deleted per batch. Default: `1000`.
+ * @property {number} [sweepIntervalMs] - How often the main process runs the
+ *   retention sweep. Default: `3600000` (1 hour).
  */
 
 /**

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1292,8 +1292,23 @@ export default class VelociousConfiguration {
       ? configured.pollIntervalMs
       : (typeof envPollInterval === "number" && Number.isFinite(envPollInterval) && envPollInterval >= 1 ? envPollInterval : 1000)
     const queues = configured.queues && typeof configured.queues === "object" ? configured.queues : {}
+    const configuredRetention = configured.retention && typeof configured.retention === "object" ? configured.retention : {}
+    const retention = {
+      completedTtlMs: typeof configuredRetention.completedTtlMs === "number" || configuredRetention.completedTtlMs === null
+        ? configuredRetention.completedTtlMs
+        : 7 * 24 * 60 * 60 * 1000,
+      failedTtlMs: typeof configuredRetention.failedTtlMs === "number" || configuredRetention.failedTtlMs === null
+        ? configuredRetention.failedTtlMs
+        : 30 * 24 * 60 * 60 * 1000,
+      batchSize: typeof configuredRetention.batchSize === "number" && configuredRetention.batchSize > 0
+        ? configuredRetention.batchSize
+        : 1000,
+      sweepIntervalMs: typeof configuredRetention.sweepIntervalMs === "number" && configuredRetention.sweepIntervalMs > 0
+        ? configuredRetention.sweepIntervalMs
+        : 60 * 60 * 1000
+    }
 
-    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, dispatchStrategy, pollIntervalMs, queues}
+    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, dispatchStrategy, pollIntervalMs, queues, retention}
   }
 
   /**


### PR DESCRIPTION
Two related background-jobs durability/scaling fixes surfaced by a production investigation.

## 1. Reclaim handed-off jobs with a null `handoff_id` (bug fix)

The orphan sweep (`markOrphanedJobs`, every 60s, 2h cutoff) reclaims jobs stuck in `handed_off` after a worker dies. It silently failed to reclaim any row whose `handoff_id` is **null**.

Each stuck row was reclaimed through `_applyFailure`, whose UPDATE was fenced on `_activeHandoffConditions(job)` = `{handoff_id: job.handoffId, id, status}`. When `job.handoffId` is `null`, that renders as `handoff_id = NULL` in SQL, which matches nothing — so `affectedRows === 0`, `_applyFailure` returns `null`, and the row stays `handed_off` **forever**. Rows with a non-null `handoff_id` orphan normally, masking the bug. A row gets a null `handoff_id` when it was handed off by an **older velocious** (before handoff-id fencing) and survived the upgrade.

**Production evidence:** 4 jobs stranded in `handed_off` for 2 days (worker died 2026-07-15) while sibling rows orphaned every 60s. All 4 stranded rows had `handoff_id IS NULL`; the reclaimed ones did not.

**Fix:** `_applyFailure` gets an optional `conditions` override (default = the active-handoff lease match, so the worker-report failure path is unchanged and keeps its fencing). The time-based orphan sweep passes `{id, status: "handed_off"}` — it already selected these rows as handed-off past the cutoff, so an id/status match is correct and null-safe.

## 2. Retention/pruning of terminal job rows (new feature)

The jobs table grew unbounded — `completed` rows were never deleted (the only `DELETE` was the test-only `clearAll`). On the same production deployment, `background_jobs` held **8.44M completed rows**, bloating storage/indexes and eventually slowing dispatch.

The main process now runs `store.pruneTerminalJobs` on an interval (default hourly), batch-deleting:
- `completed` rows older than `completedTtlMs` (default **7d**), and
- terminal `failed`/`orphaned` rows older than `failedTtlMs` (default **30d**; set `null` to keep them for debugging).

Deletion is batched by id (`SELECT` a page of ids, then `DELETE ... WHERE id IN (...)`) rather than `DELETE ... LIMIT`, which not every driver supports; each batch runs on its own connection so the sweep yields between batches. All windows + batch size are configurable under `backgroundJobs.retention`.

## Tests

- `spec/background-jobs/store-spec.js` — 27 tests pass, including:
  - reclaims handed-off jobs whose `handoff_id` is null (older-velocious legacy rows),
  - prunes completed rows past the retention window and keeps recent + non-terminal rows,
  - prunes failed and orphaned rows past the failed retention window.
- `dispatch-strategy-spec.js` (main timers) green.
- `npm run typecheck`, `eslint`, `fallow` all clean.