### PR TITLE
Run velocious background-jobs schema via db:migrate (framework schema ensure)

### DIFF
--- a/spec/cli/commands/db/migrate-ensures-framework-schema-spec.js
+++ b/spec/cli/commands/db/migrate-ensures-framework-schema-spec.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import Cli from "../../../../src/cli/index.js"
+import dummyConfiguration from "../../../dummy/src/config/configuration.js"
+import dummyDirectory from "../../../dummy/dummy-directory.js"
+import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
+
+describe("Cli - Commands - db:migrate framework schema", () => {
+  it("creates the background-jobs schema during db:migrate (not only on store boot)", {databaseCleaning: {transaction: false}}, async () => {
+    const directory = dummyDirectory()
+    const cli = new Cli({
+      configuration: dummyConfiguration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:migrate"],
+      testing: true
+    })
+
+    await cli.getConfiguration().ensureConnections(async (dbs) => {
+      // Drop the framework tables so only db:migrate — via the ensureFrameworkSchema
+      // hook — can recreate them (no runtime store boots in this test).
+      await dbs.default.withDisabledForeignKeys(async () => {
+        await dbs.default.dropTable("background_job_concurrency", {cascade: true, ifExists: true})
+        await dbs.default.dropTable("background_jobs", {cascade: true, ifExists: true})
+      })
+
+      await cli.execute()
+
+      const backgroundJobsTable = await dbs.default.getTableByName("background_jobs")
+
+      if (!backgroundJobsTable) throw new Error("db:migrate didn't create the background_jobs table")
+
+      const executionModeColumn = await backgroundJobsTable.getColumnByName("execution_mode")
+
+      if (!executionModeColumn) throw new Error("db:migrate didn't create the execution_mode column")
+
+      expect(executionModeColumn.getName()).toEqual("execution_mode")
+
+      const concurrencyTable = await dbs.default.getTableByName("background_job_concurrency")
+
+      if (!concurrencyTable) throw new Error("db:migrate didn't create the background_job_concurrency table")
+
+      expect(concurrencyTable.getName()).toEqual("background_job_concurrency")
+    })
+  })
+})

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -764,6 +764,8 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Ensures the background-jobs schema exists, reusing a caller-held connection when
+   * one is given rather than checking out its own.
    * @param {import("../database/drivers/base.js").default} [existingDb] - Reuse an
    *   already-checked-out connection (e.g. the one `db:migrate` holds) instead of
    *   checking out a nested one — the nested checkout would deadlock a database
