### PR TITLE
Automatically release held advisory locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * Database framework with familiar MVC concepts
 * Database models with migrations and validations
 * Database models that work almost the same in frontend and backend
+* Connection-scoped advisory locks with automatic cleanup before pooled connections are reused or closed (see [docs/advisory-locks.md](docs/advisory-locks.md))
 * Built-in record auditing for model lifecycle changes (see [docs/auditing.md](docs/auditing.md))
 * Declarative state machines for models, with typed event methods generated into the base model (see [docs/state-machine.md](docs/state-machine.md))
 * Migrations for schema changes and UTC datetime storage (see [docs/database-migrations.md](docs/database-migrations.md))

--- a/changelog.d/20260720141000-advisory-lock-connection-cleanup.md
+++ b/changelog.d/20260720141000-advisory-lock-connection-cleanup.md
@@ -1,0 +1,1 @@
+Database connections now track acquired advisory locks and release any leftovers before pool check-in or close, preventing abandoned caller and dedicated lock connections from retaining session locks.

--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -54,6 +54,8 @@ const isBusy = await Account.hasAdvisoryLock("sync-account-42")
 
 Both `withAdvisoryLock` and `withAdvisoryLockOrFail` release the lock in a `finally` block, so the callback's return value is propagated on success and the lock is released on either a thrown error or an early return. Calls without a positive `holdTimeoutMs` acquire and release the advisory lock on the caller's existing database connection/context to avoid extra connection overhead. Calls with a positive `holdTimeoutMs` acquire and release the advisory lock through a dedicated lock connection; the callback keeps using the caller's existing database connection/context. When `holdTimeoutMs` fires, the dedicated lock connection releases the advisory lock before `AdvisoryLockHoldTimeoutError` is thrown.
 
+Each database connection also keeps a counted registry of advisory locks it successfully acquires. Before a checked-out connection returns to its pool, Velocious releases every lock still in that registry so an abandoned critical section cannot leak a session lock into the next checkout. Closing a connection performs the same cleanup before closing the physical database session, including the dedicated connection used by positive `holdTimeoutMs` calls. Cleanup preserves re-entrant acquisition counts and attempts every tracked lock; release failures are surfaced rather than silently leaving a reusable connection poisoned.
+
 ## Scope
 
 Database advisory locks are **per session/connection**. Velocious uses the caller connection for ordinary advisory-lock calls and owns a separate lock connection for calls with a positive `holdTimeoutMs`:

