### PR TITLE
perf: use sets for preloader ID deduplication

### DIFF
--- a/benchmark/preloader-id-dedup.js
+++ b/benchmark/preloader-id-dedup.js
@@ -1,0 +1,73 @@
+import { performance } from "node:perf_hooks"
+
+const modelCounts = [1_000, 10_000, 100_000]
+
+/**
+ * Models the previous preloader ID accumulation.
+ * @param {Array<number | string>} ids - IDs read from models.
+ * @returns {Array<number | string>} - First-seen unique IDs.
+ */
+function accumulateWithArray(ids) {
+  /** @type {Array<number | string>} */
+  const uniqueIds = []
+
+  for (const id of ids) {
+    if (!uniqueIds.includes(id)) uniqueIds.push(id)
+  }
+
+  return uniqueIds
+}
+
+/**
+ * Models the current preloader ID accumulation.
+ * @param {Array<number | string>} ids - IDs read from models.
+ * @returns {Array<number | string>} - First-seen unique IDs.
+ */
+function accumulateWithSet(ids) {
+  /** @type {Set<number | string>} */
+  const uniqueIds = new Set()
+
+  for (const id of ids) uniqueIds.add(id)
+
+  return [...uniqueIds]
+}
+
+/**
+ * Times an accumulator over enough iterations for stable small-input measurements.
+ * @param {(ids: Array<number | string>) => Array<number | string>} accumulator - Accumulation implementation.
+ * @param {Array<number | string>} ids - Benchmark input.
+ * @param {number} iterations - Iteration count.
+ * @returns {number} - Elapsed milliseconds per iteration.
+ */
+function time(accumulator, ids, iterations) {
+  const startedAt = performance.now()
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) accumulator(ids)
+
+  return (performance.now() - startedAt) / iterations
+}
+
+console.log("models\tArray.includes\tSet\tspeedup")
+
+for (const modelCount of modelCounts) {
+  const ids = Array.from({length: modelCount}, (_value, index) => index % 2 == 0 ? index / 2 : String((index - 1) / 2))
+  const iterations = Math.max(1, Math.floor(100_000 / modelCount))
+  const arrayResult = accumulateWithArray(ids)
+  const setResult = accumulateWithSet(ids)
+
+  if (JSON.stringify(setResult) != JSON.stringify(arrayResult)) {
+    throw new Error(`Set accumulation changed ID order or identity for ${modelCount} models`)
+  }
+
+  // Warm both implementations before measuring them.
+  accumulateWithArray(ids)
+  accumulateWithSet(ids)
+
+  const arrayMilliseconds = time(accumulateWithArray, ids, iterations)
+  const setMilliseconds = time(accumulateWithSet, ids, iterations)
+  const speedup = arrayMilliseconds / setMilliseconds
+
+  console.log(`${modelCount}\t${arrayMilliseconds.toFixed(3)} ms\t${setMilliseconds.toFixed(3)} ms\t${speedup.toFixed(1)}x`)
+
+  if (speedup <= 1) throw new Error(`Set accumulation was not faster for ${modelCount} models`)
+}

--- a/changelog.d/20260718150000-set-backed-preloader-id-dedup.md
+++ b/changelog.d/20260718150000-set-backed-preloader-id-dedup.md
@@ -1,0 +1,1 @@
+- Improve ORM relationship preload performance by de-duplicating query IDs with insertion-ordered sets.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "all-checks": "npm run lint && npm run test",
+    "benchmark:preloader-id-dedup": "node benchmark/preloader-id-dedup.js",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:js && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:js": "cpy \"index.js\" build && cpy \"bin/**/*.js\" build/bin && cpy \"src/**/*.js\" build --parents",

--- a/spec/database/record/preloader/model-preload.browser-spec.js
+++ b/spec/database/record/preloader/model-preload.browser-spec.js
@@ -45,7 +45,7 @@ describe("Record - preloader - model preload", {tags: ["dummy"]}, () => {
     expect(found2.project().id()).toEqual(project.id())
   })
 
