### PR TITLE
test: document MySQL row materialization contract

### DIFF
--- a/benchmark/mysql-result-row-materialization.js
+++ b/benchmark/mysql-result-row-materialization.js
@@ -1,0 +1,130 @@
+import mysql from "mysql"
+import {performance} from "node:perf_hooks"
+
+const rowCount = Number(process.env.BENCHMARK_ROWS || 10_000)
+const iterations = Number(process.env.BENCHMARK_ITERATIONS || 30)
+const warmupIterations = Number(process.env.BENCHMARK_WARMUPS || 5)
+const mysqlOptions = {
+  database: process.env.MYSQL_DATABASE || "velocious_benchmark",
+  host: process.env.MYSQL_HOST || "mariadb",
+  password: process.env.MYSQL_PASSWORD || "benchmark",
+  port: Number(process.env.MYSQL_PORT || 3306),
+  user: process.env.MYSQL_USER || "benchmark"
+}
+
+/** @param {Array<Record<string, ?>>} rows - Driver rows. @param {Array<{name: string}>} fields - Driver fields. @returns {Array<Record<string, ?>>} - Materialized rows. */
+function fieldCopy(rows, fields) {
+  return rows.map((row) => {
+    const result = {}
+    for (const field of fields) result[field.name] = row[field.name]
+    return result
+  })
+}
+
+/** @param {Array<Record<string, ?>>} rows - Driver rows. @returns {Array<Record<string, ?>>} - Materialized rows. */
+function shallowClone(rows) {
+  return rows.map((row) => ({...row}))
+}
+
+/** @param {Array<Record<string, ?>>} rows - Driver rows. @returns {Array<Record<string, ?>>} - Driver rows. */
+function directRows(rows) {
+  return rows
+}
+
+const strategies = {"field copy": fieldCopy, "shallow clone": shallowClone, "direct driver rows": directRows}
+
+/** @param {import("mysql").Pool} pool - Pool. @param {string} sql - SQL. @returns {Promise<{fields: Array<{name: string}>, rows: Array<Record<string, ?>>}>} - Raw result. */
+function rawQuery(pool, sql) {
+  return new Promise((resolve, reject) => {
+    pool.query(sql, (error, rows, fields) => {
+      if (error) reject(error)
+      else resolve({fields, rows})
+    })
+  })
+}
+
+/** @param {import("mysql").Pool} pool - Pool. @param {string} sql - SQL. @param {(rows: Array<Record<string, ?>>, fields: Array<{name: string}>) => Array<Record<string, ?>>} materialize - Strategy. @returns {Promise<Array<Record<string, ?>>>} - Rows. */
+async function queryWith(pool, sql, materialize) {
+  const result = await rawQuery(pool, sql)
+  return materialize(result.rows, result.fields)
+}
+
+/** @param {number[]} values - Samples. @returns {number} - Median. */
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 == 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+}
+
+const pool = mysql.createPool({...mysqlOptions, connectionLimit: 1, timezone: "Z"})
+const tableName = `velocious_benchmark_numbers_${process.pid}`
+const sql = `SELECT n AS task_id, CONCAT('task-', n) AS task_alias, IF(n % 7 = 0, NULL, n * 1.25) AS nullable_value, TIMESTAMP('2026-07-18 12:34:56') AS occurred_at, UNHEX(LPAD(HEX(n), 16, '0')) AS payload FROM ${tableName} ORDER BY n LIMIT ${rowCount}`
+let tableCreated = false
+
+try {
+  await rawQuery(pool, `CREATE TABLE ${tableName} (n INT PRIMARY KEY)`)
+  tableCreated = true
+
+  const values = Array.from({length: rowCount}, (_value, index) => `(${index + 1})`)
+  for (let offset = 0; offset < values.length; offset += 1_000) {
+    await rawQuery(pool, `INSERT INTO ${tableName} (n) VALUES ${values.slice(offset, offset + 1_000).join(",")}`)
+  }
+
+  const raw = await rawQuery(pool, sql)
+  const baseline = fieldCopy(raw.rows, raw.fields)
+  const procedureRows = [[raw.rows[0]]]
+  const procedureFields = [[raw.fields]]
+  const procedureBaseline = fieldCopy(procedureRows, procedureFields)
+  console.log(`Node ${process.version}; rows=${rowCount}; iterations=${iterations}; warmups=${warmupIterations}`)
+  console.log("strategy\tmaterialization ms\tend-to-end ms\tcontract")
+
+  const materializationSamples = Object.fromEntries(Object.keys(strategies).map((name) => [name, []]))
+  const endToEndSamples = Object.fromEntries(Object.keys(strategies).map((name) => [name, []]))
+  const contracts = {}
+
+  for (const [name, strategy] of Object.entries(strategies)) {
+    const candidate = strategy(raw.rows, raw.fields)
+    const plain = candidate.every((row) => Object.getPrototypeOf(row) === Object.prototype)
+    const isolated = candidate !== raw.rows && candidate.every((row, index) => row !== raw.rows[index])
+    const valuesPreserved = JSON.stringify(candidate) === JSON.stringify(baseline)
+    const procedureShapePreserved = JSON.stringify(strategy(procedureRows, procedureFields)) === JSON.stringify(procedureBaseline)
+    const contract = plain && isolated && valuesPreserved && procedureShapePreserved ? "pass" : `fail (plain=${plain}, isolated=${isolated}, values=${valuesPreserved}, procedure=${procedureShapePreserved})`
+
+    contracts[name] = contract
+  }
+
+  const strategyEntries = Object.entries(strategies)
+  for (let warmup = 0; warmup < warmupIterations; warmup++) {
+    for (const [, strategy] of strategyEntries) {
+      strategy(raw.rows, raw.fields)
+      await queryWith(pool, sql, strategy)
+    }
+  }
+
+  // Rotate strategy order each round so server/cache drift does not consistently
+  // favor the implementation measured first or last.
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    const rotated = strategyEntries.slice(iteration % strategyEntries.length).concat(strategyEntries.slice(0, iteration % strategyEntries.length))
+    for (const [name, strategy] of rotated) {
+      let startedAt = performance.now()
+      strategy(raw.rows, raw.fields)
+      materializationSamples[name].push(performance.now() - startedAt)
+
+      startedAt = performance.now()
+      await queryWith(pool, sql, strategy)
+      endToEndSamples[name].push(performance.now() - startedAt)
+    }
+  }
+
+  for (const [name] of strategyEntries) {
+    console.log(`${name}\t${median(materializationSamples[name]).toFixed(3)}\t${median(endToEndSamples[name]).toFixed(3)}\t${contracts[name]}`)
+  }
+
+  console.log("Stored-procedure note: mysql CALL returns nested result sets and an OK packet; direct rows change the legacy flat-row adapter shape and are not contract-compatible.")
+} finally {
+  try {
+    if (tableCreated) await rawQuery(pool, `DROP TABLE ${tableName}`)
+  } finally {
+    await new Promise((resolve) => pool.end(resolve))
+  }
+}

