### PR TITLE
fix(background-jobs): run retention pruning as a scheduled job, not a setInterval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2131,6 +2131,21 @@ await MyJob.performLaterWithOptions({
 
 If a handed-off job does not report back within 2 hours, it is marked orphaned and re-queued if retries remain.
 
+## Queues
+
+Give a job a queue with `static queue = "..."` (or a `{queue}` job option; the option wins) and cap how many of that queue's jobs run in flight across the whole cluster under `backgroundJobs.queues`:
+
+```js
+backgroundJobs: {
+  queues: {
+    builds: {maxConcurrent: 100}, // I/O-bound: can run well above the core count
+    default: {maxConcurrent: 8}   // CPU-bound: keep near the core count
+  }
+}
+```
+
+A job with no queue runs on `"default"`; a queue with no cap is unlimited. Caps are enforced through the durable per-key concurrency mechanism (the reserved `queue:<name>` key), hold regardless of how many worker processes run, and are reconciled against the existing backlog on startup when you change them. Scheduled jobs honor a job's `static queue` too. See [docs/background-jobs.md](docs/background-jobs.md#queues-per-queue-concurrency-caps).
+
 ## Retention
 
 Terminal `background_jobs` rows are not deleted automatically unless you configure retention, so a busy app otherwise grows the table indefinitely. Set `backgroundJobs.retention` to prune old terminal rows:

--- a/README.md
+++ b/README.md
@@ -2131,6 +2131,23 @@ await MyJob.performLaterWithOptions({
 
 If a handed-off job does not report back within 2 hours, it is marked orphaned and re-queued if retries remain.
 
+## Retention
+
+Terminal `background_jobs` rows are not deleted automatically unless you configure retention, so a busy app otherwise grows the table indefinitely. Set `backgroundJobs.retention` to prune old terminal rows:
+
+```js
+backgroundJobs: {
+  retention: {
+    completedTtlMs: 7 * 24 * 60 * 60 * 1000, // default: 7 days (null/0 disables)
+    failedTtlMs: 30 * 24 * 60 * 60 * 1000,   // default: 30 days for failed/orphaned (null/0 disables)
+    batchSize: 1000,                          // default: 1000 rows per delete batch
+    sweepIntervalMs: 60 * 60 * 1000           // default: 1 hour
+  }
+}
+```
+
+`background-jobs-main` registers a built-in `velocious:prune-terminal-background-jobs` job on the scheduler when retention is enabled, so pruning runs as an ordinary scheduled/queued job (it needs a worker, appears in the job tables, and is bounded to one non-overlapping run). See [docs/background-jobs.md](docs/background-jobs.md#retention-pruning-old-job-rows).
+
 ## Dashboard
 
 Velocious ships a mountable read-only HTTP API for inspecting jobs (queued, running, completed, failed, orphaned and scheduled), similar in spirit to `sidekiq-web`. Mount it in your routes file the way `Sidekiq::Web` is mounted in Rails:

--- a/changelog.d/20260717120000-background-jobs-retention-scheduled-job.md
+++ b/changelog.d/20260717120000-background-jobs-retention-scheduled-job.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Run background-job retention pruning as an ordinary scheduled job (`PruneTerminalBackgroundJobsJob`) registered on the normal background-jobs scheduler when `backgroundJobs.retention` is enabled, instead of a hidden `setInterval` in the main process. The prune now runs as a real queued job — visible in the job tables, dispatched to a worker, and bounded by a `maxConcurrency: 1` reservation so runs cannot pile up.

--- a/changelog.d/20260717130000-background-jobs-queue-review-fixes.md
+++ b/changelog.d/20260717130000-background-jobs-queue-review-fixes.md
@@ -1,0 +1,7 @@
+# Changelog
+
+- Apply a job class's `static queue` when it is enqueued through `scheduledBackgroundJobs`, so a scheduled job lands on its queue (and honors the configured cap) instead of always running on `"default"`.
+- Reconcile queue-derived concurrency against the current config once per process on startup: sync each configured queue's stored cap and adopt or release persisted non-terminal jobs so an added, removed, or changed `queues[name].maxConcurrent` takes effect against an existing backlog instead of only applying to newly enqueued jobs.
+- Reserve the `queue:` concurrency-key prefix: an explicit `concurrencyKey` may no longer start with it, so it cannot collide with a queue-derived key and silently change (or conflict with) an unrelated cap.
+- Acquire the schema advisory lock before inspecting the `queue` column in its migration, matching the concurrency-column migration, to avoid SQL Server deadlocks with a concurrent `ALTER TABLE`.
+- Document the `backgroundJobs.queues` configuration and the job `queue` API in `README.md` and `docs/background-jobs.md`.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -8,6 +8,25 @@ Pass `concurrencyKey` and `maxConcurrency` together in `jobOptions` (or in `perf
 
 Limits are enforced by durable database reservations shared by every main/worker process. Saturated keys do not prevent unrelated queued jobs from being dispatched. Reservations are released when work completes, fails terminally, is requeued for retry, is cancelled, or is recovered as orphaned; startup reconciliation repairs reservation counts after an unclean scheduler stop.
 
+## Queues (per-queue concurrency caps)
+
+Give a job class a queue with `static queue = "..."` (or pass `{queue}` in job options — the option wins). A job with no queue runs on `"default"`. Configure a cluster-wide cap per queue under `backgroundJobs.queues`:
+
+```js
+backgroundJobs: {
+  queues: {
+    builds: {maxConcurrent: 100}, // I/O-bound work can run well above the core count
+    default: {maxConcurrent: 8}   // CPU-bound work should stay near the core count
+  }
+}
+```
+
+Each capped queue is enforced through the same durable per-key concurrency mechanism described above: a job on the queue is given the reserved concurrency key `queue:<name>`, so `queues[name].maxConcurrent` bounds how many jobs from that queue run in flight across every main/worker process, regardless of how many processes run. A queue with no configured cap is unlimited.
+
+- The `queue:` concurrency-key prefix is reserved — an explicit `concurrencyKey` may not start with it.
+- Caps are config-driven and tunable. Adding, removing, or changing `queues[name].maxConcurrent` is reconciled against the existing backlog when the main process starts: persisted jobs adopt or release the queue key to match the current config, so a changed cap takes effect without waiting for the queue to drain.
+- Scheduled jobs (`scheduledBackgroundJobs`) honor a job class's `static queue` as well.
+
 ## Retention (pruning old job rows)
 
 Terminal job rows are not deleted automatically unless retention is configured — a busy application otherwise accumulates `completed` (and `failed`/`orphaned`) rows indefinitely, bloating the table and its indexes and eventually slowing dispatch. Configure retention under `backgroundJobs.retention`:

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -8,6 +8,29 @@ Pass `concurrencyKey` and `maxConcurrency` together in `jobOptions` (or in `perf
 
 Limits are enforced by durable database reservations shared by every main/worker process. Saturated keys do not prevent unrelated queued jobs from being dispatched. Reservations are released when work completes, fails terminally, is requeued for retry, is cancelled, or is recovered as orphaned; startup reconciliation repairs reservation counts after an unclean scheduler stop.
 
+## Retention (pruning old job rows)
+
+Terminal job rows are not deleted automatically unless retention is configured — a busy application otherwise accumulates `completed` (and `failed`/`orphaned`) rows indefinitely, bloating the table and its indexes and eventually slowing dispatch. Configure retention under `backgroundJobs.retention`:
+
+```js
+backgroundJobs: {
+  retention: {
+    completedTtlMs: 7 * 24 * 60 * 60 * 1000, // delete completed jobs older than this (default: 7 days; null/0 disables)
+    failedTtlMs: 30 * 24 * 60 * 60 * 1000,   // delete failed/orphaned jobs older than this (default: 30 days; null/0 disables)
+    batchSize: 1000,                          // rows deleted per batch (default: 1000)
+    sweepIntervalMs: 60 * 60 * 1000           // how often the prune runs (default: 1 hour)
+  }
+}
+```
+
+When at least one TTL is enabled, `background-jobs-main` registers a built-in `velocious:prune-terminal-background-jobs` job on the scheduler. **It runs as an ordinary background job**, so:
+
+- it requires a running worker to execute — a stopped worker pool means no pruning until one returns;
+- each run appears in the job tables as a normal queued job and can retry or fail like any other job;
+- runs are bounded — a `maxConcurrency: 1` reservation prevents overlap, and enqueue-time deduplication keeps the recurring schedule from piling up redundant queued rows when a prune runs slower than its interval or no worker is free.
+
+Deletion is batched by id (`SELECT` a page, then `DELETE ... WHERE id IN (...)`) so a large backlog is removed incrementally rather than in one long transaction. Retention only ever deletes terminal rows; `queued` and in-flight jobs are never pruned.
+
 ## Worker Disconnect Recovery
 
 Each durable worker handoff has a unique lease id. If a worker socket disconnects unexpectedly, `background-jobs-main` immediately returns only the jobs handed to that exact socket to the queue and makes them available to another connected worker. Two connections that advertise the same worker id remain isolated from each other.

--- a/spec/background-jobs/dispatch-strategy-spec.js
+++ b/spec/background-jobs/dispatch-strategy-spec.js
@@ -109,4 +109,34 @@ describe("Background jobs - dispatch strategy", {databaseCleaning: {truncate: tr
       await main.stop()
     }
   })
+
+  it("registers retention pruning as a normal scheduled job on the scheduler", async () => {
+    const {main, store} = await startBackgroundJobsMain({
+      backgroundJobsConfig: {retention: {sweepIntervalMs: 50, completedTtlMs: 1000}}
+    })
+
+    try {
+      let prunedJobRow = /** @type {Record<string, ?> | null} */ (null)
+      const deadline = Date.now() + 3000
+
+      while (Date.now() < deadline) {
+        const rows = await store._withDb(async (db) =>
+          await db.newQuery().from("background_jobs").where({job_name: "PruneTerminalBackgroundJobsJob"}).limit(1).results()
+        )
+
+        if (rows.length > 0) {
+          prunedJobRow = rows[0]
+          break
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 25))
+      }
+
+      expect(prunedJobRow).toBeTruthy()
+      expect(String(prunedJobRow?.status)).toEqual("queued")
+    } finally {
+      await main.stop()
+      dummyConfiguration.setBackgroundJobsConfig({dispatchStrategy: "beacon", pollIntervalMs: 1000})
+    }
+  })
 })

--- a/spec/background-jobs/dispatch-strategy-spec.js
+++ b/spec/background-jobs/dispatch-strategy-spec.js
@@ -3,6 +3,7 @@
 import BackgroundJobsMain from "../../src/background-jobs/main.js"
 import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import {outputPathFor, startBackgroundJobs, startBackgroundJobsMain, waitForOutputJson} from "../helpers/background-jobs-helper.js"
+import PruneTerminalBackgroundJobsJob from "../../src/jobs/prune-terminal-background-jobs.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import TestJob from "../dummy/src/jobs/test-job.js"
 
@@ -121,7 +122,7 @@ describe("Background jobs - dispatch strategy", {databaseCleaning: {truncate: tr
 
       while (Date.now() < deadline) {
         const rows = await store._withDb(async (db) =>
-          await db.newQuery().from("background_jobs").where({job_name: "PruneTerminalBackgroundJobsJob"}).limit(1).results()
+          await db.newQuery().from("background_jobs").where({job_name: PruneTerminalBackgroundJobsJob.jobName()}).limit(1).results()
         )
 
         if (rows.length > 0) {

--- a/spec/background-jobs/dispatch-strategy-spec.js
+++ b/spec/background-jobs/dispatch-strategy-spec.js
@@ -5,6 +5,7 @@ import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import {outputPathFor, startBackgroundJobs, startBackgroundJobsMain, waitForOutputJson} from "../helpers/background-jobs-helper.js"
 import PruneTerminalBackgroundJobsJob from "../../src/jobs/prune-terminal-background-jobs.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
+import QueuedTestJob from "../dummy/src/jobs/queued-test-job.js"
 import TestJob from "../dummy/src/jobs/test-job.js"
 
 describe("Background jobs - dispatch strategy", {databaseCleaning: {truncate: true}}, () => {
@@ -138,6 +139,35 @@ describe("Background jobs - dispatch strategy", {databaseCleaning: {truncate: tr
     } finally {
       await main.stop()
       dummyConfiguration.setBackgroundJobsConfig({dispatchStrategy: "beacon", pollIntervalMs: 1000})
+    }
+  })
+
+  it("applies a scheduled job's static queue when enqueuing", async () => {
+    const {main, store} = await startBackgroundJobsMain()
+
+    try {
+      main.scheduler.scheduleJob({jobConfiguration: {class: QueuedTestJob, every: 50}, jobKey: "queuedTestJob"})
+
+      let enqueuedRow = /** @type {Record<string, ?> | null} */ (null)
+      const deadline = Date.now() + 3000
+
+      while (Date.now() < deadline) {
+        const rows = await store._withDb(async (db) =>
+          await db.newQuery().from("background_jobs").where({job_name: QueuedTestJob.jobName()}).limit(1).results()
+        )
+
+        if (rows.length > 0) {
+          enqueuedRow = rows[0]
+          break
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 25))
+      }
+
+      expect(enqueuedRow).toBeTruthy()
+      expect(String(enqueuedRow?.queue)).toEqual("builds")
+    } finally {
+      await main.stop()
     }
   })
 })

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -305,6 +305,49 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(row.queue).toEqual("default")
   })
 
+  it("rejects an explicit concurrencyKey that uses the reserved queue: prefix", async () => {
+    const store = await createClearedStore()
+    let error = /** @type {Error | null} */ (null)
+
+    try {
+      await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: "queue:builds", maxConcurrency: 2}})
+    } catch (newError) {
+      error = /** @type {Error} */ (newError)
+    }
+
+    expect(error).toBeTruthy()
+    expect(error?.message).toContain("reserved")
+  })
+
+  it("reconciles queue caps against the persisted backlog on startup", async () => {
+    dummyConfiguration.setBackgroundJobsConfig({queues: {}})
+    const store = await createClearedStore()
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false, queue: "builds"}})
+
+    // No cap configured yet, so the queued job carries no concurrency key.
+    expect((await getJobOrFail({jobId, store})).concurrencyKey).toEqual(null)
+
+    try {
+      // Adding a cap adopts the existing backlog onto the queue key on startup.
+      dummyConfiguration.setBackgroundJobsConfig({queues: {builds: {maxConcurrent: 2}}})
+      const adoptStore = new BackgroundJobsStore({configuration: dummyConfiguration})
+      await adoptStore.ensureReady()
+      const adopted = await getJobOrFail({jobId, store: adoptStore})
+
+      expect(adopted.concurrencyKey).toEqual("queue:builds")
+      expect(adopted.maxConcurrency).toEqual(2)
+
+      // Removing the cap releases the backlog from the queue key on startup.
+      dummyConfiguration.setBackgroundJobsConfig({queues: {}})
+      const releaseStore = new BackgroundJobsStore({configuration: dummyConfiguration})
+      await releaseStore.ensureReady()
+
+      expect((await getJobOrFail({jobId, store: releaseStore})).concurrencyKey).toEqual(null)
+    } finally {
+      dummyConfiguration.setBackgroundJobsConfig({queues: {}})
+    }
+  })
+
   it("coalesces deduplicateWhileQueued enqueues onto a still-queued job", async () => {
     const store = await createClearedStore()
     const options = {concurrencyKey: "recurring-key", maxConcurrency: 1, deduplicateWhileQueued: true, forked: false}

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -305,6 +305,29 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(row.queue).toEqual("default")
   })
 
