### PR TITLE
Document the Velocious release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,7 @@ For investigation-only tasks, do not push to GitHub unless explicitly asked.
 ## Branches and commits
 When asked to create branches and commit changes, come up with fitting branch names and commit messages. Split commits into smaller commits for each distinct change.
 Never commit or push directly to `master`; always use a feature branch and open a PR.
-- Do not manually bump this package's own `version` in `package.json` (or `spec/dummy/package.json`). The release happens through the release script (`npm run release:patch`), which sets the version at release time. Leave `version` untouched in feature work and PRs — a manual bump conflicts with the release flow.
+- Do not manually bump this package's own `version` in `package.json`. The release happens through the release script (`npm run release:patch`), which sets the version at release time. Leave `version` untouched in feature work and PRs — a manual bump conflicts with the release flow. Follow `docs/releasing.md` for the required clean-master, fresh-install, authentication, side-effect, and public-registry verification gates.
 - In codebases that auto-load model files with a require-context/recursive `src/models` scan, keep `src/models/**` limited to actual model classes; place helper modules under `src/utils`/`src/support` so initialization does not treat them as records.
 - Do not edit generated source files manually; regenerate them with the owning project script/command.
 - In generated frontend models, use direct class import names (for example `import Project from "./project.js"`), not suffixed aliases like `ProjectModel`.
-- When bumping package versions, update both `package.json` and `spec/dummy/package.json`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ npm run test
 npm run test:expo
 ```
 
+Maintainers cutting a package release must follow the [Velocious release runbook](docs/releasing.md); `npm run release:patch` commits, pushes, and publishes rather than acting as a local-only version command.
+
 # Code quality (fallow)
 
 [fallow](https://github.com/fallow-rs/fallow) analyzes the codebase for unused/dead code, duplication, and complexity. CI runs it as a **regression gate**: it fails only on findings beyond the committed baseline in `fallow-baselines/`, so existing backlog never blocks a PR but new issues do.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,7 +19,16 @@ Do not manually change the Velocious version before running the helper. `release
 npm run release:patch
 ```
 
-The helper pushes the version commit before it runs `npm publish`. If publication fails after the push, do not rerun the helper blindly: first reconcile the remote `master`, local version, and npm registry state so a second patch bump is not created accidentally.
+The helper's stages are npm authentication, checkout/fetch/merge of `master`, patch version bump and lifecycle/build, version-file commit, push to `origin/master`, and `npm publish`, in that order. It creates neither a Git tag nor a GitHub Release.
+
+If any stage fails, do not rerun the helper. Record the last command that completed, then reconcile local `HEAD`, `origin/master`, the versions in `package.json` and `package-lock.json`, and `npm view velocious versions --json` before taking another side-effectful action. Recover according to the stage reached:
+
+- **Before the version commit exists:** no release commit has been pushed or published. Inspect `git status` for version/build/lifecycle changes. Preserve them with `git stash push -u` if they are useful for diagnosis, then restore the clean pre-release commit before retrying the entire helper.
+- **The release commit exists locally, but its push failed:** fetch `origin` and verify that the release version is absent from npm. If `origin/master` does not contain the commit, fix the push problem and push that exact existing commit; do not rerun the helper and create another bump. If abandoning it, first preserve the commit on a recovery branch and confirm it is neither remote nor published before resetting local `master` to `origin/master`.
+- **The release commit was pushed, but publication failed:** verify that local `HEAD` and `origin/master` are the same release commit and that both version files contain its version. If npm does not contain that version, fix the publication problem and run `npm publish` from that exact clean commit. If npm already contains it, do not publish or run the helper again; proceed to verification.
+- **Publication succeeded, but independent verification failed:** do not rerun either the helper or `npm publish`. Re-fetch `origin/master`, re-read the exact version's npm metadata, and re-download the artifact. Resolve whether the check was transient or whether the remote commit, registry `gitHead`, registry checksums, or downloaded contents disagree. Treat an identity or content mismatch as an incident requiring investigation, not as a reason to create another release.
+
+At every boundary, use the exact stage reached rather than command exit alone: a timed-out push or publish may have succeeded remotely. Keep a recovery branch or stash before discarding local state, and never delete or rewrite a pushed release commit.
 
 ## Verify the published release
 
@@ -29,16 +38,26 @@ A successful command exit is not sufficient. Read the exact version back from th
 VERSION="$(npm view velocious version)"
 npm view "velocious@$VERSION" version gitHead dist.integrity dist.shasum dist.tarball --json
 git fetch origin
+git rev-parse origin/master
 git show "origin/master:package.json"
+
+ARTIFACT_DIR="$(mktemp -d)"
+(
+  cd "$ARTIFACT_DIR"
+  TARBALL="$(npm pack --silent "velocious@$VERSION")"
+  printf 'sha512-%s\n' "$(openssl dgst -sha512 -binary "$TARBALL" | openssl base64 -A)"
+  sha1sum "$TARBALL"
+)
 ```
 
 Confirm all of the following:
 
 - `origin/master` contains the reported version.
