### PR TITLE
feat(background-jobs): emit background-job-orphaned event from the orphan sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1940,7 +1940,7 @@ Velocious includes a simple background jobs system inspired by Sidekiq.
 
 Jobs can opt into cross-worker durable concurrency limits by pairing a non-empty `concurrencyKey` with a positive-integer `maxConcurrency` in their background-job options. The first cap registered for a key is stable; conflicting caps are rejected. See [durable concurrency limits](docs/background-jobs.md#durable-concurrency-limits).
 
-Production apps can listen for `background-job-failed` or its `all-error` mirror to report accepted failed attempts, including retry and terminal state metadata. See [docs/background-jobs.md](docs/background-jobs.md#failure-events).
+Production apps can listen for `background-job-failed` (or its `all-error` mirror) to report accepted failed attempts, including retry and terminal-state metadata, and for `background-job-orphaned` to react to a specific job the main process reclaimed after its worker died mid-run — e.g. enqueue a targeted recovery for the work it left behind, instead of only polling for the aftermath. See [docs/background-jobs.md](docs/background-jobs.md#failure-events).
 
 ## Setup
 

--- a/changelog.d/20260718084345-background-job-orphaned-event.md
+++ b/changelog.d/20260718084345-background-job-orphaned-event.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Add a `background-job-orphaned` error event (mirrored to `all-error`). `background-jobs-main` now emits it for each job its time-based orphan sweep reclaims after a worker died mid-run, with the same `context` shape as `background-job-failed` (`jobId`, `jobName`, `jobArgs`, `attempts`, `maxRetries`, `status`, `terminal`, `willRetry`, `stage`). Applications can react to a dead worker's specific job — enqueue a targeted recovery for the work it left behind — instead of only polling for the aftermath. `store.markOrphanedJobs()` now returns the reclaimed job rows rather than a count.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -145,6 +145,21 @@ The `background-job-failed` payload has:
 
 The mirrored `all-error` payload includes the same `error` and `context` plus `errorType: "background-job-failed"`.
 
+### Orphaned jobs
+
+`background-jobs-main` also emits a `background-job-orphaned` error event (mirrored to `all-error` as `errorType: "background-job-orphaned"`) for each job its time-based orphan sweep reclaims — a job whose worker died mid-run and stopped reporting, so it was stuck `handed_off` past the orphan timeout. Unlike `background-job-failed`, which fires on a worker's failure report, this fires from the main process's sweep, so an application can react to the specific job a dead worker left behind — enqueue a targeted recovery for the work it was doing — instead of only polling for the aftermath.
+
+```js
+configuration.getErrorEvents().on("background-job-orphaned", ({error, context}) => {
+  if (context.jobName !== "RunBuildJob") return
+
+  // context.jobArgs are the orphaned job's serialized arguments.
+  enqueueTargetedRecovery(context.jobArgs[0])
+})
+```
+
+The `background-job-orphaned` payload mirrors `background-job-failed`: `error` (the orphan reason as an `Error`) and `context` with `attempts`, `jobArgs`, `jobId`, `jobName`, `maxRetries`, `status`, `terminal`, `willRetry`, and `stage: "background-job-orphaned"`. `willRetry` is `true` when the reclaim returned the job to the queue for another attempt (retries remaining) and `false` when it was exhausted into a terminal `orphaned` state.
+
 ## Worker Shutdown And Process-Job Draining
 
 When a `background-jobs-worker` receives `SIGTERM`/`SIGINT` it stops accepting new

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -238,4 +238,41 @@ describe("Background jobs - queue", {databaseCleaning: {truncate: true}}, () => 
       await main.stop()
     }
   })
+
+  it("isolates a throwing background-job-orphaned handler so every orphaned job still notifies", async () => {
+    const {main, worker} = await startBackgroundJobs()
+    await worker.stop()
+
+    const seenJobIds = []
+    const onOrphaned = (payload) => {
+      seenJobIds.push(payload.context.jobId)
+      throw new Error("handler boom")
+    }
+
+    dummyConfiguration.getErrorEvents().on("background-job-orphaned", onOrphaned)
+
+    try {
+      const jobIds = []
+
+      for (const args of [["a"], ["b"]]) {
+        const jobId = await main.store.enqueue({jobName: "AppendJob", args, options: {forked: false, maxRetries: 0}})
+
+        await main.store.markHandedOff({jobId, workerId: "dead-worker"})
+        jobIds.push(jobId)
+      }
+
+      await main.store._withDb(async (db) => {
+        await db.query("UPDATE background_jobs SET handed_off_at_ms = 1")
+      })
+
+      await main._sweepOrphans()
+
+      // Without per-job isolation the first throwing handler would abort the loop
+      // and the second orphaned job would never fire its event.
+      expect(seenJobIds.slice().sort()).toEqual(jobIds.slice().sort())
+    } finally {
+      dummyConfiguration.getErrorEvents().off("background-job-orphaned", onOrphaned)
+      await main.stop()
+    }
+  })
 })

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -193,4 +193,49 @@ describe("Background jobs - queue", {databaseCleaning: {truncate: true}}, () => 
       await main.stop()
     }
   })