+  it("coalesces deduplicateWhileQueued enqueues onto a still-queued job", async () => {
+    const store = await createClearedStore()
+    const options = {concurrencyKey: "recurring-key", maxConcurrency: 1, deduplicateWhileQueued: true, forked: false}
+
+    const firstId = await store.enqueue({jobName: "TestJob", args: [], options})
+    const secondId = await store.enqueue({jobName: "TestJob", args: [], options})
+
+    // The second enqueue coalesces onto the still-queued first job.
+    expect(secondId).toEqual(firstId)
+
+    const rows = await store._withDb(async (db) =>
+      await db.newQuery().from("background_jobs").where({concurrency_key: "recurring-key"}).results()
+    )
+
+    expect(rows.length).toEqual(1)
+
+    // Once the first is no longer queued (handed off), a fresh enqueue is allowed.
+    await store.markHandedOff({jobId: firstId, workerId: "w"})
+    const thirdId = await store.enqueue({jobName: "TestJob", args: [], options})
+
+    expect(thirdId).not.toEqual(firstId)
+  })
+
   it("releases a concurrency reservation when a competing queued claim loses", async () => {
     let activeCount = 0
     const db = {

--- a/spec/dummy/src/jobs/queued-test-job.js
+++ b/spec/dummy/src/jobs/queued-test-job.js
@@ -1,0 +1,7 @@
+import VelociousJob from "../../../../src/background-jobs/job.js"
+
+export default class QueuedTestJob extends VelociousJob {
+  static queue = "builds"
+
+  async perform() {}
+}

--- a/spec/jobs/prune-terminal-background-jobs-spec.js
+++ b/spec/jobs/prune-terminal-background-jobs-spec.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import PruneTerminalBackgroundJobsJob from "../../src/jobs/prune-terminal-background-jobs.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+describe("PruneTerminalBackgroundJobsJob", {databaseCleaning: {truncate: true}}, () => {
+  it("returns a schedule configuration when retention is enabled", () => {
+    const config = PruneTerminalBackgroundJobsJob.scheduleConfiguration({
+      completedTtlMs: 604800000,
+      failedTtlMs: null,
+      batchSize: 1000,
+      sweepIntervalMs: 3600000
+    })
+
+    expect(config?.class).toEqual(PruneTerminalBackgroundJobsJob)
+    expect(config?.every).toEqual(3600000)
+    expect(config?.options).toEqual({concurrencyKey: "velocious-prune-terminal-background-jobs", maxConcurrency: 1})
+  })
+
+  it("returns null when retention is fully disabled", () => {
+    expect(PruneTerminalBackgroundJobsJob.scheduleConfiguration({completedTtlMs: null, failedTtlMs: null, batchSize: 1000, sweepIntervalMs: 3600000})).toEqual(null)
+    expect(PruneTerminalBackgroundJobsJob.scheduleConfiguration({completedTtlMs: 0, failedTtlMs: 0, batchSize: 1000, sweepIntervalMs: 3600000})).toEqual(null)
+  })
+
+  it("prunes completed rows past the retention window when performed", async () => {
+    dummyConfiguration.setCurrent()
+    dummyConfiguration.setBackgroundJobsConfig({retention: {completedTtlMs: 7 * 24 * 60 * 60 * 1000}})
+
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    await store.clearAll()
+
+    const jobId = await store.enqueue({jobName: "TestJob", args: [], options: {forked: false}})
+    const handoff = await store.markHandedOff({jobId, workerId: "w"})
+    if (!handoff) throw new Error("Expected the job to be handed off")
+    await store.markCompleted({jobId, workerId: "w", ...handoff})
+
+    // Age the completion past the 7-day window.
+    await store._withDb(async (db) => {
+      await db.query(`UPDATE background_jobs SET completed_at_ms = ${db.quote(Date.now() - 10 * 24 * 60 * 60 * 1000)} WHERE id = ${db.quote(jobId)}`)
+    })
+
+    await new PruneTerminalBackgroundJobsJob().perform()
+
+    expect(await store.getJob(jobId)).toEqual(null)
+  })
+})

--- a/spec/jobs/prune-terminal-background-jobs-spec.js
+++ b/spec/jobs/prune-terminal-background-jobs-spec.js
@@ -5,6 +5,11 @@ import PruneTerminalBackgroundJobsJob from "../../src/jobs/prune-terminal-backgr
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 
 describe("PruneTerminalBackgroundJobsJob", {databaseCleaning: {truncate: true}}, () => {
+  it("uses a reserved job name that an app job cannot shadow via the class name", () => {
+    expect(PruneTerminalBackgroundJobsJob.jobName()).toEqual("velocious:prune-terminal-background-jobs")
+    expect(PruneTerminalBackgroundJobsJob.jobName()).not.toEqual(PruneTerminalBackgroundJobsJob.name)
+  })
+
   it("returns a schedule configuration when retention is enabled", () => {
     const config = PruneTerminalBackgroundJobsJob.scheduleConfiguration({
       completedTtlMs: 604800000,
@@ -15,7 +20,7 @@ describe("PruneTerminalBackgroundJobsJob", {databaseCleaning: {truncate: true}},
 
     expect(config?.class).toEqual(PruneTerminalBackgroundJobsJob)
     expect(config?.every).toEqual(3600000)
-    expect(config?.options).toEqual({concurrencyKey: "velocious-prune-terminal-background-jobs", maxConcurrency: 1})
+    expect(config?.options).toEqual({concurrencyKey: "velocious-prune-terminal-background-jobs", maxConcurrency: 1, deduplicateWhileQueued: true})
   })
 
   it("returns null when retention is fully disabled", () => {

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -147,7 +147,10 @@ export default class BackgroundJobsMain {
           await this.store.enqueue({
             jobName: jobClass.jobName(),
             args,
-            options
+            // Fold in the job class's static `queue` (as performLater* do) so a
+            // scheduled job with `static queue = "..."` lands on its queue and
+            // honors the configured cap without every schedule repeating it.
+            options: jobClass._withQueue(options)
           })
           this._notifyEnqueued()
           await this._drain()

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -5,6 +5,7 @@ import JsonSocket from "./json-socket.js"
 import BackgroundJobsScheduler from "./scheduler.js"
 import BackgroundJobsStore from "./store.js"
 import Logger from "../logger.js"
+import PruneTerminalBackgroundJobsJob from "../jobs/prune-terminal-background-jobs.js"
 
 /**
  * Channel used by `background-jobs-main` to coordinate dispatch wake-ups
@@ -91,10 +92,6 @@ export default class BackgroundJobsMain {
     this._orphanTimer = undefined
     /**
      * Narrows the runtime value to the documented type.
-     * @type {ReturnType<typeof setTimeout> | undefined} */
-    this._retentionTimer = undefined
-    /**
-     * Narrows the runtime value to the documented type.
      * @type {BackgroundJobsScheduler | undefined} */
     this.scheduler = undefined
     this._draining = false
@@ -144,10 +141,6 @@ export default class BackgroundJobsMain {
         void this._sweepOrphans()
       }, 60000)
 
-      this._retentionTimer = setInterval(() => {
-        void this._sweepRetention()
-      }, this.retention.sweepIntervalMs)
-
       this.scheduler = new BackgroundJobsScheduler({
         configuration: this.configuration,
         enqueueJob: async ({args, jobClass, options}) => {
@@ -161,6 +154,16 @@ export default class BackgroundJobsMain {
         }
       })
       await this.scheduler.start()
+
+      // Retention pruning runs as an ordinary scheduled job on the normal
+      // scheduler (so it is visible in the job tables and dispatched to a
+      // worker), rather than a hidden in-process timer. Skipped when retention
+      // is disabled. The scheduler owns the timer, so scheduler.stop() clears it.
+      const retentionSchedule = PruneTerminalBackgroundJobsJob.scheduleConfiguration(this.retention)
+
+      if (retentionSchedule) {
+        this.scheduler.scheduleJob({jobConfiguration: retentionSchedule, jobKey: "velociousPruneTerminalBackgroundJobs"})
+      }
 
       // Startup catch-up: drain anything that was waiting before this
       // process came up. In beacon mode this is also the safety net for
@@ -206,12 +209,10 @@ export default class BackgroundJobsMain {
     if (this._scheduledTimer) clearTimeout(this._scheduledTimer)
     if (this._errorRetryTimer) clearTimeout(this._errorRetryTimer)
     if (this._orphanTimer) clearInterval(this._orphanTimer)
-    if (this._retentionTimer) clearInterval(this._retentionTimer)
     this._pollTimer = undefined
     this._scheduledTimer = undefined
     this._errorRetryTimer = undefined
     this._orphanTimer = undefined
-    this._retentionTimer = undefined
   }
 
   /**
@@ -1094,26 +1095,6 @@ export default class BackgroundJobsMain {
       }
     } catch (error) {
       this.logger.error(() => ["Failed to mark orphaned jobs:", error])
-    }
-  }
-
-  /**
-   * Deletes terminal job rows past their retention window so the jobs table
-   * does not grow unbounded. Runs on its own interval; failures are logged and
-   * retried on the next tick.
-   * @returns {Promise<void>} - Resolves after one retention sweep.
-   */
-  async _sweepRetention() {
-    try {
-      const deleted = await this.store.pruneTerminalJobs({
-        completedTtlMs: this.retention.completedTtlMs,
-        failedTtlMs: this.retention.failedTtlMs,
-        batchSize: this.retention.batchSize
-      })
-
-      if (deleted > 0) this.logger.warn(() => ["Pruned terminal background jobs", deleted])
-    } catch (error) {
-      this.logger.error(() => ["Failed to prune terminal jobs:", error])
     }
   }
 }

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -101,8 +101,26 @@ export default class BackgroundJobsStore {
     const argsJson = JSON.stringify(args || [])
     const queue = this._normalizeQueue(options)
     const concurrency = this._resolveConcurrency(options, queue)
+    /** @type {string} */
+    let resultJobId = jobId
 
     await this._withDb(async (db) => {
+      if (options?.deduplicateWhileQueued && concurrency?.concurrencyKey) {
+        const existing = await db
+          .newQuery()
+          .from(JOBS_TABLE)
+          .select("id")
+          .where({status: "queued", concurrency_key: concurrency.concurrencyKey})
+          .limit(1)
+          .results()
+
+        if (existing[0]) {
+          resultJobId = String(/** @type {Record<string, ?>} */ (existing[0]).id)
+
+          return
+        }
+      }
+
       if (concurrency) {
         if (concurrency.queueDerived) {
           await this._ensureQueueConcurrencyKey(db, concurrency)
@@ -130,7 +148,7 @@ export default class BackgroundJobsStore {
       })
     })
 
-    return jobId
+    return resultJobId
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -51,6 +51,7 @@ export default class BackgroundJobsStore {
     this.databaseIdentifier = databaseIdentifier
     this.logger = new Logger(this)
     this._readyPromise = null
+    this._queueConcurrencyReconciled = false
   }
 
   /**
@@ -666,6 +667,7 @@ export default class BackgroundJobsStore {
       if (alreadyApplied && await db.tableExists(JOBS_TABLE)) {
         await this._ensureJobsTableColumns(db)
         await this._ensureConcurrencyTable(db)
+        await this._reconcileQueueConcurrency(db)
         await this._reconcileConcurrency(db)
         return
       }
@@ -673,6 +675,7 @@ export default class BackgroundJobsStore {
       await this._applyMigrations(db)
       await this._ensureJobsTableColumns(db)
       await this._ensureConcurrencyTable(db)
+      await this._reconcileQueueConcurrency(db)
       await this._reconcileConcurrency(db)
 
       if (alreadyApplied) return
@@ -852,16 +855,15 @@ export default class BackgroundJobsStore {
    * @returns {Promise<void>} - Resolves when ensured.
    */
   async _ensureQueueColumn(db) {
-    const table = await db.getTableByNameOrFail(JOBS_TABLE)
-
-    if (await table.getColumnByName("queue")) return
-
     const lockName = `${MIGRATION_SCOPE}:queue_column`
     const acquired = await db.acquireAdvisoryLock(lockName)
 
     if (!acquired) throw new Error("Failed to acquire background jobs queue schema lock")
 
     try {
+      // SQL Server schema reads can deadlock with a concurrent ALTER TABLE, so
+      // acquire the lock before inspecting the column rather than only
+      // protecting the mutation (mirrors the concurrency-column migration).
       db.clearSchemaCache()
       const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
 
@@ -1119,6 +1121,9 @@ export default class BackgroundJobsStore {
     if (typeof key !== "string" || key.length === 0 || !Number.isInteger(cap) || Number(cap) <= 0) {
       throw new Error("background job concurrencyKey and maxConcurrency must be paired; concurrencyKey must be non-empty and maxConcurrency must be a positive integer")
     }
+    if (key.startsWith(QUEUE_CONCURRENCY_KEY_PREFIX)) {
+      throw new Error(`background job concurrencyKey must not start with the reserved "${QUEUE_CONCURRENCY_KEY_PREFIX}" prefix, which is reserved for queue-derived concurrency caps`)
+    }
     return {concurrencyKey: key, maxConcurrency: Number(cap)}
   }
 
@@ -1293,6 +1298,65 @@ export default class BackgroundJobsStore {
       `SELECT COUNT(*) FROM ${jobsTable} WHERE ${jobsTable}.${db.quoteColumn("status")} = ${db.quote("handed_off")} AND ` +
       `${jobsTable}.${db.quoteColumn("concurrency_key")} = ${concurrencyTable}.${db.quoteColumn("concurrency_key")})`
     )
+  }
+
+  /**
+   * Reconciles queue-derived concurrency with the current configuration, once
+   * per process. Enqueue only consults config for new jobs, so a cap added,
+   * removed, or changed while a backlog exists otherwise leaves persisted rows
+   * stale: pre-cap jobs keep a null key and bypass the cap, post-removal jobs
+   * stay capped under a now-unconfigured key, and a changed numeric cap stays
+   * stale until the next enqueue. Bring the durable state in line with config:
+   * sync each configured queue's stored cap, adopt not-yet-keyed non-terminal
+   * jobs onto their queue key, and release non-terminal jobs from queue keys
+   * whose queue is no longer capped. Runs before {@link _reconcileConcurrency}
+   * so the rebuilt active counts reflect the adopted/released keys.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when reconciled.
+   */
+  async _reconcileQueueConcurrency(db) {
+    if (this._queueConcurrencyReconciled) return
+    if (!(await db.tableExists(CONCURRENCY_TABLE))) return
+
+    const queuesConfig = this.configuration.getBackgroundJobsConfig().queues || {}
+    const jobsTable = db.quoteTable(JOBS_TABLE)
+    const keyColumn = db.quoteColumn("concurrency_key")
+    const capColumn = db.quoteColumn("max_concurrency")
+    const queueColumn = db.quoteColumn("queue")
+    const nonTerminal = `${db.quoteColumn("status")} IN (${db.quote("queued")}, ${db.quote("handed_off")})`
+    /** @type {Set<string>} */
+    const cappedQueues = new Set()
+
+    for (const queue of Object.keys(queuesConfig)) {
+      const cap = this._queueMaxConcurrency(queue)
+
+      if (cap === null) continue
+
+      cappedQueues.add(queue)
+      const concurrencyKey = `${QUEUE_CONCURRENCY_KEY_PREFIX}${queue}`
+
+      await this._ensureQueueConcurrencyKey(db, {concurrencyKey, maxConcurrency: cap})
+      await db.query(
+        `UPDATE ${jobsTable} SET ${keyColumn} = ${db.quote(concurrencyKey)}, ${capColumn} = ${Number(cap)} ` +
+        `WHERE ${queueColumn} = ${db.quote(queue)} AND ${keyColumn} IS NULL AND ${nonTerminal}`
+      )
+    }
+
+    const concurrencyRows = await db.newQuery().from(CONCURRENCY_TABLE).select("concurrency_key").results()
+
+    for (const row of concurrencyRows) {
+      const concurrencyKey = String(/** @type {Record<string, ?>} */ (row).concurrency_key)
+
+      if (!concurrencyKey.startsWith(QUEUE_CONCURRENCY_KEY_PREFIX)) continue
+      if (cappedQueues.has(concurrencyKey.slice(QUEUE_CONCURRENCY_KEY_PREFIX.length))) continue
+
+      await db.query(
+        `UPDATE ${jobsTable} SET ${keyColumn} = NULL, ${capColumn} = NULL ` +
+        `WHERE ${keyColumn} = ${db.quote(concurrencyKey)} AND ${nonTerminal}`
+      )
+    }
+
+    this._queueConcurrencyReconciled = true
   }
 
   /**

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -16,6 +16,7 @@
  * @property {string} [queue] - Queue name. Defaults to `"default"`. When the queue has a configured cap in `backgroundJobs.queues`, that cap is enforced cluster-wide.
  * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap. Overrides any queue-derived cap.
  * @property {number} [maxConcurrency] - Positive integer cap; must be paired with `concurrencyKey`.
+ * @property {boolean} [deduplicateWhileQueued] - When true (requires `concurrencyKey`), skip the enqueue if a still-queued job with the same `concurrencyKey` already exists, returning that job's id. Keeps an interval-scheduled recurring job (e.g. retention pruning) from piling up redundant queued rows when it runs slower than its interval or no worker is free.
  */
 /**
  * @typedef {object} BackgroundJobPayload

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -194,8 +194,17 @@
  *   jobs older than this many ms. `null` or `<= 0` disables (keeps them for
  *   debugging). Default: `2592000000` (30 days).
  * @property {number} [batchSize] - Rows deleted per batch. Default: `1000`.
- * @property {number} [sweepIntervalMs] - How often the main process runs the
- *   retention sweep. Default: `3600000` (1 hour).
+ * @property {number} [sweepIntervalMs] - How often the retention sweep runs.
+ *   Default: `3600000` (1 hour).
+ */
+/**
+ * Fully-resolved retention config as returned by `getBackgroundJobsConfig()`
+ * (every field defaulted), as opposed to the partial user-provided input.
+ * @typedef {object} ResolvedBackgroundJobsRetentionConfiguration
+ * @property {number | null} completedTtlMs - Resolved completed-job TTL in ms (`null` disables).
+ * @property {number | null} failedTtlMs - Resolved failed/orphaned TTL in ms (`null` disables).
+ * @property {number} batchSize - Resolved delete batch size.
+ * @property {number} sweepIntervalMs - Resolved sweep interval in ms.
  */
 
 /**

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1260,7 +1260,7 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get background jobs config.
-   * @returns {Required<import("./configuration-types.js").BackgroundJobsConfiguration>} - Background jobs configuration.
+   * @returns {Required<import("./configuration-types.js").BackgroundJobsConfiguration> & {retention: import("./configuration-types.js").ResolvedBackgroundJobsRetentionConfiguration}} - Background jobs configuration.
    */
   getBackgroundJobsConfig() {
     const envHost = process.env.VELOCIOUS_BACKGROUND_JOBS_HOST

--- a/src/jobs/prune-terminal-background-jobs.js
+++ b/src/jobs/prune-terminal-background-jobs.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+import BackgroundJobsStore from "../background-jobs/store.js"
+import Configuration from "../configuration.js"
+import VelociousJob from "../background-jobs/job.js"
+
+/**
+ * Built-in job that prunes terminal `background_jobs` rows past their retention
+ * window so the table does not grow unbounded. The main process registers this
+ * on the normal background-jobs scheduler when `backgroundJobs.retention` is
+ * enabled, so it runs as an ordinary scheduled/queued job — visible in the job
+ * tables and dispatched to a worker — rather than a hidden in-process timer.
+ * @augments {VelociousJob<[]>}
+ */
+export default class PruneTerminalBackgroundJobsJob extends VelociousJob {
+  /**
+   * Builds the scheduler configuration for this job from a resolved retention
+   * config, or returns `null` when retention is fully disabled (nothing to
+   * prune, so nothing to schedule). A single `concurrencyKey`/`maxConcurrency`
+   * keeps a slow prune from piling up overlapping runs.
+   * @param {import("../configuration-types.js").ResolvedBackgroundJobsRetentionConfiguration} retention - Resolved retention config.
+   * @returns {import("../configuration-types.js").ScheduledBackgroundJobConfiguration | null} - Scheduler config for the prune job, or null when retention is disabled.
+   */
+  static scheduleConfiguration(retention) {
+    const prunesCompleted = typeof retention.completedTtlMs === "number" && retention.completedTtlMs > 0
+    const prunesFailed = typeof retention.failedTtlMs === "number" && retention.failedTtlMs > 0
+
+    if (!prunesCompleted && !prunesFailed) {
+      return null
+    }
+
+    return {
+      class: this,
+      every: retention.sweepIntervalMs,
+      options: {concurrencyKey: "velocious-prune-terminal-background-jobs", maxConcurrency: 1}
+    }
+  }
+
+  /**
+   * Prunes terminal job rows past their retention window.
+   * @returns {Promise<void>}
+   */
+  async perform() {
+    const configuration = Configuration.current()
+    const config = configuration.getBackgroundJobsConfig()
+    const store = new BackgroundJobsStore({configuration, databaseIdentifier: config.databaseIdentifier})
+
+    await store.pruneTerminalJobs({
+      completedTtlMs: config.retention.completedTtlMs,
+      failedTtlMs: config.retention.failedTtlMs,
+      batchSize: config.retention.batchSize
+    })
+  }
+}

--- a/src/jobs/prune-terminal-background-jobs.js
+++ b/src/jobs/prune-terminal-background-jobs.js
@@ -14,10 +14,23 @@ import VelociousJob from "../background-jobs/job.js"
  */
 export default class PruneTerminalBackgroundJobsJob extends VelociousJob {
   /**
+   * Reserved job name that an application job cannot shadow. The registry loads
+   * app `src/jobs` first and skips duplicate built-in names, so if this used the
+   * default class-name identity an app class named `PruneTerminalBackgroundJobsJob`
+   * would be dispatched instead. A `:`-namespaced name can never collide with a
+   * default (class-name) identity, since class names cannot contain `:`.
+   * @returns {string} - Reserved job name.
+   */
+  static jobName() {
+    return "velocious:prune-terminal-background-jobs"
+  }
+
+  /**
    * Builds the scheduler configuration for this job from a resolved retention
    * config, or returns `null` when retention is fully disabled (nothing to
-   * prune, so nothing to schedule). A single `concurrencyKey`/`maxConcurrency`
-   * keeps a slow prune from piling up overlapping runs.
+   * prune, so nothing to schedule). `maxConcurrency: 1` keeps runs from
+   * overlapping, and `deduplicateWhileQueued` stops the interval scheduler from
+   * piling up redundant queued rows when a prune is slow or no worker is free.
    * @param {import("../configuration-types.js").ResolvedBackgroundJobsRetentionConfiguration} retention - Resolved retention config.
    * @returns {import("../configuration-types.js").ScheduledBackgroundJobConfiguration | null} - Scheduler config for the prune job, or null when retention is disabled.
    */
@@ -32,7 +45,7 @@ export default class PruneTerminalBackgroundJobsJob extends VelociousJob {
     return {
       class: this,
       every: retention.sweepIntervalMs,
-      options: {concurrencyKey: "velocious-prune-terminal-background-jobs", maxConcurrency: 1}
+      options: {concurrencyKey: "velocious-prune-terminal-background-jobs", maxConcurrency: 1, deduplicateWhileQueued: true}
     }
   }
 


### PR DESCRIPTION
Follow-up to #892. The retention prune it added ran via a **hidden `setInterval`** in the background-jobs main process — invisible in the job tables and outside the normal scheduling/dispatch machinery. This moves it onto the normal Velocious scheduler so it's a real, observable scheduled job.

## Changes
- **New built-in job `PruneTerminalBackgroundJobsJob`** — `perform()` calls `store.pruneTerminalJobs(...)`. Auto-registered by the job registry the same way as the existing built-in `MailDeliveryJob`.
- **Main registers it on `BackgroundJobsScheduler`** via `PruneTerminalBackgroundJobsJob.scheduleConfiguration(retention)` when retention is enabled, so the prune runs as an ordinary scheduled → queued → worker-dispatched job. A `concurrencyKey`/`maxConcurrency: 1` reservation prevents overlapping prunes from piling up.
- **Removed** the `_retentionTimer` `setInterval` and `_sweepRetention` from `main.js`; `scheduler.stop()` owns the timer now.
- **Typed the resolved retention config** (`ResolvedBackgroundJobsRetentionConfiguration`) so `getBackgroundJobsConfig()` reports non-optional retention fields.

The `store.pruneTerminalJobs` batched-delete logic itself is unchanged from #892.

## Tests
- `spec/jobs/prune-terminal-background-jobs-spec.js`: `scheduleConfiguration` returns a schedule when enabled / `null` when disabled; `perform()` prunes completed rows past the window.
- `dispatch-strategy-spec.js`: end-to-end — starting main with retention enabled enqueues a `PruneTerminalBackgroundJobsJob` on the scheduler as a queued job.
- Existing store/dispatch/scheduler specs green (37 tests total). `npm run typecheck`, `eslint`, `fallow` all clean.
