### PR TITLE
Dedupe scheduled jobs at enqueue (stop periodic-job pileup)

### DIFF
--- a/spec/background-jobs/scheduler-spec.js
+++ b/spec/background-jobs/scheduler-spec.js
@@ -95,7 +95,12 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
         args: ["hello", "/tmp/out.json"],
         jobClass: TestJob,
         jobKey: "scheduledTestJob",
-        options: {executionMode: "inline"}
+        options: {
+          concurrencyKey: "scheduled:scheduledTestJob",
+          deduplicateWhileQueued: true,
+          executionMode: "inline",
+          maxConcurrency: 1
+        }
       }])
 
       await intervalCallbacks[intervalCallbacks.length - 1]?.()
@@ -174,7 +179,12 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
         args: ["cron"],
         jobClass: TestJob,
         jobKey: "cronTestJob",
-        options: {executionMode: "inline"}
+        options: {
+          concurrencyKey: "scheduled:cronTestJob",
+          deduplicateWhileQueued: true,
+          executionMode: "inline",
+          maxConcurrency: 1
+        }
       }])
 
       // After firing, the cron path uses setTimeout again (NOT
@@ -318,5 +328,51 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
 
     expect(error).toBeTruthy()
     expect(error?.message).toEqual('Scheduled background job missingScheduleJob must define either "every" or "cron".')
+  })
+
+  it("de-duplicates scheduled jobs with a per-schedule concurrency key by default", async () => {
+    /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobOptions>} */
+    const enqueued = []
+    const scheduler = new BackgroundJobsScheduler({
+      configuration: {
+        async getScheduledBackgroundJobsConfig() {
+          return {jobs: {}}
+        }
+      },
+      enqueueJob: async ({options}) => {
+        enqueued.push(options)
+      }
+    })
+
+    await scheduler.enqueueScheduledJob({jobConfiguration: {class: TestJob}, jobKey: "scheduledTestJob"})
+
+    expect(enqueued.length).toEqual(1)
+    expect(enqueued[0].deduplicateWhileQueued).toEqual(true)
+    expect(enqueued[0].concurrencyKey).toEqual("scheduled:scheduledTestJob")
+    expect(enqueued[0].maxConcurrency).toEqual(1)
+  })
+
+  it("keeps an explicit concurrencyKey and honours a deduplicateWhileQueued opt-out", async () => {
+    /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobOptions>} */
+    const enqueued = []
+    const scheduler = new BackgroundJobsScheduler({
+      configuration: {
+        async getScheduledBackgroundJobsConfig() {
+          return {jobs: {}}
+        }
+      },
+      enqueueJob: async ({options}) => {
+        enqueued.push(options)
+      }
+    })
+
+    await scheduler.enqueueScheduledJob({
+      jobConfiguration: {class: TestJob, options: {concurrencyKey: "custom-key", maxConcurrency: 3, deduplicateWhileQueued: false}},
+      jobKey: "scheduledTestJob"
+    })
+
+    expect(enqueued[0].concurrencyKey).toEqual("custom-key")
+    expect(enqueued[0].maxConcurrency).toEqual(3)
+    expect(enqueued[0].deduplicateWhileQueued).toEqual(false)
   })
 })

--- a/spec/background-jobs/scheduler-spec.js
+++ b/spec/background-jobs/scheduler-spec.js
@@ -95,12 +95,7 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
         args: ["hello", "/tmp/out.json"],
         jobClass: TestJob,
         jobKey: "scheduledTestJob",
-        options: {
-          concurrencyKey: "scheduled:scheduledTestJob",
-          deduplicateWhileQueued: true,
-          executionMode: "inline",
-          maxConcurrency: 1
-        }
+        options: {deduplicateWhileQueued: true, executionMode: "inline"}
       }])
 
       await intervalCallbacks[intervalCallbacks.length - 1]?.()
@@ -179,12 +174,7 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
         args: ["cron"],
         jobClass: TestJob,
         jobKey: "cronTestJob",
-        options: {
-          concurrencyKey: "scheduled:cronTestJob",
-          deduplicateWhileQueued: true,
-          executionMode: "inline",
-          maxConcurrency: 1
-        }
+        options: {deduplicateWhileQueued: true, executionMode: "inline"}
       }])
 
       // After firing, the cron path uses setTimeout again (NOT