-- Registry `gitHead` equals the exact `origin/master` release commit.
-- Registry integrity, shasum, and tarball URL are present.
+- Registry `gitHead` equals the exact commit ID at `origin/master`, not merely a local commit with the same files.
+- The freshly downloaded tarball's computed `sha512-...` value equals registry `dist.integrity`, and its `sha1sum` equals registry `dist.shasum`.
+- Registry tarball URL is present.
 - The downloaded registry tarball contains the required `build/` output and executable CLI.
 - A fresh temporary consumer can install `velocious@$VERSION` from npm and import its public entrypoint.
 - The release checkout remains clean after lifecycle scripts finish.
 
-Recent Velocious releases intentionally use the pushed default-branch version commit plus npm `gitHead` as their immutable identity; `release-patch` does not create a tag. Do not invent a release tag unless the repository's release convention is deliberately changed.
+Recent Velocious releases intentionally use the pushed default-branch version commit plus npm `gitHead` as their immutable identity; `release-patch` creates neither a Git tag nor a GitHub Release. Do not invent either unless the repository's release convention is deliberately changed.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,44 @@
+# Releasing Velocious
+
+Velocious patch releases use `npm run release:patch`. This is a side-effectful maintainer command: it authenticates with npm, switches to and synchronizes `master`, bumps the patch version without creating a Git tag, builds the package, commits and pushes the version files directly to `master`, and publishes to npm.
+
+## Before running the release
+
+1. Obtain explicit release approval.
+2. Confirm the intended feature/fix PR is merged and all required checks are green at its current head.
+3. Start from a clean checkout whose `master` exactly matches `origin/master`.
+4. Inspect the installed `release-patch` implementation before use when its dependency version changes; do not assume its side effects are unchanged.
+5. In the same project Docker environment that will run the release, install the lockfile dependencies from scratch with `npm ci`. `release-patch` does not install dependencies, so a persistent container's existing `node_modules` is not fresh-install proof.
+6. Verify npm authentication with the same temporary npm configuration that publication will use. Never place registry tokens in the repository or print them in logs.
+
+Do not manually change the Velocious version before running the helper. `release-patch` updates both `package.json` and `package-lock.json` and creates the `chore: bump patch version` commit.
+
+## Run the release
+
+```sh
+npm run release:patch
+```
+
+The helper pushes the version commit before it runs `npm publish`. If publication fails after the push, do not rerun the helper blindly: first reconcile the remote `master`, local version, and npm registry state so a second patch bump is not created accidentally.
+
+## Verify the published release
+
+A successful command exit is not sufficient. Read the exact version back from the public registry and verify that its immutable source identity matches the pushed release commit:
+
+```sh
+VERSION="$(npm view velocious version)"
+npm view "velocious@$VERSION" version gitHead dist.integrity dist.shasum dist.tarball --json
+git fetch origin
+git show "origin/master:package.json"
+```
+
+Confirm all of the following:
+
+- `origin/master` contains the reported version.
+- Registry `gitHead` equals the exact `origin/master` release commit.
+- Registry integrity, shasum, and tarball URL are present.
+- The downloaded registry tarball contains the required `build/` output and executable CLI.
+- A fresh temporary consumer can install `velocious@$VERSION` from npm and import its public entrypoint.
+- The release checkout remains clean after lifecycle scripts finish.
+
+Recent Velocious releases intentionally use the pushed default-branch version commit plus npm `gitHead` as their immutable identity; `release-patch` does not create a tag. Do not invent a release tag unless the repository's release convention is deliberately changed.


### PR DESCRIPTION
## Summary

- add a maintainer runbook for Velocious patch releases
- document `release-patch` preflight, side effects, partial-failure recovery, and public npm verification
- link the runbook from README and AGENTS
- remove stale references to nonexistent `spec/dummy/package.json`

## Validation

- `git diff --check`
- local documentation link validation
- secret-pattern scan
- verified documented helper behavior against installed `release-patch@1.0.1` source
- verified `spec/dummy/package.json` does not exist in the current or released tree

Runtime tests and lint were skipped because this PR changes Markdown documentation only.
