### PR TITLE
Retry the whole transaction on deadlock (fixes background-jobs drain freeze under load)

### DIFF
--- a/spec/database/transactions.browser-spec.js
+++ b/spec/database/transactions.browser-spec.js
@@ -177,4 +177,54 @@ describe("database - transactions", {tags: ["dummy"]}, () => {
       expect(caught instanceof Error && caught.message).toEqual("ALWAYS_DEADLOCK")
     })
   })
+
+  it("retries when a deadlock rolls back a nested savepoint via the full-rollback fallback", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const project = await Project.create()
+      const originalRetryable = db.retryableDatabaseError.bind(db)
+      const originalRollbackSavePoint = db.rollbackSavePoint.bind(db)
+
+      let outerAttempts = 0
+
+      db.retryableDatabaseError = (/** @type {Error} */ error) => {
+        if (error instanceof Error && error.message.includes("NESTED_DEADLOCK")) {
+          return {retry: false, reconnect: false, deadlock: true, waitMs: 1}
+        }
+
+        return originalRetryable(error)
+      }
+
+      // Force the inner savepoint rollback to fail on the first attempt, exercising the
+      // full-transaction rollback fallback that the outer catch must not double-roll-back.
+      db.rollbackSavePoint = async (/** @type {string} */ name) => {
+        if (outerAttempts == 1) throw new Error("ER_SP_DOES_NOT_EXIST: SAVEPOINT does not exist")
+
+        return originalRollbackSavePoint(name)
+      }
+
+      try {
+        await db.transaction(async () => {
+          outerAttempts++
+          await Task.create({name: `Outer ${outerAttempts}`, project})
+
+          await db.transaction(async () => {
+            if (outerAttempts == 1) throw new Error("NESTED_DEADLOCK")
+
+            await Task.create({name: `Inner ${outerAttempts}`, project})
+          })
+        })
+      } finally {
+        db.retryableDatabaseError = originalRetryable
+        db.rollbackSavePoint = originalRollbackSavePoint
+      }
+
+      const names = (await Task.where({projectId: project.id()}).toArray()).map((task) => task.name()).sort()
+
+      expect(outerAttempts).toEqual(2)
+      expect(db._transactionsCount).toBe(0)
+      // The first (deadlocked) attempt rolled back entirely; only the retry's rows persisted.
+      expect(names).toEqual(["Inner 2", "Outer 2"])
+    })
+  })
 })

--- a/spec/database/transactions.browser-spec.js
+++ b/spec/database/transactions.browser-spec.js
@@ -113,4 +113,68 @@ describe("database - transactions", {tags: ["dummy"]}, () => {
       expect(db._transactionsCount).toBe(0)
     })
   })
+
+  it("retries the whole transaction when an attempt hits a deadlock", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const project = await Project.create()
+      const originalRetryable = db.retryableDatabaseError.bind(db)
+
+      // Flag a marker error as a deadlock so the outermost transaction re-runs the callback.
+      db.retryableDatabaseError = (/** @type {Error} */ error) => {
+        if (error instanceof Error && error.message.includes("SIMULATED_DEADLOCK")) {
+          return {retry: false, reconnect: false, deadlock: true, waitMs: 1}
+        }
+
+        return originalRetryable(error)
+      }
+
+      let attempts = 0
+
+      try {
+        await db.transaction(async () => {
+          attempts++
+          await Task.create({name: `Deadlock attempt ${attempts}`, project})
+
+          if (attempts == 1) throw new Error("SIMULATED_DEADLOCK")
+        })
+      } finally {
+        db.retryableDatabaseError = originalRetryable
+      }
+
+      const names = (await Task.where({projectId: project.id()}).toArray()).map((task) => task.name())
+
+      expect(attempts).toEqual(2)
+      // The first (deadlocked) attempt rolled back, so only the retry's row persisted.
+      expect(names).toEqual(["Deadlock attempt 2"])
+    })
+  })
+
+  it("gives up and rethrows after exhausting deadlock retries", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const originalRetryable = db.retryableDatabaseError.bind(db)
+
+      db.retryableDatabaseError = () => ({retry: false, reconnect: false, deadlock: true, waitMs: 1})
+
+      let attempts = 0
+      /** @type {unknown} */
+      let caught = null
+
+      try {
+        await db.transaction(async () => {
+          attempts++
+
+          throw new Error("ALWAYS_DEADLOCK")
+        })
+      } catch (error) {
+        caught = error
+      } finally {
+        db.retryableDatabaseError = originalRetryable
+      }
+
+      expect(attempts).toEqual(5)
+      expect(caught instanceof Error && caught.message).toEqual("ALWAYS_DEADLOCK")
+    })
+  })
 })

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -959,7 +959,11 @@ export default class VelociousDatabaseDriversBase {
         }
       }
 