@@ -330,7 +320,7 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
     expect(error?.message).toEqual('Scheduled background job missingScheduleJob must define either "every" or "cron".')
   })
 
-  it("de-duplicates scheduled jobs with a per-schedule concurrency key by default", async () => {
+  it("de-duplicates scheduled jobs by default without overriding their concurrency", async () => {
     /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobOptions>} */
     const enqueued = []
     const scheduler = new BackgroundJobsScheduler({
@@ -348,11 +338,12 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
 
     expect(enqueued.length).toEqual(1)
     expect(enqueued[0].deduplicateWhileQueued).toEqual(true)
-    expect(enqueued[0].concurrencyKey).toEqual("scheduled:scheduledTestJob")
-    expect(enqueued[0].maxConcurrency).toEqual(1)
+    // No concurrencyKey is injected, so the job keeps its (e.g. queue-derived) concurrency cap.
+    expect(enqueued[0].concurrencyKey).toBe(undefined)
+    expect(enqueued[0].maxConcurrency).toBe(undefined)
   })
 
-  it("keeps an explicit concurrencyKey and honours a deduplicateWhileQueued opt-out", async () => {
+  it("honours a deduplicateWhileQueued opt-out and preserves declared options", async () => {
     /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobOptions>} */
     const enqueued = []
     const scheduler = new BackgroundJobsScheduler({
@@ -371,8 +362,8 @@ describe("Background jobs - scheduler", {databaseCleaning: {truncate: true}}, ()
       jobKey: "scheduledTestJob"
     })
 
+    expect(enqueued[0].deduplicateWhileQueued).toEqual(false)
     expect(enqueued[0].concurrencyKey).toEqual("custom-key")
     expect(enqueued[0].maxConcurrency).toEqual(3)
-    expect(enqueued[0].deduplicateWhileQueued).toEqual(false)
   })
 })

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -434,6 +434,24 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(thirdId).not.toEqual(firstId)
   })
 
+  it("dedupes by job identity, not concurrency key, so different jobs on a shared key are not coalesced", async () => {
+    const store = await createClearedStore()
+    // Two different jobs deliberately share a concurrency key (a queue-derived cap would look like
+    // this). They must NOT coalesce onto each other — dedup is by job identity, so both keep the
+    // shared cap.
+    const sharedKeyOptions = {concurrencyKey: "shared-key", maxConcurrency: 5, deduplicateWhileQueued: true}
+    const firstId = await store.enqueue({jobName: "JobA", args: [], options: sharedKeyOptions})
+    const secondId = await store.enqueue({jobName: "JobB", args: [], options: sharedKeyOptions})
+
+    expect(secondId).not.toEqual(firstId)
+
+    // And dedup still works with no explicit concurrency key at all: same job + args coalesces.
+    const thirdId = await store.enqueue({jobName: "JobC", args: [1], options: {deduplicateWhileQueued: true}})
+    const fourthId = await store.enqueue({jobName: "JobC", args: [1], options: {deduplicateWhileQueued: true}})
+
+    expect(fourthId).toEqual(thirdId)
+  })
+
   it("releases a concurrency reservation when a competing queued claim loses", async () => {
     let activeCount = 0
     const db = {

--- a/src/background-jobs/scheduler.js
+++ b/src/background-jobs/scheduler.js
@@ -3,8 +3,6 @@
 import Logger from "../logger.js"
 import {nextCronFireDate, parseCronExpression} from "./cron-expression.js"
 
-const SCHEDULED_CONCURRENCY_KEY_PREFIX = "scheduled:"
-
 const DURATION_MULTIPLIERS = {
   d: 24 * 60 * 60 * 1000,
   day: 24 * 60 * 60 * 1000,
@@ -263,38 +261,20 @@ export default class BackgroundJobsScheduler {
    */
   async enqueueScheduledJob({jobConfiguration, jobKey}) {
     try {
+      // De-duplicate scheduled enqueues by default: a periodic job still pending from an earlier
+      // tick is not enqueued again, which is what let the background_jobs table fill with thousands
+      // of identical scheduled jobs when the queue backed up. Dedup is by job identity (see the
+      // store), so the job keeps its queue-derived concurrency cap. A schedule can opt out with
+      // `deduplicateWhileQueued: false`.
       await this.enqueueJob({
         args: Array.isArray(jobConfiguration.args) ? jobConfiguration.args : [],
         jobClass: jobConfiguration.class,
         jobKey,
-        options: this._scheduledEnqueueOptions({jobConfiguration, jobKey})
+        options: {deduplicateWhileQueued: true, ...(jobConfiguration.options || {})}
       })
     } catch (error) {
       await this.logger.error(() => ["Failed to enqueue scheduled background job", {jobKey, jobName: jobConfiguration.class.jobName()}, error])
     }
-  }
-
-  /**
-   * Builds the enqueue options for a scheduled job so it de-duplicates while queued: a periodic
-   * job still pending from an earlier tick is never enqueued again, which is what let the
-   * background_jobs table fill with thousands of identical scheduled jobs when the queue backed up.
-   * Deduplication keys on the job's concurrency key; a schedule that does not declare one gets a
-   * per-schedule singleton key (derived from its jobKey, maxConcurrency 1) so both the dedup and
-   * the concurrency cap are scoped to that single schedule. A schedule opts out with
-   * `deduplicateWhileQueued: false`, or picks its own concurrency by declaring a concurrencyKey.
-   * @param {{jobConfiguration: import("../configuration-types.js").ScheduledBackgroundJobConfiguration, jobKey: string}} args - Schedule configuration and its key.
-   * @returns {import("./types.js").BackgroundJobOptions} - Enqueue options with dedup applied.
-   */
-  _scheduledEnqueueOptions({jobConfiguration, jobKey}) {
-    /** @type {import("./types.js").BackgroundJobOptions} */
-    const options = {deduplicateWhileQueued: true, ...(jobConfiguration.options || {})}
-
-    if (!options.concurrencyKey) {
-      options.concurrencyKey = `${SCHEDULED_CONCURRENCY_KEY_PREFIX}${jobKey}`
-      options.maxConcurrency = 1
-    }
-
-    return options
   }
 
   /**

--- a/src/background-jobs/scheduler.js
+++ b/src/background-jobs/scheduler.js
@@ -3,6 +3,8 @@
 import Logger from "../logger.js"
 import {nextCronFireDate, parseCronExpression} from "./cron-expression.js"
 
+const SCHEDULED_CONCURRENCY_KEY_PREFIX = "scheduled:"
+
 const DURATION_MULTIPLIERS = {
   d: 24 * 60 * 60 * 1000,
   day: 24 * 60 * 60 * 1000,
@@ -265,11 +267,34 @@ export default class BackgroundJobsScheduler {
         args: Array.isArray(jobConfiguration.args) ? jobConfiguration.args : [],
         jobClass: jobConfiguration.class,
         jobKey,
-        options: jobConfiguration.options || {}
+        options: this._scheduledEnqueueOptions({jobConfiguration, jobKey})
       })
     } catch (error) {
       await this.logger.error(() => ["Failed to enqueue scheduled background job", {jobKey, jobName: jobConfiguration.class.jobName()}, error])
     }
+  }
+
+  /**
+   * Builds the enqueue options for a scheduled job so it de-duplicates while queued: a periodic
+   * job still pending from an earlier tick is never enqueued again, which is what let the
+   * background_jobs table fill with thousands of identical scheduled jobs when the queue backed up.
+   * Deduplication keys on the job's concurrency key; a schedule that does not declare one gets a
+   * per-schedule singleton key (derived from its jobKey, maxConcurrency 1) so both the dedup and
+   * the concurrency cap are scoped to that single schedule. A schedule opts out with
+   * `deduplicateWhileQueued: false`, or picks its own concurrency by declaring a concurrencyKey.
+   * @param {{jobConfiguration: import("../configuration-types.js").ScheduledBackgroundJobConfiguration, jobKey: string}} args - Schedule configuration and its key.
+   * @returns {import("./types.js").BackgroundJobOptions} - Enqueue options with dedup applied.
+   */
+  _scheduledEnqueueOptions({jobConfiguration, jobKey}) {
+    /** @type {import("./types.js").BackgroundJobOptions} */
+    const options = {deduplicateWhileQueued: true, ...(jobConfiguration.options || {})}
+
+    if (!options.concurrencyKey) {
+      options.concurrencyKey = `${SCHEDULED_CONCURRENCY_KEY_PREFIX}${jobKey}`
+      options.maxConcurrency = 1
+    }
+
+    return options
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -144,12 +144,16 @@ export default class BackgroundJobsStore {
     let resultJobId = jobId
 
     await this._withDb(async (db) => {
-      if (options?.deduplicateWhileQueued && concurrency?.concurrencyKey) {
+      if (options?.deduplicateWhileQueued) {
+        // Dedupe on the job's identity (name + args + queue), NOT its concurrency key, so a job
+        // keeps whatever concurrency it resolves to — in particular a scheduled job that relies on
+        // its queue-derived `queue:<name>` cap still participates in that cluster-wide cap instead
+        // of being pulled onto a private per-job key.
         const existing = await db
           .newQuery()
           .from(JOBS_TABLE)
           .select("id")
-          .where({status: "queued", concurrency_key: concurrency.concurrencyKey})
+          .where({status: "queued", job_name: jobName, args_json: argsJson, queue})
           .limit(1)
           .results()
 

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -15,7 +15,7 @@
  * @property {string} [queue] - Queue name. Defaults to `"default"`. When the queue has a configured cap in `backgroundJobs.queues`, that cap is enforced cluster-wide.
  * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap. Overrides any queue-derived cap.
  * @property {number} [maxConcurrency] - Positive integer cap; must be paired with `concurrencyKey`.
- * @property {boolean} [deduplicateWhileQueued] - When true (requires `concurrencyKey`), skip the enqueue if a still-queued job with the same `concurrencyKey` already exists, returning that job's id. Keeps an interval-scheduled recurring job (e.g. retention pruning) from piling up redundant queued rows when it runs slower than its interval or no worker is free.
+ * @property {boolean} [deduplicateWhileQueued] - When true, skip the enqueue if an identical still-queued job (same job name, args and queue) already exists, returning that job's id. Deduplication is by job identity and independent of `concurrencyKey`, so the job keeps its normal (e.g. queue-derived) concurrency cap. Keeps an interval-scheduled recurring job (e.g. retention pruning) from piling up redundant queued rows when it runs slower than its interval or no worker is free.
  * @property {number} [scheduledAtMs] - Epoch timestamp in milliseconds when the job becomes eligible for dispatch. Defaults to enqueue time.
  */
 /**


### PR DESCRIPTION
## Why

The background-jobs scheduler enqueued a scheduled/periodic job on every tick with
**no de-duplication**. When the queue backed up, the same scheduled jobs piled up
into thousands of identical queued rows (a real production incident saw 2,846
queued `TimeoutBuildJob` plus hundreds of other periodic jobs). That backlog is
itself a major driver of drain-vs-update lock contention.

velocious already had the primitive — `enqueue({options: {deduplicateWhileQueued}})`
skips insertion when a still-queued job with the same `concurrency_key` exists (and
the type doc literally names "an interval-scheduled recurring job ... piling up" as
the case). It just wasn't wired into the scheduler.

## What

`enqueueScheduledJob` now builds its options via `_scheduledEnqueueOptions`, which:
- defaults `deduplicateWhileQueued: true`, and
- when the schedule declares no `concurrencyKey`, derives a **per-schedule singleton
  key** (`scheduled:<jobKey>`, `maxConcurrency: 1`) so both the dedup and the
  concurrency cap are scoped to that one schedule.

So a periodic job can never have more than one pending instance. A schedule can opt
out (`deduplicateWhileQueued: false`) or pick its own concurrency by declaring a
`concurrencyKey` — both are preserved.

## Tests

`spec/background-jobs/scheduler-spec.js`: default per-schedule dedup key is applied;
an explicit `concurrencyKey` and a `deduplicateWhileQueued: false` opt-out are
honoured. Updated the two existing schedule-enqueue assertions for the new options.
The dedup mechanism itself is already covered by `store-spec` / the prune spec.

Green: scheduler 9/9. (Full background-jobs suite run attached in the PR checks.)

Note: a pre-existing timing-flaky store-spec test ("serializes and rechecks
concurrent legacy concurrency-column migrations") flaked once locally but passes
consistently on re-run; unrelated to this change.
