### PR TITLE
Support selective database connection scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 * Trusted reverse proxy handling for `request.remoteAddress()` (see [docs/trusted-proxies.md](docs/trusted-proxies.md))
 * In-process driver schema metadata caching (see [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md))
 * Planned local-first shared-resource sync architecture (see [docs/offline-sync.md](docs/offline-sync.md))
-* Named database connection checkouts, bounded pool waits, and debugging held connections (see [docs/database-connections.md](docs/database-connections.md))
+* Selective named database connection checkouts, bounded pool waits, and debugging held connections (see [docs/database-connections.md](docs/database-connections.md))
 * Optional built-in debug endpoint for inspecting server and database connection state (see [docs/debug-endpoint.md](docs/debug-endpoint.md))
 * Optional built-in API manifest endpoint describing every registered frontend-model resource as human- and machine-readable JSON (see [docs/api-manifest-endpoint.md](docs/api-manifest-endpoint.md))
 

--- a/README.md
+++ b/README.md
@@ -2033,6 +2033,8 @@ import VelociousJob from "velocious/build/src/background-jobs/job.js"
 
 /** @augments {VelociousJob<[string, string]>} */
 export default class MyJob extends VelociousJob {
+  static databaseIdentifiers = ["default"]
+
   /**
    * @param {string} arg1
    * @param {string} arg2
@@ -2050,6 +2052,8 @@ lets a type-checked codebase declare `perform`'s parameters as required and type
 Argument-less jobs use a bare `extends VelociousJob` with `async perform()` — the
 default empty-tuple type argument keeps that working unchanged. Plain (unchecked)
 JavaScript can ignore the annotation entirely.
+
+Set `static databaseIdentifiers` when a job only needs specific configured databases. Velocious checks out only those connections around `perform` in every execution mode. Use `[]` for a job that needs no ambient database connection. Leaving the property undefined preserves the existing behavior of checking out every active database. See [Background Jobs](docs/background-jobs.md#database-connection-scopes).
 
 Queue a job:
 

--- a/changelog.d/20260720114500-selective-database-connections.md
+++ b/changelog.d/20260720114500-selective-database-connections.md
@@ -1,1 +1,1 @@
-Allow `withConnections` and `ensureConnections` callers to select the database identifiers their scope checks out, avoiding unnecessary connections to unrelated configured databases.
+Allow `withConnections`, `ensureConnections`, and background jobs to select the database identifiers their scope checks out, and narrow framework-owned single-database stores and tenant migration work to avoid holding unrelated connections.

--- a/changelog.d/20260720114500-selective-database-connections.md
+++ b/changelog.d/20260720114500-selective-database-connections.md
@@ -1,0 +1,1 @@
+Allow `withConnections` and `ensureConnections` callers to select the database identifiers their scope checks out, avoiding unnecessary connections to unrelated configured databases.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -12,6 +12,18 @@ Set the runtime explicitly with `executionMode` — `"pooled"` (default), `"inli
 
 For delayed one-off work, see [Scheduling One-Off Background Jobs](scheduled-background-job-enqueue.md). Recurring schedules use the separate `scheduledBackgroundJobs` configuration described in the [README](../README.md#scheduled-jobs).
 
+## Database connection scopes
+
+By default, a job receives the existing Velocious behavior: every active configured database is checked out for the duration of `perform`. Jobs that need a known subset should declare it on the job class:
+
+```js
+export default class RefreshAccountJob extends VelociousJob {
+  static databaseIdentifiers = ["default"]
+}
+```
+
+The declaration applies to inline, forked, spawned, and pooled execution. Use `[]` for jobs that do not query through the ambient connection scope or that establish narrower scopes themselves. Leaving `databaseIdentifiers` undefined preserves all-database behavior for compatibility.
+
 ## Durable concurrency limits
 
 Pass `concurrencyKey` and `maxConcurrency` together in `jobOptions` (or in `performLaterWithOptions`). The key is an opaque, non-empty string shared by jobs that use the same limit, and the cap is a positive integer. Omitting both preserves unlimited behavior. Once a key is registered, every enqueue for that key must use the same cap; a conflicting cap is rejected.

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -10,15 +10,23 @@ await configuration.withConnections({name: "report export"}, async (dbs) => {
 
 The `name` option labels the active checkout. It is intended for debugging connection usage, especially code paths that hold onto connections longer than expected or fail to release them.
 
-`configuration.ensureConnections` accepts the same option when it needs to open a new scope:
+Use `databaseIdentifiers` when a scope only needs specific configured databases. Velocious checks out only those pools and passes only those connections to the callback:
 
 ```js
-await configuration.ensureConnections({name: "invoice cleanup"}, async (dbs) => {
+await configuration.withConnections({databaseIdentifiers: ["default"], name: "report export"}, async (dbs) => {
   await dbs.default.query("SELECT 1")
 })
 ```
 
-When a current connection scope already exists, `ensureConnections` reuses it and keeps the existing checkout name.
+`configuration.ensureConnections` accepts the same option when it needs to open a new scope:
+
+```js
+await configuration.ensureConnections({databaseIdentifiers: ["default"], name: "invoice cleanup"}, async (dbs) => {
+  await dbs.default.query("SELECT 1")
+})
+```
+
+When a current connection scope already exists, `ensureConnections` reuses the requested connections, keeps the existing checkout name, and omits unrequested connections from the callback map. Without `databaseIdentifiers`, both methods retain their existing behavior of including every active configured database identifier.
 
 `AsyncTrackedMultiConnection` pools default to a maximum of `10` live database connections per configured pool. Configure `database.<environment>.<identifier>.pool.max` when a process needs a different cap. Set `pool.max` to `null` only for deliberately unbounded pools; leaving the value out keeps the default cap and protects long-running processes from exhausting the database server.
 

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -28,6 +28,8 @@ await configuration.ensureConnections({databaseIdentifiers: ["default"], name: "
 
 When a current connection scope already exists, `ensureConnections` reuses the requested connections, keeps the existing checkout name, and omits unrequested connections from the callback map. Without `databaseIdentifiers`, both methods retain their existing behavior of including every active configured database identifier.
 
+Framework persistence stores that already own one database identifier, such as the sync and websocket replay stores, request only that identifier. Background jobs can declare their ambient scope with `static databaseIdentifiers`; see [Background Jobs](background-jobs.md#database-connection-scopes).
+
 `AsyncTrackedMultiConnection` pools default to a maximum of `10` live database connections per configured pool. Configure `database.<environment>.<identifier>.pool.max` when a process needs a different cap. Set `pool.max` to `null` only for deliberately unbounded pools; leaving the value out keeps the default cap and protects long-running processes from exhausting the database server.
 
 When every allowed connection is checked out, additional checkouts wait for a compatible connection to be checked in or for capacity to be freed. Waiting checkouts time out after `10000` ms by default. Configure `database.<environment>.<identifier>.pool.checkoutTimeoutMillis` to change that wait, or set it to `null` to wait indefinitely.

--- a/spec/background-jobs/db-context-spec.js
+++ b/spec/background-jobs/db-context-spec.js
@@ -11,8 +11,13 @@ describe("Background jobs - DB context", {tags: ["dummy"], databaseCleaning: {tr
 
     const originalWithConnections = dummyConfiguration.withConnections.bind(dummyConfiguration)
     let withConnectionsCallsAfterStart = 0
+    /** @type {Array<string> | undefined} */
+    let requestedDatabaseIdentifiers
     dummyConfiguration.withConnections = async (...args) => {
       withConnectionsCallsAfterStart++
+      const options = /** @type {{databaseIdentifiers?: string[]} | undefined} */ (args[0])
+
+      requestedDatabaseIdentifiers = options?.databaseIdentifiers
 
       return await originalWithConnections(...args)
     }
@@ -31,6 +36,7 @@ describe("Background jobs - DB context", {tags: ["dummy"], databaseCleaning: {tr
     }
 
     expect(withConnectionsCallsAfterStart).toBeGreaterThan(0)
+    expect(requestedDatabaseIdentifiers).toEqual(["default"])
 
     const result = await waitForOutputJson({outputPath})
 

--- a/spec/background-jobs/job-runner-process-title-spec.js
+++ b/spec/background-jobs/job-runner-process-title-spec.js
@@ -11,6 +11,17 @@ import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
 import runJobPayload from "../../src/background-jobs/job-runner.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 
+class ConnectionCountingSqliteDriver extends SqliteDriver {
+  /** @type {number} */
+  static connectionAttempts = 0
+
+  /** @returns {Promise<void>} - Resolves after connecting. */
+  async connect() {
+    ConnectionCountingSqliteDriver.connectionAttempts++
+    await super.connect()
+  }
+}
+
 /** @returns {string} - Repository root. */
 function repoRoot() {
   return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
@@ -36,17 +47,19 @@ async function createTempProjectDir() {
  * @param {object} args - Options.
  * @param {string} args.className - Job class name.
  * @param {string} args.fileName - Job file name.
+ * @param {string[]} [args.databaseIdentifiers] - Optional static database identifiers to declare.
  * @param {string} [args.processTitle] - Optional static processTitle to declare.
  * @returns {Promise<void>}
  */
-async function writeTitleJob(directory, {className, fileName, processTitle}) {
+async function writeTitleJob(directory, {className, databaseIdentifiers, fileName, processTitle}) {
   const jobPath = pathToFileURL(path.join(repoRoot(), "src", "background-jobs", "job.js")).href
+  const databaseIdentifiersLine = databaseIdentifiers ? `  static databaseIdentifiers = ${JSON.stringify(databaseIdentifiers)}\n` : ""
   const staticLine = processTitle ? `  static processTitle = ${JSON.stringify(processTitle)}\n` : ""
   const contents = `import fs from "fs/promises"
 import VelociousJob from ${JSON.stringify(jobPath)}
 
 export default class ${className} extends VelociousJob {
-${staticLine}  async perform(outputPath) {
+${databaseIdentifiersLine}${staticLine}  async perform(outputPath) {
     await fs.writeFile(outputPath, process.title)
   }
 }
@@ -58,10 +71,11 @@ ${staticLine}  async perform(outputPath) {
 /**
  * @param {object} args - Options.
  * @param {string} args.directory - App directory.
+ * @param {boolean} [args.includeSecondary] - Whether to configure a counted secondary database.
  * @param {string} args.name - Database name.
  * @returns {Configuration}
  */
-function createConfiguration({directory, name}) {
+function createConfiguration({directory, includeSecondary = false, name}) {
   return new Configuration({
     database: {
       test: {
@@ -71,7 +85,16 @@ function createConfiguration({directory, name}) {
           type: "sqlite",
           name,
           migrations: false
-        }
+        },
+        ...(includeSecondary ? {
+          secondary: {
+            driver: ConnectionCountingSqliteDriver,
+            poolType: SingleMultiUsePool,
+            type: "sqlite",
+            name: `${name}-secondary`,
+            migrations: false
+          }
+        } : {})
       }
     },
     directory,
@@ -157,6 +180,75 @@ describe("Background jobs - runner process title", {databaseCleaning: {transacti
       expect(process.title).toEqual(callerOwnedTitle)
     } finally {
       process.title = baseTitle
+      previousConfiguration?.setCurrent()
+      await configuration.disconnectBeacon()
+      await configuration.closeDatabaseConnections()
+      await cleanup()
+    }
+  })
+
+  it("checks out only the database identifiers declared by the job", async () => {
+    const {cleanup, directory} = await createTempProjectDir()
+    await writeTitleJob(directory, {
+      className: "SelectiveConnectionsJob",
+      databaseIdentifiers: ["default"],
+      fileName: "selective-connections-job.js"
+    })
+
+    /** @type {Configuration | undefined} */
+    let previousConfiguration
+
+    try {
+      previousConfiguration = Configuration.current()
+    } catch (error) {
+      if (!(error instanceof CurrentConfigurationNotSetError)) throw error
+    }
+
+    const configuration = createConfiguration({directory, includeSecondary: true, name: "job-runner-selective-connections"})
+    const out = path.join(directory, "selective.txt")
+
+    ConnectionCountingSqliteDriver.connectionAttempts = 0
+
+    try {
+      configuration.setCurrent()
+      await runJobPayload({jobName: "SelectiveConnectionsJob", args: [out]}, {closeConnections: false})
+
+      expect(ConnectionCountingSqliteDriver.connectionAttempts).toEqual(0)
+    } finally {
+      previousConfiguration?.setCurrent()
+      await configuration.disconnectBeacon()
+      await configuration.closeDatabaseConnections()
+      await cleanup()
+    }
+  })
+
+  it("retains all active database connections for jobs without a declaration", async () => {
+    const {cleanup, directory} = await createTempProjectDir()
+    await writeTitleJob(directory, {
+      className: "DefaultConnectionsJob",
+      fileName: "default-connections-job.js"
+    })
+
+    /** @type {Configuration | undefined} */
+    let previousConfiguration
+
+    try {
+      previousConfiguration = Configuration.current()
+    } catch (error) {
+      if (!(error instanceof CurrentConfigurationNotSetError)) throw error
+    }
+
+    const configuration = createConfiguration({directory, includeSecondary: true, name: "job-runner-default-connections"})
+    const out = path.join(directory, "default.txt")
+
+    ConnectionCountingSqliteDriver.connectionAttempts = 0
+
+    try {
+      configuration.setCurrent()
+      await runJobPayload({jobName: "DefaultConnectionsJob", args: [out]}, {closeConnections: false})
+
+      expect(ConnectionCountingSqliteDriver.connectionAttempts).toEqual(1)
+    } finally {
       previousConfiguration?.setCurrent()
       await configuration.disconnectBeacon()
       await configuration.closeDatabaseConnections()

--- a/spec/background-jobs/store-concurrency-deadlock.browser-spec.js
+++ b/spec/background-jobs/store-concurrency-deadlock.browser-spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import BackgroundJobsStore from "../../src/background-jobs/store.js"
-import dummyConfiguration from "../dummy/src/config/configuration.js"
+import Configuration from "../../src/configuration.js"
 
 /**
  * A two-party rendezvous: both callers block until both have arrived, then both proceed. Used to
@@ -45,12 +45,11 @@ async function readActiveCount({store, concurrencyKey}) {
 
 describe("background jobs store - concurrency counter deadlocks", {tags: ["dummy"], databaseCleaning: {truncate: true}}, () => {
   it("absorbs an AB-BA deadlock on the concurrency counter and keeps the counter consistent", async () => {
-    dummyConfiguration.setCurrent()
-
-    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+    const configuration = Configuration.current()
+    const store = new BackgroundJobsStore({configuration})
     await store.clearAll()
 
-    const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
+    const pool = configuration.getDatabasePool(store.getDatabaseIdentifier())
     const engineType = await pool.withConnection({name: "deadlock engine probe"}, async (db) => db.getArgs().type)
 
     // A real row-level deadlock needs an engine with row locking and two independent connections.

--- a/spec/cli/commands/db/tenants/migrate-spec.js
+++ b/spec/cli/commands/db/tenants/migrate-spec.js
@@ -86,6 +86,12 @@ import Migration from ${JSON.stringify(migrationModuleUrl)}
 
 class CreateTenantWidgets extends Migration {
   async change() {
+    const currentIdentifiers = Object.keys(this.configuration.getCurrentConnections()).sort()
+
+    if (JSON.stringify(currentIdentifiers) !== JSON.stringify(["projectTenant"])) {
+      throw new Error("Expected only projectTenant during migration but got: " + currentIdentifiers.join(", "))
+    }
+
     await this.createTable("tenant_widgets", (table) => {
       table.string("name", {null: false})
     })

--- a/spec/configuration/ensure-connections-database-identifiers-spec.js
+++ b/spec/configuration/ensure-connections-database-identifiers-spec.js
@@ -1,68 +1,7 @@
 // @ts-check
 
-import AsyncTrackedMultiConnection from "../../src/database/pool/async-tracked-multi-connection.js"
-import Configuration from "../../src/configuration.js"
-import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
-import fs from "fs/promises"
-import os from "os"
-import path from "path"
-import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import {ConnectionCountingSqliteDriver, createMultiDatabaseConfiguration} from "../helpers/selective-connections-helper.js"
 import {describe, expect, it} from "../../src/testing/test.js"
-
-class ConnectionCountingSqliteDriver extends SqliteDriver {
-  /** @type {number} */
-  static connectionAttempts = 0
-
-  /** @returns {Promise<void>} - Resolves after connecting. */
-  async connect() {
-    ConnectionCountingSqliteDriver.connectionAttempts++
-    await super.connect()
-  }
-}
-
-/**
- * @returns {Promise<{cleanup: () => Promise<void>, configuration: Configuration}>} - Isolated multi-database configuration.
- */
-async function createMultiDatabaseConfiguration() {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-selective-connections-"))
-  const configuration = new Configuration({
-    database: {
-      test: {
-        default: {
-          driver: SqliteDriver,
-          migrations: false,
-          name: "selective-connections-default",
-          poolType: AsyncTrackedMultiConnection,
-          type: "sqlite"
-        },
-        secondary: {
-          driver: ConnectionCountingSqliteDriver,
-          migrations: false,
-          name: "selective-connections-secondary",
-          poolType: AsyncTrackedMultiConnection,
-          type: "sqlite"
-        }
-      }
-    },
-    directory,
-    environment: "test",
-    environmentHandler: new EnvironmentHandlerNode(),
-    initializeModels: async () => {},
-    locale: "en",
-    localeFallbacks: {en: ["en"]},
-    locales: ["en"]
-  })
-
-  ConnectionCountingSqliteDriver.connectionAttempts = 0
-
-  return {
-    cleanup: async () => {
-      await configuration.closeDatabaseConnections()
-      await fs.rm(directory, {force: true, recursive: true})
-    },
-    configuration
-  }
-}
 
 describe("Configuration connection database identifiers", () => {
   it("checks out only requested identifiers through withConnections", async () => {

--- a/spec/configuration/ensure-connections-database-identifiers-spec.js
+++ b/spec/configuration/ensure-connections-database-identifiers-spec.js
@@ -1,0 +1,111 @@
+// @ts-check
+
+import AsyncTrackedMultiConnection from "../../src/database/pool/async-tracked-multi-connection.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class ConnectionCountingSqliteDriver extends SqliteDriver {
+  /** @type {number} */
+  static connectionAttempts = 0
+
+  /** @returns {Promise<void>} - Resolves after connecting. */
+  async connect() {
+    ConnectionCountingSqliteDriver.connectionAttempts++
+    await super.connect()
+  }
+}
+
+/**
+ * @returns {Promise<{cleanup: () => Promise<void>, configuration: Configuration}>} - Isolated multi-database configuration.
+ */
+async function createMultiDatabaseConfiguration() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-selective-connections-"))
+  const configuration = new Configuration({
+    database: {
+      test: {
+        default: {
+          driver: SqliteDriver,
+          migrations: false,
+          name: "selective-connections-default",
+          poolType: AsyncTrackedMultiConnection,
+          type: "sqlite"
+        },
+        secondary: {
+          driver: ConnectionCountingSqliteDriver,
+          migrations: false,
+          name: "selective-connections-secondary",
+          poolType: AsyncTrackedMultiConnection,
+          type: "sqlite"
+        }
+      }
+    },
+    directory,
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+
+  ConnectionCountingSqliteDriver.connectionAttempts = 0
+
+  return {
+    cleanup: async () => {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    },
+    configuration
+  }
+}
+
+describe("Configuration connection database identifiers", () => {
+  it("checks out only requested identifiers through withConnections", async () => {
+    const {cleanup, configuration} = await createMultiDatabaseConfiguration()
+
+    try {
+      await configuration.withConnections({databaseIdentifiers: ["default"]}, async (dbs) => {
+        expect(Object.keys(dbs)).toEqual(["default"])
+      })
+
+      expect(ConnectionCountingSqliteDriver.connectionAttempts).toEqual(0)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("checks out only requested database identifiers", async () => {
+    const {cleanup, configuration} = await createMultiDatabaseConfiguration()
+
+    try {
+      await configuration.ensureConnections({databaseIdentifiers: ["default"]}, async (dbs) => {
+        expect(Object.keys(dbs)).toEqual(["default"])
+        await dbs.default.query("SELECT 1")
+      })
+
+      expect(ConnectionCountingSqliteDriver.connectionAttempts).toEqual(0)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("returns only requested connections when reusing an existing scope", async () => {
+    const {cleanup, configuration} = await createMultiDatabaseConfiguration()
+
+    try {
+      await configuration.withConnections(async (outerDbs) => {
+        await configuration.ensureConnections({databaseIdentifiers: ["default"]}, async (dbs) => {
+          expect(Object.keys(dbs)).toEqual(["default"])
+          expect(dbs.default).toBe(outerDbs.default)
+        })
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/spec/configuration/selective-framework-connection-callers-spec.js
+++ b/spec/configuration/selective-framework-connection-callers-spec.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+import ServerChangeFeedStore from "../../src/sync/server-change-feed.js"
+import ServerSequenceAllocator from "../../src/sync/server-sequence-allocator.js"
+import SyncScopeStore from "../../src/sync/sync-scope-store.js"
+import VelociousHttpServerWebsocketEventLogStore from "../../src/http-server/websocket-event-log-store.js"
+import {ConnectionCountingSqliteDriver, createMultiDatabaseConfiguration} from "../helpers/selective-connections-helper.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+describe("framework-owned selective database connections", () => {
+  it("opens only the configured database for framework persistence stores", async () => {
+    const {cleanup, configuration} = await createMultiDatabaseConfiguration()
+
+    try {
+      const eventLogStore = new VelociousHttpServerWebsocketEventLogStore({configuration, databaseIdentifier: "default"})
+      const scopeStore = new SyncScopeStore({configuration, databaseIdentifier: "default"})
+      const sequenceAllocator = new ServerSequenceAllocator({configuration, databaseIdentifier: "default", tableName: "selective_server_sequences"})
+      const changeFeedStore = new ServerChangeFeedStore({configuration, databaseIdentifier: "default"})
+
+      await eventLogStore.appendEvent({channel: "selective-test", payload: {ok: true}})
+      await scopeStore.findOrCreateScope({conditions: {project_id: 1}, resourceType: "Project"})
+      await sequenceAllocator.next()
+      await changeFeedStore.append({
+        actorDeviceId: null,
+        actorUserId: null,
+        attributes: null,
+        idempotencyKey: "selective-test",
+        model: "Project",
+        operation: "update",
+        payload: null,
+        recordId: "1",
+        response: null,
+        scope: null
+      })
+
+      expect(ConnectionCountingSqliteDriver.connectionAttempts).toEqual(0)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/spec/dummy/src/jobs/db-query-job.js
+++ b/spec/dummy/src/jobs/db-query-job.js
@@ -3,6 +3,8 @@ import fs from "fs/promises"
 import User from "../models/user.js"
 
 export default class DbQueryJob extends VelociousJob {
+  static databaseIdentifiers = ["default"]
+
   async perform(outputPath) {
     const users = await User.all().toArray()
 

--- a/spec/helpers/selective-connections-helper.js
+++ b/spec/helpers/selective-connections-helper.js
@@ -1,0 +1,68 @@
+// @ts-check
+
+import AsyncTrackedMultiConnection from "../../src/database/pool/async-tracked-multi-connection.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import {fileURLToPath} from "url"
+import path from "path"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+
+export class ConnectionCountingSqliteDriver extends SqliteDriver {
+  /** @type {number} */
+  static connectionAttempts = 0
+
+  /** @returns {Promise<void>} - Resolves after connecting. */
+  async connect() {
+    ConnectionCountingSqliteDriver.connectionAttempts++
+    await super.connect()
+  }
+}
+
+/**
+ * @returns {Promise<{cleanup: () => Promise<void>, configuration: Configuration}>} - Isolated multi-database configuration.
+ */
+export async function createMultiDatabaseConfiguration() {
+  const tmpDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "tmp")
+
+  await fs.mkdir(tmpDirectory, {recursive: true})
+
+  const directory = await fs.mkdtemp(path.join(tmpDirectory, "selective-connections-"))
+  const configuration = new Configuration({
+    database: {
+      test: {
+        default: {
+          driver: SqliteDriver,
+          migrations: false,
+          name: "selective-connections-default",
+          poolType: AsyncTrackedMultiConnection,
+          type: "sqlite"
+        },
+        secondary: {
+          driver: ConnectionCountingSqliteDriver,
+          migrations: false,
+          name: "selective-connections-secondary",
+          poolType: AsyncTrackedMultiConnection,
+          type: "sqlite"
+        }
+      }
+    },
+    directory,
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+
+  ConnectionCountingSqliteDriver.connectionAttempts = 0
+
+  return {
+    cleanup: async () => {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    },
+    configuration
+  }
+}

--- a/spec/jobs/prune-terminal-background-jobs-spec.js
+++ b/spec/jobs/prune-terminal-background-jobs-spec.js
@@ -8,6 +8,7 @@ describe("PruneTerminalBackgroundJobsJob", {databaseCleaning: {truncate: true}},
   it("uses a reserved job name that an app job cannot shadow via the class name", () => {
     expect(PruneTerminalBackgroundJobsJob.jobName()).toEqual("velocious:prune-terminal-background-jobs")
     expect(PruneTerminalBackgroundJobsJob.jobName()).not.toEqual(PruneTerminalBackgroundJobsJob.name)
+    expect(PruneTerminalBackgroundJobsJob.databaseIdentifiers).toEqual([])
   })
 
   it("returns a schedule configuration when retention is enabled", () => {

--- a/spec/tenants/default-tenant-database-provisioning-spec.js
+++ b/spec/tenants/default-tenant-database-provisioning-spec.js
@@ -30,6 +30,27 @@ class FakeDriver {
 const mysqlConfig = () => /** @type {any} */ ({type: "mysql", driver: FakeDriver, database: "tenant_db", useDatabase: "maintenance_db"})
 
 describe("default tenant database provisioning", () => {
+  it("opens only the requested database for file-backed tenant provisioning", async () => {
+    /** @type {string[] | undefined} */
+    let requestedDatabaseIdentifiers
+    const configuration = {
+      ensureConnections: async (options, callback) => {
+        requestedDatabaseIdentifiers = options.databaseIdentifiers
+        await callback({})
+      },
+      runWithTenant: async (_tenant, callback) => await callback()
+    }
+
+    await createTenantDatabase({
+      configuration: /** @type {any} */ (configuration),
+      databaseConfiguration: /** @type {any} */ ({type: "sqlite", driver: FakeDriver, database: "tenant_db"}),
+      identifier: "projectTenant",
+      tenant: {}
+    })
+
+    expect(requestedDatabaseIdentifiers).toEqual(["projectTenant"])
+  })
+
   it("creates a server tenant database through the maintenance connection and the driver's createDatabaseSql", async () => {
     FakeDriver.instances = []
 

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -105,7 +105,7 @@ export default async function runJobPayload(payload, {closeConnections = true, m
 
   try {
     try {
-      await configuration.withConnections({name: `Background job runner: ${payload.jobName}`}, async () => {
+      await configuration.withConnections({databaseIdentifiers: JobClass.databaseIdentifiers, name: `Background job runner: ${payload.jobName}`}, async () => {
         await perform.apply(jobInstance, payload.args || [])
       })
     } catch (error) {

--- a/src/background-jobs/job.js
+++ b/src/background-jobs/job.js
@@ -14,6 +14,15 @@ import BackgroundJobsClient from "./client.js"
  */
 export default class VelociousJob {
   /**
+   * Database identifiers checked out while this job performs. Set an explicit
+   * list to avoid holding unrelated configured database connections, or `[]`
+   * when the job establishes any connections it needs itself. Left undefined,
+   * jobs retain the existing behavior of checking out every active database.
+   * @type {string[] | undefined}
+   */
+  static databaseIdentifiers = undefined
+
+  /**
    * Queue this job class runs on. Subclasses set e.g. `static queue = "builds"`
    * to route onto a queue with its own cluster-wide concurrency cap (configured
    * via `backgroundJobs.queues`). The `{queue}` enqueue option overrides it.

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -886,7 +886,7 @@ export default class BackgroundJobsWorker {
      * @type {(...args: Array<?>) => Promise<void>} */
     const perform = jobInstance.perform
 
-    await configuration.withConnections({name: `Background job worker inline: ${payload.jobName}`}, async () => {
+    await configuration.withConnections({databaseIdentifiers: JobClass.databaseIdentifiers, name: `Background job worker inline: ${payload.jobName}`}, async () => {
       await perform.apply(jobInstance, payload.args || [])
     })
   }

--- a/src/cli/commands/db/tenants/check.js
+++ b/src/cli/commands/db/tenants/check.js
@@ -24,7 +24,7 @@ export default class DbTenantsCheck extends BaseCommand {
         })
       }
 
-      await this.getConfiguration().ensureConnections({name: `DB tenants check: ${helper.identifier}`}, async (dbs) => {
+      await this.getConfiguration().ensureConnections({databaseIdentifiers: [helper.identifier], name: `DB tenants check: ${helper.identifier}`}, async (dbs) => {
         const db = dbs[helper.identifier]
 
         if (!db) throw new Error(`Tenant database identifier ${helper.identifier} did not open a connection`)

--- a/src/cli/commands/db/tenants/migrate.js
+++ b/src/cli/commands/db/tenants/migrate.js
@@ -22,20 +22,26 @@ export default class DbTenantsMigrate extends BaseCommand {
         databaseIdentifiers: [helper.identifier]
       })
 
-      await this.getConfiguration().ensureConnections({name: `DB tenants migrate: ${helper.identifier}`}, async () => {
-        await migrator.prepare()
-        const migrationsApplied = await migrator.migrateFiles(migrations, digg(this.getEnvironmentHandler(), "requireMigration"))
+      let migrationsApplied = 0
 
-        if (typeof helper.provider.afterMigrateTenant === "function") {
-          await helper.provider.afterMigrateTenant({
+      await this.getConfiguration().ensureConnections({databaseIdentifiers: [helper.identifier], name: `DB tenants migrate: ${helper.identifier}`}, async () => {
+        await migrator.prepare()
+        migrationsApplied = await migrator.migrateFiles(migrations, digg(this.getEnvironmentHandler(), "requireMigration"))
+      })
+
+      const afterMigrateTenant = helper.provider.afterMigrateTenant
+
+      if (typeof afterMigrateTenant === "function") {
+        await this.getConfiguration().ensureConnections({name: `DB tenants after migrate: ${helper.identifier}`}, async () => {
+          await afterMigrateTenant({
             configuration: this.getConfiguration(),
             databaseConfiguration,
             identifier: helper.identifier,
             migrationsApplied,
             tenant
           })
-        }
-      })
+        })
+      }
     })
 
     if (this.args.testing) {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -8,6 +8,7 @@
 /**
  * WithConnectionsOptionsType type.
  * @typedef {object} WithConnectionsOptionsType
+ * @property {string[]} [databaseIdentifiers] - Database identifiers to include in the connection scope.
  * @property {string} [name] - Human-readable name for the checked-out database connections.
  */
 
@@ -48,16 +49,17 @@ function currentWorkingDirectory() {
  * @param {WithConnectionsOptionsType | WithConnectionsCallbackType<T>} optionsOrCallback - Checkout options or callback function.
  * @param {WithConnectionsCallbackType<T> | undefined} callback - Callback function.
  * @param {string} defaultName - Default checkout name.
- * @returns {{name: string, callback: WithConnectionsCallbackType<T> | undefined}} Resolved checkout name and callback.
+ * @returns {{databaseIdentifiers: string[] | undefined, name: string, callback: WithConnectionsCallbackType<T> | undefined}} Resolved checkout options and callback.
  */
 function resolveWithConnectionsArgs(optionsOrCallback, callback, defaultName) {
   if (typeof optionsOrCallback == "function") {
     const actualCallback = /** @type {WithConnectionsCallbackType<T>} */ (optionsOrCallback)
 
-    return {name: defaultName, callback: actualCallback}
+    return {databaseIdentifiers: undefined, name: defaultName, callback: actualCallback}
   }
 
   return {
+    databaseIdentifiers: optionsOrCallback.databaseIdentifiers,
     name: optionsOrCallback.name || defaultName,
     callback
   }
@@ -2802,7 +2804,11 @@ export default class VelociousConfiguration {
    * @returns {Promise<T>} - Resolves with the callback result.
    */
   async withConnections(optionsOrCallback, callback) {
-    const {name, callback: actualWithConnectionsCallback} = resolveWithConnectionsArgs(optionsOrCallback, callback, "Configuration.withConnections")
+    const {
+      callback: actualWithConnectionsCallback,
+      databaseIdentifiers,
+      name
+    } = resolveWithConnectionsArgs(optionsOrCallback, callback, "Configuration.withConnections")
 
     if (!actualWithConnectionsCallback) throw new Error("withConnections requires a callback")
 
@@ -2814,7 +2820,7 @@ export default class VelociousConfiguration {
     return await this.withDatabaseIdentifierConnections({
       callback: actualWithConnectionsCallback,
       dbs,
-      identifiers: this.getDatabaseIdentifiers(),
+      identifiers: databaseIdentifiers ?? this.getDatabaseIdentifiers(),
       name,
       stackLabel: "withConnections"
     })
@@ -2858,15 +2864,16 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get current connections.
+   * @param {string[]} [databaseIdentifiers] - Database identifiers to include.
    * @returns {Record<string, import("./database/drivers/base.js").default>} A map of database connections with identifier as key
    */
-  getCurrentConnections() {
+  getCurrentConnections(databaseIdentifiers = this.getDatabaseIdentifiers()) {
     /**
      * Dbs.
      * @type {{[key: string]: import("./database/drivers/base.js").default}} */
     const dbs = {}
 
-    for (const identifier of this.getDatabaseIdentifiers()) {
+    for (const identifier of databaseIdentifiers) {
       try {
         const pool = this.getDatabasePool(identifier)
         const currentConnection = pool.getCurrentContextConnection ? pool.getCurrentContextConnection() : pool.getCurrentConnection()
@@ -2950,12 +2957,17 @@ export default class VelociousConfiguration {
    * @returns {Promise<T>} - Resolves with the callback result.
    */
   async ensureConnections(optionsOrCallback, callback) {
-    const {name, callback: actualWithConnectionsCallback} = resolveWithConnectionsArgs(optionsOrCallback, callback, "Configuration.ensureConnections")
+    const {
+      callback: actualWithConnectionsCallback,
+      databaseIdentifiers,
+      name
+    } = resolveWithConnectionsArgs(optionsOrCallback, callback, "Configuration.ensureConnections")
 
     if (!actualWithConnectionsCallback) throw new Error("ensureConnections requires a callback")
 
-    const dbs = this.getCurrentConnections()
-    const missingIdentifiers = this.getDatabaseIdentifiers().filter((identifier) => {
+    const requestedIdentifiers = databaseIdentifiers ?? this.getDatabaseIdentifiers()
+    const dbs = this.getCurrentConnections(requestedIdentifiers)
+    const missingIdentifiers = requestedIdentifiers.filter((identifier) => {
       if (!dbs[identifier]) return true
 
       return !this.getDatabasePool(identifier).hasCurrentConnectionContext()

--- a/src/database/migrator.js
+++ b/src/database/migrator.js
@@ -113,7 +113,7 @@ export default class VelociousDatabaseMigrator {
   async migrateFiles(files, importCallback) {
     let appliedCount = 0
 
-    await this.configuration.ensureConnections({name: "Database migrator: migrate files"}, async () => {
+    await this.configuration.ensureConnections({databaseIdentifiers: this.databaseIdentifiers, name: "Database migrator: migrate files"}, async () => {
       for (const migration of files) {
         const applied = await this.runMigrationFile({
           migration,
@@ -179,7 +179,7 @@ export default class VelociousDatabaseMigrator {
 
     files = files.sort((migration1, migration2) => migration1.date - migration2.date)
 
-    await this.configuration.ensureConnections({name: "Database migrator: migrate require-context files"}, async () => {
+    await this.configuration.ensureConnections({databaseIdentifiers: this.databaseIdentifiers, name: "Database migrator: migrate require-context files"}, async () => {
       for (const migration of files) {
         await this.runMigrationFile({
           migration,

--- a/src/database/record/index.js
+++ b/src/database/record/index.js
@@ -3205,7 +3205,10 @@ class VelociousDatabaseRecord {
     // first initialization would resolve metadata from the ambient tenant's
     // database, that must happen under the requested tenant. The finders inside
     // `callback` call ensureInitialized() themselves, now within this scope.
-    return await configuration.runWithTenant(tenant, () => configuration.ensureConnections({name: `usingTenant: ${this.getModelName()}`}, callback))
+    return await configuration.runWithTenant(tenant, () => configuration.ensureConnections({
+      databaseIdentifiers: [this.getDatabaseIdentifier()],
+      name: `usingTenant: ${this.getModelName()}`
+    }, callback))
   }
 
   /**
@@ -3521,7 +3524,7 @@ class VelociousDatabaseRecord {
             throw new Error(`Tenant database identifier ${identifier} is inactive while checking dependent ${instanceRelationship.getRelationship().getRelationshipName()}`)
           }
 
-          return await configuration.ensureConnections({name: `Dependent restrict count: ${TargetModelClass.getModelName()}`}, async () => {
+          return await configuration.ensureConnections({databaseIdentifiers: [identifier], name: `Dependent restrict count: ${TargetModelClass.getModelName()}`}, async () => {
             return await instanceRelationship.query().count()
           })
         })
@@ -3555,7 +3558,7 @@ class VelociousDatabaseRecord {
           throw new Error(`Tenant database identifier ${identifier} is inactive while checking dependent ${instanceRelationship.getRelationship().getRelationshipName()}`)
         }
 
-        return await configuration.ensureConnections({name: `Dependent restrict count: ${TargetModelClass.getModelName()}`}, async () => {
+        return await configuration.ensureConnections({databaseIdentifiers: [identifier], name: `Dependent restrict count: ${TargetModelClass.getModelName()}`}, async () => {
           return await instanceRelationship.query().count()
         })
       })

--- a/src/http-server/websocket-event-log-store.js
+++ b/src/http-server/websocket-event-log-store.js
@@ -412,7 +412,7 @@ export default class VelociousHttpServerWebsocketEventLogStore {
    * @returns {Promise<?>} - Callback result.
    */
   async _withDb(callback) {
-    return await this.configuration.ensureConnections({name: "Websocket event log store"}, async (dbs) => {
+    return await this.configuration.ensureConnections({databaseIdentifiers: [this.databaseIdentifier], name: "Websocket event log store"}, async (dbs) => {
       const db = dbs[this.databaseIdentifier]
 
       if (!db) throw new Error(`No database connection available for identifier: ${this.databaseIdentifier}`)

--- a/src/jobs/prune-terminal-background-jobs.js
+++ b/src/jobs/prune-terminal-background-jobs.js
@@ -13,6 +13,9 @@ import VelociousJob from "../background-jobs/job.js"
  * @augments {VelociousJob<[]>}
  */
 export default class PruneTerminalBackgroundJobsJob extends VelociousJob {
+  /** @type {string[]} */
+  static databaseIdentifiers = []
+
   /**
    * Reserved job name that an application job cannot shadow. The registry loads
    * app `src/jobs` first and skips duplicate built-in names, so if this used the

--- a/src/sync/server-change-feed.js
+++ b/src/sync/server-change-feed.js
@@ -420,7 +420,7 @@ export default class ServerChangeFeedStore {
    * @returns {Promise<?>} - Callback result.
    */
   async _withDb(callback) {
-    return await this.configuration.ensureConnections({name: "Server change-feed store"}, async (dbs) => {
+    return await this.configuration.ensureConnections({databaseIdentifiers: [this.databaseIdentifier], name: "Server change-feed store"}, async (dbs) => {
       const db = dbs[this.databaseIdentifier]
 
       if (!db) throw new Error(`No database connection available for identifier: ${this.databaseIdentifier}`)

--- a/src/sync/server-sequence-allocator.js
+++ b/src/sync/server-sequence-allocator.js
@@ -161,7 +161,7 @@ export default class ServerSequenceAllocator {
    * @returns {Promise<Result>} Callback result.
    */
   async _withDb(callback) {
-    return await this._getConfiguration().ensureConnections({name: "Server sequence allocator"}, async (dbs) => {
+    return await this._getConfiguration().ensureConnections({databaseIdentifiers: [this.databaseIdentifier], name: "Server sequence allocator"}, async (dbs) => {
       const db = dbs[this.databaseIdentifier]
 
       if (!db) throw new Error(`No database connection available for identifier: ${this.databaseIdentifier}`)

--- a/src/sync/sync-scope-store.js
+++ b/src/sync/sync-scope-store.js
@@ -263,7 +263,7 @@ export default class SyncScopeStore {
    * @returns {Promise<Result>} Callback result.
    */
   async _withDb(callback) {
-    return await this.configuration.ensureConnections({name: "Sync scope store"}, async (dbs) => {
+    return await this.configuration.ensureConnections({databaseIdentifiers: [this.databaseIdentifier], name: "Sync scope store"}, async (dbs) => {
       const db = dbs[this.databaseIdentifier]
 
       if (!db) throw new Error(`No database connection available for identifier: ${this.databaseIdentifier}`)

--- a/src/tenants/default-tenant-database-provisioning.js
+++ b/src/tenants/default-tenant-database-provisioning.js
@@ -64,13 +64,13 @@ function maintenanceConnection(databaseConfiguration, configuration) {
 
 /**
  * Creates the tenant database for one tenant.
- * @param {{configuration: import("../configuration.js").default, databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, tenant: ?}} args - Provisioning arguments.
+ * @param {{configuration: import("../configuration.js").default, databaseConfiguration: import("../configuration-types.js").DatabaseConfigurationType, identifier?: string, tenant: ?}} args - Provisioning arguments.
  * @returns {Promise<void>} - Resolves once the tenant database exists.
  */
-export async function createTenantDatabase({configuration, databaseConfiguration, tenant}) {
+export async function createTenantDatabase({configuration, databaseConfiguration, identifier, tenant}) {
   if (fileBackedDriver(databaseConfiguration)) {
     await configuration.runWithTenant(tenant, async () => {
-      await configuration.ensureConnections(async () => {})
+      await configuration.ensureConnections({databaseIdentifiers: identifier ? [identifier] : undefined, name: "Create file-backed tenant database"}, async () => {})
     })
 
     return


### PR DESCRIPTION
## Summary

- add an optional `databaseIdentifiers` filter to `withConnections` and `ensureConnections`, preserving all active databases by default
- let background jobs declare `static databaseIdentifiers` in inline, forked, spawned, and pooled execution
- narrow framework-owned sync/websocket stores, tenant migration/check work, file-backed tenant provisioning, and tenant-specific model queries to their owned database identifiers
- keep application callbacks such as tenant migration hooks on the compatible all-database scope
- document selective scopes and add a changelog fragment

## Verification

- `VELOCIOUS_DISABLE_MSSQL=1 npm test -- spec/configuration/ensure-connections-database-identifiers-spec.js spec/configuration/selective-framework-connection-callers-spec.js spec/background-jobs/job-runner-process-title-spec.js spec/background-jobs/db-context-spec.js spec/jobs/prune-terminal-background-jobs-spec.js spec/tenants/default-tenant-database-provisioning-spec.js spec/cli/commands/db/tenants/migrate-spec.js spec/database/record/tenant-database-spec.js spec/database/record/auditing.browser-spec.js spec/database/record/destroy.browser-spec.js` (52 passing)
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`

## Task

- https://tasks.diestoeckels.de/projects/111/boards/105?task_id=10438