--- a/spec/database/advisory-lock-runner-cleanup-spec.js
+++ b/spec/database/advisory-lock-runner-cleanup-spec.js
@@ -1,0 +1,163 @@
+// @ts-check
+
+import AdvisoryLockRunner from "../../src/database/advisory-lock-runner.js"
+import AsyncTrackedMultiConnection from "../../src/database/pool/async-tracked-multi-connection.js"
+import Configuration from "../../src/configuration.js"
+import DatabaseDriver from "../../src/database/drivers/base.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class InspectableSqliteDriver extends SqliteDriver {
+  /** @type {InspectableSqliteDriver[]} */
+  static instances = []
+
+  /** @returns {Promise<void>} - Resolves after connecting. */
+  async connect() {
+    await super.connect()
+    InspectableSqliteDriver.instances.push(this)
+  }
+}
+
+class ReentrantAdvisoryLockDriver extends DatabaseDriver {
+  releaseCount = 0
+
+  /** @returns {Promise<boolean>} - Resolves true for this test driver. */
+  async _tryAcquireAdvisoryLock() {
+    return true
+  }
+
+  /** @returns {Promise<boolean>} - Resolves true after recording the release. */
+  async _releaseAdvisoryLock() {
+    this.releaseCount++
+
+    return true
+  }
+}
+
+/**
+ * @param {(args: {configuration: Configuration, pool: AsyncTrackedMultiConnection}) => Promise<void>} callback - Spec body.
+ * @param {string[]} lockNames - Lock names to clean if an assertion fails before the new cleanup runs.
+ * @returns {Promise<void>} - Resolves after closing the isolated configuration.
+ */
+async function withAdvisoryLockPool(callback, lockNames) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-advisory-lock-cleanup-"))
+  const configuration = new Configuration({
+    database: {
+      test: {
+        default: {
+          driver: InspectableSqliteDriver,
+          migrations: false,
+          name: "advisory-lock-cleanup",
+          poolType: AsyncTrackedMultiConnection,
+          type: "sqlite"
+        }
+      }
+    },
+    directory,
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    locale: "en",
+    localeFallbacks: {en: ["en"]}
+  })
+  const pool = configuration.getDatabasePool("default")
+
+  if (!(pool instanceof AsyncTrackedMultiConnection)) throw new Error("Expected async tracked pool")
+
+  InspectableSqliteDriver.instances = []
+
+  try {
+    await callback({configuration, pool})
+  } finally {
+    for (const connection of InspectableSqliteDriver.instances) {
+      for (const lockName of lockNames) {
+        await connection.releaseAdvisoryLock(lockName)
+      }
+    }
+
+    await configuration.closeDatabaseConnections()
+    await fs.rm(directory, {force: true, recursive: true})
+  }
+}
+
+describe("AdvisoryLockRunner connection cleanup", () => {
+  it("releases every counted acquisition of a re-entrant lock", async () => {
+    await withAdvisoryLockPool(async ({configuration}) => {
+      const databaseConfiguration = configuration.getDatabaseConfiguration().default
+
+      if (!databaseConfiguration) throw new Error("Expected a default database configuration")
+
+      const connection = new ReentrantAdvisoryLockDriver(databaseConfiguration, configuration)
+
+      expect(await connection.tryAcquireAdvisoryLock("reentrant-lock")).toBe(true)
+      expect(await connection.tryAcquireAdvisoryLock("reentrant-lock")).toBe(true)
+
+      await connection.releaseHeldAdvisoryLocks()
+
+      expect(connection.releaseCount).toBe(2)
+    }, [])
+  })
+
+  it("releases leftover locks when the caller connection returns to the pool", async () => {
+    const runnerLockName = "runner-caller-lock"
+    const leftoverLockName = "runner-caller-leftover-lock"
+
+    await withAdvisoryLockPool(async ({configuration, pool}) => {
+      await pool.withConnection(async (connection) => {
+        const runner = new AdvisoryLockRunner({
+          configuration,
+          connectionProvider: () => connection,
+          databaseIdentifier: "default"
+        })
+
+        await runner.withAdvisoryLockOrFail(runnerLockName, async () => {
+          expect(await connection.tryAcquireAdvisoryLock(leftoverLockName)).toBe(true)
+        })
+      })
+
+      const probeConnection = await pool.spawnConnection()
+
+      try {
+        expect(await probeConnection.tryAcquireAdvisoryLock(leftoverLockName)).toBe(true)
+      } finally {
+        await probeConnection.releaseAdvisoryLock(leftoverLockName)
+        await probeConnection.close()
+      }
+    }, [runnerLockName, leftoverLockName])
+  })
+
+  it("releases leftover locks when the dedicated runner connection closes", async () => {
+    const runnerLockName = "runner-dedicated-lock"
+    const leftoverLockName = "runner-dedicated-leftover-lock"
+
+    await withAdvisoryLockPool(async ({configuration, pool}) => {
+      const runner = new AdvisoryLockRunner({
+        configuration,
+        connectionProvider: () => {
+          throw new Error("The dedicated runner must not use the caller connection")
+        },
+        databaseIdentifier: "default"
+      })
+
+      await runner.withAdvisoryLockOrFail(runnerLockName, async () => {
+        const dedicatedConnection = InspectableSqliteDriver.instances[0]
+
+        if (!dedicatedConnection) throw new Error("Expected a dedicated advisory-lock connection")
+
+        expect(await dedicatedConnection.tryAcquireAdvisoryLock(leftoverLockName)).toBe(true)
+      }, {holdTimeoutMs: 1000})
+
+      const probeConnection = await pool.spawnConnection()
+
+      try {
+        expect(await probeConnection.tryAcquireAdvisoryLock(leftoverLockName)).toBe(true)
+      } finally {
+        await probeConnection.releaseAdvisoryLock(leftoverLockName)
+        await probeConnection.close()
+      }
+    }, [runnerLockName, leftoverLockName])
+  })
+})

--- a/spec/database/drivers/mysql/reconnect-spec.js
+++ b/spec/database/drivers/mysql/reconnect-spec.js
@@ -9,6 +9,37 @@ const configuration = /** @type {any} */ ({
   getQueryLoggingEnabled: () => false
 })
 