--- a/benchmark/mysql-result-row-materialization.js
+++ b/benchmark/mysql-result-row-materialization.js
@@ -56,10 +56,34 @@ function median(values) {
   return sorted.length % 2 == 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
 }
 
+/**
+ * @param {(rows: Array<Record<string, ?>>, fields: Array<{name: string}>) => Array<Record<string, ?>>} strategy - Strategy.
+ * @param {Array<Array<Record<string, string | number | Date | Buffer | null>> | import("mysql").OkPacket>} rows - Actual CALL rows.
+ * @param {Array<Array<import("mysql").FieldInfo> | undefined>} fields - Actual CALL fields.
+ * @returns {string} - Diagnostic.
+ */
+function captureProcedureAttempt(strategy, rows, fields) {
+  const rawShape = JSON.stringify({fields, rows})
+  // Intentionally cross the ordinary-query contract boundary to diagnose how
+  // each strategy handles the exact shape returned by mysql for CALL.
+  const strategyRows = /** @type {Array<Record<string, ?>>} */ (rows)
+  const strategyFields = /** @type {Array<{name: string}>} */ (fields)
+
+  try {
+    const result = strategy(strategyRows, strategyFields)
+    if (JSON.stringify({fields, rows}) != rawShape) return "changes raw input"
+    return JSON.stringify(result) == JSON.stringify(rows) ? "preserves" : "changes shape"
+  } catch {
+    return "throws"
+  }
+}
+
 const pool = mysql.createPool({...mysqlOptions, connectionLimit: 1, timezone: "Z"})
 const tableName = `velocious_benchmark_numbers_${process.pid}`
