### PR TITLE
Add idempotent cross-database DataCopier moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -2338,6 +2338,6 @@ At runtime, the apartment-style `Tenant` façade (`velocious/build/src/tenants/t
 
 `SchemaCloner` adds a missing auto-increment column and its separate source unique index in one schema alteration, including on MySQL/MariaDB where an auto-increment column must be keyed when it is created.
 
-`DataCopier.move(...)` safely re-homes selected rows between different database connections: the target write and verification commit before the source delete, target-only row transformations are supported, and retries after the source is gone preserve the target.
+`DataCopier.move(...)` safely re-homes selected rows between different physical databases: the target write and verification commit before the source delete, target-only row transformations are supported, and retries after the source is gone preserve the target.
 
 See [docs/tenant-databases.md](docs/tenant-databases.md) for the full configuration and migration pattern.

--- a/README.md
+++ b/README.md
@@ -2338,4 +2338,6 @@ At runtime, the apartment-style `Tenant` façade (`velocious/build/src/tenants/t
 
 `SchemaCloner` adds a missing auto-increment column and its separate source unique index in one schema alteration, including on MySQL/MariaDB where an auto-increment column must be keyed when it is created.
 
+`DataCopier.move(...)` safely re-homes selected rows between different database connections: the target write and verification commit before the source delete, target-only row transformations are supported, and retries after the source is gone preserve the target.
+
 See [docs/tenant-databases.md](docs/tenant-databases.md) for the full configuration and migration pattern.

--- a/changelog.d/20260720200601-data-copier-move.md
+++ b/changelog.d/20260720200601-data-copier-move.md
@@ -1,0 +1,1 @@
+Added `DataCopier.move(...)` for idempotent row-graph movement between different databases. Target rows can be transformed without mutating the source snapshot, the verified target transaction commits before source deletion begins, target failures preserve the source, and retries after the source is gone preserve the moved target.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -152,6 +152,28 @@ await Tenant.drop({identifier: "projectTenant", tenant: {slug: "alpha"}})
 
 Provisioning a tenant database from the default/template database is mechanism the framework also provides: `SchemaCloner` clones table structure and baselines the `schema_migrations` ledger, and `DataCopier` copies a tenant's owned rows following a `TenantTablePlan`. Call these from your provider's `createDatabase`/migration hooks to materialize a new tenant. When an existing tenant table is missing an auto-increment column backed by a separate source unique index, the cloner adds the column and index in the same schema alteration so MySQL-compatible databases accept the definition.
 
+### Moving rows between databases
+
+`DataCopier.move(keyValue, {transformRow})` re-homes the selected row graph instead of retaining the source copy. It writes and verifies the target in one transaction before starting a separate source-delete transaction. A failed target write therefore leaves the source untouched; if the target committed but the source delete failed, retrying replaces the same target row IDs and attempts the source delete again. A retry after the source is already gone is a no-op and never deletes the target.
+
+The optional `transformRow` callback receives a shallow clone plus its table name. Use it for target-only ownership fields when a row becomes tenant-owned during the move; it must preserve the configured id column. Source and target must be different database connections.
+
+```js
+import DataCopier from "velocious/build/src/database/tenants/data-copier.js"
+
+const copier = new DataCopier({
+  sourceDb: defaultDb,
+  targetDb: projectTenantDb,
+  tablePlan: [{keyColumn: "id", tableName: "webhook_deliveries"}]
+})
+
+await copier.move(webhookDeliveryId, {
+  transformRow: ({row}) => ({...row, project_id: projectId})
+})
+```
+
+The target commit and source delete cannot share one transaction across independent databases. Callers that need retry routing after the source disappears must persist that routing separately, such as in their job arguments or global locator table.
+
 Because `listTenants` runs every time, tenant databases are dynamic:
 
 - newly created tenants are included in the next `db:tenants:create/check/migrate` run;

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -156,7 +156,7 @@ Provisioning a tenant database from the default/template database is mechanism t
 
 `DataCopier.move(keyValue, {transformRow})` re-homes the selected row graph instead of retaining the source copy. It writes and verifies the target in one transaction before starting a separate source-delete transaction. A failed target write therefore leaves the source untouched; if the target committed but the source delete failed, retrying replaces the same target row IDs and attempts the source delete again. A retry after the source is already gone is a no-op and never deletes the target.
 
-The optional `transformRow` callback receives a shallow clone plus its table name. Use it for target-only ownership fields when a row becomes tenant-owned during the move; it must preserve the configured id column. Source and target must be different database connections.
+The optional `transformRow` callback receives a shallow clone plus its table name. Use it for target-only ownership fields when a row becomes tenant-owned during the move; it must preserve the configured id column. Source and target must resolve to different physical databases, even when they are checked out through different configured identifiers.
 
 ```js
 import DataCopier from "velocious/build/src/database/tenants/data-copier.js"

--- a/spec/database/tenants/data-copier-spec.js
+++ b/spec/database/tenants/data-copier-spec.js
@@ -168,12 +168,41 @@ describe("DataCopier", () => {
 
       const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb: sourceDb})
 
-      await expect(async () => await copier.move("acct-a")).toThrow("DataCopier move requires different source and target database connections.")
+      await expect(async () => await copier.move("acct-a")).toThrow("DataCopier move requires different physical databases.")
 
       const sourceGizmos = await sourceDb.query("SELECT id FROM gizmos ORDER BY id")
 
       expect(sourceGizmos.map((row) => row.id)).toEqual(["g1", "g2"])
     })
+  })
+
+  it("rejects moving rows when distinct connections use the same physical database", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("data-copier-same-database")
+    const databaseConfiguration = configuration.getDatabaseConfiguration()
+
+    databaseConfiguration.analytics.name = databaseConfiguration.default.name
+
+    try {
+      await configuration.ensureConnections(async (dbs) => {
+        const sourceDb = dbs.default
+        const targetDb = dbs.analytics
+
+        expect(sourceDb === targetDb).toBe(false)
+
+        await createGizmoTables(sourceDb)
+        await seedSource(sourceDb)
+
+        const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+        await expect(async () => await copier.move("acct-a")).toThrow("DataCopier move requires different physical databases.")
+
+        const sourceGizmos = await sourceDb.query("SELECT id FROM gizmos ORDER BY id")
+
+        expect(sourceGizmos.map((row) => row.id)).toEqual(["g1", "g2"])
+      })
+    } finally {
+      await cleanup()
+    }
   })
 
   it("loadRowIds returns only the keyed tenant's ids per table, following the child traversal", async () => {

--- a/spec/database/tenants/data-copier-spec.js
+++ b/spec/database/tenants/data-copier-spec.js
@@ -83,6 +83,99 @@ describe("DataCopier", () => {
     })
   })
 
+  it("moves only the keyed tenant rows and their children out of the source database", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+      const movedRows = await copier.move("acct-a")
+      const sourceGizmos = await sourceDb.query("SELECT id FROM gizmos ORDER BY id")
+      const sourceGizmoParts = await sourceDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+      const targetGizmos = await targetDb.query("SELECT id FROM gizmos ORDER BY id")
+      const targetGizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(sourceGizmos.map((row) => row.id)).toEqual(["g2"])
+      expect(sourceGizmoParts.map((row) => row.id)).toEqual(["p3"])
+      expect(targetGizmos.map((row) => row.id)).toEqual(["g1"])
+      expect(targetGizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+      expect(movedRows.get("gizmos")?.map((row) => row.id)).toEqual(["g1"])
+    })
+  })
+
+  it("transforms rows only for the target while moving them", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.move("acct-a", {
+        transformRow: ({row, tableName}) => tableName === "gizmos"
+          ? {...row, account_id: "acct-tenant"}
+          : row
+      })
+
+      const sourceRows = await sourceDb.query("SELECT id FROM gizmos WHERE account_id = 'acct-a'")
+      const targetRows = await targetDb.query("SELECT account_id AS accountId, id FROM gizmos WHERE id = 'g1'")
+
+      expect(sourceRows).toEqual([])
+      expect(targetRows).toEqual([{accountId: "acct-tenant", id: "g1"}])
+    })
+  })
+
+  it("keeps source rows when the target write fails", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await expect(async () => {
+        await copier.move("acct-a", {
+          transformRow: ({row, tableName}) => tableName === "gizmos"
+            ? {...row, missing_column: "invalid"}
+            : row
+        })
+      }).toThrow()
+
+      const sourceGizmos = await sourceDb.query("SELECT id FROM gizmos WHERE account_id = 'acct-a'")
+      const sourceGizmoParts = await sourceDb.query("SELECT id FROM gizmo_parts WHERE gizmo_id = 'g1' ORDER BY id")
+
+      expect(sourceGizmos.map((row) => row.id)).toEqual(["g1"])
+      expect(sourceGizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+    })
+  })
+
+  it("preserves moved target rows when retried after the source is gone", async () => {
+    await withDatabases(async ({sourceDb, targetDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb})
+
+      await copier.move("acct-a")
+      const retriedRows = await copier.move("acct-a")
+      const targetGizmos = await targetDb.query("SELECT id FROM gizmos ORDER BY id")
+      const targetGizmoParts = await targetDb.query("SELECT id FROM gizmo_parts ORDER BY id")
+
+      expect(retriedRows.get("gizmos")).toEqual([])
+      expect(retriedRows.get("gizmo_parts")).toEqual([])
+      expect(targetGizmos.map((row) => row.id)).toEqual(["g1"])
+      expect(targetGizmoParts.map((row) => row.id)).toEqual(["p1", "p2"])
+    })
+  })
+
+  it("rejects moving rows when source and target use the same connection", async () => {
+    await withDatabases(async ({sourceDb}) => {
+      await seedSource(sourceDb)
+
+      const copier = new DataCopier({sourceDb, tablePlan: TABLE_PLAN, targetDb: sourceDb})
+
+      await expect(async () => await copier.move("acct-a")).toThrow("DataCopier move requires different source and target database connections.")
+
+      const sourceGizmos = await sourceDb.query("SELECT id FROM gizmos ORDER BY id")
+
+      expect(sourceGizmos.map((row) => row.id)).toEqual(["g1", "g2"])
+    })
+  })
+
   it("loadRowIds returns only the keyed tenant's ids per table, following the child traversal", async () => {
     await withDatabases(async ({sourceDb, targetDb}) => {
       await seedSource(sourceDb)

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -96,6 +96,48 @@ export default class DataCopier {
   }
 
   /**
+   * Moves every plan table's rows for `keyValue` from the source into the target. The target
+   * write commits before the source delete begins, so a target failure leaves the source
+   * untouched and a source-delete failure can be retried safely. When the source no longer has
+   * matching rows, the method returns the empty traversal without changing the target.
+   *
+   * `transformRow` can change target-only values such as a tenant ownership column. It receives
+   * a shallow clone and must preserve the configured id column so retries address the same rows.
+   * @param {string} keyValue - Tenant key selecting the rows to move.
+   * @param {{transformRow?: (args: {row: Record<string, unknown>, tableName: string}) => Record<string, unknown>}} [options] - Optional target-row transformation.
+   * @returns {Promise<Map<string, Record<string, unknown>[]>>} - Rows written to the target, grouped by table name.
+   */
+  async move(keyValue, {transformRow} = {}) {
+    if (this.sourceDb === this.targetDb) {
+      throw new Error("DataCopier move requires different source and target database connections.")
+    }
+
+    const sourceRowsByTableName = await this.loadRows(this.sourceDb, keyValue)
+
+    if (!this.rowsByTableNameHasRows(sourceRowsByTableName)) {
+      return sourceRowsByTableName
+    }
+
+    const targetRowsByTableName = this.transformRows({rowsByTableName: sourceRowsByTableName, transformRow})
+
+    await this.targetDb.withDisabledForeignKeys(async () => {
+      await this.targetDb.transaction(async () => {
+        await this.deleteRows({db: this.targetDb, rowsByTableName: sourceRowsByTableName})
+        await this.insertRows({db: this.targetDb, rowsByTableName: targetRowsByTableName})
+        await this.assertRowsExist({db: this.targetDb, rowsByTableName: targetRowsByTableName})
+      })
+    })
+
+    await this.sourceDb.withDisabledForeignKeys(async () => {
+      await this.sourceDb.transaction(async () => {
+        await this.deleteRows({db: this.sourceDb, rowsByTableName: sourceRowsByTableName})
+      })
+    })
+
+    return targetRowsByTableName
+  }
+
+  /**
    * Deletes one tenant's rows from the target database, children before parents, with
    * foreign keys disabled inside a single transaction. This is `copy` without the reinsert:
    * the same plan traversal selects the tenant's current target rows and `deleteTargetRows`
@@ -409,6 +451,15 @@ export default class DataCopier {
    * @returns {Promise<void>}
    */
   async deleteTargetRows(rowsByTableName) {
+    await this.deleteRows({db: this.targetDb, rowsByTableName})
+  }
+
+  /**
+   * Deletes the supplied rows from `db`, children before parents.
+   * @param {{db: import("../drivers/base.js").default, rowsByTableName: Map<string, Record<string, unknown>[]>}} args - Database and rows to delete.
+   * @returns {Promise<void>}
+   */
+  async deleteRows({db, rowsByTableName}) {
     for (const tableConfig of [...this.tablePlan].reverse()) {
       const rowIds = uniqueStrings((rowsByTableName.get(tableConfig.tableName) || []).map((row) => row[this.idColumn]))
 
@@ -416,13 +467,13 @@ export default class DataCopier {
         continue
       }
 
-      const quotedTable = this.targetDb.quoteTable(tableConfig.tableName)
-      const quotedIdColumn = this.targetDb.quoteColumn(this.idColumn)
+      const quotedTable = db.quoteTable(tableConfig.tableName)
+      const quotedIdColumn = db.quoteColumn(this.idColumn)
 
       for (const rowIdsChunk of chunks(rowIds, this.queryChunkSize)) {
         await this.executeQuietQuery(
-          this.targetDb,
-          `DELETE FROM ${quotedTable} WHERE ${quotedIdColumn} IN (${this.quotedValuesSql(this.targetDb, rowIdsChunk)})`
+          db,
+          `DELETE FROM ${quotedTable} WHERE ${quotedIdColumn} IN (${this.quotedValuesSql(db, rowIdsChunk)})`
         )
       }
     }
@@ -435,6 +486,15 @@ export default class DataCopier {
    * @returns {Promise<void>}
    */
   async insertTargetRows(rowsByTableName) {
+    await this.insertRows({db: this.targetDb, rowsByTableName})
+  }
+
+  /**
+   * Inserts the supplied rows into `db`, parents before children.
+   * @param {{db: import("../drivers/base.js").default, rowsByTableName: Map<string, Record<string, unknown>[]>}} args - Database and rows to insert.
+   * @returns {Promise<void>}
+   */
+  async insertRows({db, rowsByTableName}) {
     for (const tableConfig of this.tablePlan) {
       const rows = rowsByTableName.get(tableConfig.tableName) || []
 
@@ -450,10 +510,69 @@ export default class DataCopier {
       for (const rowsChunk of insertChunks) {
         await this.insertRowsQuietly({
           columns,
-          db: this.targetDb,
+          db,
           rows: rowsChunk.map((row) => columns.map((column) => row[column])),
           tableName: tableConfig.tableName
         })
+      }
+    }
+  }
+
+  /**
+   * Returns whether any table in the loaded traversal contains rows.
+   * @param {Map<string, Record<string, unknown>[]>} rowsByTableName - Rows grouped by table name.
+   * @returns {boolean} - Whether any table contains rows.
+   */
+  rowsByTableNameHasRows(rowsByTableName) {
+    for (const rows of rowsByTableName.values()) {
+      if (rows.length > 0) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
+   * Clones source rows and applies the optional target-only transformation.
+   * @param {{rowsByTableName: Map<string, Record<string, unknown>[]>, transformRow?: (args: {row: Record<string, unknown>, tableName: string}) => Record<string, unknown>}} args - Source rows and optional transformation.
+   * @returns {Map<string, Record<string, unknown>[]>} - Cloned rows prepared for the target.
+   */
+  transformRows({rowsByTableName, transformRow}) {
+    const transformedRowsByTableName = new Map()
+
+    for (const tableConfig of this.tablePlan) {
+      const sourceRows = rowsByTableName.get(tableConfig.tableName) || []
+      const transformedRows = sourceRows.map((sourceRow) => {
+        const transformedRow = transformRow
+          ? transformRow({row: {...sourceRow}, tableName: tableConfig.tableName})
+          : {...sourceRow}
+
+        if (String(transformedRow[this.idColumn]) !== String(sourceRow[this.idColumn])) {
+          throw new Error(`DataCopier move transform must preserve ${this.idColumn} for table ${tableConfig.tableName}.`)
+        }
+
+        return transformedRow
+      })
+
+      transformedRowsByTableName.set(tableConfig.tableName, transformedRows)
+    }
+
+    return transformedRowsByTableName
+  }
+
+  /**
+   * Verifies that every supplied row id exists in `db`.
+   * @param {{db: import("../drivers/base.js").default, rowsByTableName: Map<string, Record<string, unknown>[]>}} args - Database and rows to verify.
+   * @returns {Promise<void>}
+   */
+  async assertRowsExist({db, rowsByTableName}) {
+    for (const tableConfig of this.tablePlan) {
+      const expectedIds = uniqueStrings((rowsByTableName.get(tableConfig.tableName) || []).map((row) => row[this.idColumn]))
+      const existingIds = await this.queryExistingIds({db, ids: expectedIds, tableName: tableConfig.tableName})
+
+      if (existingIds.size !== expectedIds.length) {
+        throw new Error(`DataCopier move target verification failed for table ${tableConfig.tableName}.`)
       }
     }
   }

--- a/src/database/tenants/data-copier.js
+++ b/src/database/tenants/data-copier.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import {POOL_CONFIGURATION_KEY} from "../pool/base.js"
+
 const DEFAULT_INSERT_CHUNK_SIZE = 100
 const DEFAULT_QUERY_CHUNK_SIZE = 500
 const DEFAULT_STREAM_BATCH_SIZE = 1000
@@ -108,8 +110,16 @@ export default class DataCopier {
    * @returns {Promise<Map<string, Record<string, unknown>[]>>} - Rows written to the target, grouped by table name.
    */
   async move(keyValue, {transformRow} = {}) {
-    if (this.sourceDb === this.targetDb) {
-      throw new Error("DataCopier move requires different source and target database connections.")
+    const sourceDbWithPoolKey = /** @type {import("../drivers/base.js").default & {[POOL_CONFIGURATION_KEY]?: string}} */ (this.sourceDb)
+    const targetDbWithPoolKey = /** @type {import("../drivers/base.js").default & {[POOL_CONFIGURATION_KEY]?: string}} */ (this.targetDb)
+    const sourceReuseKey = sourceDbWithPoolKey[POOL_CONFIGURATION_KEY]
+    const targetReuseKey = targetDbWithPoolKey[POOL_CONFIGURATION_KEY]
+    const sameResolvedDatabase = this.sourceDb.configuration === this.targetDb.configuration
+      && sourceReuseKey !== undefined
+      && sourceReuseKey === targetReuseKey
+
+    if (this.sourceDb === this.targetDb || sameResolvedDatabase) {
+      throw new Error("DataCopier move requires different physical databases.")
     }
 
     const sourceRowsByTableName = await this.loadRows(this.sourceDb, keyValue)


### PR DESCRIPTION
## Summary

- add `DataCopier.move(...)` for moving a keyed row graph between database connections
- commit and verify the target before deleting the source so retries remain safe
- support target-only row transformations while preserving record IDs
- document the new API and cross-database transaction boundary

## Tests

- `VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npm run test -- spec/database/tenants/data-copier-spec.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`

Supports TensorBuzz task 10445: https://tasks.diestoeckels.de/projects/111/boards/105?task_id=10445
