### PR TITLE
feat(background-jobs): support scheduled enqueue timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2052,6 +2052,17 @@ await MyJob.performLaterWithOptions({
 })
 ```
 
+Schedule a one-off job for a specific epoch timestamp in milliseconds:
+
+```js
+await MyJob.performLaterWithOptions({
+  args: ["a", "b"],
+  options: {scheduledAtMs: Date.now() + 2 * 60 * 60 * 1000}
+})
+```
+
+Until `scheduledAtMs` is reached, the job remains queued but is not eligible for dispatch. The event-driven dispatcher arms its timer for the earliest future job and wakes at that timestamp. Omitting `scheduledAtMs` keeps the immediate-enqueue behavior.
+
 The older `options: {forked: false}` form is still accepted as an alias for inline execution, and `options: {forked: true}` maps to forked execution. To use the previous spawned CLI runner behavior explicitly, pass `options: {executionMode: "spawned"}`.
 
 Inline jobs share the worker process and run concurrently up to `maxConcurrentInlineJobs`, so a single slow inline job no longer blocks the queue. A single worker can also override the configured cap explicitly:

--- a/changelog.d/20260718090500-background-job-scheduled-at-option.md
+++ b/changelog.d/20260718090500-background-job-scheduled-at-option.md
@@ -1,0 +1,1 @@
+Add `scheduledAtMs` to background-job enqueue options so applications can durably schedule a one-off job for an exact future epoch timestamp. Future jobs stay queued and ineligible until their timestamp, while the event-driven dispatcher wakes at the earliest scheduled time.

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -791,6 +791,33 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(next?.scheduledAtMs).toBeGreaterThan(Date.now())
   })
 
+  it("enqueues a job for an explicit future scheduledAtMs", async () => {
+    const store = await createClearedStore()
+    const laterScheduledAtMs = Date.now() + 60000
+    const soonerScheduledAtMs = laterScheduledAtMs - 30000
+    const laterJobId = await store.enqueue({
+      jobName: "TestJob",
+      args: ["later"],
+      options: {forked: false, scheduledAtMs: laterScheduledAtMs}
+    })
+    const soonerJobId = await store.enqueue({
+      jobName: "TestJob",
+      args: ["sooner"],
+      options: {forked: false, scheduledAtMs: soonerScheduledAtMs}
+    })
+
+    expect((await getJobOrFail({jobId: laterJobId, store})).scheduledAtMs).toEqual(laterScheduledAtMs)
+    expect(await store.nextAvailableJob()).toBeNull()
+    expect((await store.nextScheduledJob())?.id).toEqual(soonerJobId)
+  })
+
+  it("rejects invalid scheduledAtMs enqueue options", async () => {
+    const store = await createClearedStore()
+
+    await expect(async () => await store.enqueue({jobName: "TestJob", args: [], options: {scheduledAtMs: -1}})).toThrow(/scheduledAtMs/)
+    await expect(async () => await store.enqueue({jobName: "TestJob", args: [], options: {scheduledAtMs: Number.POSITIVE_INFINITY}})).toThrow(/scheduledAtMs/)
+  })
+
   it("returns null from nextScheduledJob when no future-scheduled jobs exist", async () => {
     const store = await createClearedStore()
 

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -99,6 +99,7 @@ export default class BackgroundJobsStore {
     const now = Date.now()
     const executionMode = this._normalizeExecutionMode(options)
     const maxRetries = this._normalizeMaxRetries(options?.maxRetries)
+    const scheduledAtMs = this._normalizeScheduledAtMs(options?.scheduledAtMs, now)
     const argsJson = JSON.stringify(args || [])
     const queue = this._normalizeQueue(options)
     const concurrency = this._resolveConcurrency(options, queue)
@@ -141,7 +142,7 @@ export default class BackgroundJobsStore {
           max_retries: maxRetries,
           attempts: 0,
           status: "queued",
-          scheduled_at_ms: now,
+          scheduled_at_ms: scheduledAtMs,
           created_at_ms: now,
           concurrency_key: concurrency?.concurrencyKey || null,
           max_concurrency: concurrency?.maxConcurrency || null
@@ -723,6 +724,19 @@ export default class BackgroundJobsStore {
     }
 
     return DEFAULT_MAX_RETRIES
+  }
+
+  /**
+   * Runs normalize scheduled at ms.
+   * @param {number | undefined} scheduledAtMs - Requested dispatch timestamp.
+   * @param {number} defaultScheduledAtMs - Default dispatch timestamp.
+   * @returns {number} - Dispatch timestamp.
+   */
+  _normalizeScheduledAtMs(scheduledAtMs, defaultScheduledAtMs) {
+    if (scheduledAtMs === undefined) return defaultScheduledAtMs
+    if (Number.isSafeInteger(scheduledAtMs) && scheduledAtMs >= 0) return scheduledAtMs
+
+    throw new Error("background job scheduledAtMs must be a non-negative safe integer")
   }
 
   async _ensureSchema() {

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -17,6 +17,7 @@
  * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap. Overrides any queue-derived cap.
  * @property {number} [maxConcurrency] - Positive integer cap; must be paired with `concurrencyKey`.
  * @property {boolean} [deduplicateWhileQueued] - When true (requires `concurrencyKey`), skip the enqueue if a still-queued job with the same `concurrencyKey` already exists, returning that job's id. Keeps an interval-scheduled recurring job (e.g. retention pruning) from piling up redundant queued rows when it runs slower than its interval or no worker is free.
+ * @property {number} [scheduledAtMs] - Epoch timestamp in milliseconds when the job becomes eligible for dispatch. Defaults to enqueue time.
  */
 /**
  * @typedef {object} BackgroundJobPayload


### PR DESCRIPTION
## Summary
- add a validated `scheduledAtMs` one-off enqueue option
- preserve exact future timestamps in the durable queue
- document scheduled enqueue behavior

## Testing
- `npm test -- spec/background-jobs/store-spec.js:794 spec/background-jobs/store-spec.js:814`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`