### PR TITLE
Propagate the controller to preloaded-relationship serialization

### DIFF
--- a/spec/dummy/src/config/backend-projects.js
+++ b/spec/dummy/src/config/backend-projects.js
@@ -269,7 +269,7 @@ class UserFrontendResource extends FrontendModelBaseResource {
 class SystemTestCommentFrontendResource extends FrontendModelBaseResource {
   static ModelClass = Comment
 
-    static attributes = ["id", "body"]
+    static attributes = ["id", "body", {name: "requestBaseUrl", selectedByDefault: false}]
 
   static builtInCollectionCommands = ["index"]
 
@@ -278,6 +278,21 @@ class SystemTestCommentFrontendResource extends FrontendModelBaseResource {
   /** @returns {Array<string>} - Permit spec for Comment writes. */
   permittedParams() {
     return ["body"]
+  }
+
+  /**
+   * Controller-dependent virtual attribute mirroring an app resource that signs a
+   * download URL against the request. It reaches for the controller via
+   * `controllerInstance()`, which throws "requires a controller instance." unless the
+   * serialization resource has a controller — the exact gap that broke preloaded
+   * relationships until the controller was propagated to them.
+   * @param {import("../models/comment.js").default} model - Comment model instance.
+   * @returns {string} - The request base URL.
+   */
+  requestBaseUrlAttribute(model) {
+    void model
+
+    return this.controllerInstance().request().baseURL()
   }
 }
 

--- a/spec/frontend-models/base.http-integration-spec.js
+++ b/spec/frontend-models/base.http-integration-spec.js
@@ -219,12 +219,15 @@ class Comment extends FrontendModelBase {
   static resourceConfig() {
     return {
       abilities: ["read"],
-      attributes: ["id", "body"],
+      attributes: ["id", "body", "requestBaseUrl"],
       builtInCollectionCommands: ["index"],
       builtInMemberCommands: ["find"],
       primaryKey: "id"
     }
   }
+
+  /** @returns {string} */
+  requestBaseUrl() { return this.readAttribute("requestBaseUrl") }
 }
 
 FrontendModelBase.registerModel(Comment)
@@ -1284,6 +1287,33 @@ describe("Frontend models - base http integration", {databaseCleaning: {transact
         await expect(async () => {
           tasks[0].primaryInteraction()
         }).toThrow(/Task#primaryInteraction hasn't been preloaded/)
+      } finally {
+        resetFrontendModelTransport()
+      }
+    })
+  })
+
+  it("propagates the controller to preloaded relationship serialization so request-scoped attributes serialize", async () => {
+    await Dummy.run(async () => {
+      configureNodeTransport()
+
+      try {
+        const {project} = await seedHttpPreloadModels()
+        // `requestBaseUrl` is a controller-dependent virtual attribute on the Comment
+        // resource. Before the controller was propagated to preloaded-relationship
+        // serialization resources, serializing it threw "requires a controller
+        // instance." and the whole request failed. Selecting it on a preloaded
+        // relationship must now serialize the request base URL.
+        const loadedProject = await Project
+          .select({Comment: ["id", "body", "requestBaseUrl"]})
+          .preload({tasks: ["comments"]})
+          .findBy({id: project.id()})
+        const tasks = loadedProject?.getRelationshipByName("tasks").loaded() || []
+        const comments = tasks[0].getRelationshipByName("comments").loaded()
+
+        expect(comments.length).toEqual(1)
+        expect(typeof comments[0].requestBaseUrl()).toEqual("string")
+        expect(comments[0].requestBaseUrl().length > 0).toEqual(true)
       } finally {
         resetFrontendModelTransport()
       }

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -2826,6 +2826,12 @@ export default class FrontendModelController extends Controller {
       if (resourceClass) {
         return new resourceClass({
           ability: this.currentAbility(),
+          // Propagate the controller so a related/preloaded model's serialization
+          // resource can use request context (e.g. `requestBaseUrl()` for signed
+          // download URLs). Without it, any `<attr>Attribute` method that reaches
+          // for the controller throws "requires a controller instance." when a
+          // relationship is serialized as a preload.
+          controller: this,
           context: this.currentAbility()?.getContext() || {},
           locals: this.currentAbility()?.getLocals() || {},
           modelClass: /** @type {typeof import("./database/record/index.js").default} */ (model.constructor),


### PR DESCRIPTION
## Propagate the controller to preloaded-relationship serialization

### Problem
`FrontendModelController._serializationResourceInstanceForModel(model)` builds the
resource used to serialize a **related/preloaded** model (one whose class differs
from the controller's main resource). It passed `ability`, `context`, `locals`,
`modelClass`, etc. — but **not `controller`**. So the serialization resource for a
preloaded relationship had no controller, and any `<attr>Attribute` method that
reaches for request context via `controllerInstance()` — e.g. an app resource that
signs a download URL against the request base URL — threw:

```
<Resource> requires a controller instance.
```

…which failed the entire request. The main resource already receives the controller
(it's only the related/preloaded serialization path that dropped it), so this only
surfaced once a resource added a request-scoped serialized attribute and it was
loaded through a `preload`.

### Fix
Pass `controller: this` when constructing the related-model serialization resource,
so preloaded/nested serialization matches the main resource.

### Test
Adds an http-integration regression (`base.http-integration-spec.js`): the preloaded
`Comment` resource gets a controller-dependent virtual attribute
(`requestBaseUrlAttribute` → `controllerInstance().request().baseURL()`), and loading
a project with `.preload({tasks: ["comments"]})` while selecting that attribute now
serializes it. Without the fix this test fails with
`SystemTestCommentFrontendResource requires a controller instance.` via the same
nested-serialization stack (`serializeFrontendModels` → `serializeFrontendModelAttributes`
→ the attribute method → `controllerInstance()`).

`npm run lint` (eslint + tsc + fallow) clean; `base.http-integration-spec.js` green
(49 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