-      if (transactionStarted && !transactionRolledBack) {
+      // Only roll back if a transaction is still open. A nested savepoint whose rollback failed
+      // falls back to rolling back the whole transaction (above), which already closed it and
+      // dropped the count to 0; rolling back again here would issue a second ROLLBACK and drive
+      // `_transactionsCount` below zero, which would then defeat the outermost deadlock-retry guard.
+      if (transactionStarted && !transactionRolledBack && this._transactionsCount > 0) {
         this.logger.debug("Rollback transaction")
         await this.rollbackTransaction()
       }

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -47,6 +47,7 @@
  * @typedef {object} RetryableDatabaseErrorResult
  * @property {boolean} retry - Whether the error should be retried.
  * @property {boolean} reconnect - Whether to reconnect before retrying.
+ * @property {boolean} [deadlock] - Whether the error is a transaction deadlock/lock-wait-timeout that should retry the whole transaction.
  * @property {number} [maxTries] - Override the max retry attempts.
  * @property {number} [waitMs] - Wait time before retrying in milliseconds.
  */
@@ -851,11 +852,50 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
-   * Runs transaction.
+   * Runs a callback inside a database transaction (or a savepoint when already inside one).
+   * The outermost transaction retries the whole callback on a deadlock / lock-wait-timeout,
+   * because such errors roll the entire transaction back and the standard recovery is to
+   * restart it. Nested savepoints let the deadlock bubble up to this outer retry.
    * @param {() => Promise<void>} callback - Callback function.
-   * @returns {Promise<?>} - Resolves with the transaction.
+   * @returns {Promise<?>} - Resolves with the transaction result.
    */
   async transaction(callback) {
+    if (this._transactionsCount > 0) {
+      return await this._runTransactionAttempt(callback)
+    }
+
+    const maxAttempts = 5
+    let attempt = 0
+
+    while (true) {
+      attempt++
+
+      try {
+        return await this._runTransactionAttempt(callback)
+      } catch (error) {
+        const retryInfo = error instanceof Error ? this.retryableDatabaseError(error) : {retry: false, reconnect: false}
+
+        if (retryInfo.deadlock && attempt < maxAttempts && this._transactionsCount == 0) {
+          const baseWaitMs = typeof retryInfo.waitMs == "number" && retryInfo.waitMs > 0 ? retryInfo.waitMs : 50
+
+          this.logger.warn(`Retrying transaction after deadlock (attempt ${attempt}/${maxAttempts})`)
+          await wait(baseWaitMs * attempt)
+          continue
+        }
+
+        throw error
+      }
+    }
+  }
+
+  /**
+   * Runs a single transaction attempt: starts a transaction (or a savepoint when nested), runs
+   * `callback`, and commits — rolling back on error. {@link transaction} wraps this with deadlock
+   * retry at the outermost level.
+   * @param {() => Promise<void>} callback - Callback function.
+   * @returns {Promise<?>} - Resolves with the transaction result.
+   */
+  async _runTransactionAttempt(callback) {
     const savePointName = this.generateSavePointName()
     /**
      * Callback frame.

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -333,6 +333,19 @@ export default class VelociousDatabaseDriversMysql extends Base{
         return {retry: true, reconnect: false, waitMs: 50}
       }
 
+      // A deadlock or lock-wait-timeout aborts the whole transaction; it must be retried at the
+      // transaction level (re-running the callback), not the query level, so flag it as such and
+      // keep `retry` false so an in-transaction query does not retry against the dead transaction.
+      if (
+        errorCode == "ER_LOCK_DEADLOCK" ||
+        errorCode == "ER_LOCK_WAIT_TIMEOUT" ||
+        message.includes("ER_LOCK_DEADLOCK") ||
+        message.includes("Deadlock found") ||
+        message.includes("Lock wait timeout exceeded")
+      ) {
+        return {retry: false, reconnect: false, deadlock: true, waitMs: 50}
+      }
+
       shouldReconnect ||= (
         errorCode == "ECONNREFUSED" ||
         message.includes("ECONNREFUSED") ||


### PR DESCRIPTION
## Root cause (production incident 2026-07-19)

The background-jobs main's drain runs a transaction that claims jobs, while workers
run transactions that mark jobs complete — both writing `background_jobs`. Under
load these deadlock (`ER_LOCK_DEADLOCK`). But:

- `transaction()` rolled back and **rethrew with no retry**, and
- `retryableDatabaseError` did **not** classify deadlocks as retryable.

So a single deadlock **permanently failed the drain** (`BackgroundJobsMain
Background jobs drain failed: ER_LOCK_DEADLOCK`) and dispatch froze — the recurring
production job-queue freeze. It works at low load (deadlocks rare) and collapses
under sustained load (deadlocks constant).

## Fix

A deadlock / lock-wait-timeout aborts the **entire** transaction, so recovery must
re-run the whole transaction (the standard MySQL guidance is literally "try
restarting transaction") — retrying a single query inside the dead transaction is
wrong.

- **`mysql` driver `retryableDatabaseError`**: classify `ER_LOCK_DEADLOCK` /
  `ER_LOCK_WAIT_TIMEOUT` with `deadlock: true`, keeping `retry: false` so an
  in-transaction query does not retry against the already-aborted transaction.
- **base `transaction()`**: the **outermost** transaction now retries up to 5×
  with a small increasing backoff when an attempt fails with a deadlock; nested
  savepoints bubble the deadlock up to that outer retry. The single-attempt
  start/commit/rollback body moved to `_runTransactionAttempt`.

## Tests

`spec/database/transactions.browser-spec.js`: the transaction retries and commits
after a simulated deadlock (first attempt rolls back, only the retry's row
persists), and gives up + rethrows after exhausting retries.

Green: transactions 6, drivers 91, pool 43, tenants 23, background-jobs 143;
typecheck + eslint clean.

## Note

This is the core cure for the recurring freeze. The pileup that drove the load is
tracked separately (periodic jobs should dedupe at enqueue). Deploying this needs
a velocious release + TensorBuzz bump.
