### PR TITLE
Bound WebSocket outbound queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ Velocious includes a lightweight websocket entry point for API-style calls and s
 
 Inbound frames remain ordered when TCP splits a frame across reads. Velocious limits a single final client data frame and a reassembled fragmented message to 16 MiB; larger payloads close the connection.
 
-Server-to-client WebSocket delivery is bounded independently per client. The defaults retain at most 256 queued/in-flight frames or 16 MiB of serialized output; exact FIFO is preserved below both limits. A slow client that exceeds either limit is reported through the framework error events and deterministically closed without affecting other clients. Configure positive safe integers with `httpServer.websocketOutboundQueue.maxPendingFrames` and `maxPendingBytes`. See [WebSocket connections](docs/websocket-connections.md) for configuration and wire-protocol details.
+Server-to-client WebSocket delivery is bounded independently per client. The defaults retain at most 256 queued/in-flight completed frames or 16 MiB of serialized frame output; the HTTP 101 upgrade response and ordinary HTTP/file output remain outside that budget, while exact FIFO is preserved. A slow client that exceeds either limit is reported through the framework error events and deterministically closed without affecting other clients. V2 channel broadcast delivery and persistence remain isolated to the originating configuration when several applications share a process. Configure positive safe integers with `httpServer.websocketOutboundQueue.maxPendingFrames` and `maxPendingBytes`. See [WebSocket connections](docs/websocket-connections.md) for configuration and wire-protocol details.
 
 ## Connect and call a controller
 

