### PR TITLE
Strengthen background job timeout cleanup coverage

### DIFF
--- a/changelog.d/20260721162336-background-job-report-timeout-abort.md
+++ b/changelog.d/20260721162336-background-job-report-timeout-abort.md
@@ -1,6 +1,6 @@
 Background job status reports now cooperatively abort and destroy the pending socket when a report times out.
 
 - `BackgroundJobsStatusReporter.report` threads the awaitery `TimeoutControl` signal into the socket request
-- `BackgroundJobsSocketRequest.run` accepts an optional `AbortSignal`; on abort it removes its listeners, destroys (not merely ends) the pending socket, and rejects with the signal reason
+- `BackgroundJobsSocketRequest.run` accepts an optional `AbortSignal`; on abort it removes its listeners, destroys (not merely ends) the pending socket, and rejects with the signal reason when it is an Error (otherwise with a generic abort Error)
 - `BackgroundJobsStatusReporter` accepts an optional `attemptTimeoutMs` constructor option (defaults to the previous 5000ms) for deterministic timeout behavior
 - the public awaitery `TimeoutError` behavior is preserved

--- a/spec/background-jobs/status-reporter-timeout-spec.js
+++ b/spec/background-jobs/status-reporter-timeout-spec.js
@@ -7,7 +7,7 @@ import dummyConfiguration from "../dummy/src/config/configuration.js"
 import waitForEvent from "../../src/testing/wait-for-event.js"
 
 describe("BackgroundJobsStatusReporter timeout", () => {
-  it("times out a stalled report and destroys the pending socket", async () => {
+  it("times out a stalled report and forcibly destroys (rather than gracefully closing) the pending socket", async () => {
     // A server that accepts the connection and consumes incoming data but never
     // replies, so the reporter's request stalls waiting for a "job-updated".
     const server = net.createServer((socket) => {
@@ -59,7 +59,20 @@ describe("BackgroundJobsStatusReporter timeout", () => {
       // The timeout must surface as the public TimeoutError from awaitery.
       expect(reportError).toBeInstanceOf(TimeoutError)
 
-      // The pending socket must have been destroyed, not left alive.
+      // Test-only white-box assertion: read the JsonSocket wrapper's own call
+      // counters directly (the underscore fields are internal, not public API). These
+      // are incremented inside the actual JsonSocket.destroy()/close() bodies, so they
+      // are direct evidence of which teardown method ran — not a self-reported flag
+      // that a regression could keep truthful while calling the wrong method. The abort
+      // path must have forcibly destroyed the socket exactly once and never gracefully
+      // closed it; a server-side "close" watcher alone could not rule the latter out
+      // because with allowHalfOpen=false a graceful end() ALSO surfaces as a server "close".
+      const jsonSocket = reporter._lastRequest?._jsonSocket
+
+      expect(jsonSocket?._destroyCallCount).toEqual(1)
+      expect(jsonSocket?._closeCallCount).toEqual(0)
+
+      // The real stalled socket must actually be torn down (integration assertion).
       await serverSocketClosed
     } finally {
       // Destroy the accepted socket if a failed assertion left it open, otherwise

--- a/src/background-jobs/json-socket.js
+++ b/src/background-jobs/json-socket.js
@@ -44,6 +44,19 @@ export default class JsonSocket extends EventEmitter {
      * the main's liveness sweep to drop a wedged/silent worker.
      * @type {number | undefined} */
     this.lastSeenAt = undefined
+    /**
+     * Internal test-only observability counter — NOT public API. Number of times
+     * `destroy()` has run, incremented immediately before the raw socket
+     * `destroy()` call so specs can assert the actual teardown method that ran
+     * rather than a self-reported flag. Do not read or depend on this outside tests.
+     * @type {number} */
+    this._destroyCallCount = 0
+    /**
+     * Internal test-only observability counter — NOT public API. Number of times
+     * `close()` has run, incremented immediately before the raw socket `end()`
+     * call. Do not read or depend on this outside tests.
+     * @type {number} */
+    this._closeCallCount = 0
     this.buffer = ""
     this.socket.setEncoding("utf8")
     this.socket.on("data", (chunk) => this._onData(String(chunk)))
@@ -91,6 +104,7 @@ export default class JsonSocket extends EventEmitter {
    * @returns {void}
    */
   close() {
+    this._closeCallCount++
     this.socket.end()
   }
 
@@ -101,6 +115,7 @@ export default class JsonSocket extends EventEmitter {
    * @returns {void}
    */
   destroy() {
+    this._destroyCallCount++
     this.socket.destroy()
   }
 }

--- a/src/background-jobs/socket-request.js
+++ b/src/background-jobs/socket-request.js
@@ -15,6 +15,16 @@ export default class BackgroundJobsSocketRequest {
     this.host = host
     this.port = port
     this.role = role
+    /**
+     * Internal test-only observability reference — NOT public API. Holds the
+     * JsonSocket wrapper this request created so the timeout spec can inspect the
+     * wrapper's own `destroy()`/`close()` call counters — direct evidence of which
+     * teardown method actually ran, not a self-reported flag. Retains the single
+     * (already torn-down) wrapper for the request's lifetime. Do not expose or
+     * depend on this outside tests.
+     * @type {JsonSocket | undefined}
+     */
+    this._jsonSocket = undefined
   }
 
   /**
@@ -23,12 +33,14 @@ export default class BackgroundJobsSocketRequest {
    * @param {object} args - Options.
    * @param {(jsonSocket: JsonSocket) => void} args.onConnect - Called after the socket connects.
    * @param {(args: {message: import("./types.js").BackgroundJobSocketMessage, resolve: (value: T) => void, reject: (error: Error) => void}) => void} args.onMessage - Message handler.
-   * @param {AbortSignal} [args.signal] - Aborts the request; on abort the pending socket is destroyed and the promise rejects with the signal reason.
+   * @param {AbortSignal} [args.signal] - Aborts the request; on abort the pending socket is destroyed and the promise rejects with the signal reason when it is an Error, otherwise with a generic abort Error.
    * @returns {Promise<T>} - Resolved request value.
    */
   async run({onConnect, onMessage, signal}) {
     const socket = net.createConnection({host: this.host, port: this.port})
     const jsonSocket = new JsonSocket(socket)
+
+    this._jsonSocket = jsonSocket
 
     return await new Promise((resolve, reject) => {
       let finished = false

--- a/src/background-jobs/status-reporter.js
+++ b/src/background-jobs/status-reporter.js
@@ -22,6 +22,13 @@ export default class BackgroundJobsStatusReporter {
     this.host = host
     this.port = port
     this.attemptTimeoutMs = attemptTimeoutMs
+    /**
+     * Internal test-only observability state — NOT public API. References the most
+     * recent socket request so the timeout spec can inspect how its socket was torn
+     * down. Do not expose or depend on this outside tests.
+     * @type {BackgroundJobsSocketRequest | undefined}
+     */
+    this._lastRequest = undefined
     this.logger = new Logger(this)
   }
 
@@ -43,6 +50,8 @@ export default class BackgroundJobsStatusReporter {
 
     await timeout({timeout: this.attemptTimeoutMs}, async ({control}) => {
       const request = new BackgroundJobsSocketRequest({host, port, role: "reporter"})
+
+      this._lastRequest = request
 
       await request.run({
         signal: control.signal,


### PR DESCRIPTION
## Summary

- strengthen the background-job status timeout regression so it directly proves abort uses forced `JsonSocket.destroy()` rather than graceful `close()`/`end()`
- retain the real stalled-socket integration assertion and bounded `finally` cleanup
- document the actual non-`Error` `AbortSignal.reason` fallback accurately

This is a narrow follow-up to #935 prompted by an independent review result that arrived after the original PR merged.

## Validation

In a clean tar-streamed `node:24-trixie-slim` Docker environment with MSSQL disabled:

- `npm run test -- spec/background-jobs/status-reporter-timeout-spec.js`
- `npm run lint`
- `npm run build`
- `git diff --check`

Mutation check in a disposable Docker copy:

- changed the abort path from forced destroy to graceful close
- focused spec failed at the new `destroyCalls` assertion
- restored production source and reran the focused spec successfully

An independent exact-snapshot pre-commit review returned PASS.