### PR TITLE
Make WebSocket frame buffering linear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,6 +1565,8 @@ database: {
 
 Velocious includes a lightweight websocket entry point for API-style calls and server-side events.
 
+Inbound frames remain ordered when TCP splits a frame across reads. Velocious limits a single final client data frame and a reassembled fragmented message to 16 MiB; larger payloads close the connection. See [WebSocket connections](docs/websocket-connections.md) for wire-protocol details.
+
 ## Connect and call a controller
 
 ```js

--- a/benchmark/websocket-frame-buffering.js
+++ b/benchmark/websocket-frame-buffering.js
@@ -1,0 +1,115 @@
+import {performance} from "node:perf_hooks"
+
+import Configuration from "../src/configuration.js"
+import EventEmitter from "../src/utils/event-emitter.js"
+import NodeEnvironmentHandler from "../src/environment-handlers/node.js"
+import WebsocketSession from "../src/http-server/client/websocket-session.js"
+
+const mask = Buffer.from([0x01, 0x02, 0x03, 0x04])
+const tcpChunkSizes = [4096, 8192, 16384, 12288]
+
+/**
+ * Builds one masked final text frame.
+ * @param {number} payloadBytes - Approximate JSON payload size.
+ * @returns {Buffer} - Client websocket frame.
+ */
+function buildFrame(payloadBytes) {
+  const payload = Buffer.from(JSON.stringify({type: "metadata", data: {contents: "x".repeat(payloadBytes)}}))
+  const header = Buffer.alloc(14)
+  const maskedPayload = Buffer.allocUnsafe(payload.length)
+
+  header[0] = 0x81
+  header[1] = 0x80 | 127
+  header.writeBigUInt64BE(BigInt(payload.length), 2)
+  mask.copy(header, 10)
+
+  for (let index = 0; index < payload.length; index += 1) {
+    maskedPayload[index] = payload[index] ^ mask[index % mask.length]
+  }
+
+  return Buffer.concat([header, maskedPayload])
+}
+
+/**
+ * Measures one TCP-fragmented frame.
+ * @param {number} payloadBytes - Approximate frame payload size.
+ * @returns {Promise<{elapsedMs: number, frameBytes: number, oldConcatBytes: number, parserCopyBytes: number}>}
+ */
+async function measure(payloadBytes) {
+  const configuration = new Configuration({
+    autoload: false,
+    database: {},
+    directory: process.cwd(),
+    environmentHandler: new NodeEnvironmentHandler()
+  })
+  let dispatchedMessages = 0
+  const session = new WebsocketSession({
+    client: {events: new EventEmitter(), remoteAddress: "127.0.0.1"},
+    configuration,
+    messageHandler: {
+      onMessage: () => { dispatchedMessages += 1 }
+    }
+  })
+  const frame = buildFrame(payloadBytes)
+  let bufferedBytes = 0
+  let oldConcatBytes = 0
+  let offset = 0
+  let chunkIndex = 0
+  const startedAt = performance.now()
+
+  while (offset < frame.length) {
+    const chunkSize = tcpChunkSizes[chunkIndex % tcpChunkSizes.length]
+    const end = Math.min(offset + chunkSize, frame.length)
+    const chunk = frame.subarray(offset, end)
+
+    oldConcatBytes += bufferedBytes + chunk.length
+    bufferedBytes += chunk.length
+    session.onData(chunk)
+    offset = end
+    chunkIndex += 1
+  }
+
+  await session._messageChain
+
+  if (dispatchedMessages !== 1) throw new Error(`Expected one dispatched message, got ${dispatchedMessages}`)
+  if (session._bufferedFrameCopyBytes > frame.length) {
+    throw new Error(`Parser copied ${session._bufferedFrameCopyBytes} bytes for a ${frame.length}-byte frame`)
+  }
+
+  session.destroy()
+
+  return {
+    elapsedMs: performance.now() - startedAt,
+    frameBytes: frame.length,
+    oldConcatBytes,
+    parserCopyBytes: session._bufferedFrameCopyBytes
+  }
+}
+
+const measurements = []
+
+for (const payloadBytes of [1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 8 * 1024 * 1024]) {
+  measurements.push(await measure(payloadBytes))
+}
+
+console.log("frame\tparser copies\tcopy ratio\told concat equivalent\telapsed")
+for (const measurement of measurements) {
+  console.log([
+    `${(measurement.frameBytes / 1024 / 1024).toFixed(2)} MiB`,
+    `${(measurement.parserCopyBytes / 1024 / 1024).toFixed(2)} MiB`,
+    `${(measurement.parserCopyBytes / measurement.frameBytes).toFixed(2)}x`,
+    `${(measurement.oldConcatBytes / 1024 / 1024).toFixed(2)} MiB`,
+    `${measurement.elapsedMs.toFixed(2)} ms`
+  ].join("\t"))
+}
+
+for (let index = 1; index < measurements.length; index += 1) {
+  const prior = measurements[index - 1]
+  const current = measurements[index]
+  const frameGrowth = current.frameBytes / prior.frameBytes
+  const copyGrowth = current.parserCopyBytes / prior.parserCopyBytes
+
+  if (copyGrowth > frameGrowth * 1.01) {
+    throw new Error(`Copy growth ${copyGrowth.toFixed(2)}x exceeded frame growth ${frameGrowth.toFixed(2)}x`)
+  }
+}

--- a/changelog.d/20260724220000-websocket-chunk-buffering.md
+++ b/changelog.d/20260724220000-websocket-chunk-buffering.md
@@ -1,0 +1,1 @@
+WebSocket sessions now buffer incomplete TCP frame chunks without repeatedly copying the accumulated payload, and reject single final data frames larger than 16 MiB before buffering their payload.

--- a/docs/websocket-connections.md
+++ b/docs/websocket-connections.md
@@ -8,6 +8,8 @@ For the broadcast / pub-sub case, use `WebsocketChannel` instead (documented sep
 
 All messages are JSON objects sent over the shared WebSocket. Connection-related messages use a `type` prefix of `connection-`.
 
+Velocious buffers TCP-fragmented WebSocket input as chunks and assembles each frame once it is complete. A single final client data frame is limited to 16 MiB, matching the existing cap for a fragmented message; a frame declaring a larger payload is rejected before its payload is buffered. Applications that need to send more data should split it at the application level.
+
 ### Client → server
 
 ```json

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "benchmark:preloader-id-dedup": "node benchmark/preloader-id-dedup.js",
     "benchmark:mysql-result-row-materialization": "node benchmark/mysql-result-row-materialization.js",
     "benchmark:query-roundtrip-batching": "node benchmark/query-roundtrip-batching.js",
+    "benchmark:websocket-frame-buffering": "node benchmark/websocket-frame-buffering.js",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:js && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:js": "cpy \"index.js\" build && cpy \"bin/**/*.js\" build/bin && cpy \"src/**/*.js\" build --parents",

--- a/spec/http-server/websocket-fragmented-frames-spec.js
+++ b/spec/http-server/websocket-fragmented-frames-spec.js
@@ -42,6 +42,156 @@ function buildClientFrame({fin, opcode, payload}) {
 }
 
 describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: true}}, () => {
+  it("buffers one large FIN frame in TCP-sized chunks with bounded copying", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+
+    /** @type {any[]} */
+    const dispatched = []
+
+    session._handleMessage = async (message) => { dispatched.push(message) }
+
+    const body = JSON.stringify({
+      type: "metadata",
+      data: {contents: "x".repeat(2 * 1024 * 1024)}
+    })
+    const frame = buildClientFrame({
+      fin: true,
+      opcode: 0x1,
+      payload: Buffer.from(body, "utf-8")
+    })
+    const tcpChunkSizes = [1, 256]
+    let offset = 0
+    let chunkIndex = 0
+
+    while (offset < frame.length) {
+      const end = Math.min(offset + tcpChunkSizes[chunkIndex % tcpChunkSizes.length], frame.length)
+
+      session.onData(frame.subarray(offset, end))
+      offset = end
+      chunkIndex += 1
+    }
+
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(dispatched.length).toBe(1)
+    expect(dispatched[0].data.contents.length).toBe(2 * 1024 * 1024)
+    expect(session._bufferedFrameCopyBytes).toBeLessThanOrEqual(frame.length)
+  })
+
+  it("keeps incomplete payloads queued and processes following frames in order", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+
+    /** @type {any[]} */
+    const dispatched = []
+
+    session._handleMessage = async (message) => { dispatched.push(message) }
+
+    const firstFrame = buildClientFrame({
+      fin: true,
+      opcode: 0x1,
+      payload: Buffer.from(JSON.stringify({type: "metadata", data: {sequence: 1}}))
+    })
+    const secondFrame = buildClientFrame({
+      fin: true,
+      opcode: 0x1,
+      payload: Buffer.from(JSON.stringify({type: "metadata", data: {sequence: 2}}))
+    })
+
+    session.onData(firstFrame.subarray(0, 1))
+    session.onData(firstFrame.subarray(1, firstFrame.length - 3))
+    expect(dispatched.length).toBe(0)
+
+    session.onData(Buffer.concat([firstFrame.subarray(firstFrame.length - 3), secondFrame]))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(dispatched.map((message) => message.data.sequence)).toEqual([1, 2])
+  })
+
+  it("closes as soon as a single FIN frame declares an oversized payload", () => {
+    /** @type {Buffer[]} */
+    const emittedFrames = []
+    let handleCloseCalls = 0
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({
+        events: {
+          emit: (name, value) => {
+            if (name === "output" && value instanceof Buffer) emittedFrames.push(value)
+          }
+        },
+        remoteAddress: "127.0.0.1"
+      }),
+      configuration: dummyConfiguration
+    })
+    const header = Buffer.alloc(14)
+
+    header[0] = 0x81
+    header[1] = 0x80 | 127
+    header.writeBigUInt64BE(BigInt(16 * 1024 * 1024 + 1), 2)
+    header.writeUInt32BE(0x01020304, 10)
+    session._handleClose = () => { handleCloseCalls += 1 }
+
+    session.onData(header.subarray(0, 6))
+    expect(handleCloseCalls).toBe(0)
+    session.onData(header.subarray(6))
+
+    expect(handleCloseCalls).toBe(1)
+    expect(emittedFrames.some((frame) => frame[0] === 0x88)).toBe(true)
+  })
+
+  it("rejects unsafe 64-bit control-frame lengths before Number conversion", () => {
+    let handleCloseCalls = 0
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+    const header = Buffer.alloc(14)
+
+    header[0] = 0x89
+    header[1] = 0x80 | 127
+    header.writeBigUInt64BE(BigInt(Number.MAX_SAFE_INTEGER) + 1n, 2)
+    header.writeUInt32BE(0x01020304, 10)
+    session._handleClose = () => { handleCloseCalls += 1 }
+
+    session.onData(header)
+
+    expect(handleCloseCalls).toBe(1)
+    expect(session._bufferedBytes).toBe(0)
+  })
+
+  it("keeps queued chunk accounting exact across thousands of ordered frames", async () => {
+    const session = new WebsocketSession({
+      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
+      configuration: dummyConfiguration
+    })
+    /** @type {any[]} */
+    const dispatched = []
+    const frames = Array.from({length: 2000}, (_, sequence) => buildClientFrame({
+      fin: true,
+      opcode: 0x1,
+      payload: Buffer.from(JSON.stringify({type: "metadata", data: {sequence}}))
+    }))
+    const firstFrame = frames.shift()
+
+    if (!firstFrame) throw new Error("Expected a first frame")
+
+    session._handleMessage = async (message) => { dispatched.push(message) }
+    session.onData(firstFrame.subarray(0, firstFrame.length - 1))
+    session.onData(Buffer.concat([firstFrame.subarray(firstFrame.length - 1), ...frames]))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(dispatched.map((message) => message.data.sequence)).toEqual(Array.from({length: 2000}, (_, index) => index))
+    expect(session._bufferedBytes).toBe(0)
+    expect(session._bufferChunks.length).toBe(0)
+    expect(session._bufferChunkIndex).toBe(0)
+    expect(session._bufferChunkOffset).toBe(0)
+  })
+
   it("reassembles a channel-subscribe split across continuation frames", async () => {
     const session = new WebsocketSession({
       client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),

--- a/spec/http-server/websocket-fragmented-frames-spec.js
+++ b/spec/http-server/websocket-fragmented-frames-spec.js
@@ -1,9 +1,69 @@
 // @ts-check
 
 import {describe, expect, it} from "../../src/testing/test.js"
-import EventEmitter from "../../src/utils/event-emitter.js"
+import HttpServerClient from "../../src/http-server/client/index.js"
 import WebsocketSession from "../../src/http-server/client/websocket-session.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+/**
+ * Builds a session around the real HTTP server client contract.
+ * @param {import("../../src/configuration-types.js").WebsocketMessageHandler} [messageHandler] - Message observer.
+ * @returns {{client: HttpServerClient, session: WebsocketSession}}
+ */
+function buildSession(messageHandler) {
+  const client = new HttpServerClient({
+    clientCount: 1,
+    configuration: dummyConfiguration,
+    remoteAddress: "127.0.0.1"
+  })
+  const session = new WebsocketSession({
+    client,
+    configuration: dummyConfiguration,
+    messageHandler
+  })
+
+  return {client, session}
+}
+
+/**
+ * Narrows a decoded message value at the raw handler boundary.
+ * @param {?} value - Decoded message value.
+ * @param {string} description - Expected value description.
+ * @returns {Record<string, ?>}
+ */
+function expectRecord(value, description) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Expected ${description} to be an object`)
+  }
+
+  return value
+}
+
+/**
+ * Returns a required numeric property from a decoded message.
+ * @param {Record<string, ?>} record - Message record.
+ * @param {string} property - Property name.
+ * @returns {number}
+ */
+function expectNumberProperty(record, property) {
+  const value = record[property]
+
+  if (typeof value !== "number") throw new Error(`Expected ${property} to be a number`)
+  return value
+}
+
+/**
+ * Returns a required string property from a decoded message.
+ * @param {Record<string, ?>} record - Message record.
+ * @param {string} property - Property name.
+ * @returns {string}
+ */
+function expectStringProperty(record, property) {
+  const value = record[property]
+
+  if (typeof value !== "string") throw new Error(`Expected ${property} to be a string`)
+  return value
+}
 
 /**
  * Builds a single client→server websocket frame with mandatory masking,
@@ -43,15 +103,15 @@ function buildClientFrame({fin, opcode, payload}) {
 
 describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: true}}, () => {
   it("buffers one large FIN frame in TCP-sized chunks with bounded copying", async () => {
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
+    /** @type {number[]} */
+    const dispatchedContentLengths = []
+    const {session} = buildSession({
+      onMessage: ({message}) => {
+        const data = expectRecord(expectRecord(message, "message").data, "message data")
+
+        dispatchedContentLengths.push(expectStringProperty(data, "contents").length)
+      }
     })
-
-    /** @type {any[]} */
-    const dispatched = []
-
-    session._handleMessage = async (message) => { dispatched.push(message) }
 
     const body = JSON.stringify({
       type: "metadata",
@@ -76,21 +136,20 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
 
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(dispatched.length).toBe(1)
-    expect(dispatched[0].data.contents.length).toBe(2 * 1024 * 1024)
+    expect(dispatchedContentLengths).toEqual([2 * 1024 * 1024])
     expect(session._bufferedFrameCopyBytes).toBeLessThanOrEqual(frame.length)
   })
 
   it("keeps incomplete payloads queued and processes following frames in order", async () => {
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
+    /** @type {number[]} */
+    const dispatchedSequences = []
+    const {session} = buildSession({
+      onMessage: ({message}) => {
+        const data = expectRecord(expectRecord(message, "message").data, "message data")
+
+        dispatchedSequences.push(expectNumberProperty(data, "sequence"))
+      }
     })
-
-    /** @type {any[]} */
-    const dispatched = []
-
-    session._handleMessage = async (message) => { dispatched.push(message) }
 
     const firstFrame = buildClientFrame({
       fin: true,
@@ -105,72 +164,63 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
 
     session.onData(firstFrame.subarray(0, 1))
     session.onData(firstFrame.subarray(1, firstFrame.length - 3))
-    expect(dispatched.length).toBe(0)
+    expect(dispatchedSequences.length).toBe(0)
 
     session.onData(Buffer.concat([firstFrame.subarray(firstFrame.length - 3), secondFrame]))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(dispatched.map((message) => message.data.sequence)).toEqual([1, 2])
+    expect(dispatchedSequences).toEqual([1, 2])
   })
 
   it("closes as soon as a single FIN frame declares an oversized payload", () => {
     /** @type {Buffer[]} */
     const emittedFrames = []
-    let handleCloseCalls = 0
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({
-        events: {
-          emit: (name, value) => {
-            if (name === "output" && value instanceof Buffer) emittedFrames.push(value)
-          }
-        },
-        remoteAddress: "127.0.0.1"
-      }),
-      configuration: dummyConfiguration
-    })
+    let closeEvents = 0
+    const {client, session} = buildSession()
     const header = Buffer.alloc(14)
 
+    client.events.on("output", (value) => {
+      if (value instanceof Buffer) emittedFrames.push(value)
+    })
+    session.events.on("close", () => { closeEvents += 1 })
     header[0] = 0x81
     header[1] = 0x80 | 127
     header.writeBigUInt64BE(BigInt(16 * 1024 * 1024 + 1), 2)
     header.writeUInt32BE(0x01020304, 10)
-    session._handleClose = () => { handleCloseCalls += 1 }
-
     session.onData(header.subarray(0, 6))
-    expect(handleCloseCalls).toBe(0)
+    expect(closeEvents).toBe(0)
     session.onData(header.subarray(6))
 
-    expect(handleCloseCalls).toBe(1)
+    expect(closeEvents).toBe(1)
     expect(emittedFrames.some((frame) => frame[0] === 0x88)).toBe(true)
   })
 
   it("rejects unsafe 64-bit control-frame lengths before Number conversion", () => {
-    let handleCloseCalls = 0
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
-    })
+    let closeEvents = 0
+    const {session} = buildSession()
     const header = Buffer.alloc(14)
 
+    session.events.on("close", () => { closeEvents += 1 })
     header[0] = 0x89
     header[1] = 0x80 | 127
     header.writeBigUInt64BE(BigInt(Number.MAX_SAFE_INTEGER) + 1n, 2)
     header.writeUInt32BE(0x01020304, 10)
-    session._handleClose = () => { handleCloseCalls += 1 }
-
     session.onData(header)
 
-    expect(handleCloseCalls).toBe(1)
+    expect(closeEvents).toBe(1)
     expect(session._bufferedBytes).toBe(0)
   })
 
   it("keeps queued chunk accounting exact across thousands of ordered frames", async () => {
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
+    /** @type {number[]} */
+    const dispatchedSequences = []
+    const {session} = buildSession({
+      onMessage: ({message}) => {
+        const data = expectRecord(expectRecord(message, "message").data, "message data")
+
+        dispatchedSequences.push(expectNumberProperty(data, "sequence"))
+      }
     })
-    /** @type {any[]} */
-    const dispatched = []
     const frames = Array.from({length: 2000}, (_, sequence) => buildClientFrame({
       fin: true,
       opcode: 0x1,
@@ -180,12 +230,11 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
 
     if (!firstFrame) throw new Error("Expected a first frame")
 
-    session._handleMessage = async (message) => { dispatched.push(message) }
     session.onData(firstFrame.subarray(0, firstFrame.length - 1))
     session.onData(Buffer.concat([firstFrame.subarray(firstFrame.length - 1), ...frames]))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(dispatched.map((message) => message.data.sequence)).toEqual(Array.from({length: 2000}, (_, index) => index))
+    expect(dispatchedSequences).toEqual(Array.from({length: 2000}, (_, index) => index))
     expect(session._bufferedBytes).toBe(0)
     expect(session._bufferChunks.length).toBe(0)
     expect(session._bufferChunkIndex).toBe(0)
@@ -193,15 +242,20 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
   })
 
   it("reassembles a channel-subscribe split across continuation frames", async () => {
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
-    })
-
-    /** @type {any[]} */
+    /** @type {Array<{channelType: string, subscriptionId: string, authenticationTokenLength: number}>} */
     const dispatched = []
+    const {session} = buildSession({
+      onMessage: ({message}) => {
+        const record = expectRecord(message, "message")
+        const params = expectRecord(record.params, "message params")
 
-    session._handleMessage = async (message) => { dispatched.push(message) }
+        dispatched.push({
+          authenticationTokenLength: expectStringProperty(params, "authenticationToken").length,
+          channelType: expectStringProperty(record, "channelType"),
+          subscriptionId: expectStringProperty(record, "subscriptionId")
+        })
+      }
+    })
 
     const body = JSON.stringify({
       type: "channel-subscribe",
@@ -225,33 +279,31 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
 
     session.onData(Buffer.concat([firstFrame, continuationFrame]))
 
-    // Synchronous parse → _handleMessage() runs in the event loop.
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(dispatched.length).toBe(1)
-    expect(dispatched[0]).toMatchObject({
-      type: "channel-subscribe",
+    expect(dispatched).toEqual([{
+      authenticationTokenLength: 4096,
       subscriptionId: "s1",
       channelType: "ticket-scans"
-    })
-    expect(dispatched[0].params.authenticationToken.length).toBe(4096)
+    }])
   })
 
   it("handles a PING interleaved between fragments without losing the data message", async () => {
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
+    /** @type {string[]} */
+    const dispatchedLocales = []
+    /** @type {Buffer[]} */
+    const emittedFrames = []
+    const {client, session} = buildSession({
+      onMessage: ({message}) => {
+        const data = expectRecord(expectRecord(message, "message").data, "message data")
+
+        dispatchedLocales.push(expectStringProperty(data, "locale"))
+      }
     })
 
-    /** @type {any[]} */
-    const dispatched = []
-    /** @type {Array<{opcode: number, payload: Buffer}>} */
-    const sentControlFrames = []
-
-    session._handleMessage = async (message) => { dispatched.push(message) }
-    session._sendControlFrame = (opcode, payload) => {
-      sentControlFrames.push({opcode, payload: Buffer.from(payload)})
-    }
+    client.events.on("output", (value) => {
+      if (value instanceof Buffer) emittedFrames.push(value)
+    })
 
     const body = JSON.stringify({type: "metadata", data: {locale: "en"}})
     const payload = Buffer.from(body, "utf-8")
@@ -276,33 +328,23 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
     session.onData(Buffer.concat([firstFrame, pingFrame, continuationFrame]))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(sentControlFrames.length).toBe(1)
-    expect(sentControlFrames[0].opcode).toBe(0xA) // PONG
-    expect(sentControlFrames[0].payload.toString("utf-8")).toBe("ping")
-
-    expect(dispatched.length).toBe(1)
-    expect(dispatched[0]).toMatchObject({type: "metadata", data: {locale: "en"}})
+    expect(emittedFrames.length).toBe(1)
+    expect(emittedFrames[0].toString("hex")).toBe("8a0470696e67")
+    expect(dispatchedLocales).toEqual(["en"])
   })
 
   it("closes the connection when a fragmented message exceeds the per-fragment count cap", async () => {
     /** @type {Buffer[]} */
     const emittedFrames = []
-    let handleCloseCalls = 0
-
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({
-        events: {
-          emit: (name, value) => {
-            if (name === "output" && value instanceof Buffer) emittedFrames.push(value)
-          }
-        },
-        remoteAddress: "127.0.0.1"
-      }),
-      configuration: dummyConfiguration
+    let closeEvents = 0
+    const {client, session} = buildSession({
+      onMessage: () => { throw new Error("should not dispatch when caps are exceeded") }
     })
 
-    session._handleMessage = async () => { throw new Error("should not dispatch when caps are exceeded") }
-    session._handleClose = () => { handleCloseCalls += 1 }
+    client.events.on("output", (value) => {
+      if (value instanceof Buffer) emittedFrames.push(value)
+    })
+    session.events.on("close", () => { closeEvents += 1 })
 
     const chunkBodies = Array.from({length: 3000}, () => Buffer.from("x"))
     const framesIn = []
@@ -315,7 +357,7 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
     session.onData(Buffer.concat(framesIn))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(handleCloseCalls).toBe(1)
+    expect(closeEvents).toBe(1)
     // Close frame emitted (opcode 0x8 with FIN=1).
     expect(emittedFrames.length).toBeGreaterThan(0)
     expect(emittedFrames.some((frame) => frame[0] === 0x88)).toBe(true)
@@ -324,15 +366,13 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
   })
 
   it("still processes a single-frame message after a fragmented message", async () => {
-    const session = new WebsocketSession({
-      client: /** @type {any} */ ({events: new EventEmitter(), remoteAddress: "127.0.0.1"}),
-      configuration: dummyConfiguration
+    /** @type {string[]} */
+    const dispatchedTypes = []
+    const {session} = buildSession({
+      onMessage: ({message}) => {
+        dispatchedTypes.push(expectStringProperty(expectRecord(message, "message"), "type"))
+      }
     })
-
-    /** @type {any[]} */
-    const dispatched = []
-
-    session._handleMessage = async (message) => { dispatched.push(message) }
 
     const firstBody = JSON.stringify({type: "channel-subscribe", subscriptionId: "s1", channelType: "c"})
     const firstPayload = Buffer.from(firstBody, "utf-8")
@@ -351,8 +391,6 @@ describe("WebsocketSession fragmented frames", {databaseCleaning: {transaction: 
     session.onData(Buffer.concat([fragA, fragB, secondFrame]))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(dispatched.length).toBe(2)
-    expect(dispatched[0]).toMatchObject({type: "channel-subscribe", subscriptionId: "s1"})
-    expect(dispatched[1]).toMatchObject({type: "metadata", data: {theme: "dark"}})
+    expect(dispatchedTypes).toEqual(["channel-subscribe", "metadata"])
   })
 })

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -23,6 +23,11 @@ const WEBSOCKET_PAUSED_QUEUE_CAP = 1000
 /** Cap on total bytes buffered for a single fragmented message. */
 const WEBSOCKET_MAX_FRAGMENTED_MESSAGE_BYTES = 16 * 1024 * 1024
 
+/** Cap on payload bytes buffered for a single final data frame. */
+const WEBSOCKET_MAX_FINAL_FRAME_BYTES = WEBSOCKET_MAX_FRAGMENTED_MESSAGE_BYTES
+
+const WEBSOCKET_MAX_INBOUND_FRAME_BYTES_BIGINT = BigInt(WEBSOCKET_MAX_FINAL_FRAME_BYTES)
+
 /** Cap on fragment count for a single fragmented message. */
 const WEBSOCKET_MAX_FRAGMENTED_MESSAGE_FRAGMENTS = 1024
 
@@ -97,7 +102,12 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @param {Promise<import("../../configuration-types.js").WebsocketMessageHandler | void>} [args.messageHandlerPromise] - Optional raw message handler promise.
    */
   constructor({client, configuration, upgradeRequest, messageHandler, messageHandlerPromise}) {
-    this.buffer = Buffer.alloc(0)
+    /** @type {Buffer[]} */
+    this._bufferChunks = []
+    this._bufferChunkIndex = 0
+    this._bufferChunkOffset = 0
+    this._bufferedBytes = 0
+    this._bufferedFrameCopyBytes = 0
     this.client = client
     this.configuration = configuration
     this.upgradeRequest = upgradeRequest
@@ -301,7 +311,10 @@ export default class VelociousHttpServerClientWebsocketSession {
     // socket is alive. Mark it here, before `_processBuffer` may return
     // early waiting for the rest of an incomplete frame.
     this._heartbeatAlive = true
-    this.buffer = Buffer.concat([this.buffer, data])
+    if (data.length === 0) return
+
+    this._bufferChunks.push(data)
+    this._bufferedBytes += data.length
     this._processBuffer()
   }
 
@@ -588,9 +601,10 @@ export default class VelociousHttpServerClientWebsocketSession {
    * @returns {void} - No return value.
    */
   _processBuffer() {
-    while (this.buffer.length >= 2) {
-      const firstByte = this.buffer[0]
-      const secondByte = this.buffer[1]
+    while (this._bufferedBytes >= 2) {
+      const initialHeader = this._peekBufferedBytes(2)
+      const firstByte = initialHeader[0]
+      const secondByte = initialHeader[1]
       const isFinal = (firstByte & WEBSOCKET_FINAL_FRAME) === WEBSOCKET_FINAL_FRAME
       const opcode = firstByte & 0x0F
       const isMasked = (secondByte & 0x80) === 0x80
@@ -598,12 +612,21 @@ export default class VelociousHttpServerClientWebsocketSession {
       let offset = 2
 
       if (payloadLength === 126) {
-        if (this.buffer.length < offset + 2) return
-        payloadLength = this.buffer.readUInt16BE(offset)
+        if (this._bufferedBytes < offset + 2) return
+        payloadLength = this._peekBufferedBytes(offset + 2).readUInt16BE(offset)
         offset += 2
       } else if (payloadLength === 127) {
-        if (this.buffer.length < offset + 8) return
-        const bigLength = this.buffer.readBigUInt64BE(offset)
+        if (this._bufferedBytes < offset + 8) return
+        const bigLength = this._peekBufferedBytes(offset + 8).readBigUInt64BE(offset)
+
+        if (bigLength > WEBSOCKET_MAX_INBOUND_FRAME_BYTES_BIGINT) {
+          this.logger.warn(() => [
+            "Websocket frame exceeded byte cap; closing connection",
+            {frameBytes: bigLength.toString(), maxBytes: WEBSOCKET_MAX_FINAL_FRAME_BYTES}
+          ])
+          this._closeForInboundLimit()
+          return
+        }
 
         payloadLength = Number(bigLength)
         offset += 8
@@ -611,17 +634,19 @@ export default class VelociousHttpServerClientWebsocketSession {
 
       const maskLength = isMasked ? 4 : 0
 
-      if (this.buffer.length < offset + maskLength + payloadLength) return
+      const frameLength = offset + maskLength + payloadLength
+
+      if (this._bufferedBytes < frameLength) return
+
+      const frame = this._consumeBufferedBytes(frameLength)
 
       /** @type {Buffer} */
-      let payload = this.buffer.slice(offset + maskLength, offset + maskLength + payloadLength)
+      let payload = frame.subarray(offset + maskLength, frameLength)
 
       if (isMasked) {
-        const mask = this.buffer.slice(offset, offset + maskLength)
-        payload = this._unmaskPayload(payload, mask)
+        const mask = frame.subarray(offset, offset + maskLength)
+        this._unmaskPayload(payload, mask)
       }
-
-      this.buffer = this.buffer.slice(offset + maskLength + payloadLength)
 
       // Control frames (opcode >= 0x8) must not be fragmented per
       // RFC 6455 and can arrive interleaved with a fragmented data
@@ -727,6 +752,97 @@ export default class VelociousHttpServerClientWebsocketSession {
   }
 
   /**
+   * Copies the leading buffered bytes without consuming them. Header
+   * inspection is bounded to the websocket header size.
+   * @param {number} byteCount - Number of leading bytes to inspect.
+   * @returns {Buffer} - Copied prefix.
+   */
+  _peekBufferedBytes(byteCount) {
+    const prefix = Buffer.allocUnsafe(byteCount)
+    let copiedBytes = 0
+    let chunkOffset = this._bufferChunkOffset
+
+    for (let chunkIndex = this._bufferChunkIndex; chunkIndex < this._bufferChunks.length; chunkIndex += 1) {
+      const chunk = this._bufferChunks[chunkIndex]
+      const bytesFromChunk = Math.min(chunk.length - chunkOffset, byteCount - copiedBytes)
+
+      chunk.copy(prefix, copiedBytes, chunkOffset, chunkOffset + bytesFromChunk)
+      copiedBytes += bytesFromChunk
+      chunkOffset = 0
+      if (copiedBytes === byteCount) break
+    }
+
+    return prefix
+  }
+
+  /**
+   * Consumes a complete frame from the chunk queue with one bounded copy.
+   * @param {number} byteCount - Complete frame byte count.
+   * @returns {Buffer} - Contiguous frame bytes.
+   */
+  _consumeBufferedBytes(byteCount) {
+    const result = Buffer.allocUnsafe(byteCount)
+    let copiedBytes = 0
+
+    while (copiedBytes < byteCount) {
+      const chunk = this._bufferChunks[this._bufferChunkIndex]
+      const bytesFromChunk = Math.min(chunk.length - this._bufferChunkOffset, byteCount - copiedBytes)
+
+      chunk.copy(
+        result,
+        copiedBytes,
+        this._bufferChunkOffset,
+        this._bufferChunkOffset + bytesFromChunk
+      )
+      copiedBytes += bytesFromChunk
+      this._bufferChunkOffset += bytesFromChunk
+
+      if (this._bufferChunkOffset === chunk.length) {
+        this._bufferChunkIndex += 1
+        this._bufferChunkOffset = 0
+      }
+    }
+
+    if (this._bufferChunkIndex === this._bufferChunks.length) {
+      this._bufferChunks = []
+      this._bufferChunkIndex = 0
+    } else if (
+      this._bufferChunkIndex >= 64 &&
+      this._bufferChunkIndex * 2 >= this._bufferChunks.length
+    ) {
+      this._bufferChunks = this._bufferChunks.slice(this._bufferChunkIndex)
+      this._bufferChunkIndex = 0
+    }
+
+    this._bufferedBytes -= byteCount
+    this._bufferedFrameCopyBytes += byteCount
+
+    return result
+  }
+
+  /**
+   * Drops all incomplete frame chunks.
+   * @returns {void}
+   */
+  _clearBufferedFrameChunks() {
+    this._bufferChunks = []
+    this._bufferChunkIndex = 0
+    this._bufferChunkOffset = 0
+    this._bufferedBytes = 0
+  }
+
+  /**
+   * Closes after an inbound buffering limit and releases all parser-owned input.
+   * @returns {void}
+   */
+  _closeForInboundLimit() {
+    this._resetFragmentBuffer()
+    this._clearBufferedFrameChunks()
+    this.sendGoodbye(this.client)
+    this._handleClose()
+  }
+
+  /**
    * Appends a continuation-frame payload to the in-progress
    * fragmented message. Returns true when the fragment was accepted
    * and false when the per-message cap was hit and the socket has
@@ -771,10 +887,7 @@ export default class VelociousHttpServerClientWebsocketSession {
       }
     ])
 
-    this._resetFragmentBuffer()
-    this.buffer = Buffer.alloc(0)
-    this.sendGoodbye(this.client)
-    this._handleClose()
+    this._closeForInboundLimit()
 
     return false
   }
@@ -1702,19 +1815,12 @@ export default class VelociousHttpServerClientWebsocketSession {
    * Runs unmask payload.
    * @param {Buffer} payload - Payload data.
    * @param {Buffer} mask - Mask.
-   * @returns {Buffer} - The unmask payload.
+   * @returns {void} - No return value.
    */
   _unmaskPayload(payload, mask) {
-    /**
-     * Result.
-     * @type {Buffer} */
-    const result = Buffer.alloc(payload.length)
-
     for (let i = 0; i < payload.length; i++) {
-      result[i] = payload[i] ^ mask[i % 4]
+      payload[i] ^= mask[i % 4]
     }
-
-    return result
   }
 
   async _runMessageHandlerOpen() {


### PR DESCRIPTION
## Summary

- replace cumulative WebSocket receive-buffer concatenation with chunk-queue parsing and amortized compaction
- reject oversized FIN frames and unsafe 64-bit lengths from headers before payload allocation
- unmask parser-owned frame buffers in place and preserve fragmented-message/control-frame behavior
- add large-frame, tiny-chunk, 2,000-frame ordering/accounting, and oversize regressions
- add a real parser-copy benchmark plus WebSocket buffering docs/changelog

## Validation

- focused + adjacent WebSocket protocol specs: 28/28 passed
- benchmark: exactly 1.00x parser copies at 1, 2, 4, and 8 MiB
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`

## Independent review

- exact staged patch SHA-256: `34b89db953c87f52201f49b976392410d8c9916445252dcdd24049d64f09152e`
- Threadwire/Codex exact-final review: PASS

## Task

AwesomeTasks task 10348 — Performance: avoid quadratic WebSocket partial-frame buffering