+
+  it("emits background-job-orphaned when the orphan sweep reclaims a dead worker's job", async () => {
+    const {main, worker} = await startBackgroundJobs()
+    // Stop the worker first so nothing consumes the job — it must stay
+    // `handed_off` (a dead worker's lease) for the sweep to reclaim it.
+    await worker.stop()
+
+    const orphanedEvents = []
+    const onOrphaned = (payload) => {
+      orphanedEvents.push(payload)
+    }
+
+    dummyConfiguration.getErrorEvents().on("background-job-orphaned", onOrphaned)
+
+    try {
+      const jobId = await main.store.enqueue({jobName: "AppendJob", args: ["orphan", "me"], options: {forked: false, maxRetries: 0}})
+
+      await main.store.markHandedOff({jobId, workerId: "dead-worker"})
+      // Backdate the handoff so the default-cutoff sweep reclaims it immediately.
+      await main.store._withDb(async (db) => {
+        await db.query(`UPDATE background_jobs SET handed_off_at_ms = 1 WHERE id = ${db.quote(jobId)}`)
+      })
+
+      await main._sweepOrphans()
+
+      await timeout({timeout: 2000}, async () => {
+        while (true) {
+          if (orphanedEvents.length >= 1) break
+
+          await wait(0.05)
+        }
+      })
+
+      expect(orphanedEvents.length).toEqual(1)
+      expect(orphanedEvents[0].context.jobId).toEqual(jobId)
+      expect(orphanedEvents[0].context.jobName).toEqual("AppendJob")
+      expect(orphanedEvents[0].context.jobArgs).toEqual(["orphan", "me"])
+      expect(orphanedEvents[0].context.stage).toEqual("background-job-orphaned")
+      expect(orphanedEvents[0].context.terminal).toEqual(true)
+      expect(orphanedEvents[0].context.willRetry).toEqual(false)
+    } finally {
+      dummyConfiguration.getErrorEvents().off("background-job-orphaned", onOrphaned)
+      await main.stop()
+    }
+  })
 })

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -657,10 +657,10 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
       await db.query(`UPDATE background_jobs SET handoff_id = NULL WHERE id = ${db.quote(jobId)}`)
     })
 
-    const orphanedCount = await store.markOrphanedJobs({orphanedAfterMs: 0})
+    const orphanedJobs = await store.markOrphanedJobs({orphanedAfterMs: 0})
     const job = await getJobOrFail({jobId, store})
 
-    expect(orphanedCount).toEqual(1)
+    expect(orphanedJobs.length).toEqual(1)
     expect(job.status).toEqual("queued")
     expect(job.attempts).toEqual(1)
     expect(job.orphanedAtMs).toBeGreaterThan(0)
@@ -714,9 +714,9 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     const scriptedDb = /** @type {import("../../src/database/drivers/base.js").default} */ (db)
     const store = new ScriptedBackgroundJobsStore({db: scriptedDb, job: /** @type {?} */ (rawRow)})
 
-    const count = await store.markOrphanedJobs({orphanedAfterMs: 0})
+    const orphanedJobs = await store.markOrphanedJobs({orphanedAfterMs: 0})
 