@@ -781,6 +783,8 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Creates or upgrades the background-jobs tables, columns and concurrency rows on
+   * the given connection.
    * @param {import("../database/drivers/base.js").default} db - Database connection.
    * @returns {Promise<void>} - Resolves when the schema is present.
    */

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -113,7 +113,11 @@ export default class BackgroundJobsStore {
    * @returns {Promise<void>} - Resolves when the schema is present.
    */
   async ensureSchema(db) {
-    this.configuration.setCurrent()
+    // When a connection is handed in (the db:migrate path), the caller already owns
+    // the active configuration + connection context; calling setCurrent() here would
+    // clobber it (e.g. the browser test runner juggles multiple configurations).
+    if (!db) this.configuration.setCurrent()
+
     await this._ensureSchema(db)
   }
 

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -107,11 +107,14 @@ export default class BackgroundJobsStore {
    * it in the dumped structure SQL — instead of it only appearing once a store boots.
    * Idempotent: reuses the same `_ensureSchema` the runtime store uses, which skips
    * work already applied (tracked in `velocious_internal_migrations`).
+   * @param {import("../database/drivers/base.js").default} [db] - Reuse an already
+   *   checked-out connection (e.g. the one `db:migrate` holds) rather than opening a
+   *   nested checkout that would deadlock a single-connection pool.
    * @returns {Promise<void>} - Resolves when the schema is present.
    */
-  async ensureSchema() {
+  async ensureSchema(db) {
     this.configuration.setCurrent()
-    await this._ensureSchema()
+    await this._ensureSchema(db)
   }
 
   /**
@@ -760,35 +763,55 @@ export default class BackgroundJobsStore {
     throw VelociousError.safe("background job scheduledAtMs must be a non-negative safe integer")
   }
 
-  async _ensureSchema() {
-    await this._withDb(async (db) => {
-      await this._ensureMigrationsTable(db)
+  /**
+   * @param {import("../database/drivers/base.js").default} [existingDb] - Reuse an
+   *   already-checked-out connection (e.g. the one `db:migrate` holds) instead of
+   *   checking out a nested one — the nested checkout would deadlock a database
+   *   whose pool is capped at a single connection already held by the caller.
+   * @returns {Promise<void>} - Resolves when the schema is present.
+   */
+  async _ensureSchema(existingDb) {
+    if (existingDb) {
+      await this._applySchema(existingDb)
 
-      const alreadyApplied = await this._hasMigration(db)
+      return
+    }
 
-      // Even when the migration row is present, the jobs table itself can have
-      // been dropped underneath us by a transaction rollback in another caller
-      // (DDL is transactional on SQLite/MSSQL). Verify the table physically
-      // exists and recreate it when missing rather than trusting the migration
-      // row alone, otherwise later callers fail with "no such table".
-      if (alreadyApplied && await db.tableExists(JOBS_TABLE)) {
-        await this._ensureJobsTableColumns(db)
-        await this._ensureConcurrencyTable(db)
-        await this._reconcileQueueConcurrency(db)
-        await this._reconcileConcurrency(db)
-        return
-      }
+    await this._withDb((db) => this._applySchema(db))
+  }
 
-      await this._applyMigrations(db)
+  /**
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when the schema is present.
+   */
+  async _applySchema(db) {
+    await this._ensureMigrationsTable(db)
+
+    const alreadyApplied = await this._hasMigration(db)
+
+    // Even when the migration row is present, the jobs table itself can have
+    // been dropped underneath us by a transaction rollback in another caller
+    // (DDL is transactional on SQLite/MSSQL). Verify the table physically
+    // exists and recreate it when missing rather than trusting the migration
+    // row alone, otherwise later callers fail with "no such table".
+    if (alreadyApplied && await db.tableExists(JOBS_TABLE)) {
       await this._ensureJobsTableColumns(db)
       await this._ensureConcurrencyTable(db)
       await this._reconcileQueueConcurrency(db)
       await this._reconcileConcurrency(db)
 
-      if (alreadyApplied) return
+      return
+    }
 
-      await this._recordMigration(db, MIGRATION_VERSION)
-    })
+    await this._applyMigrations(db)
+    await this._ensureJobsTableColumns(db)
+    await this._ensureConcurrencyTable(db)
+    await this._reconcileQueueConcurrency(db)
+    await this._reconcileConcurrency(db)
+
+    if (alreadyApplied) return
+
+    await this._recordMigration(db, MIGRATION_VERSION)
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -101,6 +101,20 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Ensures the background-jobs schema (tables + columns) exists on the configured
+   * database, without initializing the runtime model. Lets `db:migrate` create the
+   * framework's own schema deterministically alongside app migrations — and capture
+   * it in the dumped structure SQL — instead of it only appearing once a store boots.
+   * Idempotent: reuses the same `_ensureSchema` the runtime store uses, which skips
+   * work already applied (tracked in `velocious_internal_migrations`).
+   * @returns {Promise<void>} - Resolves when the schema is present.
+   */
+  async ensureSchema() {
+    this.configuration.setCurrent()
+    await this._ensureSchema()
+  }
+
+  /**
    * Runs enqueue.
    * @param {object} args - Options.
    * @param {string} args.jobName - Job name.

--- a/src/database/migrator.js
+++ b/src/database/migrator.js
@@ -204,6 +204,11 @@ export default class VelociousDatabaseMigrator {
 
     if (!environmentHandler || Object.keys(filteredDbs).length == 0) return
 
+    // Ensure velocious' own framework schema (background jobs) before the structure
+    // dump, and unconditionally — the dump is gated to enabled environments but the
+    // framework schema must exist after every migrate so `db:migrate` (and thus
+    // schema:load of the dumped SQL) produces a complete DB in every environment.
+    await environmentHandler.ensureFrameworkSchema({dbs: filteredDbs})
     await environmentHandler.afterMigrations({dbs: filteredDbs})
   }
 

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -509,6 +509,20 @@ export default class VelociousEnvironmentHandlerBase {
   }
 
   /**
+   * Ensures velocious' own framework-owned schema (e.g. the background-jobs
+   * tables) exists after app migrations run, so `db:migrate` produces a complete
+   * schema deterministically instead of it only appearing once a runtime store
+   * boots. Runs before the structure dump. No-op by default; the node handler
+   * overrides it.
+   * @param {object} args - Options object.
+   * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs being migrated.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async ensureFrameworkSchema(args) { // eslint-disable-line no-unused-vars
+    return
+  }
+
+  /**
    * Runs require command.
    * @abstract
    * @param {object} args - Options object.

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -1006,6 +1006,22 @@ export default class VelociousEnvironmentHandlerNode extends Base{
   }
 
   /**
+   * Ensures velocious' background-jobs schema exists on its configured database
+   * as part of `db:migrate`, so the framework's own tables (background_jobs +
+   * background_job_concurrency, execution_mode etc.) are created deterministically
+   * alongside app migrations and captured in the dumped structure SQL — rather than
+   * only appearing once a runtime store boots. Reuses the store's idempotent
+   * `_ensureSchema`, so it's safe to re-run against DBs that already have it.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async ensureFrameworkSchema() {
+    const {default: BackgroundJobsStore} = await import("../background-jobs/store.js")
+    const store = new BackgroundJobsStore({configuration: this.getConfiguration()})
+
+    await store.ensureSchema()
+  }
+
+  /**
    * Runs after migrations.
    * @param {object} args - Options object.
    * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs.

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -1012,13 +1012,20 @@ export default class VelociousEnvironmentHandlerNode extends Base{
    * alongside app migrations and captured in the dumped structure SQL — rather than
    * only appearing once a runtime store boots. Reuses the store's idempotent
    * `_ensureSchema`, so it's safe to re-run against DBs that already have it.
+   * @param {object} args - Options object.
+   * @param {Record<string, import("../database/drivers/base.js").default>} args.dbs - Dbs being migrated.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async ensureFrameworkSchema() {
+  async ensureFrameworkSchema({dbs}) {
     const {default: BackgroundJobsStore} = await import("../background-jobs/store.js")
     const store = new BackgroundJobsStore({configuration: this.getConfiguration()})
+    const databaseIdentifier = store.getDatabaseIdentifier() ?? "default"
 
-    await store.ensureSchema()
+    // Reuse the connection db:migrate already holds for this database; opening a
+    // nested checkout would deadlock a database whose pool is capped at one
+    // connection. When the background-jobs database isn't among the migrated set,
+    // this passes undefined and the store checks out its own (that pool is free).
+    await store.ensureSchema(dbs[databaseIdentifier])
   }
 
   /**


### PR DESCRIPTION
## What

Velocious now creates its own `background_jobs` schema as part of `db:migrate`, instead of only at runtime when a store boots.

## Why

`BackgroundJobsStore._ensureSchema()` builds the `background_jobs` + `background_job_concurrency` tables (and columns like `execution_mode`) lazily on **store boot**, tracked in velocious's internal `velocious_internal_migrations` ledger — entirely outside `db:migrate` / `schema_migrations`. So a DB brought up by `db:migrate` (or `schema:load` of a dumped structure SQL) alone is **missing** that schema until a store runs, and the dumped `structure-default.sql` is non-deterministic (only contains `background_jobs` if velocious happened to boot when it was dumped).

That non-determinism is exactly what broke a downstream app's local base-model regeneration (dev DB missing `execution_mode`). This makes the Rails-style `schema:load`-for-new / `migrate`-for-changes flow — which velocious already supports — actually produce a complete DB in every environment.

## How

- **`BackgroundJobsStore.ensureSchema()`** — public, idempotent entry point that runs the existing `_ensureSchema()` without initializing the runtime model.
- **`EnvironmentHandlerNode.ensureFrameworkSchema()`** — ensures the background-jobs schema on its configured database (base handler = no-op default; browser inherits the no-op).
- **`Migrator._afterMigrations()`** now calls `environmentHandler.ensureFrameworkSchema({dbs})` **before** the (environment-gated) structure dump — and unconditionally, so the framework schema exists after every `db:migrate` regardless of whether a structure dump is written.

## Prod-safe

Reuses the same idempotent `_ensureSchema` that already runs in production on every store boot. It skips work already applied (via the internal ledger + `tableExists`/`getColumnByName` guards), so it's a no-op on DBs that already have the schema — no re-baselining, no duplicate-column risk on existing tables/data.

## Validation

- `typecheck` + `eslint` clean.
- `spec/background-jobs/store-spec.js` — 39/39 pass (the `ensureSchema` addition doesn't disturb the store).
- **New** `spec/cli/commands/db/migrate-ensures-framework-schema-spec.js` — drops `background_jobs` + `background_job_concurrency`, runs `db:migrate` with no store boot, and asserts the tables + `execution_mode` column are recreated by the migrate-time ensure. Passes.

## Note

The pre-existing `spec/cli/commands/db/migrate-spec.js` "runs migrations" test fails on an unrelated `project_audits` test-isolation leak (it runs with `databaseCleaning.transaction: false` and doesn't drop `project_audits`). This reproduces on clean `master` with this branch stashed — **not** introduced here.
