### PR TITLE
Fix background-jobs deadlock exhaustion under heavy contention

### DIFF
--- a/spec/background-jobs/store-concurrency-deadlock.browser-spec.js
+++ b/spec/background-jobs/store-concurrency-deadlock.browser-spec.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+/**
+ * A two-party rendezvous: both callers block until both have arrived, then both proceed. Used to
+ * hold each transaction's first row-lock at the same time so InnoDB is forced into an AB-BA
+ * deadlock rather than serializing the two transactions.
+ * @returns {() => Promise<void>} - Arrive-and-wait function.
+ */
+function createRendezvous() {
+  let arrived = 0
+  /** @type {Array<() => void>} */
+  const waiters = []
+
+  return () => {
+    arrived++
+
+    if (arrived >= 2) {
+      for (const release of waiters) release()
+
+      return Promise.resolve()
+    }
+
+    return new Promise((resolve) => waiters.push(resolve))
+  }
+}
+
+/**
+ * @param {object} args - Options.
+ * @param {BackgroundJobsStore} args.store - Background jobs store.
+ * @param {string} args.concurrencyKey - Concurrency key.
+ * @returns {Promise<number>} - The persisted `active_count` for the key (0 when the row is absent).
+ */
+async function readActiveCount({store, concurrencyKey}) {
+  const rows = await store._withDb(async (db) =>
+    await db.newQuery().from("background_job_concurrency").where({concurrency_key: concurrencyKey}).results()
+  )
+
+  if (rows.length === 0) return 0
+
+  return Number(/** @type {{active_count: number | string}} */ (rows[0]).active_count)
+}
+
+describe("background jobs store - concurrency counter deadlocks", {tags: ["dummy"], databaseCleaning: {truncate: true}}, () => {
+  it("absorbs an AB-BA deadlock on the concurrency counter and keeps the counter consistent", async () => {
+    dummyConfiguration.setCurrent()
+
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    await store.clearAll()
+
+    const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
+    const engineType = await pool.withConnection({name: "deadlock engine probe"}, async (db) => db.getArgs().type)
+
+    // A real row-level deadlock needs an engine with row locking and two independent connections.
+    // SQLite serializes writers on one shared connection, so it cannot reproduce this; only the
+    // MySQL/MariaDB CI lane exercises the real deadlock. Skip cleanly everywhere else.
+    if (engineType !== "mysql") return
+
+    const keyA = "deadlock-a"
+    const keyB = "deadlock-b"
+
+    // enqueue seeds one concurrency-counter row per key (active_count 0, nothing reserved yet).
+    await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: keyA, maxConcurrency: 4}})
+    await store.enqueue({jobName: "TestJob", args: [], options: {concurrencyKey: keyB, maxConcurrency: 4}})
+
+    const rendezvous = createRendezvous()
+
+    /**
+     * Locks two counter rows in the given order inside one transaction. Two of these running
+     * concurrently in opposite orders deadlock; the store's hardened transaction retry must absorb
+     * the deadlock instead of letting it escape.
+     * @param {import("../../src/database/drivers/base.js").default} db - Connection.
+     * @param {string} firstKey - Key locked first.
+     * @param {string} secondKey - Key locked second.
+     * @returns {Promise<number>} - Transaction attempts made (>= 2 means it deadlocked and retried).
+     */
+    const contend = async (db, firstKey, secondKey) => {
+      let attempts = 0
+
+      await db.transaction(async () => {
+        attempts++
+        await store._lockConcurrencyRow(db, firstKey)
+
+        // Rendezvous only on the first attempt, so both transactions hold their first row-lock at
+        // once and deadlock. The retry skips it, letting the surviving transaction commit first and
+        // this one then complete.
+        if (attempts === 1) await rendezvous()
+
+        await store._lockConcurrencyRow(db, secondKey)
+      })
+
+      return attempts
+    }
+
+    const attempts = await Promise.all([
+      pool.withConnection({name: "deadlock-contender-a"}, async (db) => await contend(db, keyA, keyB)),
+      pool.withConnection({name: "deadlock-contender-b"}, async (db) => await contend(db, keyB, keyA))
+    ])
+
+    // Neither call rejected (the deadlock did not escape), and one contender was the deadlock
+    // victim that retried — proving the hardened transaction retry absorbed a real deadlock.
+    expect(Math.max(...attempts)).toBeGreaterThanOrEqual(2)
+
+    // The lock is value-preserving, so both counters remain at their seeded value of 0.
+    expect(await readActiveCount({store, concurrencyKey: keyA})).toEqual(0)
+    expect(await readActiveCount({store, concurrencyKey: keyB})).toEqual(0)
+  })
+})

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -29,6 +29,22 @@ async function getJobOrFail({jobId, store}) {
 
 /**
  * @param {object} args - Options.
+ * @param {BackgroundJobsStore} args.store - Background jobs store.
+ * @param {string} args.concurrencyKey - Concurrency key.
+ * @returns {Promise<number>} - The persisted `active_count` for the key (0 when the row is absent).
+ */
+async function readActiveCount({store, concurrencyKey}) {
+  const rows = await store._withDb(async (db) =>
+    await db.newQuery().from("background_job_concurrency").where({concurrency_key: concurrencyKey}).results()
+  )
+
+  if (rows.length === 0) return 0
+
+  return Number(/** @type {{active_count: number | string}} */ (rows[0]).active_count)
+}
+
+/**
+ * @param {object} args - Options.
  * @param {number} args.maxRetries - Job max retries.
  * @param {BackgroundJobsStore} args.store - Background jobs store.
  * @returns {Promise<import("../../src/background-jobs/types.js").BackgroundJobRow>} - Orphaned job row.
@@ -603,6 +619,50 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(job.handoffId).toEqual(secondHandoff.handoffId)
     expect(job.attempts).toEqual(0)
     expect(job.lastError).toBeNull()
+  })
+
+  it("keeps the concurrency counter consistent across every release path", async () => {
+    // Regression for the deadlock lock-ordering fix: each release path now locks the shared
+    // concurrency-counter row before the job row (matching markHandedOff's concurrency-then-job
+    // order). Reordering the lock acquisition must stay counter-neutral — active_count must still
+    // equal the number of jobs currently holding a reservation, regardless of which release path
+    // (complete / fail / return-to-queue / cancel) ran.
+    const store = await createClearedStore()
+    const concurrencyKey = "release-order"
+    const maxConcurrency = 8
+
+    /** @type {string[]} */
+    const jobIds = []
+
+    for (let index = 0; index < 6; index++) {
+      jobIds.push(await store.enqueue({jobName: "TestJob", args: [String(index)], options: {concurrencyKey, maxConcurrency}}))
+    }
+
+    /** @type {Record<string, {handoffId: string, handedOffAtMs: number, workerId: string}>} */
+    const handoffs = {}
+
+    for (const jobId of jobIds) {
+      const handoff = await store.markHandedOff({jobId, workerId: "worker-1"})
+
+      if (!handoff) throw new Error(`Expected the job to be handed off: ${jobId}`)
+
+      handoffs[jobId] = {handoffId: handoff.handoffId, handedOffAtMs: handoff.handedOffAtMs, workerId: "worker-1"}
+    }
+
+    expect(await readActiveCount({store, concurrencyKey})).toEqual(6)
+
+    // Drive four of the six jobs out through each distinct release path; leave two reserved.
+    await store.markCompleted({jobId: jobIds[0], ...handoffs[jobIds[0]]})
+    await store.markFailed({jobId: jobIds[1], error: "boom", ...handoffs[jobIds[1]]})
+    await store.markReturnedToQueue({jobId: jobIds[2], handoffId: handoffs[jobIds[2]].handoffId})
+    await store.cancel(jobIds[3])
+
+    const handedOffJobs = await store._withDb(async (db) =>
+      await db.newQuery().from("background_jobs").where({concurrency_key: concurrencyKey, status: "handed_off"}).results()
+    )
+
+    expect(handedOffJobs.length).toEqual(2)
+    expect(await readActiveCount({store, concurrencyKey})).toEqual(2)
   })
 
   it("requeues failed jobs and honors max retries", async () => {

--- a/spec/database/transactions.browser-spec.js
+++ b/spec/database/transactions.browser-spec.js
@@ -150,12 +150,17 @@ describe("database - transactions", {tags: ["dummy"]}, () => {
     })
   })
 
