### PR TITLE
fix: retry MySQL check-read conflicts

### DIFF
--- a/changelog.d/20260719190700-mysql-checkread-retries.md
+++ b/changelog.d/20260719190700-mysql-checkread-retries.md
@@ -1,0 +1,1 @@
+Fixed MySQL queries failing with `ER_CHECKREAD` ("Record has changed since last read") by retrying them on the existing connection, including when the driver wraps the original error.

--- a/spec/database/drivers/mysql/reconnect-spec.js
+++ b/spec/database/drivers/mysql/reconnect-spec.js
@@ -81,6 +81,35 @@ describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction
     expect(closeCount).toEqual(2)
   })
 
+  it("retries a wrapped ER_CHECKREAD without reconnecting", async () => {
+    const driver = new MysqlDriver({}, configuration)
+    let attempts = 0
+    let reconnectCount = 0
+
+    driver.setDesiredSessionTimeZone(null)
+    driver.reconnect = async () => {
+      reconnectCount++
+    }
+    driver._queryActual = async () => {
+      attempts++
+
+      if (attempts == 1) {
+        const mysqlError = new Error("Record has changed since last read in table 'background_jobs'")
+        // @ts-expect-error MySQL attaches its symbolic error code at runtime.
+        mysqlError.code = "ER_CHECKREAD"
+        throw new Error("Query failed", {cause: mysqlError})
+      }
+
+      return [{result: 1}]
+    }
+
+    const rows = await driver.query("SELECT 1")
+
+    expect(rows).toEqual([{result: 1}])
+    expect(attempts).toEqual(2)
+    expect(reconnectCount).toEqual(0)
+  })
+
   it("raises when a reconnect would bypass an active transaction", async () => {
     const driver = new MysqlDriver({}, configuration)
     let didReconnect = false

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -320,19 +320,32 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {import("../base.js").RetryableDatabaseErrorResult} - Retry info.
    */
   retryableDatabaseError(error) {
-    const errorCode = /** @type {?} */ (error).code
-    const message = error.message || ""
-    const shouldRetry = (
-      errorCode == "ECONNREFUSED" ||
-      message.includes("ECONNREFUSED") ||
-      message.includes("connect ECONNREFUSED") ||
-      message.includes("PROTOCOL_CONNECTION_LOST") ||
-      message.includes("Connection lost")
-    )
+    /** @type {Error | undefined} */
+    let currentError = error
+    let shouldReconnect = false
+
+    while (currentError) {
+      const errorCode = "code" in currentError && typeof currentError.code == "string" ? currentError.code : undefined
+      const message = currentError.message || ""
+
+      if (errorCode == "ER_CHECKREAD" || message.includes("Record has changed since last read")) {
+        return {retry: true, reconnect: false, waitMs: 50}
+      }
+
+      shouldReconnect ||= (
+        errorCode == "ECONNREFUSED" ||
+        message.includes("ECONNREFUSED") ||
+        message.includes("connect ECONNREFUSED") ||
+        message.includes("PROTOCOL_CONNECTION_LOST") ||
+        message.includes("Connection lost")
+      )
+
+      currentError = currentError.cause instanceof Error ? currentError.cause : undefined
+    }
 
     return {
-      retry: shouldRetry,
-      reconnect: shouldRetry,
+      retry: shouldReconnect,
+      reconnect: shouldReconnect,
       waitMs: 50
     }
   }


### PR DESCRIPTION
## Summary
- classify MariaDB `ER_CHECKREAD` / “Record has changed since last read” failures as retryable transient conflicts
- preserve the existing query retry loop without reconnecting the database pool
- follow wrapped error causes so driver errors survive query-context wrapping

## Production evidence
TensorBuzz background-job concurrency releases intermittently failed with `ER_CHECKREAD`, leaving completed jobs handed off and queue concurrency occupied until the worker was recycled.

## Test plan
- [x] `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npm test -- database/drivers/mysql/reconnect-spec.js`
- [x] `npm run lint`
- [x] `git diff --check`
