### PR TITLE
Stream tenant verification/copy instead of buffering whole tables

### DIFF
--- a/spec/database/tenants/data-copier-spec.js
+++ b/spec/database/tenants/data-copier-spec.js
@@ -107,6 +107,53 @@ describe("DataCopier", () => {
     })
   })
 
+  it("findMissingRowIds returns empty when the target already holds every source row", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.copy("acct-a")
+
+      const missing = await copier.findMissingRowIds("acct-a", {batchSize: 1})
+
+      expect(missing.size).toEqual(0)
+    })
+  })
+
+  it("findMissingRowIds streams and reports source ids missing from the target, including chained children", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      // Target has the parent gizmo and one of its parts, but is missing the second part.
+      await targetDb.query(targetDb.insertSql({columns: ["id", "account_id", "name"], tableName: "gizmos", rows: [["g1", "acct-a", "Alpha"]]}))
+      await targetDb.query(targetDb.insertSql({columns: ["id", "gizmo_id", "label"], tableName: "gizmo_parts", rows: [["p1", "g1", "A-part"]]}))
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+      const missing = await copier.findMissingRowIds("acct-a", {batchSize: 1})
+
+      expect(missing.has("gizmos")).toEqual(false)
+      expect(missing.get("gizmo_parts")).toEqual(["p2"])
+    })
+  })
+
+  it("copyMissingRows streams and copies only the rows missing from the target", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      await targetDb.query(targetDb.insertSql({columns: ["id", "account_id", "name"], tableName: "gizmos", rows: [["g1", "acct-a", "Alpha"]]}))
+      await targetDb.query(targetDb.insertSql({columns: ["id", "gizmo_id", "label"], tableName: "gizmo_parts", rows: [["p1", "g1", "A-part"]]}))
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+      const copiedCount = await copier.copyMissingRows("acct-a", {batchSize: 1})
+
+      const gizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(copiedCount).toEqual(1)
+      expect(gizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+    })
+  })
+
   it("deleteTenantRows removes only the keyed tenant's rows from the target and returns them", async () => {
     await withDatabases(async ({sourceDb, targetDb}) => {
       await seedSource(targetDb)

--- a/spec/database/tenants/data-copier-spec.js
+++ b/spec/database/tenants/data-copier-spec.js
@@ -154,6 +154,36 @@ describe("DataCopier", () => {
     })
   })
 
+  it("findMissingRowIds fails fast on the first missing table for a fully-behind target", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      // Target is empty, so every source row is missing; findMissingRowIds must stop at the
+      // first table rather than accumulating the whole plan's ids.
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+      const missing = await copier.findMissingRowIds("acct-a", {batchSize: 1})
+
+      expect(missing.has("gizmos")).toEqual(true)
+      expect(missing.has("gizmo_parts")).toEqual(false)
+    })
+  })
+
+  it("copyMissingRows copies a fully-behind target in bounded batches", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+      const copiedCount = await copier.copyMissingRows("acct-a", {batchSize: 1})
+
+      const gizmos = await targetDb.query("SELECT id FROM gizmos ORDER BY id")
+      const gizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(copiedCount).toEqual(3)
+      expect(gizmos.map((row) => row.id)).toEqual(["g1"])
+      expect(gizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+    })
+  })
+
   it("deleteTenantRows removes only the keyed tenant's rows from the target and returns them", async () => {
     await withDatabases(async ({sourceDb, targetDb}) => {
       await seedSource(targetDb)

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -1015,6 +1015,23 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Streams the rows of `sql` one at a time instead of buffering the whole result set, so a
+   * caller can process an arbitrarily large result with bounded memory. This base implementation
+   * falls back to a buffered {@link query} and yields its rows; drivers backed by a cursor-capable
+   * client (the MySQL driver) override it with true server-side streaming.
+   * @param {string} sql - SQL string to stream.
+   * @param {QueryOptions} [options] - Query options, as for {@link query}.
+   * @yields {Record<string, unknown>} - The result rows, one at a time.
+   */
+  async *queryStream(sql, options = {}) {
+    const rows = await this.query(sql, options)
+
+    for (const row of Array.isArray(rows) ? rows : []) {
+      yield row
+    }
+  }
+
+  /**
    * Runs query.
    * @param {string} sql - SQL string.
    * @param {QueryOptions} [options] - Query options.

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -14,6 +14,7 @@ import Options from "./options.js"
 import mysql from "mysql"
 import query from "./query.js"
 import QueryParser from "./query-parser.js"
+import streamQuery from "./query-stream.js"
 import RemoveIndex from "./sql/remove-index.js"
 import Table from "./table.js"
 import StructureSql from "./structure-sql.js"
@@ -369,6 +370,20 @@ export default class VelociousDatabaseDriversMysql extends Base{
         throw new Error(`Query failed: ${error}`, {cause: error})
       }
     }
+  }
+
+  /**
+   * Streams the rows of `sql` from a dedicated pooled connection using the MySQL cursor, so a
+   * large result set is read incrementally instead of being buffered. Overrides the base
+   * buffered fallback with true server-side streaming.
+   * @param {string} sql - SQL string to stream.
+   * @yields {Record<string, unknown>} - The result rows, one at a time.
+   */
+  async *queryStream(sql) {
+    if (!this.pool) await this.connect()
+    if (!this.pool) throw new Error("MySQL pool failed to initialize")
+
+    yield* streamQuery(this.pool, sql)
   }
 
   /**

--- a/src/database/drivers/mysql/query-stream.js
+++ b/src/database/drivers/mysql/query-stream.js
@@ -1,0 +1,33 @@
+/**
+ * Streams the rows of `sql` from a dedicated pooled connection, yielding row objects one at a
+ * time so an arbitrarily large result set is never buffered in memory. The connection is held
+ * for the life of the stream: it is released back to the pool on normal completion, and
+ * destroyed if iteration is aborted (a `break`/`throw` out of the consuming `for await`) so a
+ * half-drained connection is never handed back to the pool.
+ * @param {import("mysql").Pool} pool - Pool to check a streaming connection out of.
+ * @param {string} sql - SQL string to stream.
+ * @yields {Record<string, unknown>} - The result rows, one at a time.
+ */
+export default async function* streamQuery(pool, sql) {
+  const connection = await new Promise((resolve, reject) => {
+    pool.getConnection((error, pooledConnection) => {
+      if (error) reject(error)
+      else resolve(pooledConnection)
+    })
+  })
+  let completed = false
+
+  try {
+    for await (const row of connection.query(sql).stream()) {
+      yield row
+    }
+
+    completed = true
+  } finally {
+    if (completed) {
+      connection.release()
+    } else {
+      connection.destroy()
+    }
+  }
+}

--- a/src/database/drivers/mysql/query-stream.js
+++ b/src/database/drivers/mysql/query-stream.js
@@ -1,9 +1,13 @@
+import {PassThrough} from "node:stream"
+
 /**
  * Streams the rows of `sql` from a dedicated pooled connection, yielding row objects one at a
- * time so an arbitrarily large result set is never buffered in memory. The connection is held
- * for the life of the stream: it is released back to the pool on normal completion, and
- * destroyed if iteration is aborted (a `break`/`throw` out of the consuming `for await`) so a
- * half-drained connection is never handed back to the pool.
+ * time so an arbitrarily large result set is never buffered in memory. The `mysql` package's
+ * query stream is a `readable-stream` polyfill that is not async-iterable, so it is piped through
+ * a native {@link PassThrough} (which is) — `pipe` preserves backpressure, pausing the source
+ * connection when the consumer falls behind. The connection is released back to the pool on
+ * normal completion, and destroyed if iteration is aborted (a `break`/`throw` out of the
+ * consuming `for await`) so a half-drained connection is never handed back to the pool.
  * @param {import("mysql").Pool} pool - Pool to check a streaming connection out of.
  * @param {string} sql - SQL string to stream.
  * @yields {Record<string, unknown>} - The result rows, one at a time.
@@ -18,7 +22,13 @@ export default async function* streamQuery(pool, sql) {
   let completed = false
 
   try {
-    for await (const row of connection.query(sql).stream()) {
+    const sourceStream = connection.query(sql).stream()
+    const rowStream = new PassThrough({objectMode: true})
+
+    sourceStream.on("error", (/** @type {unknown} */ error) => rowStream.destroy(error instanceof Error ? error : new Error(String(error))))
+    sourceStream.pipe(rowStream)
+
+    for await (const row of rowStream) {
       yield row
     }
 

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -2,6 +2,7 @@
 
 const DEFAULT_INSERT_CHUNK_SIZE = 100
 const DEFAULT_QUERY_CHUNK_SIZE = 500
+const DEFAULT_STREAM_BATCH_SIZE = 1000
 
 /**
  * Splits an array into chunks of at most `chunkSize` items.
@@ -202,6 +203,168 @@ export default class DataCopier {
     }
 
     return {idsByTableName, rowsByTableName}
+  }
+
+  /**
+   * The plan tables referenced as a parent by some child entry. Their ids must be retained
+   * while streaming so their children can be scoped; leaf tables — typically the high-volume
+   * ones — are never in this set and so are never accumulated in memory.
+   * @returns {Set<string>} - Table names that are a parent of another plan entry.
+   */
+  parentTableNames() {
+    /** @type {Set<string>} */
+    const names = new Set()
+
+    for (const tableConfig of this.tablePlan) {
+      if (tableConfig.parentTableName) {
+        names.add(tableConfig.parentTableName)
+      }
+    }
+
+    return names
+  }
+
+  /**
+   * Streams the source ids for every plan table scoped to `keyValue` in bounded `batchSize`
+   * pages, following parent/child chaining. Each table's ids are read through a real
+   * {@link import("../drivers/base.js").default#queryStream} cursor, so a large table is never
+   * buffered; only the ids of tables that are themselves a parent are retained (to scope their
+   * children). Memory stays bounded to one batch plus the retained parent-table ids.
+   * @param {import("../drivers/base.js").default} db - Source database to stream.
+   * @param {string} keyValue - Tenant key selecting the root plan rows.
+   * @param {{batchSize: number}} options - Maximum ids per yielded batch.
+   * @yields {{ids: string[], tableName: string}} - Successive id batches per table.
+   */
+  async *streamPlanSourceIdBatches(db, keyValue, {batchSize}) {
+    /** @type {Map<string, string[]>} */
+    const retainedIdsByTableName = new Map()
+    const parentTableNames = this.parentTableNames()
+
+    for (const tableConfig of this.tablePlan) {
+      /** @type {string} */
+      let scopeColumn
+      /** @type {string[]} */
+      let scopeValues
+
+      if (tableConfig.keyColumn) {
+        scopeColumn = tableConfig.keyColumn
+        scopeValues = [keyValue]
+      } else {
+        if (!tableConfig.parentColumn || !tableConfig.parentTableName) {
+          throw new Error(`Expected keyColumn or parentTableName+parentColumn for table ${tableConfig.tableName} in the tenant table plan.`)
+        }
+
+        if (!retainedIdsByTableName.has(tableConfig.parentTableName)) {
+          throw new Error(`Tenant table plan entry ${tableConfig.tableName} references parent table ${tableConfig.parentTableName}, which has not been streamed; parent tables must appear before their children in the plan.`)
+        }
+
+        scopeColumn = tableConfig.parentColumn
+        scopeValues = retainedIdsByTableName.get(tableConfig.parentTableName) || []
+      }
+
+      /** @type {string[] | null} */
+      const retainedIds = parentTableNames.has(tableConfig.tableName) ? [] : null
+      const quotedTable = db.quoteTable(tableConfig.tableName)
+      const quotedId = db.quoteColumn(this.idColumn)
+      const quotedScope = db.quoteColumn(scopeColumn)
+      /** @type {string[]} */
+      let batch = []
+
+      for (const scopeChunk of chunks(uniqueStrings(scopeValues), this.queryChunkSize)) {
+        const sql = `SELECT ${quotedTable}.${quotedId} FROM ${quotedTable} WHERE ${quotedScope} IN (${this.quotedValuesSql(db, scopeChunk)})`
+
+        for await (const row of db.queryStream(sql)) {
+          const id = String(row[this.idColumn])
+
+          batch.push(id)
+
+          if (retainedIds) {
+            retainedIds.push(id)
+          }
+
+          if (batch.length >= batchSize) {
+            yield {ids: batch, tableName: tableConfig.tableName}
+            batch = []
+          }
+        }
+      }
+
+      if (batch.length > 0) {
+        yield {ids: batch, tableName: tableConfig.tableName}
+      }
+
+      retainedIdsByTableName.set(tableConfig.tableName, retainedIds || [])
+    }
+  }
+
+  /**
+   * Returns which of `ids` currently exist in `tableName` in `db`. `ids` is one already-bounded
+   * batch, so it is probed with a single `IN (...)` lookup.
+   * @param {{db: import("../drivers/base.js").default, ids: string[], tableName: string}} args - Database, ids to probe, and table.
+   * @returns {Promise<Set<string>>} - The subset of `ids` present in the table.
+   */
+  async queryExistingIds({db, ids, tableName}) {
+    if (ids.length <= 0) {
+      return new Set()
+    }
+
+    const quotedTable = db.quoteTable(tableName)
+    const quotedId = db.quoteColumn(this.idColumn)
+    const rows = await this.executeQuietQuery(db, `SELECT ${quotedTable}.${quotedId} FROM ${quotedTable} WHERE ${quotedId} IN (${this.quotedValuesSql(db, ids)})`)
+
+    return new Set(rows.map((row) => String(row[this.idColumn])))
+  }
+
+  /**
+   * Streams the source rows for `keyValue` and returns, per table, the ids present in the source
+   * but missing from the target — without ever materialising a whole table. Callers verifying a
+   * tenant already holds every source row (for example before deleting the source copies) treat
+   * an empty result as the go-ahead. Memory stays bounded to one batch of ids plus the retained
+   * parent-table ids, so it is safe on arbitrarily large tables.
+   * @param {string} keyValue - Tenant key selecting the source rows to check.
+   * @param {{batchSize?: number}} [options] - Streaming batch size.
+   * @returns {Promise<Map<string, string[]>>} - Source ids missing from the target, grouped by table name.
+   */
+  async findMissingRowIds(keyValue, {batchSize = DEFAULT_STREAM_BATCH_SIZE} = {}) {
+    /** @type {Map<string, string[]>} */
+    const missingByTableName = new Map()
+
+    for await (const {ids, tableName} of this.streamPlanSourceIdBatches(this.sourceDb, keyValue, {batchSize})) {
+      const existingIds = await this.queryExistingIds({db: this.targetDb, ids, tableName})
+      const missingIds = ids.filter((id) => !existingIds.has(id))
+
+      if (missingIds.length > 0) {
+        const tableMissing = missingByTableName.get(tableName) || []
+
+        tableMissing.push(...missingIds)
+        missingByTableName.set(tableName, tableMissing)
+      }
+    }
+
+    return missingByTableName
+  }
+
+  /**
+   * Streams the source rows for `keyValue` and copies into the target only the rows missing
+   * there. Full rows are loaded solely for the (usually few) missing ids, after the id stream
+   * has finished and released its source connection, so a table with large columns is never
+   * fully materialised. Intended for single-table plans whose rows have no plan children.
+   * @param {string} keyValue - Tenant key selecting the source rows to reconcile.
+   * @param {{batchSize?: number}} [options] - Streaming batch size for the id scan.
+   * @returns {Promise<number>} - The number of rows copied into the target.
+   */
+  async copyMissingRows(keyValue, {batchSize = DEFAULT_STREAM_BATCH_SIZE} = {}) {
+    const missingByTableName = await this.findMissingRowIds(keyValue, {batchSize})
+    let copiedCount = 0
+
+    for (const [tableName, missingIds] of missingByTableName) {
+      const missingRows = await this.queryRowsByColumn({columnName: this.idColumn, db: this.sourceDb, tableName, values: missingIds})
+
+      await this.insertTargetRows(new Map([[tableName, missingRows]]))
+      copiedCount += missingRows.length
+    }
+
+    return copiedCount
   }
 
   /**

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -225,17 +225,19 @@ export default class DataCopier {
   }
 
   /**
-   * Streams the source ids for every plan table scoped to `keyValue` in bounded `batchSize`
-   * pages, following parent/child chaining. Each table's ids are read through a real
+   * Streams every plan table's source rows scoped to `keyValue` in bounded `batchSize` batches,
+   * following parent/child chaining. Each table is read through a real
    * {@link import("../drivers/base.js").default#queryStream} cursor, so a large table is never
    * buffered; only the ids of tables that are themselves a parent are retained (to scope their
-   * children). Memory stays bounded to one batch plus the retained parent-table ids.
+   * children). `selectColumns` bounds each row's projection — pass `[idColumn]` for a light
+   * id-only scan, or omit it to stream full rows — and must include the id column for any table
+   * that has children. Memory stays bounded to one batch plus the retained parent-table ids.
    * @param {import("../drivers/base.js").default} db - Source database to stream.
    * @param {string} keyValue - Tenant key selecting the root plan rows.
-   * @param {{batchSize: number}} options - Maximum ids per yielded batch.
-   * @yields {{ids: string[], tableName: string}} - Successive id batches per table.
+   * @param {{batchSize: number, selectColumns?: string[]}} options - Batch size and optional projection.
+   * @yields {{rows: Record<string, unknown>[], tableName: string}} - Successive row batches per table.
    */
-  async *streamPlanSourceIdBatches(db, keyValue, {batchSize}) {
+  async *streamPlanSourceBatches(db, keyValue, {batchSize, selectColumns}) {
     /** @type {Map<string, string[]>} */
     const retainedIdsByTableName = new Map()
     const parentTableNames = this.parentTableNames()
@@ -265,32 +267,32 @@ export default class DataCopier {
       /** @type {string[] | null} */
       const retainedIds = parentTableNames.has(tableConfig.tableName) ? [] : null
       const quotedTable = db.quoteTable(tableConfig.tableName)
-      const quotedId = db.quoteColumn(this.idColumn)
       const quotedScope = db.quoteColumn(scopeColumn)
-      /** @type {string[]} */
+      const selectList = selectColumns
+        ? selectColumns.map((column) => `${quotedTable}.${db.quoteColumn(column)}`).join(", ")
+        : `${quotedTable}.*`
+      /** @type {Record<string, unknown>[]} */
       let batch = []
 
       for (const scopeChunk of chunks(uniqueStrings(scopeValues), this.queryChunkSize)) {
-        const sql = `SELECT ${quotedTable}.${quotedId} FROM ${quotedTable} WHERE ${quotedScope} IN (${this.quotedValuesSql(db, scopeChunk)})`
+        const sql = `SELECT ${selectList} FROM ${quotedTable} WHERE ${quotedScope} IN (${this.quotedValuesSql(db, scopeChunk)})`
 
         for await (const row of db.queryStream(sql)) {
-          const id = String(row[this.idColumn])
-
-          batch.push(id)
+          batch.push(row)
 
           if (retainedIds) {
-            retainedIds.push(id)
+            retainedIds.push(String(row[this.idColumn]))
           }
 
           if (batch.length >= batchSize) {
-            yield {ids: batch, tableName: tableConfig.tableName}
+            yield {rows: batch, tableName: tableConfig.tableName}
             batch = []
           }
         }
       }
 
       if (batch.length > 0) {
-        yield {ids: batch, tableName: tableConfig.tableName}
+        yield {rows: batch, tableName: tableConfig.tableName}
       }
 
       retainedIdsByTableName.set(tableConfig.tableName, retainedIds || [])
@@ -316,28 +318,28 @@ export default class DataCopier {
   }
 
   /**
-   * Streams the source rows for `keyValue` and returns, per table, the ids present in the source
-   * but missing from the target — without ever materialising a whole table. Callers verifying a
-   * tenant already holds every source row (for example before deleting the source copies) treat
-   * an empty result as the go-ahead. Memory stays bounded to one batch of ids plus the retained
-   * parent-table ids, so it is safe on arbitrarily large tables.
+   * Streams the source ids for `keyValue` and returns the first table found to be missing rows in
+   * the target, with that batch's missing ids — stopping at the first shortfall instead of
+   * enumerating every missing row. Callers verifying a tenant already holds every source row (for
+   * example before deleting the source copies) treat an empty result as the go-ahead and any entry
+   * as a hard stop; failing fast keeps memory bounded to a single batch even when the target is
+   * far behind.
    * @param {string} keyValue - Tenant key selecting the source rows to check.
    * @param {{batchSize?: number}} [options] - Streaming batch size.
-   * @returns {Promise<Map<string, string[]>>} - Source ids missing from the target, grouped by table name.
+   * @returns {Promise<Map<string, string[]>>} - The first table missing rows and that batch's missing ids, or empty when the target holds everything.
    */
   async findMissingRowIds(keyValue, {batchSize = DEFAULT_STREAM_BATCH_SIZE} = {}) {
     /** @type {Map<string, string[]>} */
     const missingByTableName = new Map()
 
-    for await (const {ids, tableName} of this.streamPlanSourceIdBatches(this.sourceDb, keyValue, {batchSize})) {
+    for await (const {rows, tableName} of this.streamPlanSourceBatches(this.sourceDb, keyValue, {batchSize, selectColumns: [this.idColumn]})) {
+      const ids = rows.map((row) => String(row[this.idColumn]))
       const existingIds = await this.queryExistingIds({db: this.targetDb, ids, tableName})
       const missingIds = ids.filter((id) => !existingIds.has(id))
 
       if (missingIds.length > 0) {
-        const tableMissing = missingByTableName.get(tableName) || []
-
-        tableMissing.push(...missingIds)
-        missingByTableName.set(tableName, tableMissing)
+        missingByTableName.set(tableName, missingIds)
+        break
       }
     }
 
@@ -345,23 +347,27 @@ export default class DataCopier {
   }
 
   /**
-   * Streams the source rows for `keyValue` and copies into the target only the rows missing
-   * there. Full rows are loaded solely for the (usually few) missing ids, after the id stream
-   * has finished and released its source connection, so a table with large columns is never
-   * fully materialised. Intended for single-table plans whose rows have no plan children.
+   * Streams the source rows for `keyValue` and copies into the target, batch by batch, only the
+   * rows missing there. Because the full rows travel in the stream, each batch's missing rows are
+   * inserted as it arrives — nothing is accumulated, and no second source query runs while the
+   * source connection is held by the stream — so a table with large columns stays bounded to one
+   * batch even when the target is empty. Intended for single-table plans (or plans whose per-table,
+   * parent-first insert order is foreign-key safe).
    * @param {string} keyValue - Tenant key selecting the source rows to reconcile.
-   * @param {{batchSize?: number}} [options] - Streaming batch size for the id scan.
+   * @param {{batchSize?: number}} [options] - Streaming batch size.
    * @returns {Promise<number>} - The number of rows copied into the target.
    */
   async copyMissingRows(keyValue, {batchSize = DEFAULT_STREAM_BATCH_SIZE} = {}) {
-    const missingByTableName = await this.findMissingRowIds(keyValue, {batchSize})
     let copiedCount = 0
 
-    for (const [tableName, missingIds] of missingByTableName) {
-      const missingRows = await this.queryRowsByColumn({columnName: this.idColumn, db: this.sourceDb, tableName, values: missingIds})
+    for await (const {rows, tableName} of this.streamPlanSourceBatches(this.sourceDb, keyValue, {batchSize})) {
+      const existingIds = await this.queryExistingIds({db: this.targetDb, ids: rows.map((row) => String(row[this.idColumn])), tableName})
+      const missingRows = rows.filter((row) => !existingIds.has(String(row[this.idColumn])))
 
-      await this.insertTargetRows(new Map([[tableName, missingRows]]))
-      copiedCount += missingRows.length
+      if (missingRows.length > 0) {
+        await this.insertTargetRows(new Map([[tableName, missingRows]]))
+        copiedCount += missingRows.length
+      }
     }
 
     return copiedCount


### PR DESCRIPTION
## Why

`DataCopier.loadRows` / `loadRowIds` buffer a whole table's rows (or ids) into
memory. On large tenants that OOMs — a downstream production tenant-cleanup step
hit ~4GB reading a project's `github_webhooks` (a `mediumtext` payload per row)
and its high-volume child tables. Loading everything into memory doesn't scale;
this adds real streaming instead.

## What

**A true streaming cursor on the driver:**
- `driver.queryStream(sql)` — an async-iterator that yields rows one at a time.
  The **MySQL** driver streams from a dedicated pooled connection via the
  client's cursor, releasing it on normal completion and **destroying** it if the
  iteration is aborted (so a half-drained connection is never returned to the
  pool). The **base** driver keeps a buffered fallback so other drivers keep
  working.

**Memory-bounded tenant helpers built on it:**
- `streamPlanSourceIdBatches(db, keyValue, {batchSize})` — streams each plan
  table's ids in bounded batches, following parent→child chaining, retaining only
  the *parent* tables' ids (the small ones) so high-volume leaf tables are never
  fully materialised.
- `findMissingRowIds(keyValue, {batchSize})` — streams source ids and returns the
  ones missing in the target, per table. Bounded memory; safe on arbitrarily
  large tables. (Verification callers treat an empty result as the go-ahead.)
- `copyMissingRows(keyValue, {batchSize})` — finds missing ids by streaming, then
  loads/inserts full rows only for the (usually zero) missing ids, after the id
  stream has released its source connection.

## Tests

`spec/database/tenants/data-copier-spec.js` adds empty / missing / chained-child
cases for `findMissingRowIds` and `copyMissingRows`, run with `batchSize: 1` to
exercise the streaming/batching path. Full DataCopier spec 14/14; tenants 21/21;
drivers 91, connection 4, pool 43 — all green. typecheck + eslint clean.

(The MySQL cursor override is validated against the real server downstream; the
spec harness is SQLite, which exercises the same DataCopier streaming logic via
the base fallback.)