-    expect(count).toEqual(0)
+    expect(orphanedJobs.length).toEqual(0)
     expect(capturedConditions).toEqual({id: "stranded-1", status: "handed_off", handed_off_at_ms: 1000})
     expect(releaseCalls).toEqual(0)
   })

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -785,6 +785,37 @@ export default class BackgroundJobsMain {
   }
 
   /**
+   * Emits `background-job-orphaned` (mirrored to `all-error`) for a job the time-based orphan sweep
+   * reclaimed after its worker died mid-run. Unlike `background-job-failed`, which fires on a
+   * worker's failure report, this fires from the main process's sweep, so applications can react to
+   * a dead worker's specific job — recover the work it left behind — without polling. `willRetry`
+   * reflects whether the reclaim returned the job to the queue for another attempt.
+   * @param {{job: import("./types.js").BackgroundJobRow}} args - The orphaned job.
+   * @returns {void}
+   */
+  _emitBackgroundJobOrphaned({job}) {
+    const normalizedError = this._normalizeFailureError(job.lastError ?? "Job orphaned after timeout")
+    const payload = {
+      context: {
+        attempts: job.attempts,
+        jobArgs: job.args,
+        jobId: job.id,
+        jobName: job.jobName,
+        maxRetries: job.maxRetries,
+        stage: "background-job-orphaned",
+        status: job.status,
+        terminal: job.status === "failed" || job.status === "orphaned",
+        willRetry: job.status === "queued"
+      },
+      error: normalizedError
+    }
+    const errorEvents = this.configuration.getErrorEvents()
+
+    errorEvents.emit("background-job-orphaned", payload)
+    errorEvents.emit("all-error", {...payload, errorType: "background-job-orphaned"})
+  }
+
+  /**
    * Runs normalize failure error.
    * @param {?} error - Reported failure value.
    * @returns {Error} Normalized error.
@@ -1170,10 +1201,16 @@ export default class BackgroundJobsMain {
 
   async _sweepOrphans() {
     try {
-      const count = await this.store.markOrphanedJobs()
+      const orphanedJobs = await this.store.markOrphanedJobs()
 
-      if (count > 0) {
-        this.logger.warn(() => ["Marked orphaned background jobs", count])
+      if (orphanedJobs.length > 0) {
+        this.logger.warn(() => ["Marked orphaned background jobs", orphanedJobs.length])
+        // Emit an event per orphaned job so applications can react to a dead
+        // worker's specific job (e.g. targeted recovery) instead of only
+        // polling for its aftermath.
+        for (const job of orphanedJobs) {
+          this._emitBackgroundJobOrphaned({job})
+        }
         // Reclaimed orphans become `queued` again — wake the dispatcher
         // so they aren't stranded until the next external signal.
         this._notifyEnqueued()

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -1205,16 +1205,22 @@ export default class BackgroundJobsMain {
 
       if (orphanedJobs.length > 0) {
         this.logger.warn(() => ["Marked orphaned background jobs", orphanedJobs.length])
-        // Emit an event per orphaned job so applications can react to a dead
-        // worker's specific job (e.g. targeted recovery) instead of only
-        // polling for its aftermath.
-        for (const job of orphanedJobs) {
-          this._emitBackgroundJobOrphaned({job})
-        }
-        // Reclaimed orphans become `queued` again — wake the dispatcher
-        // so they aren't stranded until the next external signal.
+        // Reclaimed orphans become `queued` again — wake the dispatcher first so
+        // an application event handler that throws below cannot strand them
+        // queued until the next external enqueue/reconnect.
         this._notifyEnqueued()
         await this._drain()
+        // Emit an event per orphaned job so applications can react to a dead
+        // worker's specific job (e.g. targeted recovery) instead of only polling
+        // for its aftermath. Isolate each so one throwing handler can't suppress
+        // the events for the rest.
+        for (const job of orphanedJobs) {
+          try {
+            this._emitBackgroundJobOrphaned({job})
+          } catch (error) {
+            this.logger.error(() => ["A background-job-orphaned event handler threw:", error])
+          }
+        }
       }
     } catch (error) {
       this.logger.error(() => ["Failed to mark orphaned jobs:", error])

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -1076,10 +1076,30 @@ export default class BackgroundJobsStore {
     if (affectedRows !== 1) return null
     await this._releaseConcurrency(db, job.concurrencyKey)
 
-    const updatedJob = await this._getJobRowById(db, job.id)
+    // Return a snapshot of the transition this update just applied rather than re-reading the row.
+    // We won the conditional update (affectedRows === 1), so this state is authoritative; re-reading
+    // could instead observe a newer state if another dispatcher reclaims a requeued job between the
+    // update and the read (overlapping mains / polling dispatch), which would misreport the
+    // status/terminal/willRetry of this transition to failure/orphan event listeners.
+    const status = shouldRetry ? "queued" : (markOrphaned ? "orphaned" : "failed")
+    /** @type {import("./types.js").BackgroundJobRow} */
+    const transitionedJob = {
+      ...job,
+      attempts: nextAttempt,
+      handedOffAtMs: null,
+      lastError: failureMessage,
+      status,
+      workerId: null
+    }
 