+class FailingAdvisoryLockReleaseMysqlDriver extends MysqlDriver {
+  reconnectCount = 0
+  releaseAttempts = 0
+
+  /** @returns {Promise<void>} - Records an unexpected reconnect. */
+  async reconnect() {
+    this.reconnectCount++
+  }
+
+  /**
+   * Simulates one acquired lock followed by a lost connection during release.
+   * @param {string} sql - SQL string.
+   * @returns {Promise<import("../../../../src/database/drivers/base.js").QueryResultType>} - Query rows.
+   */
+  async _queryActual(sql) {
+    if (sql.startsWith("SELECT GET_LOCK")) return [{velocious_advisory_lock_result: 1}]
+
+    if (sql.startsWith("SELECT RELEASE_LOCK")) {
+      this.releaseAttempts++
+
+      const connectionError = new Error("Connection lost during advisory lock release")
+      // @ts-expect-error MySQL attaches its symbolic error code at runtime.
+      connectionError.code = "PROTOCOL_CONNECTION_LOST"
+
+      throw new Error("Query failed", {cause: connectionError})
+    }
+
+    return []
+  }
+}
+
 describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction: false, truncate: false}}, () => {
   it("connects when the pool is missing", async () => {
     const driver = new MysqlDriver({}, configuration)
@@ -138,5 +169,20 @@ describe("Database - drivers - mysql reconnect", {databaseCleaning: {transaction
       await driver.query("SELECT 1")
     }).toThrowError("Cannot reconnect while a transaction is active (1). Original error: Query failed: Query failed because of Error: connect ECONNREFUSED 127.0.0.1:3306: SELECT 1")
     expect(didReconnect).toBeFalse()
+  })
+
+  it("does not reconnect while closing a session with an advisory lock", async () => {
+    const driver = new FailingAdvisoryLockReleaseMysqlDriver({}, configuration)
+
+    driver.setDesiredSessionTimeZone(null)
+
+    expect(await driver.tryAcquireAdvisoryLock("release-without-reconnect")).toBeTrue()
+
+    await expect(async () => {
+      await driver.close()
+    }).toThrowError("Query failed")
+
+    expect(driver.releaseAttempts).toEqual(1)
+    expect(driver.reconnectCount).toEqual(0)
   })
 })