--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,9 @@ database: {
 
 Velocious includes a lightweight websocket entry point for API-style calls and server-side events.
 
-Inbound frames remain ordered when TCP splits a frame across reads. Velocious limits a single final client data frame and a reassembled fragmented message to 16 MiB; larger payloads close the connection. See [WebSocket connections](docs/websocket-connections.md) for wire-protocol details.
+Inbound frames remain ordered when TCP splits a frame across reads. Velocious limits a single final client data frame and a reassembled fragmented message to 16 MiB; larger payloads close the connection.
+
+Server-to-client WebSocket delivery is bounded independently per client. The defaults retain at most 256 queued/in-flight frames or 16 MiB of serialized output; exact FIFO is preserved below both limits. A slow client that exceeds either limit is reported through the framework error events and deterministically closed without affecting other clients. Configure positive safe integers with `httpServer.websocketOutboundQueue.maxPendingFrames` and `maxPendingBytes`. See [WebSocket connections](docs/websocket-connections.md) for configuration and wire-protocol details.
 
 ## Connect and call a controller
 

--- a/benchmark/websocket-outbound-queue.js
+++ b/benchmark/websocket-outbound-queue.js
@@ -1,0 +1,57 @@
+import ClientDeliveryQueue from "../src/http-server/client-delivery-queue.js"
+
+const frameBytes = 64 * 1024
+const maxBytes = 8 * 1024 * 1024
+const maxFrames = 256
+const attemptedFrames = 100_000
+let acceptedFrames = 0
+let overflowCount = 0
+let peakBytes = 0
+let peakFrames = 0
+const blockedWrite = new Promise(() => {})
+let queue
+
+queue = new ClientDeliveryQueue({
+  clientCount: 1,
+  maxBytes,
+  maxFrames,
+  onOverflow: () => {
+    overflowCount += 1
+    queue.destroy()
+  }
+})
+
+for (let index = 0; index < attemptedFrames; index += 1) {
+  const before = queue.snapshot()
+  const delivery = queue.enqueueFrame({
+    byteLength: frameBytes,
+    delivery: async () => await blockedWrite
+  })
+
+  if (!queue.destroyed) acceptedFrames += 1
+  peakBytes = Math.max(peakBytes, before.pendingBytes, queue.snapshot().pendingBytes)
+  peakFrames = Math.max(peakFrames, before.pendingFrames, queue.snapshot().pendingFrames)
+  void delivery.catch(() => {})
+}
+
+if (acceptedFrames !== maxBytes / frameBytes) {
+  throw new Error(`Expected ${maxBytes / frameBytes} accepted frames, got ${acceptedFrames}`)
+}
+if (overflowCount !== 1) throw new Error(`Expected one overflow, got ${overflowCount}`)
+if (peakBytes > maxBytes || peakFrames > maxFrames) {
+  throw new Error(`Queue exceeded its limits: ${peakFrames} frames / ${peakBytes} bytes`)
+}
+if (queue.snapshot().pendingBytes !== 0 || queue.snapshot().pendingFrames !== 0) {
+  throw new Error("Destroyed queue retained accounting")
+}
+
+console.log(JSON.stringify({
+  acceptedFrames,
+  attemptedFrames,
+  maxBytes,
+  maxFrames,
+  overflowCount,
+  peakBytes,
+  peakFrames,
+  retainedAfterDestroy: queue.snapshot()
+}, null, 2))

--- a/changelog.d/20260725003000-websocket-outbound-queue-limits.md
+++ b/changelog.d/20260725003000-websocket-outbound-queue-limits.md
@@ -1,0 +1,1 @@
+Bound live per-client WebSocket outbound queues by frame count and serialized bytes, reporting and closing slow consumers on overflow.

--- a/changelog.d/20260725003000-websocket-outbound-queue-limits.md
+++ b/changelog.d/20260725003000-websocket-outbound-queue-limits.md
@@ -1,1 +1,1 @@
-Bound live per-client WebSocket outbound queues by frame count and serialized bytes, reporting and closing slow consumers on overflow.
+Bound live per-client WebSocket outbound queues by explicitly completed frame count and serialized bytes, excluding the HTTP upgrade response, report and close slow consumers on overflow, and isolate V2 broadcast fanout and persistence to the originating configuration.

--- a/docs/websocket-connections.md
+++ b/docs/websocket-connections.md
@@ -26,7 +26,9 @@ const configuration = new Configuration({
 })
 ```
 
-Byte accounting uses serialized output bytes, not JavaScript string length. Queued and in-flight buffers remain charged until the socket callback settles; socket close, error, or overflow teardown explicitly releases the queue. Limits are per client, so a stalled consumer cannot consume another client's allowance.
+Byte accounting uses serialized output bytes, not JavaScript string length. Only completed WebSocket frame emissions consume the frame and byte limits; the HTTP 101 upgrade response and ordinary HTTP/file output remain ordering-only operations outside that budget. Queued and in-flight frame buffers remain charged until the socket callback settles; socket close, error, or overflow teardown explicitly releases the queue. Limits are per client, so a stalled consumer cannot consume another client's allowance.
+
+V2 channel broadcasts retain their originating configuration identity through host and worker fanout. Delivery and event-log persistence are therefore isolated to that configuration even when multiple applications with identical channel and subscription names share a process. The internal `websocketEventsHost.broadcastV2(...)` transport now requires its `configuration` argument; application-facing `configuration.broadcastToChannel(...)` is unchanged.
 
 ### Client → server
 

--- a/docs/websocket-connections.md
+++ b/docs/websocket-connections.md
@@ -10,6 +10,24 @@ All messages are JSON objects sent over the shared WebSocket. Connection-related
 
 Velocious buffers TCP-fragmented WebSocket input as chunks and assembles each frame once it is complete. A single final client data frame is limited to 16 MiB, matching the existing cap for a fragmented message; a frame declaring a larger payload is rejected before its payload is buffered. Applications that need to send more data should split it at the application level.
 
+Server-to-client frames are also bounded per live client. The delivery queue retains at most 256 complete frames or 16 MiB by default, including the frame currently waiting for its socket write callback. FIFO order is exact while both limits are respected. If either next-frame admission would exceed its high-water mark, Velocious reports a `framework-error` and `all-error` with `context.websocketOutboundQueueOverflow === true`, then destroys only that client. It does not silently discard or coalesce protocol events.
+
+Configure both positive safe-integer limits at the configuration boundary:
+
+```js
+const configuration = new Configuration({
+  // ...
+  httpServer: {
+    websocketOutboundQueue: {
+      maxPendingFrames: 128,
+      maxPendingBytes: 8 * 1024 * 1024
+    }
+  }
+})
+```
+
+Byte accounting uses serialized output bytes, not JavaScript string length. Queued and in-flight buffers remain charged until the socket callback settles; socket close, error, or overflow teardown explicitly releases the queue. Limits are per client, so a stalled consumer cannot consume another client's allowance.
+
 ### Client → server
 
 ```json
@@ -109,6 +127,6 @@ connection.close()
 
 - Grace-period resumption after WS drop.
 - Message acks / deliverability guarantees.
-- Client-side or server-side outbound queues.
+- Client-side outbound queues.
 - Authorization hooks (`canOpen`) — app enforces via the current-user check inside `onConnect()` for now.
 - Typed `connection-request`/`connection-response` round-trips. Use `sendMessage` + your own correlation id for V1.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "benchmark:preloader-id-dedup": "node benchmark/preloader-id-dedup.js",
     "benchmark:mysql-result-row-materialization": "node benchmark/mysql-result-row-materialization.js",
     "benchmark:query-roundtrip-batching": "node benchmark/query-roundtrip-batching.js",
+    "benchmark:websocket-outbound-queue": "node benchmark/websocket-outbound-queue.js",
     "benchmark:websocket-frame-buffering": "node benchmark/websocket-frame-buffering.js",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:js && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",

--- a/spec/background-jobs/count-deltas-spec.js
+++ b/spec/background-jobs/count-deltas-spec.js
@@ -2,7 +2,10 @@
 
 import BackgroundJobsStore, {BACKGROUND_JOB_COUNTS_CHANNEL} from "../../src/background-jobs/store.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
-import {describe, expect, it} from "../../src/testing/test.js"
+import {afterEach, describe, expect, it} from "../../src/testing/test.js"
+
+/** @type {Set<import("../../src/http-server/websocket-channel.js").default>} */
+const registeredSubscriptions = new Set()
 
 /**
  * Builds one process-like store over shared prune state. Each store has its own
@@ -93,11 +96,20 @@ async function setupStore() {
   })
 
   dummyConfiguration._registerWebsocketChannelSubscription(BACKGROUND_JOB_COUNTS_CHANNEL, subscription)
+  registeredSubscriptions.add(subscription)
 
   return {events, revision, store}
 }
 
 describe("Background jobs - count deltas", {databaseCleaning: {truncate: true}}, () => {
+  afterEach(() => {
+    for (const subscription of registeredSubscriptions) {
+      dummyConfiguration._unregisterWebsocketChannelSubscription(BACKGROUND_JOB_COUNTS_CHANNEL, subscription)
+    }
+
+    registeredSubscriptions.clear()
+  })
+
   it("returns a canonical snapshot with a durable revision", async () => {
     const {revision, store} = await setupStore()
 

--- a/spec/beacon/configuration-integration-spec.js
+++ b/spec/beacon/configuration-integration-spec.js
@@ -147,7 +147,7 @@ describe("Beacon configuration integration", {databaseCleaning: {transaction: fa
     const publisherConfig = buildConfiguration({beacon: {host: "127.0.0.1", port}})
     const subscriberConfig = buildConfiguration({beacon: {host: "127.0.0.1", port}})
 
-    /** @type {Array<{channel: string, broadcastParams: Record<string, any>, body: any}>} */
+    /** @type {Array<{channel: string, broadcastParams: Record<string, any>, body: any, configuration: Configuration}>} */
     const captured = []
 
     /** @type {any} */
@@ -173,6 +173,7 @@ describe("Beacon configuration integration", {databaseCleaning: {transaction: fa
     expect(captured[0].channel).toBe("frontend-models")
     expect(captured[0].broadcastParams).toEqual({model: "Build"})
     expect(captured[0].body).toEqual({action: "update", id: "42"})
+    expect(captured[0].configuration).toBe(subscriberConfig)
 
     await publisherConfig.disconnectBeacon()
     await subscriberConfig.disconnectBeacon()

--- a/spec/http-server/client-delivery-queue-spec.js
+++ b/spec/http-server/client-delivery-queue-spec.js
@@ -1,0 +1,105 @@
+// @ts-check
+
+import ClientDeliveryQueue from "../../src/http-server/client-delivery-queue.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/**
+ * @returns {{promise: Promise<void>, resolve: () => void}} - Manually resolved delivery.
+ */
+function deferredDelivery() {
+  let resolve
+  const promise = new Promise((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return {promise, resolve}
+}
+
+describe("HttpServer - client delivery queue", {databaseCleaning: {transaction: true}}, () => {
+  it("preserves FIFO at both exact high-water boundaries and releases accounting on completion", async () => {
+    const deliveries = []
+    const first = deferredDelivery()
+    const second = deferredDelivery()
+    const queue = new ClientDeliveryQueue({
+      clientCount: 1,
+      maxBytes: 6,
+      maxFrames: 2,
+      onOverflow: () => {
+        throw new Error("Unexpected overflow")
+      }
+    })
+    const firstQueued = queue.enqueueFrame({
+      byteLength: 3,
+      delivery: async () => {
+        deliveries.push("first")
+        await first.promise
+      }
+    })
+    const secondQueued = queue.enqueueFrame({
+      byteLength: 3,
+      delivery: async () => {
+        deliveries.push("second")
+        await second.promise
+      }
+    })
+
+    expect(deliveries).toEqual(["first"])
+    expect(queue.snapshot()).toEqual({pendingBytes: 6, pendingFrames: 2})
+
+    first.resolve()
+    await firstQueued
+    expect(deliveries).toEqual(["first", "second"])
+    expect(queue.snapshot()).toEqual({pendingBytes: 3, pendingFrames: 1})
+
+    second.resolve()
+    await secondQueued
+    expect(queue.snapshot()).toEqual({pendingBytes: 0, pendingFrames: 0})
+  })
+
+  it("reports overflow once and explicitly releases queued and in-flight accounting", async () => {
+    const blocked = deferredDelivery()
+    const overflows = []
+    const queue = new ClientDeliveryQueue({
+      clientCount: 2,
+      maxBytes: 4,
+      maxFrames: 2,
+      onOverflow: (error) => {
+        overflows.push(error)
+        queue.destroy()
+      }
+    })
+    const active = queue.enqueueFrame({byteLength: 2, delivery: async () => await blocked.promise})
+    const queued = queue.enqueueFrame({byteLength: 2, delivery: async () => {}})
+
+    await expect(() => queue.enqueueFrame({byteLength: 1, delivery: async () => {}})).toThrow(/exceeded its outbound queue limit/u)
+    await active
+    await queued
+
+    expect(overflows.length).toEqual(1)
+    expect(queue.snapshot()).toEqual({pendingBytes: 0, pendingFrames: 0})
+
+    blocked.resolve()
+    queue.destroy()
+    expect(overflows.length).toEqual(1)
+  })
+
+  it("isolates accounting, completion, and teardown between clients", async () => {
+    const firstBlocked = deferredDelivery()
+    const secondBlocked = deferredDelivery()
+    const firstQueue = new ClientDeliveryQueue({clientCount: 3, maxBytes: 2, maxFrames: 1, onOverflow: () => firstQueue.destroy()})
+    const secondQueue = new ClientDeliveryQueue({clientCount: 4, maxBytes: 2, maxFrames: 1, onOverflow: () => secondQueue.destroy()})
+    const firstDelivery = firstQueue.enqueueFrame({byteLength: 2, delivery: async () => await firstBlocked.promise})
+    const secondDelivery = secondQueue.enqueueFrame({byteLength: 2, delivery: async () => await secondBlocked.promise})
+
+    await expect(() => firstQueue.enqueueFrame({byteLength: 1, delivery: async () => {}})).toThrow(/exceeded its outbound queue limit/u)
+    expect(firstQueue.snapshot()).toEqual({pendingBytes: 0, pendingFrames: 0})
+    expect(secondQueue.snapshot()).toEqual({pendingBytes: 2, pendingFrames: 1})
+
+    secondBlocked.resolve()
+    await secondDelivery
+    await firstDelivery
+
+    expect(secondQueue.snapshot()).toEqual({pendingBytes: 0, pendingFrames: 0})
+    firstBlocked.resolve()
+  })
+})

--- a/spec/http-server/server-client-spec.js
+++ b/spec/http-server/server-client-spec.js
@@ -73,6 +73,22 @@ class SlowFakeSocket extends FakeSocket {
   }
 }
 
+class BlockedWriteSocket extends FakeSocket {
+  /** @type {Array<(error?: Error) => void>} */
+  writeCallbacks = []
+
+  /**
+   * @param {string | Uint8Array} _data - Data payload.
+   * @param {(error?: Error) => void} [callback] - Callback.
+   * @returns {boolean} - False while the write is blocked.
+   */
+  write(_data, callback) {
+    if (callback) this.writeCallbacks.push(callback)
+
+    return false
+  }
+}
+
 /** @returns {Configuration} - Minimal server-client test configuration. */
 function buildConfiguration() {
   return new Configuration({
@@ -89,6 +105,34 @@ function buildConfiguration() {
 }
 
 describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, () => {
+  it("validates WebSocket outbound queue defaults and configured high-water marks", async () => {
+    const defaults = buildConfiguration()
+    const configured = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      httpServer: {websocketOutboundQueue: {maxPendingBytes: 1024, maxPendingFrames: 8}},
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      logging: {console: false, file: false}
+    })
+
+    expect(defaults.getWebsocketOutboundQueueLimits()).toEqual({maxBytes: 16 * 1024 * 1024, maxFrames: 256})
+    expect(configured.getWebsocketOutboundQueueLimits()).toEqual({maxBytes: 1024, maxFrames: 8})
+
+    const invalidValues = [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.POSITIVE_INFINITY]
+    for (const invalidValue of invalidValues) {
+      await expect(() => new Configuration({
+        database: {test: {}},
+        environmentHandler: new EnvironmentHandlerNode(),
+        httpServer: {websocketOutboundQueue: {maxPendingBytes: invalidValue}}
+      })).toThrow(/maxPendingBytes must be a positive safe integer/u)
+    }
+  })
+
   it("handles socket errors without crashing and emits close once", async () => {
     const configuration = buildConfiguration()
     const socket = new FakeSocket()
@@ -115,6 +159,24 @@ describe("HttpServer - server client", {databaseCleaning: {transaction: true}}, 
 
     socket.emitWriteError = true
     await client.send("should-not-hang")
+  })
+
+  it("keeps send pending until the socket write callback settles", async () => {
+    const socket = new BlockedWriteSocket()
+    const client = new ServerClient({clientCount: 7, configuration: buildConfiguration(), socket})
+    let settled = false
+    const sending = client.send("blocked-frame").then(() => {
+      settled = true
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(settled).toEqual(false)
+    expect(socket.writeCallbacks.length).toEqual(1)
+
+    socket.writeCallbacks.shift()?.()
+    await sending
+
+    expect(settled).toEqual(true)
   })
 
   it("resolves end immediately for already closed sockets", async () => {

--- a/spec/http-server/websocket-channel-spec.js
+++ b/spec/http-server/websocket-channel-spec.js
@@ -84,6 +84,24 @@ async function expectRejectedSubscription(subscription) {
 }
 
 describe("WebsocketChannelV2 ()", {databaseCleaning: {transaction: true}}, () => {
+  it("establishes a connection when one completed frame fits the outbound budget", async () => {
+    await Dummy.run(async () => {
+      const client = new WebsocketClient()
+      const queueConfiguration = dummyConfiguration.httpServer.websocketOutboundQueue
+      const previousMaxPendingFrames = queueConfiguration.maxPendingFrames
+
+      queueConfiguration.maxPendingFrames = 1
+
+      try {
+        await client.connect()
+        expect(client.isOpen()).toBe(true)
+      } finally {
+        queueConfiguration.maxPendingFrames = previousMaxPendingFrames
+        await client.close()
+      }
+    })
+  })
+
   it("queues channel subscriptions until the network monitor reports online", async () => {
     await Dummy.run(async () => {
       const {client, setOnline} = reconnectingClientWithManualNetwork(false)

--- a/spec/http-server/websocket-events-host-spec.js
+++ b/spec/http-server/websocket-events-host-spec.js
@@ -1,9 +1,35 @@
 // @ts-check
 
 import {describe, expect, it} from "../../src/testing/test.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
 import {VelociousHttpServerWebsocketEventsHost} from "../../src/http-server/websocket-events-host.js"
 
 describe("HttpServer - websocket events host", {databaseCleaning: {transaction: true}}, () => {
+  it("keeps broadcast handlers separate from subscription debug state", () => {
+    const host = new VelociousHttpServerWebsocketEventsHost()
+    const subscription = {debugSnapshot: () => ({topic: "debug"})}
+    const handler = {
+      configuration: dummyConfiguration,
+      dispatchWebsocketV2Broadcast: () => {},
+      websocketV2BroadcastDispatchKey: () => dummyConfiguration
+    }
+
+    dummyConfiguration._registerWebsocketChannelSubscription("RegistrySeparation", /** @type {?} */ (subscription))
+    const unregister = host.register(/** @type {?} */ (handler))
+
+    expect(dummyConfiguration._websocketChannelSubscriptions.get("RegistrySeparation")).toEqual(new Set([subscription]))
+    expect(host.broadcastHandlersByConfiguration.get(dummyConfiguration)).toEqual(new Set([handler]))
+    expect(dummyConfiguration.getLocalDebugSnapshot().websockets.subscriptions.find(({channel}) => channel === "RegistrySeparation")).toEqual({
+      channel: "RegistrySeparation",
+      count: 1,
+      details: [{count: 1, details: {topic: "debug"}}]
+    })
+
+    unregister()
+    dummyConfiguration._unregisterWebsocketChannelSubscription("RegistrySeparation", /** @type {?} */ (subscription))
+    expect(host.broadcastHandlersByConfiguration.has(dummyConfiguration)).toEqual(false)
+  })
+
   it("isolates configuration-local broadcasts and deduplicates shared in-process handlers", async () => {
     const host = new VelociousHttpServerWebsocketEventsHost()
     const configurationA = {

--- a/spec/http-server/websocket-events-host-spec.js
+++ b/spec/http-server/websocket-events-host-spec.js
@@ -1,0 +1,50 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {VelociousHttpServerWebsocketEventsHost} from "../../src/http-server/websocket-events-host.js"
+
+describe("HttpServer - websocket events host", {databaseCleaning: {transaction: true}}, () => {
+  it("isolates configuration-local broadcasts and deduplicates shared in-process handlers", async () => {
+    const host = new VelociousHttpServerWebsocketEventsHost()
+    const configurationA = {
+      withoutCurrentConnectionContexts: async (callback) => await callback()
+    }
+    const configurationB = {
+      withoutCurrentConnectionContexts: async (callback) => await callback()
+    }
+    const deliveries = []
+
+    for (const mountContext of ["a-1", "a-2"]) {
+      host.register({
+        configuration: configurationA,
+        dispatchWebsocketV2Broadcast: ({body}) => deliveries.push({body, configuration: "A", mountContext}),
+        websocketV2BroadcastDispatchKey: () => configurationA
+      })
+    }
+
+    host.register({
+      configuration: configurationB,
+      dispatchWebsocketV2Broadcast: ({body}) => deliveries.push({body, configuration: "B", mountContext: "b-1"}),
+      websocketV2BroadcastDispatchKey: () => configurationB
+    })
+
+    host.broadcastV2({
+      body: {count: 1},
+      broadcastParams: {subscription: "shared"},
+      channel: "Counter",
+      configuration: configurationA
+    })
+    host.broadcastV2({
+      body: {count: 2},
+      broadcastParams: {subscription: "shared"},
+      channel: "Counter",
+      configuration: configurationB
+    })
+    await host.awaitPendingBroadcasts()
+
+    expect(deliveries).toEqual([
+      {body: {count: 1}, configuration: "A", mountContext: "a-1"},
+      {body: {count: 2}, configuration: "B", mountContext: "b-1"}
+    ])
+  })
+})

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -115,6 +115,44 @@ function buildHandlerConfiguration({maxBytes = 16 * 1024 * 1024, maxFrames = 256
 }
 
 describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}}, () => {
+  it("tags only explicitly completed frames across the worker boundary", () => {
+    const {postedMessages, workerThread} = buildWorkerThread()
+
+    workerThread.handleNewClient({clientCount: 99, remoteAddress: "127.0.0.1"})
+    workerThread.clients[99].events.emit("output", "HTTP/1.1 101 Switching Protocols\r\n\r\n")
+    workerThread.clients[99].events.emit("output", Buffer.from([0x81, 0x00]), {websocketFrame: true})
+
+    expect(postedMessages.map(({clientCount, command, websocketFrame}) => ({clientCount, command, websocketFrame}))).toEqual([
+      {clientCount: 99, command: "clientOutput", websocketFrame: false},
+      {clientCount: 99, command: "clientOutput", websocketFrame: true}
+    ])
+    expect(postedMessages[0].output).toEqual("HTTP/1.1 101 Switching Protocols\r\n\r\n")
+    expect(Array.from(postedMessages[1].output)).toEqual([0x81, 0x00])
+  })
+
+  it("excludes the completed HTTP upgrade response from a one-frame WebSocket budget", async () => {
+    const configuration = buildHandlerConfiguration({maxFrames: 1})
+    const handler = new InProcessHandler({configuration, workerCount: 0})
+    const socket = new BlockedWriteSocket()
+    const serverClient = new ServerClient({clientCount: 100, configuration, socket})
+
+    handler.addSocketConnection(serverClient)
+    handler.clients[100].httpClient.websocketSession = /** @type {?} */ ({})
+    handler.clients[100].httpClient.events.emit("output", "HTTP/1.1 101 Switching Protocols\r\n\r\n")
+    handler.clients[100].httpClient.events.emit("output", Buffer.from([0x81, 0x00]), {websocketFrame: true})
+
+    await waitFor(() => expect(socket.writes.length).toEqual(1))
+    expect(socket.writes[0].data.toString()).toEqual("HTTP/1.1 101 Switching Protocols\r\n\r\n")
+    expect(socket.destroyed).toEqual(false)
+    expect(handler.clients[100].deliveryQueue.snapshot().pendingFrames).toEqual(1)
+
+    socket.writes[0].callback()
+    await waitFor(() => expect(socket.writes.length).toEqual(2))
+    socket.writes[1].callback()
+    serverClient.destroy(new Error("Test teardown"))
+    handler.unregisterFromEventsHost()
+  })
+
   it("bounds in-process output retained behind a blocked socket write", async () => {
     const configuration = buildHandlerConfiguration({maxBytes: 6, maxFrames: 2})
     const reportedErrors = []
@@ -124,17 +162,16 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
     configuration.getErrorEvents().on("framework-error", ({error}) => reportedErrors.push(error))
     handler.addSocketConnection(serverClient)
-    handler.clients[101].httpClient.websocketSession = /** @type {?} */ ({})
     configuration.getErrorEvents().on("framework-error", () => {
       handler.clients[101]?.httpClient.events.emit("output", "recursive-report-output")
     })
-    handler.clients[101].httpClient.events.emit("output", "abc")
-    handler.clients[101].httpClient.events.emit("output", "def")
+    handler.clients[101].httpClient.events.emit("output", "abc", {websocketFrame: true})
+    handler.clients[101].httpClient.events.emit("output", "def", {websocketFrame: true})
 
     await waitFor(() => expect(socket.writes.length).toEqual(1))
     expect(socket.destroyed).toEqual(false)
 
-    handler.clients[101].httpClient.events.emit("output", "g")
+    handler.clients[101].httpClient.events.emit("output", "g", {websocketFrame: true})
     await waitFor(() => expect(socket.destroyed).toEqual(true))
 
     expect(reportedErrors.length).toEqual(1)
@@ -156,15 +193,15 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     configuration.getErrorEvents().on("framework-error", ({error}) => reportedErrors.push(error))
     handler.clients[102] = client
     handler.clients[103] = isolatedClient
-    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "abc", websocket: true})
-    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "def", websocket: true})
-    handler.onWorkerMessage({clientCount: 103, command: "clientOutput", output: "safe", websocket: true})
+    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "abc", websocketFrame: true})
+    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "def", websocketFrame: true})
+    handler.onWorkerMessage({clientCount: 103, command: "clientOutput", output: "safe", websocketFrame: true})
 
     await waitFor(() => expect(socket.writes.length).toEqual(1))
     await waitFor(() => expect(isolatedSocket.writes.length).toEqual(1))
     expect(socket.destroyed).toEqual(false)
 
-    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "g", websocket: true})
+    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "g", websocketFrame: true})
     await waitFor(() => expect(socket.destroyed).toEqual(true))
 
     expect(isolatedSocket.destroyed).toEqual(false)
@@ -179,9 +216,8 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     const serverClient = new ServerClient({clientCount: 104, configuration, socket})
 
     handler.addSocketConnection(serverClient)
-    handler.clients[104].httpClient.websocketSession = /** @type {?} */ ({})
-    handler.clients[104].httpClient.events.emit("output", "abc")
-    handler.clients[104].httpClient.events.emit("output", "def")
+    handler.clients[104].httpClient.events.emit("output", "abc", {websocketFrame: true})
+    handler.clients[104].httpClient.events.emit("output", "def", {websocketFrame: true})
 
     await waitFor(() => expect(socket.writes.length).toEqual(1))
     expect(handler.clients[104].deliveryQueue.snapshot()).toEqual({pendingBytes: 6, pendingFrames: 2})
@@ -597,13 +633,23 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     }
 
     try {
-      websocketEventsHost.broadcastV2({body: {action: "create", id: "1"}, broadcastParams: {model: "Build"}, channel: "frontend-models"})
+      websocketEventsHost.broadcastV2({
+        body: {action: "create", id: "1"},
+        broadcastParams: {model: "Build"},
+        channel: "frontend-models",
+        configuration: handler.configuration
+      })
       await websocketEventsHost.awaitPendingBroadcasts()
 
       expect(sentMessages).toEqual([])
 
       handler.onWorkerMessage({command: "started"})
-      websocketEventsHost.broadcastV2({body: {action: "update", id: "1"}, broadcastParams: {model: "Build"}, channel: "frontend-models"})
+      websocketEventsHost.broadcastV2({
+        body: {action: "update", id: "1"},
+        broadcastParams: {model: "Build"},
+        channel: "frontend-models",
+        configuration: handler.configuration
+      })
       await websocketEventsHost.awaitPendingBroadcasts()
 
       expect(sentMessages).toEqual([{
@@ -616,12 +662,82 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
       }])
 
       handler.onWorkerExit(0)
-      websocketEventsHost.broadcastV2({body: {action: "destroy", id: "1"}, broadcastParams: {model: "Build"}, channel: "frontend-models"})
+      websocketEventsHost.broadcastV2({
+        body: {action: "destroy", id: "1"},
+        broadcastParams: {model: "Build"},
+        channel: "frontend-models",
+        configuration: handler.configuration
+      })
       await websocketEventsHost.awaitPendingBroadcasts()
 
       expect(sentMessages.length).toEqual(1)
     } finally {
       handler.unregisterFromEventsHostIfNeeded()
+      websocketEventsHost.handlers.clear()
+
+      for (const originalHandler of originalHandlers) {
+        websocketEventsHost.handlers.add(originalHandler)
+      }
+    }
+  })
+
+  it("routes worker-originated V2 broadcasts only to workers for the originating configuration", async () => {
+    await websocketEventsHost.awaitPendingBroadcasts()
+
+    const originalHandlers = new Set(websocketEventsHost.handlers)
+    const configurationA = {
+      debug: false,
+      withoutCurrentConnectionContexts: (callback) => callback()
+    }
+    const configurationB = {
+      debug: false,
+      withoutCurrentConnectionContexts: (callback) => callback()
+    }
+    const handlers = [
+      new WorkerHandler({configuration: configurationA, workerCount: 1}),
+      new WorkerHandler({configuration: configurationA, workerCount: 2}),
+      new WorkerHandler({configuration: configurationB, workerCount: 1})
+    ]
+    const sentMessages = handlers.map(() => [])
+
+    websocketEventsHost.handlers.clear()
+
+    try {
+      handlers.forEach((handler, index) => {
+        handler.workerStarted = true
+        handler.worker = {postMessage: (message) => sentMessages[index].push(message)}
+        handler.registerWithEventsHost()
+      })
+
+      handlers[0].onWorkerMessage({
+        body: {configuration: "A"},
+        broadcastParams: {subscription: "shared"},
+        channel: "SharedChannel",
+        command: "websocketV2Broadcast"
+      })
+      await websocketEventsHost.awaitPendingBroadcasts()
+
+      expect(sentMessages.map((messages) => messages.map(({body}) => body))).toEqual([
+        [{configuration: "A"}],
+        [{configuration: "A"}],
+        []
+      ])
+
+      handlers[2].onWorkerMessage({
+        body: {configuration: "B"},
+        broadcastParams: {subscription: "shared"},
+        channel: "SharedChannel",
+        command: "websocketV2Broadcast"
+      })
+      await websocketEventsHost.awaitPendingBroadcasts()
+
+      expect(sentMessages.map((messages) => messages.map(({body}) => body))).toEqual([
+        [{configuration: "A"}],
+        [{configuration: "A"}],
+        [{configuration: "B"}]
+      ])
+    } finally {
+      handlers.forEach((handler) => handler.unregisterFromEventsHostIfNeeded())
       websocketEventsHost.handlers.clear()
 
       for (const originalHandler of originalHandlers) {

--- a/spec/http-server/worker-handler-spec.js
+++ b/spec/http-server/worker-handler-spec.js
@@ -7,7 +7,42 @@ import HttpServer from "../../src/http-server/index.js"
 import {describe, expect, it} from "../../src/testing/test.js"
 import websocketEventsHost from "../../src/http-server/websocket-events-host.js"
 import InProcessHandler from "../../src/http-server/worker-handler/in-process.js"
+import ServerClient from "../../src/http-server/server-client.js"
 import WorkerThreadHandler from "../../src/http-server/worker-handler/worker-thread.js"
+
+class BlockedWriteSocket extends EventEmitter {
+  remoteAddress = "127.0.0.1"
+  destroyed = false
+  writable = true
+  writableEnded = false
+  /** @type {Array<{callback: (error?: Error) => void, data: Buffer}>} */
+  writes = []
+
+  /**
+   * @param {string | Uint8Array} data - Data payload.
+   * @param {(error?: Error) => void} callback - Write completion callback.
+   * @returns {boolean} - False while blocked.
+   */
+  write(data, callback) {
+    this.writes.push({callback, data: Buffer.from(data)})
+    return false
+  }
+
+  /** @returns {void} - No return value. */
+  end() {
+    this.destroy()
+  }
+
+  /** @returns {void} - No return value. */
+  destroy() {
+    if (this.destroyed) return
+
+    this.destroyed = true
+    this.writable = false
+    this.writableEnded = true
+    this.emit("close")
+  }
+}
 
 class FakeWorkerHandler {
   /**
@@ -64,7 +99,101 @@ function buildWorkerThread() {
   return {errorEvents, postedMessages, workerThread}
 }
 
+/**
+ * @param {{maxBytes?: number, maxFrames?: number}} [limits] - Queue limits.
+ * @returns {object} - Minimal handler configuration.
+ */
+function buildHandlerConfiguration({maxBytes = 16 * 1024 * 1024, maxFrames = 256} = {}) {
+  const errorEvents = new EventEmitter()
+
+  return {
+    debug: false,
+    getErrorEvents: () => errorEvents,
+    getWebsocketOutboundQueueLimits: () => ({maxBytes, maxFrames}),
+    logging: {console: false, file: false}
+  }
+}
+
 describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}}, () => {
+  it("bounds in-process output retained behind a blocked socket write", async () => {
+    const configuration = buildHandlerConfiguration({maxBytes: 6, maxFrames: 2})
+    const reportedErrors = []
+    const handler = new InProcessHandler({configuration, workerCount: 0})
+    const socket = new BlockedWriteSocket()
+    const serverClient = new ServerClient({clientCount: 101, configuration, socket})
+
+    configuration.getErrorEvents().on("framework-error", ({error}) => reportedErrors.push(error))
+    handler.addSocketConnection(serverClient)
+    handler.clients[101].httpClient.websocketSession = /** @type {?} */ ({})
+    configuration.getErrorEvents().on("framework-error", () => {
+      handler.clients[101]?.httpClient.events.emit("output", "recursive-report-output")
+    })
+    handler.clients[101].httpClient.events.emit("output", "abc")
+    handler.clients[101].httpClient.events.emit("output", "def")
+
+    await waitFor(() => expect(socket.writes.length).toEqual(1))
+    expect(socket.destroyed).toEqual(false)
+
+    handler.clients[101].httpClient.events.emit("output", "g")
+    await waitFor(() => expect(socket.destroyed).toEqual(true))
+
+    expect(reportedErrors.length).toEqual(1)
+    expect(reportedErrors[0].name).toEqual("ClientDeliveryQueueOverflowError")
+    expect(socket.writes.length).toEqual(1)
+    await waitFor(() => expect(handler.clients[101]).toEqual(undefined))
+    handler.unregisterFromEventsHost()
+  })
+
+  it("bounds worker output retained behind a blocked socket write", async () => {
+    const configuration = buildHandlerConfiguration({maxBytes: 6, maxFrames: 2})
+    const reportedErrors = []
+    const handler = new WorkerHandler({configuration, workerCount: 1})
+    const socket = new BlockedWriteSocket()
+    const isolatedSocket = new BlockedWriteSocket()
+    const client = new ServerClient({clientCount: 102, configuration, socket})
+    const isolatedClient = new ServerClient({clientCount: 103, configuration, socket: isolatedSocket})
+
+    configuration.getErrorEvents().on("framework-error", ({error}) => reportedErrors.push(error))
+    handler.clients[102] = client
+    handler.clients[103] = isolatedClient
+    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "abc", websocket: true})
+    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "def", websocket: true})
+    handler.onWorkerMessage({clientCount: 103, command: "clientOutput", output: "safe", websocket: true})
+
+    await waitFor(() => expect(socket.writes.length).toEqual(1))
+    await waitFor(() => expect(isolatedSocket.writes.length).toEqual(1))
+    expect(socket.destroyed).toEqual(false)
+
+    handler.onWorkerMessage({clientCount: 102, command: "clientOutput", output: "g", websocket: true})
+    await waitFor(() => expect(socket.destroyed).toEqual(true))
+
+    expect(isolatedSocket.destroyed).toEqual(false)
+    expect(reportedErrors.length).toEqual(1)
+    expect(reportedErrors[0].name).toEqual("ClientDeliveryQueueOverflowError")
+  })
+
+  it("releases in-process frame accounting only after the blocked write callback", async () => {
+    const configuration = buildHandlerConfiguration({maxBytes: 6, maxFrames: 2})
+    const handler = new InProcessHandler({configuration, workerCount: 0})
+    const socket = new BlockedWriteSocket()
+    const serverClient = new ServerClient({clientCount: 104, configuration, socket})
+
+    handler.addSocketConnection(serverClient)
+    handler.clients[104].httpClient.websocketSession = /** @type {?} */ ({})
+    handler.clients[104].httpClient.events.emit("output", "abc")
+    handler.clients[104].httpClient.events.emit("output", "def")
+
+    await waitFor(() => expect(socket.writes.length).toEqual(1))
+    expect(handler.clients[104].deliveryQueue.snapshot()).toEqual({pendingBytes: 6, pendingFrames: 2})
+
+    socket.writes[0].callback()
+    await waitFor(() => expect(socket.writes.length).toEqual(2))
+
+    expect(handler.clients[104].deliveryQueue.snapshot()).toEqual({pendingBytes: 3, pendingFrames: 1})
+    serverClient.destroy(new Error("Test teardown"))
+    handler.unregisterFromEventsHost()
+  })
+
   it("starts the configured worker handlers", async () => {
     const startedHandlers = []
     const stoppedHandlers = []
@@ -141,15 +270,20 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     const handler = new WorkerHandler({configuration, workerCount: 1})
 
     const closed = new Set()
+    const destroyedQueues = new Set()
     handler.clients = {
       1: {end: () => { closed.add(1) }},
       2: {end: () => { closed.add(2) }}
     }
+    handler._clientDeliveryQueues.set(1, {destroy: () => { destroyedQueues.add(1) }})
+    handler._clientDeliveryQueues.set(2, {destroy: () => { destroyedQueues.add(2) }})
 
     handler.unregisterFromEventsHost = () => {}
 
     expect(() => handler.onWorkerExit(1)).toThrowError("Client worker stopped with exit code 1")
     expect(closed).toEqual(new Set([1, 2]))
+    expect(destroyedQueues).toEqual(new Set([1, 2]))
+    expect(handler._clientDeliveryQueues.size).toEqual(0)
     expect(Object.keys(handler.clients)).toEqual([])
   })
 
@@ -219,7 +353,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
       releaseCleanup = resolve
     })
     const shutdownEvents = []
-    const handler = new InProcessHandler({configuration: {logging: {console: false, file: false}}, workerCount: 0})
+    const handler = new InProcessHandler({configuration: buildHandlerConfiguration(), workerCount: 0})
     const serverClientEvents = new EventEmitter()
     let socketClosed = false
     const serverClient = /** @type {import("../../src/http-server/server-client.js").default} */ (/** @type {?} */ ({
@@ -300,7 +434,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
   it("propagates parent socket close and settles a waiting worker descriptor once as aborted", async () => {
     const {workerThread} = buildWorkerThread()
-    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+    const handler = new WorkerHandler({configuration: buildHandlerConfiguration(), workerCount: 1})
     const parentClientEvents = new EventEmitter()
     const parentClient = {
       clientCount: 8,
@@ -318,7 +452,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
       }
     }
     handler.addSocketConnection(parentClient)
-    handler._clientDeliveryQueues.set(8, new Promise(() => {}))
+    handler._clientDeliveryQueues.set(8, {destroy: () => {}})
 
     const results = []
     const transfer = workerThread.clients[8].sendFileOutput("/tmp/waiting.bin", true, (result) => results.push(result))
@@ -390,7 +524,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
 
   it("acknowledges missing-client file descriptors as aborted", () => {
     const postedMessages = []
-    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+    const handler = new WorkerHandler({configuration: buildHandlerConfiguration(), workerCount: 1})
 
     handler.worker = {postMessage: (message) => postedMessages.push(message)}
     handler.onWorkerMessage({clientCount: 99, command: "clientFile", filePath: "/tmp/example.bin", sendBody: true, transferId: 4})
@@ -405,7 +539,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     const outputDelivered = new Promise((resolve) => {
       releaseOutput = resolve
     })
-    const handler = new WorkerHandler({configuration: {debug: false}, workerCount: 1})
+    const handler = new WorkerHandler({configuration: buildHandlerConfiguration(), workerCount: 1})
 
     handler.worker = {postMessage: (message) => postedMessages.push(message)}
     handler.clients[3] = {
@@ -426,7 +560,7 @@ describe("HttpServer - worker handler", {databaseCleaning: {transaction: true}},
     await waitFor(() => expect(deliveries).toEqual(["headers"]))
 
     releaseOutput()
-    await handler._clientDeliveryQueues.get(3)
+    await waitFor(() => expect(postedMessages.length).toEqual(1))
 
     expect(deliveries).toEqual(["headers", "file"])
     expect(postedMessages).toEqual([{command: "clientFileResult", result: "completed", transferId: 5}])

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -255,6 +255,7 @@
  * @property {boolean} [inProcess] - Run HTTP handlers in the main thread instead of worker threads.
  * @property {number} [maxWorkers] - Backward-compatible alias for workers.
  * @property {number} [port] - Port to bind the HTTP server to.
+ * @property {{maxPendingBytes?: number, maxPendingFrames?: number}} [websocketOutboundQueue] - Per-client retained outbound WebSocket frame limits.
  * @property {number} [workers] - Worker handlers to start for the HTTP server.
  */
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -114,6 +114,25 @@ function resolveBeaconUnreachableReportMs(value) {
   return 30_000
 }
 
+const DEFAULT_WEBSOCKET_OUTBOUND_MAX_PENDING_BYTES = 16 * 1024 * 1024
+const DEFAULT_WEBSOCKET_OUTBOUND_MAX_PENDING_FRAMES = 256
+
+/**
+ * Validates a positive safe integer configuration value.
+ * @param {?} value - Configured positive safe integer.
+ * @param {string} name - Configuration key.
+ * @param {number} defaultValue - Default value.
+ * @returns {number} - Validated configured or default value.
+ */
+function positiveSafeInteger(value, name, defaultValue) {
+  if (value === undefined) return defaultValue
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`)
+  }
+
+  return value
+}
+
 export default class VelociousConfiguration {
   /**
    * Close database connections promise.
@@ -209,7 +228,15 @@ export default class VelociousConfiguration {
      * @type {Promise<void> | undefined}
      */
     this._initializePromise = undefined
-    this.httpServer = httpServer || {}
+    const websocketOutboundQueue = httpServer?.websocketOutboundQueue
+
+    this.httpServer = {
+      ...(httpServer || {}),
+      websocketOutboundQueue: {
+        maxPendingBytes: positiveSafeInteger(websocketOutboundQueue?.maxPendingBytes, "httpServer.websocketOutboundQueue.maxPendingBytes", DEFAULT_WEBSOCKET_OUTBOUND_MAX_PENDING_BYTES),
+        maxPendingFrames: positiveSafeInteger(websocketOutboundQueue?.maxPendingFrames, "httpServer.websocketOutboundQueue.maxPendingFrames", DEFAULT_WEBSOCKET_OUTBOUND_MAX_PENDING_FRAMES)
+      }
+    }
     /**
      * Stores the http server instance value.
      * @type {{getDebugSnapshot: () => Promise<Record<string, ?>>} | undefined} */
@@ -2341,6 +2368,19 @@ export default class VelociousConfiguration {
    * @returns {number} - Interval (seconds) between server→client heartbeat pings; 0 disables reaping.
    */
   getWebsocketSessionHeartbeatSeconds() { return this._websocketSessionHeartbeatSeconds }
+
+  /**
+   * Gets per-client WebSocket outbound queue limits.
+   * @returns {{maxBytes: number, maxFrames: number}} - Per-client outbound queue high-water marks.
+   */
+  getWebsocketOutboundQueueLimits() {
+    const queue = this.httpServer.websocketOutboundQueue
+
+    return {
+      maxBytes: queue.maxPendingBytes,
+      maxFrames: queue.maxPendingFrames
+    }
+  }
 
   /**
    * Registers a wrapper invoked around every WS-borne request /

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1720,7 +1720,8 @@ export default class VelociousConfiguration {
       websocketEvents.broadcastV2({
         channel: message.channel,
         broadcastParams: message.broadcastParams,
-        body: message.body
+        body: message.body,
+        configuration: this
       })
       return
     }
@@ -2577,7 +2578,7 @@ export default class VelociousConfiguration {
     const websocketEvents = this._websocketEvents
 
     if (websocketEvents && typeof websocketEvents.broadcastV2 === "function") {
-      websocketEvents.broadcastV2({channel: name, broadcastParams, body})
+      websocketEvents.broadcastV2({channel: name, broadcastParams, body, configuration: this})
       return
     }
 

--- a/src/http-server/client-delivery-queue.js
+++ b/src/http-server/client-delivery-queue.js
@@ -1,0 +1,168 @@
+// @ts-check
+
+export class ClientDeliveryQueueOverflowError extends Error {
+  /**
+   * Builds an outbound queue overflow error.
+   * @param {object} args - Overflow details.
+   * @param {number} args.clientCount - Client identifier.
+   * @param {number} args.maxBytes - Configured byte high-water mark.
+   * @param {number} args.maxFrames - Configured frame high-water mark.
+   * @param {number} args.pendingBytes - Bytes retained before rejecting the frame.
+   * @param {number} args.pendingFrames - Frames retained before rejecting the frame.
+   * @param {number} args.rejectedBytes - Rejected frame size.
+   */
+  constructor({clientCount, maxBytes, maxFrames, pendingBytes, pendingFrames, rejectedBytes}) {
+    super(`WebSocket client ${clientCount} exceeded its outbound queue limit (${pendingFrames}/${maxFrames} frames, ${pendingBytes}/${maxBytes} bytes; rejected ${rejectedBytes} bytes)`)
+    this.name = "ClientDeliveryQueueOverflowError"
+  }
+}
+
+/**
+ * @typedef {object} DeliveryTask
+ * @property {number} byteLength - Retained complete-buffer bytes.
+ * @property {boolean} countedFrame - Whether this task is an outbound frame.
+ * @property {() => Promise<void>} delivery - Delivery operation.
+ * @property {(error?: Error) => void} settle - Settles the enqueue promise.
+ */
+
+export default class ClientDeliveryQueue {
+  /**
+   * Builds a per-client delivery queue.
+   * @param {object} args - Queue options.
+   * @param {number} args.clientCount - Client identifier.
+   * @param {number} args.maxBytes - Byte high-water mark.
+   * @param {number} args.maxFrames - Frame high-water mark.
+   * @param {(error: ClientDeliveryQueueOverflowError) => void} args.onOverflow - Overflow handler.
+   */
+  constructor({clientCount, maxBytes, maxFrames, onOverflow}) {
+    this.clientCount = clientCount
+    this.maxBytes = maxBytes
+    this.maxFrames = maxFrames
+    this.onOverflow = onOverflow
+    /** @type {DeliveryTask[]} */
+    this.tasks = []
+    /** @type {DeliveryTask | undefined} */
+    this.activeTask = undefined
+    this.pendingBytes = 0
+    this.pendingFrames = 0
+    this.destroyed = false
+  }
+
+  /**
+   * Enqueues one complete output buffer.
+   * @param {object} args - Delivery details.
+   * @param {number} args.byteLength - Exact buffer byte length.
+   * @param {() => Promise<void>} args.delivery - Delivery operation.
+   * @returns {Promise<void>} - Settles after delivery or teardown.
+   */
+  enqueueFrame({byteLength, delivery}) {
+    if (this.destroyed) return Promise.resolve()
+
+    if (this.pendingFrames + 1 > this.maxFrames || this.pendingBytes + byteLength > this.maxBytes) {
+      const error = new ClientDeliveryQueueOverflowError({
+        clientCount: this.clientCount,
+        maxBytes: this.maxBytes,
+        maxFrames: this.maxFrames,
+        pendingBytes: this.pendingBytes,
+        pendingFrames: this.pendingFrames,
+        rejectedBytes: byteLength
+      })
+
+      this.onOverflow(error)
+      return Promise.reject(error)
+    }
+
+    this.pendingFrames += 1
+    this.pendingBytes += byteLength
+    return this._enqueue({byteLength, countedFrame: true, delivery})
+  }
+
+  /**
+   * Enqueues an ordering-only operation that retains no complete output frame.
+   * @param {() => Promise<void>} delivery - Delivery operation.
+   * @returns {Promise<void>} - Settles after delivery or teardown.
+   */
+  enqueueControl(delivery) {
+    if (this.destroyed) return Promise.resolve()
+
+    return this._enqueue({byteLength: 0, countedFrame: false, delivery})
+  }
+
+  /**
+   * Releases queued and active accounting during explicit client teardown.
+   * @returns {void}
+   */
+  destroy() {
+    if (this.destroyed) return
+
+    this.destroyed = true
+    const tasks = this.activeTask ? [this.activeTask, ...this.tasks] : this.tasks
+
+    this.activeTask = undefined
+    this.tasks = []
+    this.pendingBytes = 0
+    this.pendingFrames = 0
+
+    for (const task of tasks) task.settle()
+  }
+
+  /**
+   * Gets current retained-buffer accounting.
+   * @returns {{pendingBytes: number, pendingFrames: number}} - Current retained-buffer accounting.
+   */
+  snapshot() {
+    return {pendingBytes: this.pendingBytes, pendingFrames: this.pendingFrames}
+  }
+
+  /**
+   * Enqueues a delivery task.
+   * @param {Omit<DeliveryTask, "settle">} task - Task to enqueue.
+   * @returns {Promise<void>} - Task completion.
+   */
+  _enqueue(task) {
+    const promise = new Promise((resolve, reject) => {
+      this.tasks.push({
+        ...task,
+        settle: (error) => error ? reject(error) : resolve(undefined)
+      })
+    })
+
+    this._drain()
+    return promise
+  }
+
+  /**
+   * Starts the next task when idle.
+   * @returns {void} - No return value.
+   */
+  _drain() {
+    if (this.destroyed || this.activeTask) return
+
+    const task = this.tasks.shift()
+    if (!task) return
+
+    this.activeTask = task
+    void task.delivery().then(
+      () => this._finish(task),
+      (error) => this._finish(task, error)
+    )
+  }
+
+  /**
+   * Finishes the active delivery task.
+   * @param {DeliveryTask} task - Completed task.
+   * @param {Error} [error] - Delivery error.
+   * @returns {void}
+   */
+  _finish(task, error) {
+    if (this.destroyed || this.activeTask !== task) return
+
+    this.activeTask = undefined
+    if (task.countedFrame) {
+      this.pendingBytes -= task.byteLength
+      this.pendingFrames -= 1
+    }
+    task.settle(error)
+    this._drain()
+  }
+}

--- a/src/http-server/client/websocket-session.js
+++ b/src/http-server/client/websocket-session.js
@@ -423,7 +423,7 @@ export default class VelociousHttpServerClientWebsocketSession {
   sendGoodbye(client) {
     const frame = Buffer.from([WEBSOCKET_FINAL_FRAME | WEBSOCKET_OPCODE_CLOSE, 0x00])
 
-    client.events.emit("output", frame)
+    client.events.emit("output", frame, {websocketFrame: true})
   }
 
   /**
@@ -967,7 +967,7 @@ export default class VelociousHttpServerClientWebsocketSession {
     header[0] = WEBSOCKET_FINAL_FRAME | opcode
     header[1] = payload.length
 
-    this.client.events.emit("output", Buffer.concat([header, payload]))
+    this.client.events.emit("output", Buffer.concat([header, payload]), {websocketFrame: true})
   }
 
   /**
@@ -1012,7 +1012,7 @@ export default class VelociousHttpServerClientWebsocketSession {
 
     header[0] = WEBSOCKET_FINAL_FRAME | WEBSOCKET_OPCODE_TEXT
 
-    this.client.events.emit("output", Buffer.concat([header, payload]))
+    this.client.events.emit("output", Buffer.concat([header, payload]), {websocketFrame: true})
   }
 
   /**

--- a/src/http-server/server-client.js
+++ b/src/http-server/server-client.js
@@ -77,6 +77,15 @@ export default class ServerClient {
   }
 
   /**
+   * Immediately destroys the socket and all transport-owned write buffers.
+   * @param {Error} error - Destruction reason.
+   * @returns {void}
+   */
+  destroy(error) {
+    if (!this.socket.destroyed) this.socket.destroy(error)
+  }
+
+  /**
    * On socket data.
    * @param {Buffer} chunk - Chunk.
    * @returns {void} - No return value.

--- a/src/http-server/websocket-events-host.js
+++ b/src/http-server/websocket-events-host.js
@@ -8,6 +8,10 @@ export class VelociousHttpServerWebsocketEventsHost {
      * Narrows the runtime value to the documented type.
      * @type {Set<import("./worker-handler/index.js").default>} */
     this.handlers = new Set()
+    /**
+     * Broadcast handlers grouped by the configuration that owns them.
+     * @type {Map<import("../configuration.js").default, Set<import("./worker-handler/index.js").default>>} */
+    this.broadcastHandlersByConfiguration = new Map()
     this.publishQueue = Promise.resolve()
   }
 
@@ -30,8 +34,23 @@ export class VelociousHttpServerWebsocketEventsHost {
    */
   register(handler) {
     this.handlers.add(handler)
+    let configurationHandlers = this.broadcastHandlersByConfiguration.get(handler.configuration)
 
-    return () => this.handlers.delete(handler)
+    if (!configurationHandlers) {
+      configurationHandlers = new Set()
+      this.broadcastHandlersByConfiguration.set(handler.configuration, configurationHandlers)
+    }
+
+    configurationHandlers.add(handler)
+
+    return () => {
+      this.handlers.delete(handler)
+      configurationHandlers.delete(handler)
+
+      if (configurationHandlers.size === 0) {
+        this.broadcastHandlersByConfiguration.delete(handler.configuration)
+      }
+    }
   }
 
   /**
@@ -81,9 +100,7 @@ export class VelociousHttpServerWebsocketEventsHost {
       const persistedEvent = await this._persistV2EventIfNeeded({body, channel, configuration})
       const dispatchedTargets = new Set()
 
-      for (const handler of this.handlers) {
-        if (handler.configuration !== configuration) continue
-
+      for (const handler of this.broadcastHandlersByConfiguration.get(configuration) || []) {
         const dispatchKey = handler.websocketV2BroadcastDispatchKey()
 
         if (dispatchedTargets.has(dispatchKey)) continue

--- a/src/http-server/websocket-events-host.js
+++ b/src/http-server/websocket-events-host.js
@@ -69,17 +69,26 @@ export class VelociousHttpServerWebsocketEventsHost {
    * @param {string} args.channel - Channel name.
    * @param {Record<string, ?>} args.broadcastParams - Routing filter params.
    * @param {?} args.body - Message body.
+   * @param {import("../configuration.js").default} args.configuration - Originating configuration.
    * @returns {void}
    */
-  broadcastV2({body, broadcastParams, channel}) {
+  broadcastV2({body, broadcastParams, channel, configuration}) {
     // Chain onto publishQueue so persistence completes before
     // the next broadcast — without this, a subscriber that connects
     // immediately after a broadcast could miss the just-persisted
     // event when replaying from lastEventId on a slow DB.
     this._queuePublish(async () => {
-      const persistedEvent = await this._persistV2EventIfNeeded({body, channel})
+      const persistedEvent = await this._persistV2EventIfNeeded({body, channel, configuration})
+      const dispatchedTargets = new Set()
 
       for (const handler of this.handlers) {
+        if (handler.configuration !== configuration) continue
+
+        const dispatchKey = handler.websocketV2BroadcastDispatchKey()
+
+        if (dispatchedTargets.has(dispatchKey)) continue
+
+        dispatchedTargets.add(dispatchKey)
         handler.dispatchWebsocketV2Broadcast({
           body,
           broadcastParams,
@@ -88,18 +97,19 @@ export class VelociousHttpServerWebsocketEventsHost {
           createdAt: persistedEvent?.createdAt
         })
       }
-    }, "Failed to persist/broadcast V2 event")
+    }, "Failed to persist/broadcast V2 event", configuration)
   }
 
   /**
    * Runs queue publish.
    * @param {() => Promise<void>} callback - Publish work to run in order.
    * @param {string} errorMessage - Message logged when publish work fails.
+   * @param {import("../configuration.js").default} [originatingConfiguration] - Configuration whose context owns the work.
    * @returns {void}
    */
-  _queuePublish(callback, errorMessage) {
+  _queuePublish(callback, errorMessage, originatingConfiguration) {
     const handler = this.handlers.values().next().value
-    const configuration = handler?.configuration
+    const configuration = originatingConfiguration || handler?.configuration
 
     this.publishQueue = this.publishQueue
       .then(async () => {
@@ -120,10 +130,11 @@ export class VelociousHttpServerWebsocketEventsHost {
    * @param {object} args - Options.
    * @param {?} args.body - Event body.
    * @param {string} args.channel - Channel name.
+   * @param {import("../configuration.js").default} args.configuration - Originating configuration.
    * @returns {Promise<{createdAt: string, id: string} | null>} - Persisted event metadata when storage is enabled.
    */
-  async _persistV2EventIfNeeded({body, channel}) {
-    return await this._persistChannelEventIfNeeded({channel, payload: body})
+  async _persistV2EventIfNeeded({body, channel, configuration}) {
+    return await this._persistChannelEventIfNeeded({channel, payload: body, configuration})
   }
 
   /**
@@ -142,14 +153,16 @@ export class VelociousHttpServerWebsocketEventsHost {
    * @param {object} args - Options object.
    * @param {string} args.channel - Channel name.
    * @param {?} args.payload - Payload data.
+   * @param {import("../configuration.js").default} [args.configuration] - Configuration owning the event store.
    * @returns {Promise<{createdAt: string, id: string} | null>} - Persisted event metadata.
    */
-  async _persistChannelEventIfNeeded({channel, payload}) {
+  async _persistChannelEventIfNeeded({channel, payload, configuration}) {
     const handler = this.handlers.values().next().value
+    const eventConfiguration = configuration || handler?.configuration
 
-    if (!handler?.configuration) return null
+    if (!eventConfiguration) return null
 
-    const websocketEventLogStore = websocketEventLogStoreForConfiguration(handler.configuration)
+    const websocketEventLogStore = websocketEventLogStoreForConfiguration(eventConfiguration)
     const shouldPersist = await websocketEventLogStore.shouldPersistChannel(channel)
 
     if (!shouldPersist) return null

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -69,10 +69,10 @@ export default class VelociousHttpServerInProcessHandler {
       }
     })
 
-    httpClient.events.on("output", (output) => {
+    httpClient.events.on("output", (output, {websocketFrame = false} = {}) => {
       if (output !== null && output !== undefined) {
         const delivery = () => serverClient.send(output)
-        const queued = httpClient.websocketSession
+        const queued = websocketFrame
           ? deliveryQueue.enqueueFrame({
             byteLength: typeof output === "string" ? Buffer.byteLength(output) : output.byteLength,
             delivery
@@ -187,6 +187,14 @@ export default class VelociousHttpServerInProcessHandler {
     if (!this.configuration) return
 
     return this.configuration._broadcastToChannelLocal(channel, broadcastParams, body, {eventId})
+  }
+
+  /**
+   * Gets the configuration-wide V2 broadcast target shared by in-process handlers.
+   * @returns {import("../../configuration.js").default} - Shared configuration target.
+   */
+  websocketV2BroadcastDispatchKey() {
+    return this.configuration
   }
 
   /**

--- a/src/http-server/worker-handler/in-process.js
+++ b/src/http-server/worker-handler/in-process.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import Client from "../client/index.js"
+import ClientDeliveryQueue from "../client-delivery-queue.js"
 import dispatchChannelSubscribers from "./channel-subscriber-dispatch.js"
 import Logger from "../../logger.js"
 import websocketEventsHost from "../websocket-events-host.js"
@@ -23,7 +24,7 @@ export default class VelociousHttpServerInProcessHandler {
 
     /**
      * Narrows the runtime value to the documented type.
-     * @type {Record<number, {httpClient: Client, serverClient: import("../server-client.js").default}>} */
+     * @type {Record<number, {deliveryQueue: ClientDeliveryQueue, httpClient: Client, serverClient: import("../server-client.js").default}>} */
     this.clients = {}
 
     /** @type {Set<Promise<void>>} */
@@ -56,25 +57,36 @@ export default class VelociousHttpServerInProcessHandler {
       remoteAddress: serverClient.remoteAddress
     })
 
-    let deliveryQueue = Promise.resolve()
-    const enqueueDelivery = (/** @type {() => Promise<void>} */ delivery) => {
-      deliveryQueue = deliveryQueue
-        .catch(() => {})
-        .then(delivery)
-
-      return deliveryQueue
-    }
+    const {maxBytes, maxFrames} = this.configuration.getWebsocketOutboundQueueLimits()
+    const deliveryQueue = new ClientDeliveryQueue({
+      clientCount,
+      maxBytes,
+      maxFrames,
+      onOverflow: (error) => {
+        deliveryQueue.destroy()
+        serverClient.destroy(error)
+        this._reportOutboundQueueOverflow({clientCount, error})
+      }
+    })
 
     httpClient.events.on("output", (output) => {
       if (output !== null && output !== undefined) {
-        void enqueueDelivery(() => serverClient.send(output)).catch((error) => {
+        const delivery = () => serverClient.send(output)
+        const queued = httpClient.websocketSession
+          ? deliveryQueue.enqueueFrame({
+            byteLength: typeof output === "string" ? Buffer.byteLength(output) : output.byteLength,
+            delivery
+          })
+          : deliveryQueue.enqueueControl(delivery)
+
+        void queued.catch((error) => {
           this.logger.error(() => ["Failed to deliver client output", {clientCount}, error])
         })
       }
     })
 
     httpClient.events.on("file", ({filePath, sendBody, settle}) => {
-      void enqueueDelivery(async () => {
+      void deliveryQueue.enqueueControl(async () => {
         await settle(await serverClient.sendFile(filePath, sendBody))
       }).catch((error) => {
         this.logger.error(() => ["Failed to deliver file response", {clientCount, filePath}, error])
@@ -83,11 +95,12 @@ export default class VelociousHttpServerInProcessHandler {
     })
 
     httpClient.events.on("close", () => {
-      void enqueueDelivery(() => serverClient.end())
+      void deliveryQueue.enqueueControl(() => serverClient.end())
         .finally(() => delete this.clients[clientCount])
     })
 
     serverClient.events.on("close", () => {
+      deliveryQueue.destroy()
       const cleanup = httpClient.abortPendingFileResponses()
         .catch((error) => {
           this.logger.warn("Failed to abort file responses after client close", error)
@@ -100,7 +113,7 @@ export default class VelociousHttpServerInProcessHandler {
       this.pendingClientCloseCleanups.add(cleanup)
     })
 
-    this.clients[clientCount] = {httpClient, serverClient}
+    this.clients[clientCount] = {deliveryQueue, httpClient, serverClient}
 
     // Create a message-port shim so ServerClient.onSocketData can route data
     // to the in-process HTTP Client without needing a real worker thread.
@@ -116,6 +129,24 @@ export default class VelociousHttpServerInProcessHandler {
 
     serverClient.setWorker(messagePortShim)
     serverClient.listen()
+  }
+
+  /**
+   * Reports a per-client outbound queue overflow.
+   * @param {object} args - Overflow details.
+   * @param {number} args.clientCount - Affected client.
+   * @param {Error} args.error - Overflow error.
+   * @returns {void}
+   */
+  _reportOutboundQueueOverflow({clientCount, error}) {
+    const errorPayload = {
+      context: {clientCount, websocketOutboundQueueOverflow: true, workerCount: this.workerCount},
+      error
+    }
+    const errorEvents = this.configuration.getErrorEvents()
+
+    errorEvents.emit("framework-error", errorPayload)
+    errorEvents.emit("all-error", {...errorPayload, errorType: "framework-error"})
   }
 
   /**

--- a/src/http-server/worker-handler/index.js
+++ b/src/http-server/worker-handler/index.js
@@ -188,7 +188,7 @@ export default class VelociousHttpServerWorker {
    * @param {string} [data.filePath] - File path.
    * @param {boolean} [data.sendBody] - Whether to send the file body.
    * @param {number} [data.transferId] - File transfer id.
-   * @param {boolean} [data.websocket] - Whether output belongs to an upgraded WebSocket.
+   * @param {boolean} [data.websocketFrame] - Whether output is a completed WebSocket frame.
    * @param {string} [data.channel] - Channel name.
    * @param {number} [data.requestId] - Debug request id.
    * @param {Record<string, ?>} [data.snapshot] - Worker debug snapshot.
@@ -226,7 +226,7 @@ export default class VelociousHttpServerWorker {
       if (output !== null && output !== undefined) {
         const outputLength = typeof output === "string" ? output.length : output.byteLength
 
-        const delivery = data.websocket === true
+        const delivery = data.websocketFrame === true
           ? this.enqueueClientFrame(client, output)
           : this.enqueueClientControl(client, () => client.send(output))
 
@@ -300,7 +300,12 @@ export default class VelociousHttpServerWorker {
         throw new Error("Worker websocket v2-broadcast channel must be a string")
       }
 
-      websocketEventsHost.broadcastV2({body, broadcastParams: broadcastParams || {}, channel})
+      websocketEventsHost.broadcastV2({
+        body,
+        broadcastParams: broadcastParams || {},
+        channel,
+        configuration: this.configuration
+      })
     } else {
       throw new Error(`Unknown command: ${command}`)
     }
@@ -465,6 +470,14 @@ export default class VelociousHttpServerWorker {
     if (!this.worker || typeof this.worker.postMessage !== "function") return
 
     this.worker.postMessage({body, broadcastParams, channel, command: "websocketV2Broadcast", eventId, createdAt})
+  }
+
+  /**
+   * Gets this worker's isolated V2 broadcast target.
+   * @returns {VelociousHttpServerWorker} - This worker handler.
+   */
+  websocketV2BroadcastDispatchKey() {
+    return this
   }
 
   /**

--- a/src/http-server/worker-handler/index.js
+++ b/src/http-server/worker-handler/index.js
@@ -2,6 +2,7 @@
 
 import {ensureError} from "typanic"
 import Logger from "../../logger.js"
+import ClientDeliveryQueue from "../client-delivery-queue.js"
 import {Worker} from "worker_threads"
 import websocketEventsHost from "../websocket-events-host.js"
 
@@ -59,7 +60,7 @@ export default class VelociousHttpServerWorker {
      * @type {Map<number, {resolve: (snapshot: Record<string, ?>) => void}>} */
     this._debugSnapshotRequests = new Map()
 
-    /** @type {Map<number, Promise<void>>} */
+    /** @type {Map<number, ClientDeliveryQueue>} */
     this._clientDeliveryQueues = new Map()
   }
 
@@ -117,6 +118,7 @@ export default class VelociousHttpServerWorker {
     if (!this.clients[clientCount] && !this._clientDeliveryQueues.has(clientCount)) return
 
     delete this.clients[clientCount]
+    this._clientDeliveryQueues.get(clientCount)?.destroy()
     this._clientDeliveryQueues.delete(clientCount)
     this.worker?.postMessage({command: "clientAbort", clientCount})
   }
@@ -163,6 +165,10 @@ export default class VelociousHttpServerWorker {
   _closeAllClients() {
     const clients = Object.values(this.clients)
     this.clients = {}
+    const deliveryQueues = this._clientDeliveryQueues
+    this._clientDeliveryQueues = new Map()
+
+    for (const queue of deliveryQueues.values()) queue.destroy()
 
     for (const client of clients) {
       try {
@@ -182,6 +188,7 @@ export default class VelociousHttpServerWorker {
    * @param {string} [data.filePath] - File path.
    * @param {boolean} [data.sendBody] - Whether to send the file body.
    * @param {number} [data.transferId] - File transfer id.
+   * @param {boolean} [data.websocket] - Whether output belongs to an upgraded WebSocket.
    * @param {string} [data.channel] - Channel name.
    * @param {number} [data.requestId] - Debug request id.
    * @param {Record<string, ?>} [data.snapshot] - Worker debug snapshot.
@@ -219,7 +226,11 @@ export default class VelociousHttpServerWorker {
       if (output !== null && output !== undefined) {
         const outputLength = typeof output === "string" ? output.length : output.byteLength
 
-        void this.enqueueClientDelivery(client.clientCount, () => client.send(output)).then(() => {
+        const delivery = data.websocket === true
+          ? this.enqueueClientFrame(client, output)
+          : this.enqueueClientControl(client, () => client.send(output))
+
+        void delivery.then(() => {
           this.logger.debug(() => ["Client output delivered", {
             clientCount,
             outputLength,
@@ -243,7 +254,7 @@ export default class VelociousHttpServerWorker {
         return
       }
 
-      void this.enqueueClientDelivery(client.clientCount, async () => {
+      void this.enqueueClientControl(client, async () => {
         const result = await client.sendFile(filePath, sendBody !== false)
 
         this.worker?.postMessage({command: "clientFileResult", result, transferId})
@@ -260,7 +271,7 @@ export default class VelociousHttpServerWorker {
         return
       }
 
-      void this.enqueueClientDelivery(client.clientCount, () => client.end())
+      void this.enqueueClientControl(client, () => client.end())
         .finally(() => delete this.clients[client.clientCount])
     } else if (command == "debugSnapshot") {
       const {requestId, snapshot} = data
@@ -297,24 +308,70 @@ export default class VelociousHttpServerWorker {
 
   /**
    * Preserves socket output ordering for one client.
-   * @param {number} clientCount - Client count.
+   * @param {import("../server-client.js").default} client - Client instance.
+   * @param {string | Uint8Array} output - Complete output buffer.
+   * @returns {Promise<void>} - Queued delivery.
+   */
+  enqueueClientFrame(client, output) {
+    const byteLength = typeof output === "string" ? Buffer.byteLength(output) : output.byteLength
+
+    return this._deliveryQueueFor(client).enqueueFrame({
+      byteLength,
+      delivery: () => client.send(output)
+    })
+  }
+
+  /**
+   * Preserves ordering for a delivery that retains no complete output frame.
+   * @param {import("../server-client.js").default} client - Client instance.
    * @param {() => Promise<void>} delivery - Delivery operation.
    * @returns {Promise<void>} - Queued delivery.
    */
-  enqueueClientDelivery(clientCount, delivery) {
-    const previous = this._clientDeliveryQueues.get(clientCount) || Promise.resolve()
-    const queued = previous
-      .catch(() => {})
-      .then(delivery)
+  enqueueClientControl(client, delivery) {
+    return this._deliveryQueueFor(client).enqueueControl(delivery)
+  }
 
-    this._clientDeliveryQueues.set(clientCount, queued)
-    const clearQueue = () => {
-      if (this._clientDeliveryQueues.get(clientCount) === queued) this._clientDeliveryQueues.delete(clientCount)
+  /**
+   * Gets or creates one client's delivery queue.
+   * @param {import("../server-client.js").default} client - Client instance.
+   * @returns {ClientDeliveryQueue} - Client-owned delivery queue.
+   */
+  _deliveryQueueFor(client) {
+    const existing = this._clientDeliveryQueues.get(client.clientCount)
+    if (existing) return existing
+
+    const {maxBytes, maxFrames} = this.configuration.getWebsocketOutboundQueueLimits()
+    const queue = new ClientDeliveryQueue({
+      clientCount: client.clientCount,
+      maxBytes,
+      maxFrames,
+      onOverflow: (error) => {
+        queue.destroy()
+        client.destroy(error)
+        this._reportOutboundQueueOverflow({clientCount: client.clientCount, error})
+      }
+    })
+
+    this._clientDeliveryQueues.set(client.clientCount, queue)
+    return queue
+  }
+
+  /**
+   * Reports a per-client outbound queue overflow.
+   * @param {object} args - Overflow details.
+   * @param {number} args.clientCount - Affected client.
+   * @param {Error} args.error - Overflow error.
+   * @returns {void}
+   */
+  _reportOutboundQueueOverflow({clientCount, error}) {
+    const errorPayload = {
+      context: {clientCount, websocketOutboundQueueOverflow: true, workerCount: this.workerCount},
+      error
     }
+    const errorEvents = this.configuration.getErrorEvents()
 
-    void queued.then(clearQueue, clearQueue)
-
-    return queued
+    errorEvents.emit("framework-error", errorPayload)
+    errorEvents.emit("all-error", {...errorPayload, errorType: "framework-error"})
   }
 
   /**

--- a/src/http-server/worker-handler/worker-thread.js
+++ b/src/http-server/worker-handler/worker-thread.js
@@ -154,8 +154,8 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
       remoteAddress
     })
 
-    client.events.on("output", (output) => {
-      this.parentPort.postMessage({command: "clientOutput", clientCount, output, websocket: Boolean(client.websocketSession)})
+    client.events.on("output", (output, {websocketFrame = false} = {}) => {
+      this.parentPort.postMessage({command: "clientOutput", clientCount, output, websocketFrame})
     })
 
     client.events.on("file", ({filePath, sendBody, settle}) => {

--- a/src/http-server/worker-handler/worker-thread.js
+++ b/src/http-server/worker-handler/worker-thread.js
@@ -155,7 +155,7 @@ export default class VelociousHttpServerWorkerHandlerWorkerThread {
     })
 
     client.events.on("output", (output) => {
-      this.parentPort.postMessage({command: "clientOutput", clientCount, output})
+      this.parentPort.postMessage({command: "clientOutput", clientCount, output, websocket: Boolean(client.websocketSession)})
     })
 
     client.events.on("file", ({filePath, sendBody, settle}) => {


### PR DESCRIPTION
## Summary

- add one explicit per-client outbound delivery queue for completed WebSocket frames
- enforce configurable byte/frame caps across queued and active writes in both in-process and worker-thread handlers
- tear down overflowed clients before reporting framework errors, preventing recursive overflow output
- clear queue state deterministically on close, error, and worker exit while keeping ordinary HTTP/file streaming outside the WebSocket cap
- add blocked-write lifecycle tests, a 100,000-attempt bounded-state benchmark, docs, config typing, and changelog coverage

## Validation

- 52 focused/adjacent WebSocket and queue tests passed
- benchmark: 100,000 attempts; 128 × 64 KiB admitted at 8 MiB; one overflow; zero retained bytes/frames after destroy
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --cached --check`

## Review

- exact staged patch SHA-256: `8224dae4d29ce712fd66599265829e561cdffe6325ed7029457f3efb0c2fe791`
- independent exact-final Threadwire review: PASS

## Task

AwesomeTasks task 10349 — Performance: bound live WebSocket outbound queues for slow consumers.