-    if (!updatedJob) return null
-    return updatedJob
+    if (markOrphaned) transitionedJob.orphanedAtMs = now
+    if (shouldRetry) {
+      transitionedJob.scheduledAtMs = scheduledAt
+    } else if (!markOrphaned) {
+      transitionedJob.failedAtMs = now
+    }
+
+    return transitionedJob
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -547,7 +547,7 @@ export default class BackgroundJobsStore {
    * Runs mark orphaned jobs.
    * @param {object} [args] - Options.
    * @param {number} [args.orphanedAfterMs] - Mark jobs orphaned after this duration.
-   * @returns {Promise<number>} - Count of orphaned jobs.
+   * @returns {Promise<import("./types.js").BackgroundJobRow[]>} - The jobs this sweep marked orphaned.
    */
   async markOrphanedJobs({orphanedAfterMs = ORPHANED_AFTER_MS} = {}) {
     await this.ensureReady()
@@ -562,7 +562,8 @@ export default class BackgroundJobsStore {
 
       const rows = await query.results()
 
-      let orphanedCount = 0
+      /** @type {import("./types.js").BackgroundJobRow[]} */
+      const orphanedJobs = []
 
       for (const row of rows) {
         const job = this._normalizeJobRow(row)
@@ -588,10 +589,10 @@ export default class BackgroundJobsStore {
           conditions: {id: job.id, status: "handed_off", handed_off_at_ms: job.handedOffAtMs}
         })
 
-        if (orphanedJob) orphanedCount += 1
+        if (orphanedJob) orphanedJobs.push(orphanedJob)
       }
 
-      return orphanedCount
+      return orphanedJobs
     })
   }
 


### PR DESCRIPTION
## Summary

The `background-jobs-main` time-based orphan sweep marks a dead worker's job orphaned (`markOrphanedJobs`) but emitted **no event** — so applications could only discover the aftermath by polling. This adds a `background-job-orphaned` error event so consumers can react to the *specific* job a dead worker left behind (e.g. enqueue a targeted recovery) instead of scanning periodically.

## Changes

- **New `background-job-orphaned` event** (mirrored to `all-error` as `errorType: "background-job-orphaned"`), emitted per reclaimed job from `_sweepOrphans`. Its `context` mirrors `background-job-failed`: `jobId`, `jobName`, `jobArgs`, `attempts`, `maxRetries`, `status`, `terminal`, `willRetry`, `stage: "background-job-orphaned"`. `willRetry` is `true` when the reclaim re-queued the job (retries remaining), `false` when it exhausted into a terminal `orphaned` state.
- `store.markOrphanedJobs()` now returns the reclaimed job rows instead of a count, so the main can emit per job (only callers: `main` + specs, both updated).

```js
configuration.getErrorEvents().on("background-job-orphaned", ({context}) => {
  if (context.jobName !== "RunBuildJob") return
  enqueueTargetedRecovery(context.jobArgs[0])
})
```

## Tests / docs

- `queue-spec.js`: new integration test — a `handed_off` job whose worker "died" is reclaimed by the sweep and emits `background-job-orphaned` with the right `jobName`/`jobArgs`/`terminal`/`willRetry`.
- `store-spec.js`: updated to assert the returned job list.
- Docs: new "Orphaned jobs" subsection under Failure Events; changelog fragment.

## Checks

`npm run lint` (eslint + tsc + fallow) green; `spec/background-jobs/store-spec.js` 34/34, `spec/background-jobs/queue-spec.js` 6/6.

## Context

Enables the downstream TensorBuzz work (AwesomeTasks #10381): react to an orphaned `RunBuildJob` with a targeted orphaned-build recovery + docker-server slot reconcile, so the 1-minute scanning jobs can be demoted to hourly backstops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
