### PR TITLE
Add Migration#indexExists mirroring columnExists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,8 @@ export default class CreateEvents extends Migration {
 }
 ```
 
+Migrations that must be rerunnable can guard changes with `tableExists(...)`, `columnExists(table, column)` and `indexExists(table, index)` — a missing table yields `false` rather than throwing. See [docs/database-migrations.md](docs/database-migrations.md#guarding-schema-changes-in-rerunnable-migrations).
+
 ## Run migrations from the command line
 
 ```bash

--- a/changelog.d/20260719153000-migration-index-exists.md
+++ b/changelog.d/20260719153000-migration-index-exists.md
@@ -1,0 +1,1 @@
+Add `Migration#indexExists(tableName, indexName)` for guarding index creation in rerunnable migrations, mirroring `columnExists`. Missing tables resolve to `false` instead of throwing.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -54,6 +54,22 @@ await this.removeIndex("tasks", "index_tasks_slug_unique")
 
 Use the columns form for indexes created by `addIndex(...)` without an explicit name so SQLite and the other drivers drop their own generated names correctly.
 
+## Guarding schema changes in rerunnable migrations
+
+A migration that must be rerunnable — for example a data backfill or repair that may run against a partially-patched schema — can guard each change with the schema-inspection helpers so it stays idempotent:
+
+* `tableExists(tableName)` — whether a table exists.
+* `columnExists(tableName, columnName)` — whether a column exists.
+* `indexExists(tableName, indexName)` — whether a named index exists. A missing table resolves to `false` rather than throwing, so it is safe to call before the table has been created.
+
+```js
+if (!await this.indexExists("tasks", "index_tasks_slug_unique")) {
+  await this.addIndex("tasks", ["slug"], {name: "index_tasks_slug_unique", unique: true})
+}
+```
+
+Prefer a plain forward migration when the schema state is known — reach for these guards only when a migration genuinely needs to be rerunnable, so real schema drift still fails loudly instead of being silently skipped.
+
 ## Datetime Storage
 
 Velocious stores persisted `Date` values as UTC instants. Runtime-local timezone and `timezoneOffsetMinutes` are not applied when records are inserted, updated, queried, or read back from storage.

--- a/spec/database/migration/index-exists.browser-spec.js
+++ b/spec/database/migration/index-exists.browser-spec.js
@@ -1,0 +1,37 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import {describe, it} from "../../../src/testing/test.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration", {tags: ["dummy"]}, () => {
+  it("checks if an index exists", async () => {
+    const configuration = Configuration.current()
+    await configuration.ensureConnections(async (dbs) => {
+      const migration = new Migration({
+        configuration,
+        databaseIdentifier: "default",
+        db: dbs.default
+      })
+
+      // Resolve a real index name through the driver so the assertion holds
+      // across databases with different auto-generated index names.
+      const table = await dbs.default.getTableByNameOrFail("authentication_tokens")
+      const indexes = await table.getIndexes()
+
+      expect(indexes.length).toBeGreaterThan(0)
+
+      const existingIndexExists = await migration.indexExists("authentication_tokens", indexes[0].getName())
+
+      expect(existingIndexExists).toBe(true)
+
+      const missingIndexExists = await migration.indexExists("authentication_tokens", "some_non_existing_index")
+
+      expect(missingIndexExists).toBe(false)
+
+      const missingTableIndexExists = await migration.indexExists("some_non_existing_table", "some_non_existing_index")
+
+      expect(missingTableIndexExists).toBe(false)
+    })
+  })
+})

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -469,6 +469,26 @@ export default class VelociousDatabaseMigration {
   }
 
   /**
+   * Checks whether an index with the given name exists on a table.
+   * @param {string} tableName - Table name.
+   * @param {string} indexName - Index name to look for.
+   * @returns {Promise<boolean>} - Whether the index exists on the table.
+   */
+  async indexExists(tableName, indexName) {
+    const table = await this.getDriver().getTableByName(tableName, {throwError: false})
+
+    if (table) {
+      for (const index of await table.getIndexes()) {
+        if (index.getName() == indexName) {
+          return true
+        }
+      }
+    }
+
+    return false
+  }
+
+  /**
    * Sets up the database schema for a gap-less positional list. Adds the
    * position column (INT NOT NULL) if absent and creates a UNIQUE index on
    * (scope, position). This is the schema-side counterpart of


### PR DESCRIPTION
## Summary

- Add `Migration#indexExists(tableName, indexName)`, mirroring `columnExists`, so idempotent expand-style migrations can guard `addIndex` the same way they guard `addColumn`. `velocious-int-to-uuid`'s expand plan calls `migration.indexExists(...)` structurally and currently fails at runtime with `TypeError: migration.indexExists is not a function` when run inside a real Velocious migration (hit while rolling out the AwesomeTasks UUID expand migration).
- Missing tables resolve to `false` (via `getTableByName(..., {throwError: false})`) instead of throwing, matching `columnExists` semantics.

## Validation

- New dummy-app spec `spec/database/migration/index-exists.browser-spec.js` asserts an introspected real index answers `true`, a missing index answers `false`, and a missing table answers `false`.
- `./run-tests.sh spec/database/migration/index-exists.browser-spec.js spec/database/migration/column-exists.browser-spec.js spec/database/migration/remove-index.browser-spec.js` green.
- `npm run lint` green.

Note: this checkout had unrelated uncommitted changes from another session (`src/background-jobs/store.js`, `src/database/migrator.js`, `src/environment-handlers/*`); this PR stages only the files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