+const procedureName = `velocious_benchmark_procedure_${process.pid}`
 const sql = `SELECT n AS task_id, CONCAT('task-', n) AS task_alias, IF(n % 7 = 0, NULL, n * 1.25) AS nullable_value, TIMESTAMP('2026-07-18 12:34:56') AS occurred_at, UNHEX(LPAD(HEX(n), 16, '0')) AS payload FROM ${tableName} ORDER BY n LIMIT ${rowCount}`
 let tableCreated = false
+let procedureCreated = false
 
 try {
   await rawQuery(pool, `CREATE TABLE ${tableName} (n INT PRIMARY KEY)`)
@@ -72,9 +96,11 @@ try {
 
   const raw = await rawQuery(pool, sql)
   const baseline = fieldCopy(raw.rows, raw.fields)
-  const procedureRows = [[raw.rows[0]]]
-  const procedureFields = [[raw.fields]]
-  const procedureBaseline = fieldCopy(procedureRows, procedureFields)
+
+  await rawQuery(pool, `CREATE PROCEDURE ${procedureName}() SELECT n AS task_id, CONCAT('task-', n) AS task_alias, IF(n % 7 = 0, NULL, n * 1.25) AS nullable_value, TIMESTAMP('2026-07-18 12:34:56') AS occurred_at, UNHEX(LPAD(HEX(n), 16, '0')) AS payload FROM ${tableName} ORDER BY n LIMIT 1`)
+  procedureCreated = true
+
+  const procedureRaw = await rawQuery(pool, `CALL ${procedureName}()`)
   console.log(`Node ${process.version}; rows=${rowCount}; iterations=${iterations}; warmups=${warmupIterations}`)
   console.log("strategy\tmaterialization ms\tend-to-end ms\tcontract")
 
@@ -87,8 +113,7 @@ try {
     const plain = candidate.every((row) => Object.getPrototypeOf(row) === Object.prototype)
     const isolated = candidate !== raw.rows && candidate.every((row, index) => row !== raw.rows[index])
     const valuesPreserved = JSON.stringify(candidate) === JSON.stringify(baseline)
-    const procedureShapePreserved = JSON.stringify(strategy(procedureRows, procedureFields)) === JSON.stringify(procedureBaseline)
-    const contract = plain && isolated && valuesPreserved && procedureShapePreserved ? "pass" : `fail (plain=${plain}, isolated=${isolated}, values=${valuesPreserved}, procedure=${procedureShapePreserved})`
+    const contract = plain && isolated && valuesPreserved ? "pass" : `fail (plain=${plain}, isolation=${isolated}, values=${valuesPreserved})`
 
     contracts[name] = contract
   }
@@ -120,10 +145,19 @@ try {
     console.log(`${name}\t${median(materializationSamples[name]).toFixed(3)}\t${median(endToEndSamples[name]).toFixed(3)}\t${contracts[name]}`)
   }
 
-  console.log("Stored-procedure note: mysql CALL returns nested result sets and an OK packet; direct rows change the legacy flat-row adapter shape and are not contract-compatible.")
+  console.log("\nCALL diagnostic (not part of SELECT contract)")
+  console.log("strategy\toutcome")
+  for (const [name, strategy] of strategyEntries) {
+    console.log(`${name}\t${captureProcedureAttempt(strategy, procedureRaw.rows, procedureRaw.fields)}`)
+  }
+  console.log("Note: mysql CALL returns nested result sets plus an OK packet; field copy throws on the undefined terminal fields slot. This benchmark does not claim stored-procedure compatibility.")
 } finally {
   try {
-    if (tableCreated) await rawQuery(pool, `DROP TABLE ${tableName}`)
+    try {
+      if (procedureCreated) await rawQuery(pool, `DROP PROCEDURE ${procedureName}`)
+    } finally {
+      if (tableCreated) await rawQuery(pool, `DROP TABLE ${tableName}`)
+    }
   } finally {
     await new Promise((resolve) => pool.end(resolve))
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "all-checks": "npm run lint && npm run test",
     "benchmark:preloader-id-dedup": "node benchmark/preloader-id-dedup.js",
+    "benchmark:mysql-result-row-materialization": "node benchmark/mysql-result-row-materialization.js",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:js && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:js": "cpy \"index.js\" build && cpy \"bin/**/*.js\" build/bin && cpy \"src/**/*.js\" build --parents",

--- a/spec/database/drivers/mysql/query-spec.js
+++ b/spec/database/drivers/mysql/query-spec.js
@@ -1,0 +1,67 @@
+import query from "../../../../src/database/drivers/mysql/query.js"
+
+class DriverRow {
+  constructor(values) {
+    Object.assign(this, values)
+  }
+}
+
+/**
+ * Builds a pool that returns one predetermined driver response.
+ * @param {Array<DriverRow | Array<DriverRow>>} results - Driver results.
+ * @param {Array<{name: string}> | Array<Array<{name: string}>>} fields - Driver fields.
+ * @returns {import("mysql").Pool} - Pool-shaped test double.
+ */
+function poolReturning(results, fields) {
+  return /** @type {import("mysql").Pool} */ ({
+    query(_sql, callback) {
+      callback(null, results, fields)
+    }
+  })
+}
+
+describe("Database - Drivers - Mysql - Query", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("materializes selected fields as isolated plain records", async () => {
+    const date = new Date("2026-07-18T12:34:56.000Z")
+    const buffer = Buffer.from([0, 1, 2, 255])
+    const driverRow = new DriverRow({aliased_name: "task", ignored: "driver metadata", nullable: null, occurred_at: date, payload: buffer})
+    const pool = poolReturning([driverRow], [
+      {name: "aliased_name"},
+      {name: "nullable"},
+      {name: "occurred_at"},
+      {name: "payload"}
+    ])
+
+    const rows = await query(pool, "SELECT contract fields")
+
+    expect(rows).toEqual([{aliased_name: "task", nullable: null, occurred_at: date, payload: buffer}])
+    expect(Object.getPrototypeOf(rows[0])).toBe(Object.prototype)
+    expect(rows[0].occurred_at).toBe(date)
+    expect(rows[0].payload).toBe(buffer)
+
+    rows[0].aliased_name = "changed"
+    expect(driverRow.aliased_name).toBe("task")
+  })
+
+  it("uses field order while preserving the last value for duplicate aliases", async () => {
+    const pool = poolReturning([new DriverRow({duplicate_name: "last driver value"})], [
+      {name: "duplicate_name"},
+      {name: "duplicate_name"}
+    ])
+
+    expect(await query(pool, "SELECT duplicate aliases")).toEqual([{duplicate_name: "last driver value"}])
+  })
+
+  it("keeps the legacy flat-row contract for stored-procedure result shapes", async () => {
+    const procedureRows = [new DriverRow({task_name: "from procedure"})]
+    const pool = poolReturning([procedureRows], [[{name: "task_name"}]])
+
+    // mysql returns CALL results as nested row/field arrays. The public query
+    // adapter has historically exposed only flat SELECT rows, so it does not
+    // pass the nested driver result through.
+    const rows = await query(pool, "CALL task_names()")
+
+    expect(Object.keys(rows[0])).toEqual(["undefined"])
+    expect(rows[0].undefined).toBe(undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- establish the current MySQL plain-record materialization contract with focused regression coverage
- add a reproducible end-to-end benchmark comparing field copying, shallow cloning, and direct driver rows
- retain the current implementation because shallow cloning has no meaningful end-to-end advantage and direct driver rows break required plain-record and mutation-isolation contracts
- diagnose stored-procedure handling from an actual MariaDB `CALL` instead of a fabricated result shape

## Research result
Node 24.18.0 with MariaDB 11.8, 10,000 rows, 30 measured iterations:

| Strategy | Materialization | End-to-end | Ordinary SELECT contract |
| --- | ---: | ---: | --- |
| Field copy | 1.051 ms | 15.832 ms | pass |
| Shallow clone | 0.780 ms | 17.338 ms | pass |
| Direct driver rows | 0.000 ms | 13.769 ms | fail: plain records and mutation isolation |

The actual `CALL` diagnostic reports:

| Strategy | Actual mysql CALL outcome |
| --- | --- |
| Field copy | throws on the terminal undefined fields slot |
| Shallow clone | changes the nested result/OK-packet shape |
| Direct driver rows | preserves the raw driver shape |

The stored-procedure diagnostic is intentionally separate from the ordinary SELECT contract. The benchmark does not claim current stored-procedure compatibility.

No production source or changelog change is included.

## Validation
- focused MySQL query contract spec in disposable Node 24 Docker container with SQLite dummy config: 3 passed
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run fallow`: pass
- benchmark against disposable MariaDB 11.8: pass
- independent review of the review fix: no actionable findings

AwesomeTasks: #10346
