### PR TITLE
Respect schedule order when deduplicating queued jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2077,6 +2077,8 @@ await MyJob.performLaterWithOptions({
 
 Until `scheduledAtMs` is reached, the job remains queued but is not eligible for dispatch. The event-driven dispatcher arms its timer for the earliest future job and wakes at that timestamp. Omitting `scheduledAtMs` keeps the immediate-enqueue behavior.
 
+Set `deduplicateWhileQueued: true` to coalesce an enqueue onto the earliest identical queued job with the same job name, arguments, and queue when that existing job is scheduled no later than the new request. A retry backed off into the future does not suppress a new immediate enqueue, while repeated immediate triggers and equal or later schedules still coalesce.
+
 Select a non-default runtime explicitly with `options: {executionMode: "inline" | "forked" | "spawned"}`.
 
 Inline jobs share the worker process and run concurrently up to `maxConcurrentInlineJobs`, so a single slow inline job no longer blocks the queue. A single worker can also override the configured cap explicitly:

--- a/changelog.d/20260720102500-background-job-dedup-schedule-order.md
+++ b/changelog.d/20260720102500-background-job-dedup-schedule-order.md
@@ -1,0 +1,1 @@
+`deduplicateWhileQueued` now preserves schedule ordering: future retry rows no longer suppress an identical job that needs to run sooner, while equal or later enqueues still coalesce onto the earliest queued job.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -48,6 +48,10 @@ Unlike Sidekiq's strict queue ordering, priority **composes with the per-queue c
 
 The cap-fallthrough guarantee is a property of the **queue-derived** cap. A job that supplies its own explicit `concurrencyKey`/`maxConcurrency` bypasses the queue cap entirely — an explicit key always wins (see above) — so it is bounded only by that explicit key, not by `queues[name].maxConcurrent`. Such a job is therefore never held back by the queue's cap; priority just orders it normally against the rest. If you want a job to be bounded by both a queue cap and a finer-grained key, model the finer-grained limit as its own queue rather than an explicit `concurrencyKey`.
 
+## Enqueue deduplication
+
+`deduplicateWhileQueued: true` coalesces an enqueue by job identity: job name, serialized arguments, and queue. It returns the earliest identical queued job only when that job is scheduled no later than the new enqueue. This preserves one queued copy for repeated immediate or recurring triggers, but a failed job whose retry is backed off into the future cannot block fresh immediate work.
+
 ## Retention (pruning old job rows)
 
 Terminal job rows are not deleted automatically unless retention is configured — a busy application otherwise accumulates `completed` (and `failed`/`orphaned`) rows indefinitely, bloating the table and its indexes and eventually slowing dispatch. Configure retention under `backgroundJobs.retention`:

--- a/spec/background-jobs/store-spec.js
+++ b/spec/background-jobs/store-spec.js
@@ -450,6 +450,33 @@ describe("Background jobs - store", {databaseCleaning: {truncate: true}}, () => 
     expect(thirdId).not.toEqual(firstId)
   })
 
+  it("does not let a future retry deduplicate an earlier enqueue", async () => {
+    const store = await createClearedStore()
+    const options = {deduplicateWhileQueued: true}
+    const futureId = await store.enqueue({jobName: "TestJob", args: ["planner"], options: {...options, maxRetries: 1}})
+    const handoff = await store.markHandedOff({jobId: futureId, workerId: "planner-worker"})
+
+    if (!handoff) throw new Error("Expected the planner job to be handed off")
+
+    await store.markFailed({jobId: futureId, error: "planner failed", workerId: "planner-worker", ...handoff})
+
+    const futureRetry = await getJobOrFail({jobId: futureId, store})
+
+    expect(futureRetry.scheduledAtMs).toBeGreaterThan(Date.now())
+
+    const immediateId = await store.enqueue({jobName: "TestJob", args: ["planner"], options})
+    const duplicateImmediateId = await store.enqueue({jobName: "TestJob", args: ["planner"], options})
+
+    expect(immediateId).not.toEqual(futureId)
+    expect(duplicateImmediateId).toEqual(immediateId)
+
+    const rows = await store._withDb(async (db) =>
+      await db.newQuery().from("background_jobs").where({job_name: "TestJob"}).results()
+    )
+
+    expect(rows.length).toEqual(2)
+  })
+
   it("dedupes by job identity, not concurrency key, so different jobs on a shared key are not coalesced", async () => {
     const store = await createClearedStore()
     // Two different jobs deliberately share a concurrency key (a queue-derived cap would look like

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -146,14 +146,16 @@ export default class BackgroundJobsStore {
     await this._withDb(async (db) => {
       if (options?.deduplicateWhileQueued) {
         // Dedupe on the job's identity (name + args + queue), NOT its concurrency key, so a job
-        // keeps whatever concurrency it resolves to — in particular a scheduled job that relies on
-        // its queue-derived `queue:<name>` cap still participates in that cluster-wide cap instead
-        // of being pulled onto a private per-job key.
+        // keeps whatever concurrency it resolves to. Only an existing job scheduled no later than
+        // this enqueue can cover it; a retry backed off into the future must not suppress earlier
+        // work. Ordering returns the earliest covering job when several queued rows already exist.
         const existing = await db
           .newQuery()
           .from(JOBS_TABLE)
           .select("id")
           .where({status: "queued", job_name: jobName, args_json: argsJson, queue})
+          .where(`scheduled_at_ms <= ${db.quote(scheduledAtMs)}`)
+          .order("scheduled_at_ms ASC")
           .limit(1)
           .results()
 

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -15,7 +15,7 @@
  * @property {string} [queue] - Queue name. Defaults to `"default"`. When the queue has a configured cap in `backgroundJobs.queues`, that cap is enforced cluster-wide.
  * @property {string} [concurrencyKey] - Opaque non-empty key used to share a concurrency cap. Overrides any queue-derived cap.
  * @property {number} [maxConcurrency] - Positive integer cap; must be paired with `concurrencyKey`.
- * @property {boolean} [deduplicateWhileQueued] - When true, skip the enqueue if an identical still-queued job (same job name, args and queue) already exists, returning that job's id. Deduplication is by job identity and independent of `concurrencyKey`, so the job keeps its normal (e.g. queue-derived) concurrency cap. Keeps an interval-scheduled recurring job (e.g. retention pruning) from piling up redundant queued rows when it runs slower than its interval or no worker is free.
+ * @property {boolean} [deduplicateWhileQueued] - When true, skip the enqueue if an identical still-queued job (same job name, args and queue) is scheduled no later than this enqueue, returning the earliest matching job's id. A future retry does not suppress earlier work. Deduplication is independent of `concurrencyKey`, so the job keeps its normal (e.g. queue-derived) concurrency cap. Keeps an interval-scheduled recurring job (e.g. retention pruning) from piling up redundant queued rows when it runs slower than its interval or no worker is free.
  * @property {number} [scheduledAtMs] - Epoch timestamp in milliseconds when the job becomes eligible for dispatch. Defaults to enqueue time.
  */
 /**


### PR DESCRIPTION
## Summary

- make `deduplicateWhileQueued` respect schedule ordering
- allow immediate work to bypass an identical retry backed off into the future
- keep repeated immediate and equal/later enqueues coalesced

## Verification

- `npm test -- spec/background-jobs/store-spec.js` (42 passing)
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`

## Context

TensorBuzz task 10444: a failed build planner could remain queued with an hours-later retry timestamp and suppress every fresh immediate planner dispatch.
