### PR TITLE
Preserve CLI failure exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,8 @@ Evaluate inline JavaScript (Rails-style runner) with initialized app/database co
 npx velocious runner "const users = await db.query('SELECT COUNT(*) AS count FROM users'); console.log(users[0].count)"
 ```
 
+Successful CLI commands exit with status `0`. If command execution rejects, Velocious marks the process failed before rethrowing the original error and running final database cleanup. The failure therefore remains nonzero even when application code installs an `uncaughtException` listener that reports and consumes the error. See [CLI process exit behavior](docs/cli.md#process-exit-behavior).
+
 By default, migrations write `db/structure-<identifier>.sql` files for each database in non-test environments. Test skips these automatic writes unless you explicitly opt in. Configure allow/deny lists in your configuration:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -1180,7 +1180,7 @@ Evaluate inline JavaScript (Rails-style runner) with initialized app/database co
 npx velocious runner "const users = await db.query('SELECT COUNT(*) AS count FROM users'); console.log(users[0].count)"
 ```
 
-Successful CLI commands exit with status `0`. If command execution rejects, Velocious marks the process failed before rethrowing the original error and running final database cleanup. The failure therefore remains nonzero even when application code installs an `uncaughtException` listener that reports and consumes the error. See [CLI process exit behavior](docs/cli.md#process-exit-behavior).
+Successful CLI commands exit with status `0`. If command execution rejects, Velocious marks the process failed and always runs final database cleanup. Successful cleanup preserves and rethrows the original command error unchanged; if cleanup also fails, an `AggregateError` retains the command error first and as its `cause`, followed by the cleanup error. Cleanup-only failures also exit nonzero. These failures therefore remain nonzero even when application code installs an `uncaughtException` listener that reports and consumes the error. See [CLI process exit behavior](docs/cli.md#process-exit-behavior).
 
 By default, migrations write `db/structure-<identifier>.sql` files for each database in non-test environments. Test skips these automatic writes unless you explicitly opt in. Configure allow/deny lists in your configuration:
 

--- a/bin/velocious.js
+++ b/bin/velocious.js
@@ -39,13 +39,37 @@ const cli = new Cli({
   processArgs
 })
 
+let commandError
+let commandFailed = false
+
 try {
   await cli.execute()
 } catch (error) {
+  commandError = error
+  commandFailed = true
   process.exitCode = 1
-  throw error
-} finally {
-  await configuration.closeDatabaseConnections()
 }
+
+let cleanupError
+let cleanupFailed = false
+
+try {
+  await configuration.closeDatabaseConnections()
+} catch (error) {
+  cleanupError = error
+  cleanupFailed = true
+  process.exitCode = 1
+}
+
+if (commandFailed && cleanupFailed) {
+  throw new AggregateError(
+    [commandError, cleanupError],
+    "Velocious CLI command execution and database cleanup both failed",
+    {cause: commandError}
+  )
+}
+
+if (commandFailed) throw commandError
+if (cleanupFailed) throw cleanupError
 
 process.exit(0)

--- a/bin/velocious.js
+++ b/bin/velocious.js
@@ -41,6 +41,9 @@ const cli = new Cli({
 
 try {
   await cli.execute()
+} catch (error) {
+  process.exitCode = 1
+  throw error
 } finally {
   await configuration.closeDatabaseConnections()
 }

--- a/changelog.d/20260728083605-cli-failure-exit.md
+++ b/changelog.d/20260728083605-cli-failure-exit.md
@@ -1,1 +1,1 @@
-Ensure rejected CLI commands exit nonzero even when application `uncaughtException` handlers consume the original error.
+Ensure rejected CLI commands and final cleanup failures exit nonzero even when application `uncaughtException` handlers consume the error, preserving simultaneous command and cleanup failures in primary-first order.

--- a/changelog.d/20260728083605-cli-failure-exit.md
+++ b/changelog.d/20260728083605-cli-failure-exit.md
@@ -1,0 +1,1 @@
+Ensure rejected CLI commands exit nonzero even when application `uncaughtException` handlers consume the original error.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/api-manifest-endpoint.md`: Built-in frontend-model API manifest endpoint — opt-in, token-protectable, returns resource/attribute/command metadata as pretty-printed JSON.
 - `docs/auditing.md`: Built-in lifecycle audit rows, manual audit events, and audit-missing scopes.
 - `docs/background-jobs.md`: Background job operational behavior, including failure events for production error reporting.
+- `docs/cli.md`: CLI process exit behavior for successful and rejected commands.
 - `docs/database-migrations.md`: Migration helpers, UTC datetime storage, implicit primary keys, and reference column defaults.
 - `docs/http-server.md`: HTTP server worker configuration and socket distribution behavior.
 - `docs/expo-metro-compatibility.md`: Expo/Metro integration rules and the repository Expo export check.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,9 @@
+# Command-line interface
+
+## Process exit behavior
+
+A Velocious CLI invocation exits with status `0` after its commands complete successfully.
+
+When command execution rejects, the Node CLI sets a nonzero process exit status before rethrowing the original error. Configuration database cleanup still runs in the entrypoint's `finally` block, and the rethrown value retains its original error identity and stack.
+
+This ordering provides a failure-status backstop for applications that install an `uncaughtException` listener to report and consume top-level errors: deployment scripts and other callers still observe a failed CLI process. Application handlers should not reset `process.exitCode`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,6 +4,6 @@
 
 A Velocious CLI invocation exits with status `0` after its commands complete successfully.
 
-When command execution rejects, the Node CLI sets a nonzero process exit status before rethrowing the original error. Configuration database cleanup still runs in the entrypoint's `finally` block, and the rethrown value retains its original error identity and stack.
+When command execution rejects, the Node CLI sets a nonzero process exit status and still runs the entrypoint's configuration database cleanup step. If cleanup succeeds, the same command error is rethrown with its original identity and stack. If cleanup also rejects, Velocious throws an `AggregateError` whose errors contain the command failure first and cleanup failure second, with the command failure as `cause`. A cleanup-only rejection is propagated and also sets a nonzero exit status.
 
 This ordering provides a failure-status backstop for applications that install an `uncaughtException` listener to report and consume top-level errors: deployment scripts and other callers still observe a failed CLI process. Application handlers should not reset `process.exitCode`.

--- a/spec/cli/failure-exit-spec.js
+++ b/spec/cli/failure-exit-spec.js
@@ -1,0 +1,81 @@
+// @ts-check
+
+import {spawnSync} from "node:child_process"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+const cliEntryPath = path.join(repositoryRoot, "bin", "velocious.js")
+
+/**
+ * Creates an isolated app whose error reporter consumes uncaught exceptions.
+ * @returns {Promise<{cleanup: () => Promise<void>, directory: string}>} - Fixture helpers.
+ */
+async function createFixture() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-failure-exit-"))
+  const configurationPath = path.join(directory, "src", "config", "configuration.js")
+  const configurationImportPath = new URL("../../src/configuration.js", import.meta.url).href
+  const environmentHandlerImportPath = new URL("../../src/environment-handlers/node.js", import.meta.url).href
+
+  await fs.mkdir(path.dirname(configurationPath), {recursive: true})
+  await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+  await fs.writeFile(configurationPath, `
+import Configuration from ${JSON.stringify(configurationImportPath)}
+import NodeEnvironmentHandler from ${JSON.stringify(environmentHandlerImportPath)}
+
+process.on("uncaughtException", (error) => {
+  console.error(error instanceof Error ? error.stack : error)
+})
+
+class CliFailureExitConfiguration extends Configuration {
+  isDatabasePoolInitialized() { return true }
+}
+
+export default new CliFailureExitConfiguration({
+  autoload: false,
+  database: {test: {}},
+  directory: ${JSON.stringify(directory)},
+  environment: "test",
+  environmentHandler: new NodeEnvironmentHandler(),
+  initializeModels: async () => {},
+  locale: () => "en",
+  localeFallbacks: {en: ["en"]},
+  locales: ["en"]
+})
+`)
+  await fs.writeFile(path.join(directory, "throwing-script.js"), `
+export default async function throwingScript() {
+  throw new Error("Intentional CLI failure")
+}
+`)
+
+  return {
+    cleanup: async () => await fs.rm(directory, {recursive: true, force: true}),
+    directory
+  }
+}
+
+describe("Velocious CLI failure exit", () => {
+  it("exits nonzero when an application uncaughtException listener consumes a command failure", {databaseCleaning: {transaction: false, truncate: false}}, async () => {
+    const {cleanup, directory} = await createFixture()
+
+    try {
+      const result = spawnSync(process.execPath, [cliEntryPath, "run-script", "throwing-script.js"], {
+        cwd: directory,
+        encoding: "utf8",
+        env: {...process.env, VELOCIOUS_ENV: "test"}
+      })
+
+      expect(result.error).toEqual(undefined)
+      expect(result.signal).toEqual(null)
+      expect(result.stderr.includes("Intentional CLI failure")).toBeTrue()
+      expect(result.stderr.includes("throwing-script.js")).toBeTrue()
+      expect(result.status).toEqual(1)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/spec/cli/failure-exit-spec.js
+++ b/spec/cli/failure-exit-spec.js
@@ -12,9 +12,10 @@ const cliEntryPath = path.join(repositoryRoot, "bin", "velocious.js")
 
 /**
  * Creates an isolated app whose error reporter consumes uncaught exceptions.
+ * @param {{failFinalCleanup?: boolean}} [options] - Fixture behavior.
  * @returns {Promise<{cleanup: () => Promise<void>, directory: string}>} - Fixture helpers.
  */
-async function createFixture() {
+async function createFixture({failFinalCleanup = false} = {}) {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-failure-exit-"))
   const configurationPath = path.join(directory, "src", "config", "configuration.js")
   const configurationImportPath = new URL("../../src/configuration.js", import.meta.url).href
@@ -26,11 +27,33 @@ async function createFixture() {
 import Configuration from ${JSON.stringify(configurationImportPath)}
 import NodeEnvironmentHandler from ${JSON.stringify(environmentHandlerImportPath)}
 
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
 process.on("uncaughtException", (error) => {
-  console.error(error instanceof Error ? error.stack : error)
+  const cause = error instanceof Error ? error.cause : undefined
+
+  console.error(JSON.stringify({
+    causeMessage: cause === undefined ? null : errorMessage(cause),
+    errorMessages: error instanceof AggregateError ? error.errors.map(errorMessage) : [],
+    message: errorMessage(error),
+    name: error instanceof Error ? error.name : typeof error,
+    stack: error instanceof Error ? error.stack : null
+  }))
 })
 
+let closeDatabaseConnectionsCalls = 0
+
 class CliFailureExitConfiguration extends Configuration {
+  async closeDatabaseConnections() {
+    closeDatabaseConnectionsCalls += 1
+
+    if (${JSON.stringify(failFinalCleanup)} && closeDatabaseConnectionsCalls == 3) {
+      throw new Error("Intentional CLI cleanup failure")
+    }
+  }
+
   isDatabasePoolInitialized() { return true }
 }
 
@@ -50,6 +73,9 @@ export default new CliFailureExitConfiguration({
 export default async function throwingScript() {
   throw new Error("Intentional CLI failure")
 }
+`)
+  await fs.writeFile(path.join(directory, "successful-script.js"), `
+export default async function successfulScript() {}
 `)
 
   return {
@@ -74,6 +100,49 @@ describe("Velocious CLI failure exit", () => {
       expect(result.stderr.includes("Intentional CLI failure")).toBeTrue()
       expect(result.stderr.includes("throwing-script.js")).toBeTrue()
       expect(result.status).toEqual(1)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("preserves the command failure as primary when command execution and final cleanup both fail", {databaseCleaning: {transaction: false, truncate: false}}, async () => {
+    const {cleanup, directory} = await createFixture({failFinalCleanup: true})
+
+    try {
+      const result = spawnSync(process.execPath, [cliEntryPath, "run-script", "throwing-script.js"], {
+        cwd: directory,
+        encoding: "utf8",
+        env: {...process.env, VELOCIOUS_ENV: "test"}
+      })
+
+      expect(result.error).toEqual(undefined)
+      expect(result.signal).toEqual(null)
+      expect(result.status).toEqual(1)
+      expect(result.stderr.includes("\"name\":\"AggregateError\"")).toBeTrue()
+      expect(result.stderr.includes("\"causeMessage\":\"Intentional CLI failure\"")).toBeTrue()
+      expect(result.stderr.includes("\"errorMessages\":[\"Intentional CLI failure\",\"Intentional CLI cleanup failure\"]")).toBeTrue()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("exits nonzero and surfaces a final cleanup failure after successful command execution", {databaseCleaning: {transaction: false, truncate: false}}, async () => {
+    const {cleanup, directory} = await createFixture({failFinalCleanup: true})
+
+    try {
+      const result = spawnSync(process.execPath, [cliEntryPath, "run-script", "successful-script.js"], {
+        cwd: directory,
+        encoding: "utf8",
+        env: {...process.env, VELOCIOUS_ENV: "test"}
+      })
+
+      expect(result.error).toEqual(undefined)
+      expect(result.signal).toEqual(null)
+      expect(result.status).toEqual(1)
+      expect(result.stderr.includes("\"name\":\"Error\"")).toBeTrue()
+      expect(result.stderr.includes("\"message\":\"Intentional CLI cleanup failure\"")).toBeTrue()
+      expect(result.stderr.includes("\"causeMessage\":null")).toBeTrue()
+      expect(result.stderr.includes("\"errorMessages\":[]")).toBeTrue()
     } finally {
       await cleanup()
     }

--- a/spec/frontend-models/transport-deadline-spec.js
+++ b/spec/frontend-models/transport-deadline-spec.js
@@ -14,6 +14,7 @@ import {listenOnLocalhost} from "../helpers/local-server-helper.js"
  * @typedef {object} ControlledServer
  * @property {() => Promise<void>} close - Stops the server.
  * @property {number} port - Bound TCP port.
+ * @property {Promise<void>} socketClosed - Resolves when the client socket closes.
  * @property {{requestReceived: boolean, socketClosed: boolean}} state - Observed connection state.
  */
 
@@ -26,6 +27,11 @@ import {listenOnLocalhost} from "../helpers/local-server-helper.js"
  */
 async function startControlledServer(handler) {
   const state = {requestReceived: false, socketClosed: false}
+  /** @type {() => void} */
+  let resolveSocketClosed = () => {}
+  const socketClosed = new Promise((resolve) => {
+    resolveSocketClosed = () => resolve(undefined)
+  })
   const server = http.createServer((req, res) => {
     state.requestReceived = true
     handler(req, res)
@@ -34,6 +40,7 @@ async function startControlledServer(handler) {
   server.on("connection", (socket) => {
     socket.on("close", () => {
       state.socketClosed = true
+      resolveSocketClosed()
     })
   })
 
@@ -46,25 +53,8 @@ async function startControlledServer(handler) {
       server.close(() => resolve(undefined))
     }),
     port,
+    socketClosed,
     state
-  }
-}
-
-/**
- * Polls until the condition holds or the timeout elapses.
- * @param {() => boolean} conditionFn - Condition to await.
- * @param {{timeoutMs?: number}} [options] - Poll options.
- * @returns {Promise<void>} - Resolves once the condition holds.
- */
-async function waitForCondition(conditionFn, {timeoutMs = 1000} = {}) {
-  const start = Date.now()
-
-  while (!conditionFn()) {
-    if (Date.now() - start > timeoutMs) {
-      throw new Error("Condition was not met within the allotted time")
-    }
-
-    await wait(5)
   }
 }
 
@@ -121,7 +111,7 @@ describe("frontend-models - transport deadline", () => {
         expect(error).toBeInstanceOf(TimeoutError)
         expect(controlled.state.requestReceived).toBeTrue()
 
-        await waitForCondition(() => controlled.state.socketClosed)
+        await controlled.socketClosed
 
         expect(controlled.state.socketClosed).toBeTrue()
       } finally {


### PR DESCRIPTION
## Summary
- mark rejected Velocious CLI execution as failed before rethrowing
- preserve the original error/stack and existing database cleanup
- add a real subprocess regression using an application handler that consumes `uncaughtException`
- document CLI process exit behavior

## Root cause
A rejected top-level CLI await reached Node's uncaught-exception handling before `process.exitCode` was set. An application-installed reporting listener could consume that error and let the command exit 0.

## Validation
- `MSSQL_SA_PASSWORD=unused VELOCIOUS_DISABLE_MSSQL=1 npm test -- spec/cli/failure-exit-spec.js` — 1 successful test
- required SQLite-config `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run fallow` — passed
- independent Codex GPT-5.6 Sol (`xhigh`) exact-diff review — PASS
