### PR TITLE
fix(background-jobs): expose schedule validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 * Cross-process broadcast bus for `broadcastToChannel` via `velocious beacon`, including background job runner processes (see [docs/beacon.md](docs/beacon.md))
 * Configurable HTTP server worker handlers plus backpressured, descriptor-only file responses with completion callbacks (see [docs/http-server.md](docs/http-server.md))
 * Background jobs with failure events for production reporting (see [docs/background-jobs.md](docs/background-jobs.md))
+* Durable one-off background-job scheduling with exact epoch timestamps (see [docs/scheduled-background-job-enqueue.md](docs/scheduled-background-job-enqueue.md))
 * Rails-style request and database query logging (see [docs/logging.md](docs/logging.md))
 * EJS-backed mailers with delivery, queueing, and payload rendering support (see [docs/mailers.md](docs/mailers.md))
 * Trusted reverse proxy handling for `request.remoteAddress()` (see [docs/trusted-proxies.md](docs/trusted-proxies.md))
@@ -2052,7 +2053,7 @@ await MyJob.performLaterWithOptions({
 })
 ```
 
-Schedule a one-off job for a specific epoch timestamp in milliseconds:
+[Schedule a one-off job](docs/scheduled-background-job-enqueue.md) for a specific epoch timestamp in milliseconds:
 
 ```js
 await MyJob.performLaterWithOptions({

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -2,6 +2,8 @@
 
 Velocious background jobs are documented in the main README. This page covers behavior that applications usually need when operating background jobs in production.
 
+For delayed one-off work, see [Scheduling One-Off Background Jobs](scheduled-background-job-enqueue.md). Recurring schedules use the separate `scheduledBackgroundJobs` configuration described in the [README](../README.md#scheduled-jobs).
+
 ## Durable concurrency limits
 
 Pass `concurrencyKey` and `maxConcurrency` together in `jobOptions` (or in `performLaterWithOptions`). The key is an opaque, non-empty string shared by jobs that use the same limit, and the cap is a positive integer. Omitting both preserves unlimited behavior. Once a key is registered, every enqueue for that key must use the same cap; a conflicting cap is rejected.

--- a/docs/scheduled-background-job-enqueue.md
+++ b/docs/scheduled-background-job-enqueue.md
@@ -1,0 +1,16 @@
+# Scheduling One-Off Background Jobs
+
+Pass `scheduledAtMs` to `performLaterWithOptions` when a job should become eligible at one exact epoch timestamp in milliseconds:
+
+```js
+await MyJob.performLaterWithOptions({
+  args: ["account-123"],
+  options: {scheduledAtMs: Date.now() + 2 * 60 * 60 * 1000}
+})
+```
+
+The job is persisted immediately with status `queued`, but workers cannot receive it before `scheduledAtMs`. The event-driven dispatcher arms a timer for the earliest future job and re-evaluates the queue at that timestamp. A main-process restart does not lose the schedule because the timestamp lives in the background-jobs table.
+
+`scheduledAtMs` must be a non-negative JavaScript safe integer. Invalid values reject the enqueue promise with the validation message. A timestamp in the past, including `0`, is valid and makes the job eligible for immediate dispatch. Omitting the option preserves immediate enqueue behavior.
+
+This option schedules one job once. For recurring jobs, use the [`scheduledBackgroundJobs` configuration](../README.md#scheduled-jobs). For queue limits, retries, worker recovery, and operational behavior, see [Background Jobs](background-jobs.md).

--- a/spec/background-jobs/basic-spec.js
+++ b/spec/background-jobs/basic-spec.js
@@ -181,6 +181,36 @@ describe("Background jobs", {databaseCleaning: {truncate: true}}, () => {
     await main.stop()
   })
 
+  it("returns scheduledAtMs validation errors to enqueue callers", async () => {
+    const {main} = await startBackgroundJobsMain()
+    const errorEvents = dummyConfiguration.getErrorEvents()
+    let frameworkErrorCount = 0
+    const onFrameworkError = () => {
+      frameworkErrorCount += 1
+    }
+
+    dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: main.getPort()})
+
+    /** @type {Error | undefined} */
+    let enqueueError
+
+    errorEvents.on("framework-error", onFrameworkError)
+
+    try {
+      await TestJob.performLaterWithOptions({args: [], options: {scheduledAtMs: -1}})
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
+
+      enqueueError = error
+    } finally {
+      errorEvents.off("framework-error", onFrameworkError)
+      await main.stop()
+    }
+
+    expect(enqueueError?.message).toEqual("background job scheduledAtMs must be a non-negative safe integer")
+    expect(frameworkErrorCount).toEqual(0)
+  })
+
   it("runs a job in a true forked worker child", async () => {
     const {main, store, worker} = await startBackgroundJobs()
     const outputPath = await outputPathFor("forked-job")

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -6,6 +6,7 @@ import BackgroundJobsScheduler from "./scheduler.js"
 import BackgroundJobsStore from "./store.js"
 import Logger from "../logger.js"
 import PruneTerminalBackgroundJobsJob from "../jobs/prune-terminal-background-jobs.js"
+import VelociousError from "../velocious-error.js"
 
 /**
  * Channel used by `background-jobs-main` to coordinate dispatch wake-ups
@@ -683,7 +684,21 @@ export default class BackgroundJobsMain {
       this._notifyEnqueued()
       await this._drain()
     } catch (error) {
-      this.logger.error(() => ["Failed to enqueue background job:", error])
+      if (error instanceof VelociousError && error.safeToExpose) {
+        jsonSocket.send({type: "enqueue-error", error: error.message})
+        return
+      }
+
+      const normalizedError = error instanceof Error ? error : new Error(String(error))
+      const payload = {
+        context: {jobName: message.jobName, stage: "background-job-enqueue"},
+        error: normalizedError
+      }
+      const errorEvents = this.configuration.getErrorEvents()
+
+      this.logger.error(() => ["Failed to enqueue background job:", normalizedError])
+      errorEvents.emit("framework-error", payload)
+      errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
       jsonSocket.send({type: "enqueue-error", error: "Failed to enqueue job"})
     }
   }

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -3,6 +3,7 @@
 import {randomUUID} from "crypto"
 import Logger from "../logger.js"
 import TableData from "../database/table-data/index.js"
+import VelociousError from "../velocious-error.js"
 import BackgroundJobRecord from "./job-record.js"
 import normalizeBackgroundJobError from "./normalize-error.js"
 
@@ -736,7 +737,7 @@ export default class BackgroundJobsStore {
     if (scheduledAtMs === undefined) return defaultScheduledAtMs
     if (Number.isSafeInteger(scheduledAtMs) && scheduledAtMs >= 0) return scheduledAtMs
 
-    throw new Error("background job scheduledAtMs must be a non-negative safe integer")
+    throw VelociousError.safe("background job scheduledAtMs must be a non-negative safe integer")
   }
 
   async _ensureSchema() {


### PR DESCRIPTION
## Summary
- expose client-safe `scheduledAtMs` validation errors through the enqueue socket
- keep unexpected enqueue failures generic for callers while reporting them through framework error events
- add the required dedicated one-off scheduling documentation and cross-links

## Tests
- `npm test -- spec/background-jobs/basic-spec.js:184 spec/background-jobs/store-spec.js:794 spec/background-jobs/store-spec.js:814`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`

## Context
- Follow-up to #904, which merged while these review fixes were being validated.
- Task: https://tasks.diestoeckels.de/projects/111/boards/105?task_id=10379