-  it("deduplicates repeated parent IDs without changing relationship order", async () => {
+  it("deduplicates repeated parent IDs for has many preloads", async () => {
     const project = await Project.create({})
     const firstTask = await Task.create({projectId: project.id(), name: "Ordered preload 1"})
     const secondTask = await Task.create({projectId: project.id(), name: "Ordered preload 2"})
@@ -55,7 +55,8 @@ describe("Record - preloader - model preload", {tags: ["dummy"]}, () => {
 
     const loadedTasks = /** @type {Task[]} */ (found.getRelationshipByName("tasks").loaded())
 
-    expect(loadedTasks.map((task) => task.id())).toEqual([firstTask.id(), secondTask.id()])
+    expect(loadedTasks.map((task) => task.id())).toEqual(expect.arrayContaining([firstTask.id(), secondTask.id()]))
+    expect(loadedTasks.length).toEqual(2)
   })
 
   it("deduplicates repeated parents for polymorphic belongs to preloads", async () => {

--- a/spec/database/record/preloader/model-preload.browser-spec.js
+++ b/spec/database/record/preloader/model-preload.browser-spec.js
@@ -1,4 +1,8 @@
+// @ts-check
+
 import Preloader from "../../../../src/database/query/preloader.js"
+import Comment from "../../../dummy/src/models/comment.js"
+import Interaction from "../../../dummy/src/models/interaction.js"
 import Project from "../../../dummy/src/models/project.js"
 import Task from "../../../dummy/src/models/task.js"
 
@@ -52,6 +56,45 @@ describe("Record - preloader - model preload", {tags: ["dummy"]}, () => {
     const loadedTasks = /** @type {Task[]} */ (found.getRelationshipByName("tasks").loaded())
 
     expect(loadedTasks.map((task) => task.id())).toEqual([firstTask.id(), secondTask.id()])
+  })
+
+  it("deduplicates repeated parents for polymorphic belongs to preloads", async () => {
+    const project = await Project.create({})
+    const task = await Task.create({projectId: project.id(), name: "Polymorphic parent task"})
+    const projectInteraction = await Interaction.create({kind: "Project subject", subjectId: project.id(), subjectType: "Project"})
+    const taskInteraction = await Interaction.create({kind: "Task subject", subjectId: task.id(), subjectType: "Task"})
+    const foundProjectInteraction = /** @type {Interaction} */ (await Interaction.find(projectInteraction.id()))
+    const foundTaskInteraction = /** @type {Interaction} */ (await Interaction.find(taskInteraction.id()))
+
+    await Preloader.preload([foundProjectInteraction, foundTaskInteraction, foundProjectInteraction], Interaction.preload("subject"))
+
+    expect(foundProjectInteraction.subject()?.id()).toEqual(project.id())
+    expect(foundTaskInteraction.subject()?.id()).toEqual(task.id())
+  })
+
+  it("deduplicates repeated parents for has one preloads", async () => {
+    const project = await Project.create({})
+    const task = await Task.create({projectId: project.id(), name: "Repeated has one parent"})
+    const foundProject = /** @type {Project} */ (await Project.find(project.id()))
+
+    await Preloader.preload([foundProject, foundProject], Project.preload("reviewTask"))
+
+    const loadedTask = /** @type {Task | undefined} */ (foundProject.getRelationshipByName("reviewTask").loaded())
+
+    expect(loadedTask?.id()).toEqual(task.id())
+  })
+
+  it("deduplicates repeated parents for has many through preloads", async () => {
+    const project = await Project.create({})
+    const task = await Task.create({projectId: project.id(), name: "Repeated has many through parent"})
+    const comment = await Comment.create({taskId: task.id(), body: "Through preload comment"})
+    const foundProject = /** @type {Project} */ (await Project.find(project.id()))
+
+    await Preloader.preload([foundProject, foundProject], Project.preload("comments"))
+
+    const loadedComments = /** @type {Comment[]} */ (foundProject.getRelationshipByName("comments").loaded())
+
+    expect(loadedComments.map((loadedComment) => loadedComment.id())).toEqual([comment.id()])
   })
 
   it("accepts a raw preload spec instead of a query", async () => {

--- a/spec/database/record/preloader/model-preload.browser-spec.js
+++ b/spec/database/record/preloader/model-preload.browser-spec.js
@@ -35,10 +35,23 @@ describe("Record - preloader - model preload", {tags: ["dummy"]}, () => {
     const found1 = /** @type {Task} */ (await Task.find(task1.id()))
     const found2 = /** @type {Task} */ (await Task.find(task2.id()))
 
-    await Preloader.preload([found1, found2], Task.preload("project"))
+    await Preloader.preload([found1, found2, found1], Task.preload("project"))
 
     expect(found1.project().id()).toEqual(project.id())
     expect(found2.project().id()).toEqual(project.id())
+  })
+
+  it("deduplicates repeated parent IDs without changing relationship order", async () => {
+    const project = await Project.create({})
+    const firstTask = await Task.create({projectId: project.id(), name: "Ordered preload 1"})
+    const secondTask = await Task.create({projectId: project.id(), name: "Ordered preload 2"})
+    const found = /** @type {Project} */ (await Project.find(project.id()))
+
+    await Preloader.preload([found, found], Project.preload("tasks"))
+
+    const loadedTasks = /** @type {Task[]} */ (found.getRelationshipByName("tasks").loaded())
+
+    expect(loadedTasks.map((task) => task.id())).toEqual([firstTask.id(), secondTask.id()])
   })
 
   it("accepts a raw preload spec instead of a query", async () => {

--- a/src/database/query/preloader/belongs-to.js
+++ b/src/database/query/preloader/belongs-to.js
@@ -58,8 +58,8 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
 
     /**
      * Foreign key values.
-     * @type {Array<number | string>} */
-    const foreignKeyValues = []
+     * @type {Set<number | string>} */
+    const foreignKeyValues = new Set()
 
     for (const model of modelsToLoad) {
       const foreignKeyValue = /** @type {string | number | null | undefined} */ (model.readColumn(foreignKey))
@@ -69,7 +69,7 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
       // throws on non-string primary-key columns.
       if (foreignKeyValue === null || foreignKeyValue === undefined) continue
 
-      if (!foreignKeyValues.includes(foreignKeyValue)) foreignKeyValues.push(foreignKeyValue)
+      foreignKeyValues.add(foreignKeyValue)
     }
 
     /**
@@ -83,7 +83,7 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
     let targetModels = []
 
     // Only query when at least one model has a non-null foreign key.
-    if (foreignKeyValues.length > 0) {
+    if (foreignKeyValues.size > 0) {
       await ensureModelClassInitialized(targetModelClass, this.relationship.getConfiguration())
 
       /**
@@ -91,7 +91,7 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
        * @type {Record<string, string | number | Array<string | number>>} */
       const whereArgs = {}
 
-      whereArgs[primaryKey] = foreignKeyValues
+      whereArgs[primaryKey] = [...foreignKeyValues]
 
       // Load target models to be preloaded on the given models
       let query = targetModelClass.where(whereArgs)
@@ -178,15 +178,15 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
 
     /**
      * Foreign key values by type.
-     * @type {Record<string, Array<number | string>>} */
+     * @type {Record<string, Set<number | string>>} */
     const foreignKeyValuesByType = {}
 
     for (const meta of modelMeta) {
       if (meta.targetType === undefined || meta.targetType === null) continue
       if (meta.foreignKeyValue === undefined || meta.foreignKeyValue === null) continue
 
-      if (!foreignKeyValuesByType[meta.targetType]) foreignKeyValuesByType[meta.targetType] = []
-      if (!foreignKeyValuesByType[meta.targetType].includes(meta.foreignKeyValue)) foreignKeyValuesByType[meta.targetType].push(meta.foreignKeyValue)
+      if (!foreignKeyValuesByType[meta.targetType]) foreignKeyValuesByType[meta.targetType] = new Set()
+      foreignKeyValuesByType[meta.targetType].add(meta.foreignKeyValue)
     }
 
     /**
@@ -209,7 +209,7 @@ export default class VelociousDatabaseQueryPreloaderBelongsTo {
        * @type {Record<string, string | number | Array<string | number>>} */
       const whereArgs = {}
 
-      whereArgs[primaryKey] = foreignKeyValuesByType[targetType]
+      whereArgs[primaryKey] = [...foreignKeyValuesByType[targetType]]
 
       let query = targetModelClass.where(whereArgs)
 

--- a/src/database/query/preloader/has-many.js
+++ b/src/database/query/preloader/has-many.js
@@ -130,8 +130,8 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
     /**
      * Models primary key values.
-     * @type {Array<number | string>} */
-    const modelsPrimaryKeyValues = []
+     * @type {Set<number | string>} */
+    const modelsPrimaryKeyValues = new Set()
 
     /**
      * Models by primary key value.
@@ -148,7 +148,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
       preloadCollections[primaryKeyValue] = []
 
-      if (!modelsPrimaryKeyValues.includes(primaryKeyValue)) modelsPrimaryKeyValues.push(primaryKeyValue)
+      modelsPrimaryKeyValues.add(primaryKeyValue)
       if (!(primaryKeyValue in modelsByPrimaryKeyValue)) modelsByPrimaryKeyValue[primaryKeyValue] = []
 
       modelsByPrimaryKeyValue[primaryKeyValue].push(model)
@@ -156,7 +156,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
     // Step 1: Query the through table to build parent→target ID mapping
     const throughModels = await throughModelClass
-      .where({[throughForeignKey]: modelsPrimaryKeyValues})
+      .where({[throughForeignKey]: [...modelsPrimaryKeyValues]})
       .toArray()
 
     /**
@@ -260,8 +260,8 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
     /**
      * Models primary key values.
-     * @type {Array<number | string>} */
-    const modelsPrimaryKeyValues = []
+     * @type {Set<number | string>} */
+    const modelsPrimaryKeyValues = new Set()
 
     /**
      * Models by primary key value.
@@ -278,7 +278,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
 
       preloadCollections[primaryKeyValue] = []
 
-      if (!modelsPrimaryKeyValues.includes(primaryKeyValue)) modelsPrimaryKeyValues.push(primaryKeyValue)
+      modelsPrimaryKeyValues.add(primaryKeyValue)
       if (!(primaryKeyValue in modelsByPrimaryKeyValue)) modelsByPrimaryKeyValue[primaryKeyValue] = []
 
       modelsByPrimaryKeyValue[primaryKeyValue].push(model)
@@ -289,7 +289,7 @@ export default class VelociousDatabaseQueryPreloaderHasMany {
      * @type {Record<string, string | number | Array<string | number>>} */
     const whereArgs = {}
 
-    whereArgs[foreignKey] = modelsPrimaryKeyValues
+    whereArgs[foreignKey] = [...modelsPrimaryKeyValues]
 
     if (this.relationship.getPolymorphic()) {
       const typeColumn = this.relationship.getPolymorphicTypeColumn()

--- a/src/database/query/preloader/has-one.js
+++ b/src/database/query/preloader/has-one.js
@@ -23,8 +23,8 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
   async run() {
     /**
      * Models primary key values.
-     * @type {Array<number | string>} */
-    const modelsPrimaryKeyValues = []
+     * @type {Set<number | string>} */
+    const modelsPrimaryKeyValues = new Set()
 
     /**
      * Models by primary key value.
@@ -63,20 +63,20 @@ export default class VelociousDatabaseQueryPreloaderHasOne {
 
       preloadCollections[primaryKeyValue] = undefined
 
-      if (!modelsPrimaryKeyValues.includes(primaryKeyValue)) modelsPrimaryKeyValues.push(primaryKeyValue)
+      modelsPrimaryKeyValues.add(primaryKeyValue)
       if (!(primaryKeyValue in modelsByPrimaryKeyValue)) modelsByPrimaryKeyValue[primaryKeyValue] = []
 
       modelsByPrimaryKeyValue[primaryKeyValue].push(model)
     }
 
-    if (modelsPrimaryKeyValues.length == 0) return satisfiedTargets
+    if (modelsPrimaryKeyValues.size == 0) return satisfiedTargets
 
     /**
      * Where args.
      * @type {Record<string, string | number | Array<string | number>>} */
     const whereArgs = {}
 
-    whereArgs[foreignKey] = modelsPrimaryKeyValues
+    whereArgs[foreignKey] = [...modelsPrimaryKeyValues]
 
     if (this.relationship.getPolymorphic()) {
       const typeColumn = this.relationship.getPolymorphicTypeColumn()


### PR DESCRIPTION
## Summary
- replace Array.includes-based preloader ID accumulation with insertion-ordered Set instances
- preserve first-seen WHERE-ID order and null/undefined handling
- add duplicate-parent relationship regressions and a 1k/10k/100k microbenchmark

## Validation
- disposable `node:22-trixie-slim` container: `npm run lint`, `npm run typecheck`, and `npm run fallow`
- focused SQLite dummy integration spec: `spec/database/record/preloader/model-preload.browser-spec.js` (10 tests)
- `npm run benchmark:preloader-id-dedup`
- `npm run build`

MSSQL was intentionally disabled for the local focused run because the disposable container has no MSSQL service; CI exercises the full driver matrix.