-  it("gives up and rethrows after exhausting deadlock retries", async () => {
+  it("gives up and rethrows after exhausting the configured deadlock retries", async () => {
     await Configuration.current().ensureConnections(async (dbs) => {
       const db = dbs.default
       const originalRetryable = db.retryableDatabaseError.bind(db)
+      const originalGetArgs = db.getArgs.bind(db)
+      const originalWaitMs = db._waitMs.bind(db)
 
-      db.retryableDatabaseError = () => ({retry: false, reconnect: false, deadlock: true, waitMs: 1})
+      db.retryableDatabaseError = () => ({retry: false, reconnect: false, deadlock: true})
+      // Pin the retry budget so the assertion is against a controlled value, not the default.
+      db.getArgs = () => ({...originalGetArgs(), deadlockMaxRetries: 3})
+      db._waitMs = async () => {}
 
       let attempts = 0
       /** @type {unknown} */
@@ -171,10 +176,90 @@ describe("database - transactions", {tags: ["dummy"]}, () => {
         caught = error
       } finally {
         db.retryableDatabaseError = originalRetryable
+        db.getArgs = originalGetArgs
+        db._waitMs = originalWaitMs
       }
 
-      expect(attempts).toEqual(5)
+      expect(attempts).toEqual(3)
       expect(caught instanceof Error && caught.message).toEqual("ALWAYS_DEADLOCK")
+    })
+  })
+
+  it("backs off with capped full-jitter exponential delays between deadlock retries", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const originalRetryable = db.retryableDatabaseError.bind(db)
+      const originalGetArgs = db.getArgs.bind(db)
+      const originalWaitMs = db._waitMs.bind(db)
+      const originalRandom = Math.random
+      /** @type {number[]} */
+      const waits = []
+
+      db.retryableDatabaseError = (/** @type {Error} */ error) =>
+        error instanceof Error && error.message.includes("SIMULATED_DEADLOCK")
+          ? {retry: false, reconnect: false, deadlock: true}
+          : originalRetryable(error)
+      db.getArgs = () => ({...originalGetArgs(), deadlockBaseWaitMs: 100, deadlockMaxWaitMs: 1000, deadlockMaxRetries: 8})
+      db._waitMs = async (/** @type {number} */ ms) => { waits.push(ms) }
+      // Fix the jitter fraction so the delays are deterministic; full jitter picks in [0, ceiling].
+      Math.random = () => 0.5
+
+      let attempts = 0
+
+      try {
+        await db.transaction(async () => {
+          attempts++
+          if (attempts <= 5) throw new Error("SIMULATED_DEADLOCK")
+        })
+      } finally {
+        db.retryableDatabaseError = originalRetryable
+        db.getArgs = originalGetArgs
+        db._waitMs = originalWaitMs
+        Math.random = originalRandom
+      }
+
+      expect(attempts).toEqual(6)
+      // Ceilings double until the cap: min(100 * 2^(n-1), 1000) = 100,200,400,800,1000 for
+      // attempts 1..5. Full jitter with Math.random()==0.5 yields floor(0.5 * (ceiling + 1)).
+      // The old linear `base * attempt` would have been [100,200,300,400,500] with no jitter.
+      expect(waits).toEqual([50, 100, 200, 400, 500])
+    })
+  })
+
+  it("can back off with zero delay when the jitter resolves to its lower bound", async () => {
+    await Configuration.current().ensureConnections(async (dbs) => {
+      const db = dbs.default
+      const originalRetryable = db.retryableDatabaseError.bind(db)
+      const originalGetArgs = db.getArgs.bind(db)
+      const originalWaitMs = db._waitMs.bind(db)
+      const originalRandom = Math.random
+      /** @type {number[]} */
+      const waits = []
+
+      db.retryableDatabaseError = (/** @type {Error} */ error) =>
+        error instanceof Error && error.message.includes("SIMULATED_DEADLOCK")
+          ? {retry: false, reconnect: false, deadlock: true}
+          : originalRetryable(error)
+      db.getArgs = () => ({...originalGetArgs(), deadlockBaseWaitMs: 100, deadlockMaxWaitMs: 1000, deadlockMaxRetries: 8})
+      db._waitMs = async (/** @type {number} */ ms) => { waits.push(ms) }
+      Math.random = () => 0
+
+      let attempts = 0
+
+      try {
+        await db.transaction(async () => {
+          attempts++
+          if (attempts <= 3) throw new Error("SIMULATED_DEADLOCK")
+        })
+      } finally {
+        db.retryableDatabaseError = originalRetryable
+        db.getArgs = originalGetArgs
+        db._waitMs = originalWaitMs
+        Math.random = originalRandom
+      }
+
+      expect(attempts).toEqual(4)
+      expect(waits).toEqual([0, 0, 0])
     })
   })
 

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -476,6 +476,7 @@ export default class BackgroundJobsStore {
       if (!job) return false
       if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return false
 
+      await this._lockConcurrencyRow(db, job.concurrencyKey)
       const affectedRows = await this._updateAffectedRows(db, {
         tableName: JOBS_TABLE,
         data: {
@@ -504,6 +505,7 @@ export default class BackgroundJobsStore {
     await this._withDb(async (db) => await db.transaction(async () => {
       const job = await this._getJobRowById(db, jobId)
       if (!job || job.handoffId !== handoffId || job.status !== "handed_off") return
+      await this._lockConcurrencyRow(db, job.concurrencyKey)
       const affectedRows = await this._updateAffectedRows(db, {
         tableName: JOBS_TABLE,
         data: {
@@ -723,6 +725,9 @@ export default class BackgroundJobsStore {
     return await this._withDb(async (db) => await this._transactionResult(db, async () => {
       const job = await this._getJobRowById(db, jobId)
       if (!job || (job.status !== "queued" && job.status !== "handed_off")) return false
+      // Only a handed_off job holds a concurrency reservation, so only that case touches the
+      // shared counter row and needs the concurrency-then-job lock ordering.
+      if (job.status === "handed_off") await this._lockConcurrencyRow(db, job.concurrencyKey)
       const affectedRows = await this._updateAffectedRows(db, {tableName: JOBS_TABLE, data: {status: "cancelled"}, conditions: {id: job.id, status: job.status}})
       if (affectedRows !== 1) return false
       if (job.status === "handed_off") await this._releaseConcurrency(db, job.concurrencyKey)
@@ -1198,6 +1203,7 @@ export default class BackgroundJobsStore {
       shouldRetry
     })
 
+    await this._lockConcurrencyRow(db, job.concurrencyKey)
     const affectedRows = await this._updateAffectedRows(db, {
       tableName: JOBS_TABLE,
       data: update,
@@ -1471,6 +1477,28 @@ export default class BackgroundJobsStore {
     }
     const configured = /** @type {{max_concurrency?: number | string}} */ (rows[0])
     if (this._normalizeNumber(configured.max_concurrency) !== maxConcurrency) throw new Error(`Conflicting maxConcurrency for background job concurrencyKey: ${concurrencyKey}`)
+  }
+
+  /**
+   * Locks the concurrency counter row so a job-release transaction acquires it *before* the job
+   * row. {@link markHandedOff} reserves capacity (locking the counter row) before it updates the
+   * job, so it locks concurrency-then-job; the release paths update the job before releasing
+   * capacity, which is job-then-concurrency. Those opposite orders on the same shared counter row
+   * are what deadlock (AB-BA) under a draining worker. Taking this lock first gives every
+   * transaction a single concurrency-then-job order and removes the cycle.
+   *
+   * Uses a value-preserving `UPDATE` rather than `SELECT ... FOR UPDATE` so it stays portable
+   * across drivers without row-level locking reads (e.g. SQLite); on row-locking engines the
+   * matched row is write-locked for the rest of the transaction even though its value is unchanged.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {string | null} concurrencyKey - Concurrency key.
+   * @returns {Promise<void>} - Resolves when the counter row is locked.
+   */
+  async _lockConcurrencyRow(db, concurrencyKey) {
+    if (!concurrencyKey) return
+    const table = db.quoteTable(CONCURRENCY_TABLE)
+    const count = db.quoteColumn("active_count")
+    await db.query(`UPDATE ${table} SET ${count} = ${count} WHERE ${db.quoteColumn("concurrency_key")} = ${db.quote(concurrencyKey)}`)
   }
 
   /**

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -64,6 +64,9 @@
  * @property {string} [databaseCharset] - Default character set applied by `db:create` via mysql/mariadb `CREATE DATABASE ... CHARACTER SET`. Distinct from `charset`, which is the client connection charset forwarded to the mysql2 driver.
  * @property {string} [databaseCollation] - Default collation applied by `db:create` via mysql/mariadb `CREATE DATABASE ... COLLATE`.
  * @property {string} [database] - Database name for this connection.
+ * @property {number} [deadlockMaxRetries] - Maximum attempts for the outermost transaction when it keeps hitting deadlocks. Defaults to 8.
+ * @property {number} [deadlockBaseWaitMs] - Base delay (ms) for the deadlock retry backoff; the per-attempt ceiling doubles from here. Defaults to 50.
+ * @property {number} [deadlockMaxWaitMs] - Cap (ms) on the deadlock retry backoff ceiling so the jittered wait stays bounded. Defaults to 1000.
  * @property {typeof import("./database/drivers/base.js").default} [driver] - Driver class to use for this database.
  * @property {typeof import("./database/pool/base.js").default} [poolType] - Pool class to use for this database.
  * @property {function() : ?} [getConnection] - Custom connection factory override.

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -122,6 +122,7 @@ import TableData from "../table-data/index.js"
 import TableColumn from "../table-data/table-column.js"
 import TableForeignKey from "../table-data/table-foreign-key.js"
 import wait from "awaitery/build/wait.js"
+import {optionalPositiveInteger} from "typanic"
 
 /**
  * Runs now ms.
@@ -864,7 +865,10 @@ export default class VelociousDatabaseDriversBase {
       return await this._runTransactionAttempt(callback)
     }
 
-    const maxAttempts = 5
+    const args = this.getArgs()
+    const maxAttempts = optionalPositiveInteger(args.deadlockMaxRetries, "deadlockMaxRetries") ?? 8
+    const deadlockBaseWaitMs = optionalPositiveInteger(args.deadlockBaseWaitMs, "deadlockBaseWaitMs") ?? 50
+    const deadlockMaxWaitMs = optionalPositiveInteger(args.deadlockMaxWaitMs, "deadlockMaxWaitMs") ?? 1000
     let attempt = 0
 
     while (true) {
@@ -876,16 +880,35 @@ export default class VelociousDatabaseDriversBase {
         const retryInfo = error instanceof Error ? this.retryableDatabaseError(error) : {retry: false, reconnect: false}
 
         if (retryInfo.deadlock && attempt < maxAttempts && this._transactionsCount == 0) {
-          const baseWaitMs = typeof retryInfo.waitMs == "number" && retryInfo.waitMs > 0 ? retryInfo.waitMs : 50
+          const baseWaitMs = typeof retryInfo.waitMs == "number" && retryInfo.waitMs > 0 ? retryInfo.waitMs : deadlockBaseWaitMs
+
+          // Full-jitter exponential backoff: wait a uniform-random duration in
+          // [0, min(base * 2^(attempt-1), cap)]. The doubling ceiling spreads retries out as
+          // contention persists, and the jitter de-correlates transactions that deadlocked in
+          // lockstep so they stop re-colliding on the same wait (the linear `base * attempt`
+          // this replaces had every victim retry after an identical delay). `attempt` is
+          // 1-based here, so 2^(attempt-1) is 1, 2, 4, ... The cap keeps the tail sub-second.
+          const ceilingWaitMs = Math.min(baseWaitMs * (2 ** (attempt - 1)), deadlockMaxWaitMs)
+          const jitteredWaitMs = Math.floor(Math.random() * (ceilingWaitMs + 1))
 
           this.logger.warn(`Retrying transaction after deadlock (attempt ${attempt}/${maxAttempts})`)
-          await wait(baseWaitMs * attempt)
+          await this._waitMs(jitteredWaitMs)
           continue
         }
 
         throw error
       }
     }
+  }
+
+  /**
+   * Waits `ms` milliseconds. Isolated in its own method so tests can observe (and skip) the
+   * deadlock-retry backoff without a real timer.
+   * @param {number} ms - Milliseconds to wait.
+   * @returns {Promise<void>} - Resolves after the delay.
+   */
+  async _waitMs(ms) {
+    await wait(ms)
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -867,7 +867,7 @@ export default class VelociousDatabaseDriversBase {
 
     const args = this.getArgs()
     const maxAttempts = optionalPositiveInteger(args.deadlockMaxRetries, "deadlockMaxRetries") ?? 8
-    const deadlockBaseWaitMs = optionalPositiveInteger(args.deadlockBaseWaitMs, "deadlockBaseWaitMs") ?? 50
+    const configuredBaseWaitMs = optionalPositiveInteger(args.deadlockBaseWaitMs, "deadlockBaseWaitMs")
     const deadlockMaxWaitMs = optionalPositiveInteger(args.deadlockMaxWaitMs, "deadlockMaxWaitMs") ?? 1000
     let attempt = 0
 
@@ -880,7 +880,10 @@ export default class VelociousDatabaseDriversBase {
         const retryInfo = error instanceof Error ? this.retryableDatabaseError(error) : {retry: false, reconnect: false}
 
         if (retryInfo.deadlock && attempt < maxAttempts && this._transactionsCount == 0) {
-          const baseWaitMs = typeof retryInfo.waitMs == "number" && retryInfo.waitMs > 0 ? retryInfo.waitMs : deadlockBaseWaitMs
+          // An explicitly-configured base wins so the tuning knob is effective even on drivers
+          // whose classifier supplies its own `waitMs` (MySQL/MariaDB return a fixed 50ms for
+          // deadlocks); otherwise honor that classifier hint, then fall back to 50ms.
+          const baseWaitMs = configuredBaseWaitMs ?? (typeof retryInfo.waitMs == "number" && retryInfo.waitMs > 0 ? retryInfo.waitMs : 50)
 
           // Full-jitter exponential backoff: wait a uniform-random duration in
           // [0, min(base * 2^(attempt-1), cap)]. The doubling ceiling spreads retries out as


### PR DESCRIPTION
## Context

In the 2026-07-20 deploy, a draining old release's background-jobs drain hit `ER_LOCK_DEADLOCK` and **failed after exhausting all 5 transaction retries**, preceded by repeated `ER_CHECKREAD` retries on the `background_job_concurrency` counter. Even the whole-transaction deadlock retry wasn't enough under heavy contention. (TensorBuzz task #10436, P1.)

## Root cause

`background_job_concurrency` has one row per concurrency key that every job-lifecycle transaction locks together with a job row — but in **inconsistent order**:

- `markHandedOff` locks the **counter row first** (`_reserveConcurrency`, `active_count + 1`), then the job → concurrency-then-job.
- `markCompleted` / `markReturnedToQueue` / `_applyFailure` (markFailed + orphan sweep) / `cancel` update the **job first**, then `_releaseConcurrency` → job-then-concurrency.

Those opposite orders on the same shared counter row deadlock (AB-BA) under a draining worker, and the retry loop's **linear, jitter-free** backoff (`wait(base * attempt)`) made lockstep victims re-collide until the 5-attempt budget was exhausted.

## The fix — two layers

**1. Consistent lock ordering (root cause).** New `_lockConcurrencyRow(db, key)` takes the counter row's write lock via a value-preserving `UPDATE active_count = active_count WHERE concurrency_key = ?` — portable across drivers (unlike `SELECT ... FOR UPDATE`, which SQLite/MSSQL don't share). It's acquired *before* the job update in the four release paths, so every transaction locks concurrency-then-job (matching `markHandedOff`), removing the cycle. Counter-neutral: the `+1`/`-1` arithmetic and every `WHERE` guard are unchanged.

**2. Retry hardening (defense in depth).** `transaction()` now uses **capped full-jitter exponential backoff** (`wait(random(0, min(base·2^(attempt-1), cap)))`) instead of the linear delay, and the budget/backoff are configurable per-connection driver args — `deadlockMaxRetries` (default **8**, up from 5), `deadlockBaseWaitMs` (50), `deadlockMaxWaitMs` (1000). Jitter de-correlates lockstep retriers. Config knobs read via `typanic`'s `optionalPositiveInteger` (throws loudly on a bad value).

## Tests

- `spec/database/transactions.browser-spec.js` — capped full-jitter exponential backoff (exact delays), zero-jitter lower bound, and configurable `deadlockMaxRetries` exhaustion (replaces the hardcoded `toEqual(5)`). Run on sqlite. ✅
- `spec/background-jobs/store-spec.js` — counter stays consistent across **every** release path (complete/fail/return-to-queue/cancel), proving the reorder is counter-neutral. Run on sqlite. ✅
- `spec/background-jobs/store-concurrency-deadlock.browser-spec.js` (new) — two connections deadlock AB-BA on the counter; asserts the hardened retry **absorbs** the deadlock (no escape, one contender retried) and the counter stays consistent. Real row-locking engine only, so it **self-skips off MySQL** and runs in the MariaDB CI lane.

`npm run lint` (eslint + tsc + fallow) clean. Existing background-jobs/transaction specs green.

> Note: the drain-clean invariant ("counter returns to the correct value after a batch drains") is covered by the store-level counter-consistency test rather than a dedicated worker-shutdown test. No local MySQL/Docker on the dev machine, so the AB-BA integration test is validated in the MariaDB CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)