--- a/spec/database/pool/single-multi-use-spec.js
+++ b/spec/database/pool/single-multi-use-spec.js
@@ -6,6 +6,35 @@ import dummyConfiguration from "../../dummy/src/config/configuration.js"
 import SingleMultiUsePool from "../../../src/database/pool/single-multi-use.js"
 
 describe("SingleMultiUsePool context handling", () => {
+  it("releases held advisory locks only after the shared connection's final check-in", async () => {
+    const lockName = "single-multi-use-final-checkin"
+
+    await Dummy.run(async () => {
+      const pool = new SingleMultiUsePool({configuration: dummyConfiguration, identifier: "default"})
+      const firstCheckout = await pool.checkout()
+      const secondCheckout = await pool.checkout()
+      const probeConnection = await pool.spawnConnection()
+
+      try {
+        expect(firstCheckout).toBe(secondCheckout)
+        expect(await firstCheckout.tryAcquireAdvisoryLock(lockName)).toBe(true)
+
+        await pool.checkin(firstCheckout)
+
+        expect(await probeConnection.tryAcquireAdvisoryLock(lockName)).toBe(false)
+
+        await pool.checkin(secondCheckout)
+
+        expect(await probeConnection.tryAcquireAdvisoryLock(lockName)).toBe(true)
+      } finally {
+        await firstCheckout.releaseAdvisoryLock(lockName)
+        await probeConnection.releaseAdvisoryLock(lockName)
+        await probeConnection.close()
+        await pool.closeAll()
+      }
+    })
+  })
+
   it("suppresses the shared current connection across async callbacks", async () => {
     await Dummy.run(async () => {
       const pool = dummyConfiguration.getDatabasePool("default")

--- a/spec/database/record/advisory-lock-hold-timeout-spec.js
+++ b/spec/database/record/advisory-lock-hold-timeout-spec.js
@@ -216,6 +216,8 @@ describe("Record - advisory lock hold timeout", () => {
         return true
       },
 
+      async releaseHeldAdvisoryLocks() {},
+
       async tryAcquireAdvisoryLock(name) {
         events.push(`lock acquire ${name}`)
 

--- a/src/database/advisory-lock-runner.js
+++ b/src/database/advisory-lock-runner.js
@@ -148,7 +148,9 @@ export default class AdvisoryLockRunner {
     try {
       return await callback(connection)
     } finally {
-      if (!connection.getArgs().getConnection) {
+      if (connection.getArgs().getConnection) {
+        await connection.releaseHeldAdvisoryLocks()
+      } else {
         await connection.close()
       }
     }

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -170,6 +170,8 @@ export default class VelociousDatabaseDriversBase {
    * Active query.
    * @type {ActiveQueryState | null} */
   _activeQuery = null
+  /** @type {Map<string, number>} */
+  _heldAdvisoryLocks = new Map()
 
   /**
    * Runs constructor.
@@ -239,10 +241,40 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
-   * Optional close hook for database drivers.
-   * @returns {Promise<void>} - Resolves when complete.
+   * Releases tracked advisory locks and closes the physical database connection.
+   * @returns {Promise<void>} - Resolves when cleanup and close complete.
    */
   async close() {
+    /** @type {Error | undefined} */
+    let advisoryLockError
+
+    try {
+      await this.releaseHeldAdvisoryLocks()
+    } catch (error) {
+      advisoryLockError = error instanceof Error ? error : new Error("Failed to release held advisory locks", {cause: error})
+    }
+
+    try {
+      await this._close()
+      this._heldAdvisoryLocks.clear()
+    } catch (error) {
+      const closeError = error instanceof Error ? error : new Error("Failed to close database connection", {cause: error})
+
+      if (advisoryLockError) {
+        throw new AggregateError([advisoryLockError, closeError], "Failed to release advisory locks and close database connection", {cause: error})
+      }
+
+      throw closeError
+    }
+
+    if (advisoryLockError) throw advisoryLockError
+  }
+
+  /**
+   * Driver-specific physical close hook.
+   * @returns {Promise<void>} - Resolves when the underlying connection closes.
+   */
+  async _close() {
     // No-op by default
   }
 
@@ -1773,33 +1805,124 @@ export default class VelociousDatabaseDriversBase {
    * table locks; they are purely cooperative between callers that use the
    * same name and let you serialize functionality without blocking readers
    * or writers that do not participate in the same lock.
-   * @abstract
    * @param {string} name - Lock name.
-   * @param {{timeoutMs?: number | null}} [_args] - Optional timeout in milliseconds; `null` or undefined blocks forever.
+   * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null` or undefined blocks forever.
    * @returns {Promise<boolean>} - Resolves to true when the lock has been acquired, false if the timeout elapsed.
    */
-  acquireAdvisoryLock(name, _args = {}) {
-    throw new Error(`'acquireAdvisoryLock' not implemented for ${this.constructor.name}`)
+  async acquireAdvisoryLock(name, args = {}) {
+    const acquired = await this._acquireAdvisoryLock(name, args)
+
+    if (acquired) this._trackAdvisoryLock(name)
+
+    return acquired
+  }
+
+  /**
+   * Driver-specific blocking advisory-lock acquisition hook.
+   * @abstract
+   * @param {string} name - Lock name.
+   * @param {{timeoutMs?: number | null}} [_args] - Lock timeout options.
+   * @returns {Promise<boolean>} - Whether the lock was acquired.
+   */
+  _acquireAdvisoryLock(name, _args = {}) {
+    throw new Error(`'_acquireAdvisoryLock' not implemented for ${this.constructor.name}`)
   }
 
   /**
    * Attempts to acquire a named advisory lock without blocking.
-   * @abstract
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - Resolves to true if the lock was acquired, false if it was already held.
    */
-  tryAcquireAdvisoryLock(name) { // eslint-disable-line no-unused-vars
-    throw new Error(`'tryAcquireAdvisoryLock' not implemented for ${this.constructor.name}`)
+  async tryAcquireAdvisoryLock(name) {
+    const acquired = await this._tryAcquireAdvisoryLock(name)
+
+    if (acquired) this._trackAdvisoryLock(name)
+
+    return acquired
+  }
+
+  /**
+   * Driver-specific non-blocking advisory-lock acquisition hook.
+   * @abstract
+   * @param {string} name - Lock name.
+   * @returns {Promise<boolean>} - Whether the lock was acquired.
+   */
+  _tryAcquireAdvisoryLock(name) { // eslint-disable-line no-unused-vars
+    throw new Error(`'_tryAcquireAdvisoryLock' not implemented for ${this.constructor.name}`)
   }
 
   /**
    * Releases a named advisory lock previously acquired on this connection.
-   * @abstract
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - Resolves to true if the lock was held by this session and has now been released.
    */
-  releaseAdvisoryLock(name) { // eslint-disable-line no-unused-vars
-    throw new Error(`'releaseAdvisoryLock' not implemented for ${this.constructor.name}`)
+  async releaseAdvisoryLock(name) {
+    const released = await this._releaseAdvisoryLock(name)
+
+    if (released) {
+      this._untrackAdvisoryLock(name)
+    } else {
+      this._heldAdvisoryLocks.delete(name)
+    }
+
+    return released
+  }
+
+  /**
+   * Driver-specific advisory-lock release hook.
+   * @abstract
+   * @param {string} name - Lock name.
+   * @returns {Promise<boolean>} - Whether the lock was released.
+   */
+  _releaseAdvisoryLock(name) { // eslint-disable-line no-unused-vars
+    throw new Error(`'_releaseAdvisoryLock' not implemented for ${this.constructor.name}`)
+  }
+
+  /**
+   * Releases every advisory lock still tracked on this connection.
+   * @returns {Promise<void>} - Resolves when every tracked lock is released.
+   */
+  async releaseHeldAdvisoryLocks() {
+    /** @type {Error[]} */
+    const errors = []
+
+    for (const name of [...this._heldAdvisoryLocks.keys()]) {
+      while (this._heldAdvisoryLocks.has(name)) {
+        try {
+          await this.releaseAdvisoryLock(name)
+        } catch (error) {
+          errors.push(error instanceof Error ? error : new Error(`Failed to release advisory lock ${JSON.stringify(name)}`, {cause: error}))
+          break
+        }
+      }
+    }
+
+    if (errors.length == 1) throw errors[0]
+    if (errors.length > 1) throw new AggregateError(errors, "Failed to release held advisory locks")
+  }
+
+  /**
+   * Records one successful acquisition, including re-entrant acquisitions.
+   * @param {string} name - Lock name.
+   * @returns {void}
+   */
+  _trackAdvisoryLock(name) {
+    this._heldAdvisoryLocks.set(name, (this._heldAdvisoryLocks.get(name) || 0) + 1)
+  }
+
+  /**
+   * Removes one successful acquisition from the connection registry.
+   * @param {string} name - Lock name.
+   * @returns {void}
+   */
+  _untrackAdvisoryLock(name) {
+    const remainingCount = (this._heldAdvisoryLocks.get(name) || 0) - 1
+
+    if (remainingCount > 0) {
+      this._heldAdvisoryLocks.set(name, remainingCount)
+    } else {
+      this._heldAdvisoryLocks.delete(name)
+    }
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -57,6 +57,7 @@
  * @property {string} [logName] - Query log subject.
  * @property {boolean} [logQuery] - Whether to log the query.
  * @property {boolean} [processListComment] - Whether to add process-list comments to the query.
+ * @property {boolean} [retry] - Whether retryable errors may retry the query; defaults to true.
  * @property {boolean} [sessionTimeZone] - Whether to ensure the configured database session time zone before the query.
  * @property {string} [sourceStack] - Stack captured at the caller boundary.
  */
@@ -1159,7 +1160,7 @@ export default class VelociousDatabaseDriversBase {
 
         const retryInfo = this.retryableDatabaseError(error)
 
-        if (tries < maxTries && retryInfo.retry) {
+        if (options.retry !== false && tries < maxTries && retryInfo.retry) {
           if (retryInfo.reconnect) {
             if (this._transactionsCount > 0) {
               throw new Error(`Cannot reconnect while a transaction is active (${this._transactionsCount}). Original error: ${error.message}`, {cause: error})

--- a/src/database/drivers/mssql/index.js
+++ b/src/database/drivers/mssql/index.js
@@ -47,7 +47,7 @@ export default class VelociousDatabaseDriversMssql extends Base{
     }
   }
 
-  async close() {
+  async _close() {
     if (!this.connection) return
 
     const connection = this.connection
@@ -616,7 +616,7 @@ export default class VelociousDatabaseDriversMssql extends Base{
    * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null`, `undefined`, or negative blocks forever.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if the timeout elapsed.
    */
-  async acquireAdvisoryLock(name, {timeoutMs} = {}) {
+  async _acquireAdvisoryLock(name, {timeoutMs} = {}) {
     const timeoutValue = typeof timeoutMs === "number" && timeoutMs >= 0 ? Math.ceil(timeoutMs) : -1
     const rows = await this.query(
       `DECLARE @velocious_advisory_lock_result INT; EXEC @velocious_advisory_lock_result = sp_getapplock @Resource = ${this.quote(name)}, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = ${timeoutValue}; SELECT @velocious_advisory_lock_result AS velocious_advisory_lock_result`
@@ -634,8 +634,8 @@ export default class VelociousDatabaseDriversMssql extends Base{
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if it was already held.
    */
-  async tryAcquireAdvisoryLock(name) {
-    return await this.acquireAdvisoryLock(name, {timeoutMs: 0})
+  async _tryAcquireAdvisoryLock(name) {
+    return await this._acquireAdvisoryLock(name, {timeoutMs: 0})
   }
 
   /**
@@ -643,7 +643,7 @@ export default class VelociousDatabaseDriversMssql extends Base{
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was held by this session and has now been released.
    */
-  async releaseAdvisoryLock(name) {
+  async _releaseAdvisoryLock(name) {
     const rows = await this.query(
       `DECLARE @velocious_advisory_lock_result INT; EXEC @velocious_advisory_lock_result = sp_releaseapplock @Resource = ${this.quote(name)}, @LockOwner = 'Session'; SELECT @velocious_advisory_lock_result AS velocious_advisory_lock_result`
     )

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -63,7 +63,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * Runs close.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async close() {
+  async _close() {
     await this.pool?.end()
     this.pool = undefined
     this.resetCurrentSessionTimeZone()
@@ -574,7 +574,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null`, `undefined`, or negative blocks for `MYSQL_INDEFINITE_LOCK_TIMEOUT_SECONDS`.
    * @returns {Promise<boolean>} - True if acquired, false if the timeout elapsed.
    */
-  async acquireAdvisoryLock(name, {timeoutMs} = {}) {
+  async _acquireAdvisoryLock(name, {timeoutMs} = {}) {
     const timeoutSeconds = typeof timeoutMs === "number" && timeoutMs >= 0
       ? Math.ceil(timeoutMs / 1000)
       : MYSQL_INDEFINITE_LOCK_TIMEOUT_SECONDS
@@ -593,7 +593,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if it was already held.
    */
-  async tryAcquireAdvisoryLock(name) {
+  async _tryAcquireAdvisoryLock(name) {
     const rows = await this.query(`SELECT GET_LOCK(${this.quote(name)}, 0) AS velocious_advisory_lock_result`)
     const result = rows?.[0]?.velocious_advisory_lock_result
 
@@ -609,7 +609,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was held by this session and has now been released.
    */
-  async releaseAdvisoryLock(name) {
+  async _releaseAdvisoryLock(name) {
     const rows = await this.query(`SELECT RELEASE_LOCK(${this.quote(name)}) AS velocious_advisory_lock_result`)
     const result = rows?.[0]?.velocious_advisory_lock_result
 

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -610,7 +610,7 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<boolean>} - True if the lock was held by this session and has now been released.
    */
   async _releaseAdvisoryLock(name) {
-    const rows = await this.query(`SELECT RELEASE_LOCK(${this.quote(name)}) AS velocious_advisory_lock_result`)
+    const rows = await this.query(`SELECT RELEASE_LOCK(${this.quote(name)}) AS velocious_advisory_lock_result`, {retry: false})
     const result = rows?.[0]?.velocious_advisory_lock_result
 
     return Number(result) === 1

--- a/src/database/drivers/pgsql/index.js
+++ b/src/database/drivers/pgsql/index.js
@@ -60,7 +60,7 @@ export default class VelociousDatabaseDriversPgsql extends Base{
     return connectArgs
   }
 
-  async close() {
+  async _close() {
     await this.connection?.end()
     this.connection = undefined
     this._transactionsCount = 0
@@ -411,7 +411,7 @@ export default class VelociousDatabaseDriversPgsql extends Base{
    * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null`, `undefined`, or negative blocks forever.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if the timeout elapsed.
    */
-  async acquireAdvisoryLock(name, {timeoutMs} = {}) {
+  async _acquireAdvisoryLock(name, {timeoutMs} = {}) {
     const key = this.advisoryLockKey(name)
 
     if (typeof timeoutMs !== "number" || timeoutMs < 0) {
@@ -423,7 +423,7 @@ export default class VelociousDatabaseDriversPgsql extends Base{
     const pollIntervalMs = 50
 
     while (true) {
-      if (await this.tryAcquireAdvisoryLock(name)) return true
+      if (await this._tryAcquireAdvisoryLock(name)) return true
       if (Date.now() >= deadline) return false
 
       const remaining = deadline - Date.now()
@@ -437,7 +437,7 @@ export default class VelociousDatabaseDriversPgsql extends Base{
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if it was already held.
    */
-  async tryAcquireAdvisoryLock(name) {
+  async _tryAcquireAdvisoryLock(name) {
     const key = this.advisoryLockKey(name)
     const rows = await this.query(`SELECT pg_try_advisory_lock(${key}) AS velocious_advisory_lock_result`)
     const result = rows?.[0]?.velocious_advisory_lock_result
@@ -450,7 +450,7 @@ export default class VelociousDatabaseDriversPgsql extends Base{
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was held by this session and has now been released.
    */
-  async releaseAdvisoryLock(name) {
+  async _releaseAdvisoryLock(name) {
     const key = this.advisoryLockKey(name)
     const rows = await this.query(`SELECT pg_advisory_unlock(${key}) AS velocious_advisory_lock_result`)
     const result = rows?.[0]?.velocious_advisory_lock_result

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -385,7 +385,7 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
    * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null`, `undefined`, or negative blocks forever.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if the timeout elapsed.
    */
-  async acquireAdvisoryLock(name, {timeoutMs} = {}) {
+  async _acquireAdvisoryLock(name, {timeoutMs} = {}) {
     const state = VelociousDatabaseDriversSqliteBase._advisoryLockState
 
     while (state.ownersByName.has(name)) {
@@ -445,7 +445,7 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was acquired, false if it was already held.
    */
-  async tryAcquireAdvisoryLock(name) {
+  async _tryAcquireAdvisoryLock(name) {
     const state = VelociousDatabaseDriversSqliteBase._advisoryLockState
 
     if (state.ownersByName.has(name)) return false
@@ -464,7 +464,7 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - True if the lock was held by this driver and has now been released.
    */
-  async releaseAdvisoryLock(name) {
+  async _releaseAdvisoryLock(name) {
     const state = VelociousDatabaseDriversSqliteBase._advisoryLockState
     const owner = state.ownersByName.get(name)
 

--- a/src/database/drivers/sqlite/index.js
+++ b/src/database/drivers/sqlite/index.js
@@ -62,7 +62,7 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
     return `VelociousDatabaseDriversSqlite---${args.name}`
   }
 
-  async close() {
+  async _close() {
     await this.connection?.close()
     this.connection = undefined
   }
@@ -105,10 +105,10 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * @param {{timeoutMs?: number | null}} [args] - Optional timeout in milliseconds; `null`, `undefined`, or negative blocks forever.
    * @returns {Promise<boolean>} - Whether the advisory lock was acquired.
    */
-  async acquireAdvisoryLock(name, {timeoutMs} = {}) {
+  async _acquireAdvisoryLock(name, {timeoutMs} = {}) {
     const deadline = typeof timeoutMs === "number" && timeoutMs >= 0 ? Date.now() + timeoutMs : null
     const remainingForInProcess = deadline !== null ? Math.max(0, deadline - Date.now()) : null
-    const inProcessAcquired = await super.acquireAdvisoryLock(name, {timeoutMs: remainingForInProcess})
+    const inProcessAcquired = await super._acquireAdvisoryLock(name, {timeoutMs: remainingForInProcess})
 
     if (!inProcessAcquired) return false
 
@@ -117,11 +117,11 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
       const fileAcquired = await this._acquireAdvisoryLockFile(name, {timeoutMs: remainingForFile})
 
       if (!fileAcquired) {
-        await super.releaseAdvisoryLock(name)
+        await super._releaseAdvisoryLock(name)
         return false
       }
     } catch (error) {
-      await super.releaseAdvisoryLock(name)
+      await super._releaseAdvisoryLock(name)
       throw error
     }
 
@@ -133,8 +133,8 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - Whether the advisory lock was acquired immediately.
    */
-  async tryAcquireAdvisoryLock(name) {
-    const inProcessAcquired = await super.tryAcquireAdvisoryLock(name)
+  async _tryAcquireAdvisoryLock(name) {
+    const inProcessAcquired = await super._tryAcquireAdvisoryLock(name)
 
     if (!inProcessAcquired) return false
 
@@ -142,11 +142,11 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
       const fileAcquired = await this._tryAcquireAdvisoryLockFile(name)
 
       if (!fileAcquired) {
-        await super.releaseAdvisoryLock(name)
+        await super._releaseAdvisoryLock(name)
         return false
       }
     } catch (error) {
-      await super.releaseAdvisoryLock(name)
+      await super._releaseAdvisoryLock(name)
       throw error
     }
 
@@ -163,8 +163,8 @@ export default class VelociousDatabaseDriversSqliteNode extends Base {
    * @param {string} name - Lock name.
    * @returns {Promise<boolean>} - Whether the advisory lock was released.
    */
-  async releaseAdvisoryLock(name) {
-    const inProcessReleased = await super.releaseAdvisoryLock(name)
+  async _releaseAdvisoryLock(name) {
+    const inProcessReleased = await super._releaseAdvisoryLock(name)
 
     if (inProcessReleased) {
       await this._releaseAdvisoryLockFile(name)

--- a/src/database/drivers/sqlite/index.native.js
+++ b/src/database/drivers/sqlite/index.native.js
@@ -64,7 +64,7 @@ export default class VelociousDatabaseDriversSqliteNative extends Base {
     return connectArgs
   }
 
-  async close() {
+  async _close() {
     await this.connection.closeAsync()
     this.connection = undefined
   }

--- a/src/database/drivers/sqlite/index.web.js
+++ b/src/database/drivers/sqlite/index.web.js
@@ -48,7 +48,7 @@ export default class VelociousDatabaseDriversSqliteWeb extends Base {
     }
   }
 
-  async close() {
+  async _close() {
     await this.getConnection().close()
   }
 

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -125,6 +125,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
     try {
       await this.rollbackLeftOpenTransaction(connection)
+      await connection.releaseHeldAdvisoryLocks()
       await connection.clearConnectionCheckoutName()
     } catch (error) {
       await this.closeCheckedOutConnectionAfterCheckinFailure(connection, id, error)

--- a/src/database/pool/single-multi-use.js
+++ b/src/database/pool/single-multi-use.js
@@ -3,6 +3,7 @@
 import BasePool from "./base.js"
 
 export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
+  activeCheckoutCount = 0
   suppressedConnectionContextCount = 0
 
   /**
@@ -11,7 +12,32 @@ export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async checkin(connection) {
-    await connection.clearConnectionCheckoutName()
+    if (this.connection === connection && this.activeCheckoutCount > 0) {
+      this.activeCheckoutCount--
+
+      if (this.activeCheckoutCount > 0) return
+    }
+
+    try {
+      await connection.releaseHeldAdvisoryLocks()
+      await connection.clearConnectionCheckoutName()
+    } catch (error) {
+      if (this.connection === connection) {
+        this.activeCheckoutCount = 0
+        this.connection = undefined
+      }
+
+      try {
+        await connection.close()
+      } catch (closeError) {
+        const cleanupError = error instanceof Error ? error : new Error("Failed to clean checked-in database connection", {cause: error})
+        const connectionCloseError = closeError instanceof Error ? closeError : new Error("Failed to close database connection after check-in cleanup failed", {cause: closeError})
+
+        throw new AggregateError([cleanupError, connectionCloseError], "Failed to clean and close checked-in database connection", {cause: closeError})
+      }
+
+      throw error
+    }
   }
 
   /**
@@ -23,6 +49,7 @@ export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
     if (this.connection && !this.connectionMatchesCurrentConfiguration(this.connection)) {
       const previousConnection = this.connection
 
+      this.activeCheckoutCount = 0
       this.connection = undefined
 
       await previousConnection.close()
@@ -33,6 +60,7 @@ export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
     }
 
     await this.connection.setConnectionCheckoutName(options.name)
+    this.activeCheckoutCount++
 
     return this.connection
   }
@@ -103,6 +131,7 @@ export default class VelociousDatabasePoolSingleMultiUser extends BasePool {
 
     const connection = this.connection
 
+    this.activeCheckoutCount = 0
     this.connection = undefined
 
     await connection.close()


### PR DESCRIPTION
## Summary

- track counted advisory-lock acquisitions on each database connection
- release leftover locks before pool reuse and physical connection close
- cover caller, dedicated, re-entrant, async-pool, and shared-pool cleanup paths
- document the connection cleanup contract

## Verification

- 15 AdvisoryLockRunner and record lock tests
- 5 Node SQLite advisory-lock tests
- 2 SingleMultiUsePool tests
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`

## Task

- https://tasks.diestoeckels.de/projects/111/boards/105?task_id=10450