### PR TITLE
Fix foreign key reference rollbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,8 @@ export default class CreateEvents extends Migration {
 }
 ```
 
+To reverse an `addReference("tasks", "project", {foreignKey: true, type: "uuid"})` migration, use `await this.removeReference("tasks", "project")` in `down()`. It removes the generated foreign key, index, and column; see [removing references and foreign keys](docs/database-migrations.md#removing-references-and-foreign-keys) for custom-column and foreign-key-only cases.
+
 Migrations that must be rerunnable can guard changes with `tableExists(...)`, `columnExists(table, column)` and `indexExists(table, index)` — a missing table yields `false` rather than throwing. See [docs/database-migrations.md](docs/database-migrations.md#guarding-schema-changes-in-rerunnable-migrations).
 
 ## Run migrations from the command line

--- a/changelog.d/20260728100250-remove-reference-foreign-key.md
+++ b/changelog.d/20260728100250-remove-reference-foreign-key.md
@@ -1,0 +1,2 @@
+* Add `removeForeignKey(...)` for removing introspected foreign-key constraints without dropping their columns or indexes.
+* Make `removeReference(...)` await removal of matching foreign keys, generated single-column indexes (including unique indexes), and the reference column across database drivers.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -54,6 +54,39 @@ await this.removeIndex("tasks", "index_tasks_slug_unique")
 
 Use the columns form for indexes created by `addIndex(...)` without an explicit name so SQLite and the other drivers drop their own generated names correctly.
 
+## Removing References and Foreign Keys
+
+`await migration.removeReference(tableName, referenceName, args)` reverses an `addReference(...)` change. It awaits each step: removes foreign keys on the reference column, removes the exact generated single-column non-primary index (whether unique or non-unique), then removes the column. It does not remove composite or unrelated indexes. The two-argument form remains valid; `columnName` and `indexName` override the derived column and generated index when needed.
+
+For example, a UUID reference with a foreign key can be added and removed in a reversible migration:
+
+```js
+export default class AddTaskProjectReference extends Migration {
+  async up() {
+    await this.addReference("tasks", "project", {foreignKey: true, type: "uuid"})
+  }
+
+  async down() {
+    await this.removeReference("tasks", "project")
+  }
+}
+```
+
+`await migration.removeForeignKey(tableName, referenceName, {columnName})` removes only matching foreign-key constraints and leaves the column and indexes in place. The column normally derives as `<underscored_reference>_id`; use `columnName` when the schema uses a custom name:
+
+```js
+await this.addIndex("articles", ["writer_id"], {name: "index_articles_on_writer_id"})
+await this.addForeignKey("articles", "author", {
+  columnName: "writer_id",
+  referencedTableName: "writers"
+})
+
+await this.removeForeignKey("articles", "author", {columnName: "writer_id"})
+// `writer_id` and `index_articles_on_writer_id` remain.
+```
+
+Both helpers reject unknown options and discover constraints from real table metadata rather than requiring a constraint-name argument. `removeForeignKey` fails clearly when the table or matching foreign key is absent; `removeReference` tolerates a reference column with no foreign key. On SQLite, schema rebuilds preserve unrelated foreign keys and indexes while omitting removed-column indexes. MySQL/MariaDB remove the foreign key before its supporting index and column; PostgreSQL and MSSQL use the introspected constraint name.
+
 ## Guarding schema changes in rerunnable migrations
 
 A migration that must be rerunnable — for example a data backfill or repair that may run against a partially-patched schema — can guard each change with the schema-inspection helpers so it stays idempotent:

--- a/spec/database/drivers/mssql/columns-index-spec.js
+++ b/spec/database/drivers/mssql/columns-index-spec.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+import { describe, expect, it } from "../../../../src/testing/test.js"
+import MssqlColumnsIndex from "../../../../src/database/drivers/mssql/columns-index.js"
+import MssqlDriver from "../../../../src/database/drivers/mssql/index.js"
+import MssqlTable, { groupMssqlIndexRows } from "../../../../src/database/drivers/mssql/table.js"
+import { normalizeIndexMetadataRow } from "../../../../src/database/drivers/index-metadata.js"
+
+describe("database/drivers/mssql/columns-index", {databaseCleaning: {transaction: true}}, () => {
+  it("groups ordered metadata rows and exposes complete index columns", () => {
+    const indexData = groupMssqlIndexRows([
+      {column_name: "status", index_name: "index_tasks_on_status_and_category", is_primary_key: false, is_unique: false, table_name: "tasks"},
+      {column_name: "category", index_name: "index_tasks_on_status_and_category", is_primary_key: false, is_unique: false, table_name: "tasks"},
+      {column_name: "id", index_name: "PK_tasks", is_primary_key: true, is_unique: true, table_name: "tasks"}
+    ].map((row) => normalizeIndexMetadataRow(row)))
+    const table = new MssqlTable(new MssqlDriver({sqlConfig: {}}), {TABLE_NAME: "tasks"})
+    const compositeIndex = new MssqlColumnsIndex(table, indexData[0])
+    const primaryIndex = new MssqlColumnsIndex(table, indexData[1])
+
+    expect(compositeIndex.getColumnNames()).toEqual(["status", "category"])
+    expect(compositeIndex.isUnique()).toBe(false)
+    expect(compositeIndex.isPrimaryKey()).toBe(false)
+    expect(primaryIndex.getColumnNames()).toEqual(["id"])
+    expect(primaryIndex.isUnique()).toBe(true)
+    expect(primaryIndex.isPrimaryKey()).toBe(true)
+  })
+})

--- a/spec/database/drivers/pgsql/columns-index-spec.js
+++ b/spec/database/drivers/pgsql/columns-index-spec.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+import { describe, expect, it } from "../../../../src/testing/test.js"
+import PgsqlColumnsIndex from "../../../../src/database/drivers/pgsql/columns-index.js"
+import PgsqlDriver from "../../../../src/database/drivers/pgsql/index.js"
+import PgsqlTable, { groupPgsqlIndexRows } from "../../../../src/database/drivers/pgsql/table.js"
+import { normalizeIndexMetadataRow } from "../../../../src/database/drivers/index-metadata.js"
+
+describe("database/drivers/pgsql/columns-index", {databaseCleaning: {transaction: true}}, () => {
+  it("groups ordered metadata rows and exposes complete index columns", () => {
+    const indexRows = [
+      {column_name: "status", index_name: "index_tasks_on_status_and_category", is_primary_key: false, is_unique: false, table_name: "tasks"},
+      {column_name: "category", index_name: "index_tasks_on_status_and_category", is_primary_key: false, is_unique: false, table_name: "tasks"},
+      {column_name: "id", index_name: "tasks_pkey", is_primary_key: true, is_unique: true, table_name: "tasks"}
+    ].map((row) => normalizeIndexMetadataRow(row))
+    const indexData = groupPgsqlIndexRows(indexRows)
+    const table = new PgsqlTable(new PgsqlDriver({}), {table_name: "tasks"})
+    const compositeIndex = new PgsqlColumnsIndex(table, indexData[0])
+    const primaryIndex = new PgsqlColumnsIndex(table, indexData[1])
+
+    expect(indexRows[0]).toEqual({column_name: "status", index_name: "index_tasks_on_status_and_category", is_primary_key: false, is_unique: false, table_name: "tasks"})
+    expect(compositeIndex.getColumnNames()).toEqual(["status", "category"])
+    expect(compositeIndex.isUnique()).toBe(false)
+    expect(compositeIndex.isPrimaryKey()).toBe(false)
+    expect(primaryIndex.getColumnNames()).toEqual(["id"])
+    expect(primaryIndex.isUnique()).toBe(true)
+    expect(primaryIndex.isPrimaryKey()).toBe(true)
+  })
+})

--- a/spec/database/migration/remove-foreign-key.browser-spec.js
+++ b/spec/database/migration/remove-foreign-key.browser-spec.js
@@ -15,7 +15,7 @@ describe("database - migration - removeForeignKey", {tags: ["dummy"]}, () => {
       const childTableName = "remove_foreign_key_custom_articles"
 
       try {
-        await dropRemoveForeignKeyTables(driver, childTableName, parentTableName)
+        await dropRemoveForeignKeyTables(driver, childTableName, [parentTableName])
         await migration.createTable(parentTableName, {id: {type: "uuid"}})
         await migration.createTable(childTableName, {id: {type: "uuid"}}, (table) => {
           table.uuid("writer_id", {null: true})
@@ -44,7 +44,51 @@ describe("database - migration - removeForeignKey", {tags: ["dummy"]}, () => {
         expect(indexNames).toContain("index_remove_foreign_key_custom_articles_on_writer_id")
         expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain("writer_id")
       } finally {
-        await dropRemoveForeignKeyTables(driver, childTableName, parentTableName)
+        await dropRemoveForeignKeyTables(driver, childTableName, [parentTableName])
+      }
+    })
+  })
+
+  it("removes every foreign key on the requested column after each SQLite rebuild", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const authorTableName = "remove_foreign_key_multi_authors"
+      const editorTableName = "remove_foreign_key_multi_editors"
+      const childTableName = "remove_foreign_key_multi_articles"
+
+      try {
+        await dropRemoveForeignKeyTables(driver, childTableName, [authorTableName, editorTableName])
+        await migration.createTable(authorTableName, {id: {type: "uuid"}})
+        await migration.createTable(editorTableName, {id: {type: "uuid"}})
+        await migration.createTable(childTableName, {id: {type: "uuid"}}, (table) => {
+          table.uuid("writer_id", {null: true})
+        })
+        await migration.addForeignKey(childTableName, "author", {
+          columnName: "writer_id",
+          name: "fk_remove_foreign_key_multi_author",
+          referencedTableName: authorTableName
+        })
+        await migration.addForeignKey(childTableName, "editor", {
+          columnName: "writer_id",
+          name: "fk_remove_foreign_key_multi_editor",
+          referencedTableName: editorTableName
+        })
+
+        const tableWithForeignKeys = await driver.getTableByNameOrFail(childTableName)
+
+        expect((await tableWithForeignKeys.getForeignKeys()).filter((foreignKey) => foreignKey.getColumnName() === "writer_id")).toHaveLength(2)
+
+        await migration.removeForeignKey(childTableName, "author", {columnName: "writer_id"})
+
+        const tableWithoutForeignKeys = await driver.getTableByNameOrFail(childTableName)
+        const remainingForeignKeys = await tableWithoutForeignKeys.getForeignKeys()
+
+        expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain("writer_id")
+      } finally {
+        await dropRemoveForeignKeyTables(driver, childTableName, [authorTableName, editorTableName])
       }
     })
   })
@@ -53,11 +97,14 @@ describe("database - migration - removeForeignKey", {tags: ["dummy"]}, () => {
 /**
  * @param {import("../../../src/database/drivers/base.js").default} driver - Database driver.
  * @param {string} childTableName - Child table name.
- * @param {string} parentTableName - Parent table name.
+ * @param {string[]} parentTableNames - Parent table names.
  * @returns {Promise<void>}
  */
-async function dropRemoveForeignKeyTables(driver, childTableName, parentTableName) {
+async function dropRemoveForeignKeyTables(driver, childTableName, parentTableNames) {
   await driver.dropTable(`${childTableName}_velocious_rebuild`, {cascade: true, ifExists: true})
   await driver.dropTable(childTableName, {cascade: true, ifExists: true})
-  await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
+
+  for (const parentTableName of parentTableNames) {
+    await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
+  }
 }

--- a/spec/database/migration/remove-foreign-key.browser-spec.js
+++ b/spec/database/migration/remove-foreign-key.browser-spec.js
@@ -57,6 +57,7 @@ describe("database - migration - removeForeignKey", {tags: ["dummy"]}, () => {
  * @returns {Promise<void>}
  */
 async function dropRemoveForeignKeyTables(driver, childTableName, parentTableName) {
+  await driver.dropTable(`${childTableName}_velocious_rebuild`, {cascade: true, ifExists: true})
   await driver.dropTable(childTableName, {cascade: true, ifExists: true})
   await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
 }

--- a/spec/database/migration/remove-foreign-key.browser-spec.js
+++ b/spec/database/migration/remove-foreign-key.browser-spec.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration - removeForeignKey", {tags: ["dummy"]}, () => {
+  it("removes the requested foreign key without removing its column or ordinary index", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const parentTableName = "remove_foreign_key_custom_writers"
+      const childTableName = "remove_foreign_key_custom_articles"
+
+      try {
+        await dropRemoveForeignKeyTables(driver, childTableName, parentTableName)
+        await migration.createTable(parentTableName, {id: {type: "uuid"}})
+        await migration.createTable(childTableName, {id: {type: "uuid"}}, (table) => {
+          table.uuid("writer_id", {null: true})
+        })
+        await migration.addIndex(childTableName, ["writer_id"], {name: "index_remove_foreign_key_custom_articles_on_writer_id"})
+        await migration.addForeignKey(childTableName, "author", {
+          columnName: "writer_id",
+          name: "fk_custom_writer",
+          referencedColumnName: "id",
+          referencedTableName: parentTableName
+        })
+
+        const tableWithForeignKey = await driver.getTableByNameOrFail(childTableName)
+        const foreignKeys = await tableWithForeignKey.getForeignKeys()
+
+        expect(foreignKeys.map((foreignKey) => foreignKey.getColumnName())).toContain("writer_id")
+
+        await migration.removeForeignKey(childTableName, "author", {columnName: "writer_id"})
+
+        const tableWithoutForeignKey = await driver.getTableByNameOrFail(childTableName)
+        const columnNames = (await tableWithoutForeignKey.getColumns()).map((column) => column.getName())
+        const indexNames = (await tableWithoutForeignKey.getIndexes()).map((index) => index.getName())
+        const remainingForeignKeys = await tableWithoutForeignKey.getForeignKeys()
+
+        expect(columnNames).toContain("writer_id")
+        expect(indexNames).toContain("index_remove_foreign_key_custom_articles_on_writer_id")
+        expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain("writer_id")
+      } finally {
+        await dropRemoveForeignKeyTables(driver, childTableName, parentTableName)
+      }
+    })
+  })
+})
+
+/**
+ * @param {import("../../../src/database/drivers/base.js").default} driver - Database driver.
+ * @param {string} childTableName - Child table name.
+ * @param {string} parentTableName - Parent table name.
+ * @returns {Promise<void>}
+ */
+async function dropRemoveForeignKeyTables(driver, childTableName, parentTableName) {
+  await driver.dropTable(childTableName, {cascade: true, ifExists: true})
+  await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
+}

--- a/spec/database/migration/remove-reference.browser-spec.js
+++ b/spec/database/migration/remove-reference.browser-spec.js
@@ -1,0 +1,96 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
+  it("removes a reference column, its ordinary index, and its foreign key", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const parentTableName = "remove_reference_members"
+      const childTableName = "remove_reference_enrollments"
+
+      try {
+        await dropRemoveReferenceTables(driver, childTableName, parentTableName)
+        await migration.createTable(parentTableName, {id: {type: "uuid"}})
+        await migration.createTable(childTableName, {id: {type: "uuid"}})
+        await migration.addReference(childTableName, "member", {foreignKey: true, type: "uuid"})
+
+        const tableWithReference = await driver.getTableByNameOrFail(childTableName)
+        const columnNames = (await tableWithReference.getColumns()).map((column) => column.getName())
+        const memberIndexes = (await tableWithReference.getIndexes())
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+        const foreignKeys = await tableWithReference.getForeignKeys()
+
+        expect(columnNames).toContain("member_id")
+        expect(memberIndexes).toHaveLength(1)
+        expect(memberIndexes[0].isUnique()).toBe(false)
+        expect(foreignKeys.map((foreignKey) => foreignKey.getColumnName())).toContain("member_id")
+
+        await migration.removeReference(childTableName, "member")
+
+        const tableWithoutReference = await driver.getTableByNameOrFail(childTableName)
+        const remainingColumnNames = (await tableWithoutReference.getColumns()).map((column) => column.getName())
+        const remainingMemberIndexes = (await tableWithoutReference.getIndexes())
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+        const remainingForeignKeys = await tableWithoutReference.getForeignKeys()
+
+        expect(remainingColumnNames).not.toContain("member_id")
+        expect(remainingMemberIndexes).toHaveLength(0)
+        expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain("member_id")
+      } finally {
+        await dropRemoveReferenceTables(driver, childTableName, parentTableName)
+      }
+    })
+  })
+
+  it("removes a reference column and its ordinary index when no foreign key was added", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const childTableName = "remove_reference_drafts"
+
+      try {
+        await driver.dropTable(childTableName, {cascade: true, ifExists: true})
+        await migration.createTable(childTableName, {id: {type: "uuid"}})
+        await migration.addReference(childTableName, "member", {type: "uuid"})
+
+        const tableWithReference = await driver.getTableByNameOrFail(childTableName)
+        const memberIndexes = (await tableWithReference.getIndexes())
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+
+        expect((await tableWithReference.getColumns()).map((column) => column.getName())).toContain("member_id")
+        expect(memberIndexes).toHaveLength(1)
+        expect(memberIndexes[0].isUnique()).toBe(false)
+
+        await migration.removeReference(childTableName, "member")
+
+        const tableWithoutReference = await driver.getTableByNameOrFail(childTableName)
+        const remainingMemberIndexes = (await tableWithoutReference.getIndexes())
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+
+        expect((await tableWithoutReference.getColumns()).map((column) => column.getName())).not.toContain("member_id")
+        expect(remainingMemberIndexes).toHaveLength(0)
+      } finally {
+        await driver.dropTable(childTableName, {cascade: true, ifExists: true})
+      }
+    })
+  })
+})
+
+/**
+ * @param {import("../../../src/database/drivers/base.js").default} driver - Database driver.
+ * @param {string} childTableName - Child table name.
+ * @param {string} parentTableName - Parent table name.
+ * @returns {Promise<void>}
+ */
+async function dropRemoveReferenceTables(driver, childTableName, parentTableName) {
+  await driver.dropTable(childTableName, {cascade: true, ifExists: true})
+  await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
+}

--- a/spec/database/migration/remove-reference.browser-spec.js
+++ b/spec/database/migration/remove-reference.browser-spec.js
@@ -13,6 +13,8 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
       const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
       const parentTableName = "remove_reference_members"
       const childTableName = "remove_reference_enrollments"
+      const referenceName = "removeReferenceMember"
+      const referenceColumnName = "remove_reference_member_id"
 
       try {
         await dropRemoveReferenceTables(driver, childTableName, parentTableName)
@@ -22,32 +24,32 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
           table.string("category", {null: false})
         })
         await migration.addIndex(childTableName, ["status", "category"], {name: "index_remove_reference_enrollments_on_status_and_category"})
-        await migration.addReference(childTableName, "member", {foreignKey: true, type: "uuid"})
+        await migration.addReference(childTableName, referenceName, {foreignKey: true, type: "uuid"})
 
         const tableWithReference = await driver.getTableByNameOrFail(childTableName)
         const columnNames = (await tableWithReference.getColumns()).map((column) => column.getName())
         const memberIndexes = (await tableWithReference.getIndexes())
-          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === referenceColumnName)
         const foreignKeys = await tableWithReference.getForeignKeys()
 
-        expect(columnNames).toContain("member_id")
+        expect(columnNames).toContain(referenceColumnName)
         expect(memberIndexes).toHaveLength(1)
         expect(memberIndexes[0].isUnique()).toBe(false)
-        expect(foreignKeys.map((foreignKey) => foreignKey.getColumnName())).toContain("member_id")
+        expect(foreignKeys.map((foreignKey) => foreignKey.getColumnName())).toContain(referenceColumnName)
 
-        await migration.removeReference(childTableName, "member")
+        await migration.removeReference(childTableName, referenceName)
 
         const tableWithoutReference = await driver.getTableByNameOrFail(childTableName)
         const remainingColumnNames = (await tableWithoutReference.getColumns()).map((column) => column.getName())
         const remainingMemberIndexes = (await tableWithoutReference.getIndexes())
-          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === referenceColumnName)
         const remainingForeignKeys = await tableWithoutReference.getForeignKeys()
         const remainingCompositeIndex = (await tableWithoutReference.getIndexes())
           .find((index) => index.getName() === "index_remove_reference_enrollments_on_status_and_category")
 
-        expect(remainingColumnNames).not.toContain("member_id")
+        expect(remainingColumnNames).not.toContain(referenceColumnName)
         expect(remainingMemberIndexes).toHaveLength(0)
-        expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain("member_id")
+        expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain(referenceColumnName)
         expect(remainingCompositeIndex?.getColumnNames()).toEqual(["status", "category"])
       } finally {
         await dropRemoveReferenceTables(driver, childTableName, parentTableName)

--- a/spec/database/migration/remove-reference.browser-spec.js
+++ b/spec/database/migration/remove-reference.browser-spec.js
@@ -17,7 +17,11 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
       try {
         await dropRemoveReferenceTables(driver, childTableName, parentTableName)
         await migration.createTable(parentTableName, {id: {type: "uuid"}})
-        await migration.createTable(childTableName, {id: {type: "uuid"}})
+        await migration.createTable(childTableName, {id: {type: "uuid"}}, (table) => {
+          table.string("status", {null: false})
+          table.string("category", {null: false})
+        })
+        await migration.addIndex(childTableName, ["status", "category"], {name: "index_remove_reference_enrollments_on_status_and_category"})
         await migration.addReference(childTableName, "member", {foreignKey: true, type: "uuid"})
 
         const tableWithReference = await driver.getTableByNameOrFail(childTableName)
@@ -38,10 +42,13 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
         const remainingMemberIndexes = (await tableWithoutReference.getIndexes())
           .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
         const remainingForeignKeys = await tableWithoutReference.getForeignKeys()
+        const remainingCompositeIndex = (await tableWithoutReference.getIndexes())
+          .find((index) => index.getName() === "index_remove_reference_enrollments_on_status_and_category")
 
         expect(remainingColumnNames).not.toContain("member_id")
         expect(remainingMemberIndexes).toHaveLength(0)
         expect(remainingForeignKeys.map((foreignKey) => foreignKey.getColumnName())).not.toContain("member_id")
+        expect(remainingCompositeIndex?.getColumnNames()).toEqual(["status", "category"])
       } finally {
         await dropRemoveReferenceTables(driver, childTableName, parentTableName)
       }

--- a/spec/database/migration/remove-reference.browser-spec.js
+++ b/spec/database/migration/remove-reference.browser-spec.js
@@ -57,7 +57,7 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
       const childTableName = "remove_reference_drafts"
 
       try {
-        await driver.dropTable(childTableName, {cascade: true, ifExists: true})
+        await dropRemoveReferenceTables(driver, childTableName)
         await migration.createTable(childTableName, {id: {type: "uuid"}})
         await migration.addReference(childTableName, "member", {type: "uuid"})
 
@@ -78,7 +78,42 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
         expect((await tableWithoutReference.getColumns()).map((column) => column.getName())).not.toContain("member_id")
         expect(remainingMemberIndexes).toHaveLength(0)
       } finally {
-        await driver.dropTable(childTableName, {cascade: true, ifExists: true})
+        await dropRemoveReferenceTables(driver, childTableName)
+      }
+    })
+  })
+
+  it("removes a reference column and its unique index when no foreign key was added", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const childTableName = "remove_reference_unique_drafts"
+
+      try {
+        await dropRemoveReferenceTables(driver, childTableName)
+        await migration.createTable(childTableName, {id: {type: "uuid"}})
+        await migration.addReference(childTableName, "member", {type: "uuid", unique: true})
+
+        const tableWithReference = await driver.getTableByNameOrFail(childTableName)
+        const memberIndexes = (await tableWithReference.getIndexes())
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+
+        expect((await tableWithReference.getColumns()).map((column) => column.getName())).toContain("member_id")
+        expect(memberIndexes).toHaveLength(1)
+        expect(memberIndexes[0].isUnique()).toBe(true)
+
+        await migration.removeReference(childTableName, "member")
+
+        const tableWithoutReference = await driver.getTableByNameOrFail(childTableName)
+        const remainingMemberIndexes = (await tableWithoutReference.getIndexes())
+          .filter((index) => index.getColumnNames().length === 1 && index.getColumnNames()[0] === "member_id")
+
+        expect((await tableWithoutReference.getColumns()).map((column) => column.getName())).not.toContain("member_id")
+        expect(remainingMemberIndexes).toHaveLength(0)
+      } finally {
+        await dropRemoveReferenceTables(driver, childTableName)
       }
     })
   })
@@ -87,10 +122,11 @@ describe("database - migration - removeReference", {tags: ["dummy"]}, () => {
 /**
  * @param {import("../../../src/database/drivers/base.js").default} driver - Database driver.
  * @param {string} childTableName - Child table name.
- * @param {string} parentTableName - Parent table name.
+ * @param {string | undefined} [parentTableName] - Parent table name.
  * @returns {Promise<void>}
  */
 async function dropRemoveReferenceTables(driver, childTableName, parentTableName) {
+  await driver.dropTable(`${childTableName}_velocious_rebuild`, {cascade: true, ifExists: true})
   await driver.dropTable(childTableName, {cascade: true, ifExists: true})
-  await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
+  if (parentTableName) await driver.dropTable(parentTableName, {cascade: true, ifExists: true})
 }

--- a/spec/database/migration/sqlite-rename-column-indexes.browser-spec.js
+++ b/spec/database/migration/sqlite-rename-column-indexes.browser-spec.js
@@ -1,0 +1,56 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import Migration from "../../../src/database/migration/index.js"
+
+describe("database - migration - SQLite rename column indexes", {tags: ["dummy"]}, () => {
+  it("preserves ordinary and unique indexes with their renamed ordered columns", async () => {
+    const configuration = Configuration.current()
+
+    await configuration.ensureConnections(async (dbs) => {
+      const driver = dbs.default
+
+      if (driver.getType() !== "sqlite") return
+
+      const migration = new Migration({configuration, databaseIdentifier: "default", db: driver})
+      const tableName = "rename_column_indexes_tasks"
+
+      try {
+        await dropRenameColumnIndexesTable(driver, tableName)
+        await migration.createTable(tableName, {id: {type: "uuid"}}, (table) => {
+          table.string("state", {null: false})
+          table.string("category", {null: false})
+          table.string("slug", {null: false})
+        })
+        await migration.addIndex(tableName, ["state", "category"], {name: "index_sqlite_rename_tasks_on_state_and_category"})
+        await migration.addIndex(tableName, ["category", "slug"], {name: "index_sqlite_rename_tasks_on_category_and_slug", unique: true})
+
+        await migration.renameColumn(tableName, "state", "status")
+        await migration.renameColumn(tableName, "category", "classification")
+
+        const table = await driver.getTableByNameOrFail(tableName)
+        const indexes = await table.getIndexes()
+        const ordinaryIndex = indexes.find((index) => index.getName() === "index_sqlite_rename_tasks_on_state_and_category")
+        const uniqueIndex = indexes.find((index) => index.getName() === "index_sqlite_rename_tasks_on_category_and_slug")
+
+        expect(ordinaryIndex?.getColumnNames()).toEqual(["status", "classification"])
+        expect(ordinaryIndex?.isUnique()).toBe(false)
+        expect(uniqueIndex?.getColumnNames()).toEqual(["classification", "slug"])
+        expect(uniqueIndex?.isUnique()).toBe(true)
+      } finally {
+        await dropRenameColumnIndexesTable(driver, tableName)
+      }
+    })
+  })
+})
+
+/**
+ * @param {import("../../../src/database/drivers/base.js").default} driver - Database driver.
+ * @param {string} tableName - Scratch table name.
+ * @returns {Promise<void>}
+ */
+async function dropRenameColumnIndexesTable(driver, tableName) {
+  await driver.dropTable(`${tableName}_velocious_rebuild`, {cascade: true, ifExists: true})
+  await driver.dropTable(tableName, {cascade: true, ifExists: true})
+}

--- a/src/database/drivers/base-table.js
+++ b/src/database/drivers/base-table.js
@@ -104,13 +104,15 @@ export default class VelociousDatabaseDriversBaseTable {
     }
 
     for (const foreignKey of await this.getForeignKeys()) {
-      tableData.addForeignKey(foreignKey.getTableDataForeignKey())
+      const tableDataForeignKey = foreignKey.getTableDataForeignKey()
+
+      tableData.addForeignKey(tableDataForeignKey)
 
       const tableDataColumn = tableDataColumns.find((tableDataColumn) => tableDataColumn.getName() == foreignKey.getColumnName())
 
       if (!tableDataColumn) throw new Error(`Couldn't find table data column for foreign key: ${foreignKey.getColumnName()}`)
 
-      tableDataColumn.setForeignKey(foreignKey)
+      tableDataColumn.setForeignKey(tableDataForeignKey)
     }
 
     for (const index of await this.getIndexes()) {
@@ -153,4 +155,3 @@ export default class VelociousDatabaseDriversBaseTable {
     return await this.getDriver().query(sql)
   }
 }
-

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -225,6 +225,34 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Runs remove foreign key.
+   * @param {string} tableName - Table name.
+   * @param {import("./base-foreign-key.js").default} foreignKeyMetadata - Foreign key metadata.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async removeForeignKey(tableName, foreignKeyMetadata) {
+    this._assertNotReadOnly()
+
+    const tableForeignKey = new TableForeignKey({
+      columnName: foreignKeyMetadata.getColumnName(),
+      dropForeignKey: true,
+      name: foreignKeyMetadata.getName(),
+      referencedColumnName: foreignKeyMetadata.getReferencedColumnName(),
+      referencedTableName: foreignKeyMetadata.getReferencedTableName(),
+      tableName
+    })
+    const tableData = new TableData(tableName)
+
+    tableData.addForeignKey(tableForeignKey)
+
+    const alterTableSQLs = await this.alterTableSQLs(tableData)
+
+    for (const alterTableSQL of alterTableSQLs) {
+      await this.query(alterTableSQL)
+    }
+  }
+
+  /**
    * Runs alter table sqls.
    * @abstract
    * @param {import("../table-data/index.js").default} _tableData - Table data.

--- a/src/database/drivers/index-metadata.js
+++ b/src/database/drivers/index-metadata.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+import { forcedBoolean, forcedString } from "typanic"
+
+/**
+ * IndexMetadataType type.
+ * @typedef {object} IndexMetadataType
+ * @property {string} column_name - Index column name.
+ * @property {string} index_name - Index name.
+ * @property {boolean} is_primary_key - Whether the index is primary.
+ * @property {boolean} is_unique - Whether the index is unique.
+ * @property {string} table_name - Table name.
+ */
+
+/**
+ * Normalizes one untrusted database index metadata row.
+ * @param {import("./base.js").QueryRowType} row - Database index metadata row.
+ * @returns {IndexMetadataType} - Validated index metadata.
+ */
+export function normalizeIndexMetadataRow(row) {
+  return {
+    column_name: forcedString(row.column_name, "index column_name"),
+    index_name: forcedString(row.index_name, "index index_name"),
+    is_primary_key: forcedBoolean(row.is_primary_key, "index is_primary_key"),
+    is_unique: forcedBoolean(row.is_unique, "index is_unique"),
+    table_name: forcedString(row.table_name, "index table_name")
+  }
+}

--- a/src/database/drivers/mssql/column.js
+++ b/src/database/drivers/mssql/column.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import BaseColumn from "../base-column.js"
-import ColumnsIndex from "./columns-index.js"
 import {digg} from "diggerize"
 
 export default class VelociousDatabaseDriversMssqlColumn extends BaseColumn {
@@ -19,39 +18,9 @@ export default class VelociousDatabaseDriversMssqlColumn extends BaseColumn {
   getAutoIncrement() { return digg(this, "data", "isIdentity") === 1 }
 
   async getIndexes() {
-    const options = this.getOptions()
-    const sql = `
-      SELECT
-        sys.tables.name AS TableName,
-        sys.columns.name AS ColumnName,
-        sys.indexes.name AS index_name,
-        sys.indexes.type_desc AS IndexType,
-        sys.index_columns.is_included_column AS IsIncludedColumn,
-        sys.indexes.is_unique,
-        sys.indexes.is_primary_key,
-        sys.indexes.is_unique_constraint
-      FROM sys.indexes
-      INNER JOIN sys.index_columns ON sys.indexes.object_id = sys.index_columns.object_id AND sys.indexes.index_id = sys.index_columns.index_id
-      INNER JOIN sys.columns ON sys.index_columns.object_id = sys.columns.object_id AND sys.index_columns.column_id = sys.columns.column_id
-      INNER JOIN sys.tables ON sys.indexes.object_id = sys.tables.object_id
-      WHERE
-        sys.tables.name = ${options.quote(this.getTable().getName())} AND
-        sys.columns.name = ${options.quote(this.getName())}
-      ORDER BY
-        sys.indexes.name,
-        sys.index_columns.key_ordinal
-    `
+    const indexes = await this.getTable().getIndexes()
 
-    const rows = await this.getDriver().query(sql)
-    const indexes = []
-
-    for (const row of rows) {
-      const index = new ColumnsIndex(this.getTable(), row)
-
-      indexes.push(index)
-    }
-
-    return indexes
+    return indexes.filter((index) => index.getColumnNames().includes(this.getName()))
   }
 
   getDefault() { return digg(this, "data", "COLUMN_DEFAULT") }
@@ -71,4 +40,3 @@ export default class VelociousDatabaseDriversMssqlColumn extends BaseColumn {
   getPrimaryKey() { return digg(this, "data", "isIdentity") === 1 }
   getType() { return digg(this, "data", "DATA_TYPE") }
 }
-

--- a/src/database/drivers/mssql/columns-index.js
+++ b/src/database/drivers/mssql/columns-index.js
@@ -1,6 +1,43 @@
 // @ts-check
 
 import BaseColumnsIndex from "../base-columns-index.js"
+import TableIndex from "../../table-data/table-index.js"
+
+/**
+ * MssqlColumnsIndexDataType type.
+ * @typedef {object} MssqlColumnsIndexDataType
+ * @property {string[]} columnNames - Ordered index column names.
+ * @property {string} index_name - Index name.
+ * @property {boolean} is_primary_key - Whether the index is primary.
+ * @property {boolean} is_unique - Whether the index is unique.
+ * @property {string} table_name - Table name.
+ */
 
 export default class VelociousDatabaseDriversMssqlColumnsIndex extends BaseColumnsIndex {
+  /**
+   * Runs constructor.
+   * @param {import("../base-table.js").default} table - Table.
+   * @param {MssqlColumnsIndexDataType} data - Grouped index metadata.
+   */
+  constructor(table, data) {
+    super(table, data)
+    this.indexData = data
+  }
+
+  /**
+   * Runs get column names.
+   * @returns {string[]} - Ordered index column names.
+   */
+  getColumnNames() { return this.indexData.columnNames }
+
+  /**
+   * Runs get table data index.
+   * @returns {TableIndex} - Table-data index.
+   */
+  getTableDataIndex() {
+    return new TableIndex(this.getColumnNames(), {
+      name: this.getName(),
+      unique: this.isUnique()
+    })
+  }
 }

--- a/src/database/drivers/mssql/table.js
+++ b/src/database/drivers/mssql/table.js
@@ -5,6 +5,51 @@ import Column from "./column.js"
 import ColumnsIndex from "./columns-index.js"
 import {digg} from "diggerize"
 import ForeignKey from "./foreign-key.js"
+import { normalizeIndexMetadataRow } from "../index-metadata.js"
+
+/**
+ * MssqlGroupedIndexDataType type.
+ * @typedef {object} MssqlGroupedIndexDataType
+ * @property {string[]} columnNames - Ordered index column names.
+ * @property {string} index_name - Index name.
+ * @property {boolean} is_primary_key - Whether the index is primary.
+ * @property {boolean} is_unique - Whether the index is unique.
+ * @property {string} table_name - Table name.
+ */
+
+/**
+ * Groups ordered SQL Server index rows into one metadata value per index.
+ * @param {import("../index-metadata.js").IndexMetadataType[]} indexRows - Ordered index metadata rows.
+ * @returns {MssqlGroupedIndexDataType[]} - Grouped index metadata.
+ */
+export function groupMssqlIndexRows(indexRows) {
+  /** @type {Map<string, MssqlGroupedIndexDataType>} */
+  const indexDataByName = new Map()
+  /** @type {MssqlGroupedIndexDataType[]} */
+  const groupedIndexData = []
+
+  for (const indexRow of indexRows) {
+    const existingIndexData = indexDataByName.get(indexRow.index_name)
+
+    if (existingIndexData) {
+      existingIndexData.columnNames.push(indexRow.column_name)
+      continue
+    }
+
+    const indexData = {
+      columnNames: [indexRow.column_name],
+      index_name: indexRow.index_name,
+      is_primary_key: indexRow.is_primary_key,
+      is_unique: indexRow.is_unique,
+      table_name: indexRow.table_name
+    }
+
+    indexDataByName.set(indexRow.index_name, indexData)
+    groupedIndexData.push(indexData)
+  }
+
+  return groupedIndexData
+}
 
 export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
   /**
@@ -84,20 +129,18 @@ export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
       const options = this.getOptions()
       const sql = `
         SELECT
-          sys.tables.name AS TableName,
-          sys.columns.name AS ColumnName,
+          sys.tables.name AS table_name,
+          sys.columns.name AS column_name,
           sys.indexes.name AS index_name,
-          sys.indexes.type_desc AS IndexType,
-          sys.index_columns.is_included_column AS IsIncludedColumn,
           sys.indexes.is_unique,
-          sys.indexes.is_primary_key,
-          sys.indexes.is_unique_constraint
+          sys.indexes.is_primary_key
         FROM sys.indexes
         INNER JOIN sys.index_columns ON sys.indexes.object_id = sys.index_columns.object_id AND sys.indexes.index_id = sys.index_columns.index_id
         INNER JOIN sys.columns ON sys.index_columns.object_id = sys.columns.object_id AND sys.index_columns.column_id = sys.columns.column_id
         INNER JOIN sys.tables ON sys.indexes.object_id = sys.tables.object_id
         WHERE
-          sys.tables.name = ${options.quote(this.getName())}
+          sys.tables.name = ${options.quote(this.getName())} AND
+          sys.index_columns.is_included_column = 0
         ORDER BY
           sys.indexes.name,
           sys.index_columns.key_ordinal
@@ -105,9 +148,10 @@ export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
 
       const rows = await this.getDriver().query(sql)
       const indexes = []
+      const indexRows = rows.map((row) => normalizeIndexMetadataRow(row))
 
-      for (const row of rows) {
-        const index = new ColumnsIndex(this, row)
+      for (const indexData of groupMssqlIndexRows(indexRows)) {
+        const index = new ColumnsIndex(this, indexData)
 
         indexes.push(index)
       }

--- a/src/database/drivers/mssql/table.js
+++ b/src/database/drivers/mssql/table.js
@@ -43,7 +43,7 @@ export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
     return await this.getDriver()._cachedTableSchemaMetadata(this.getName(), "foreignKeys", async () => {
       const sql = `
         SELECT
-            fk.name AS ForeignKeyName,
+            fk.name AS CONSTRAINT_NAME,
             tp.name AS ParentTable,
             ref.name AS ReferencedTable,
             cp.name AS ParentColumn,
@@ -63,7 +63,7 @@ export default class VelociousDatabaseDriversMssqlTable extends BaseTable {
             ON fkc.referenced_object_id = cref.object_id
             AND fkc.referenced_column_id = cref.column_id
         WHERE tp.name = ${this.driver.quote(this.getName())}
-        ORDER BY ForeignKeyName, ParentTable, ReferencedTable;
+        ORDER BY CONSTRAINT_NAME, ParentTable, ReferencedTable;
       `
 
       const foreignKeyRows = await this.driver.query(sql)

--- a/src/database/drivers/mysql/sql/alter-table.js
+++ b/src/database/drivers/mysql/sql/alter-table.js
@@ -5,6 +5,19 @@ import TableColumn from "../../../table-data/table-column.js"
 
 export default class VelociousDatabaseConnectionDriversMysqlSqlAlterTable extends AlterTableBase {
   /**
+   * Runs get drop foreign key sql.
+   * @param {import("../../../table-data/table-foreign-key.js").default} foreignKey - Foreign key to drop.
+   * @returns {string} - SQL fragment that removes the foreign key.
+   */
+  getDropForeignKeySQL(foreignKey) {
+    const name = foreignKey.getName()
+
+    if (!name) throw new Error(`Cannot remove unnamed foreign key on ${foreignKey.getTableName()}.${foreignKey.getColumnName()}`)
+
+    return `DROP FOREIGN KEY ${this.getOptions().quoteIndexName(name)}`
+  }
+
+  /**
    * Builds MySQL ALTER TABLE statements, adding indexes atomically with columns.
    * @returns {Promise<string[]>} - Resolves with SQL statements.
    */

--- a/src/database/drivers/pgsql/column.js
+++ b/src/database/drivers/pgsql/column.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import BaseColumn from "../base-column.js"
-import ColumnsIndex from "./columns-index.js"
 import {digg} from "diggerize"
 
 export default class VelociousDatabaseDriversPgsqlColumn extends BaseColumn {
@@ -25,33 +24,9 @@ export default class VelociousDatabaseDriversPgsqlColumn extends BaseColumn {
   }
 
   async getIndexes() {
-    const options = this.getOptions()
+    const indexes = await this.getTable().getIndexes()
 
-    const indexesRows = await this.table.getDriver().query(`
-      SELECT
-        pg_attribute.attname AS column_name,
-        pg_index.indexrelid::regclass as index_name,
-        pg_class.relnamespace::regnamespace as schema_name,
-        pg_class.relname as table_name,
-        pg_index.indisprimary as is_primary_key,
-        pg_index.indisunique as is_unique
-      FROM pg_index
-      JOIN pg_class ON pg_class.oid = pg_index.indrelid
-      JOIN pg_attribute ON pg_attribute.attrelid = pg_class.oid AND pg_attribute.attnum = ANY(pg_index.indkey)
-      WHERE
-        pg_attribute.attname = ${options.quote(this.getName())} AND
-        pg_class.relname = ${options.quote(this.getTable().getName())}
-    `)
-
-    const indexes = []
-
-    for (const indexRow of indexesRows) {
-      const columnsIndex = new ColumnsIndex(this.getTable(), indexRow)
-
-      indexes.push(columnsIndex)
-    }
-
-    return indexes
+    return indexes.filter((index) => index.getColumnNames().includes(this.getName()))
   }
 
   getDefault() {

--- a/src/database/drivers/pgsql/columns-index.js
+++ b/src/database/drivers/pgsql/columns-index.js
@@ -1,6 +1,43 @@
 // @ts-check
 
 import BaseColumnsIndex from "../base-columns-index.js"
+import TableIndex from "../../table-data/table-index.js"
+
+/**
+ * PgsqlColumnsIndexDataType type.
+ * @typedef {object} PgsqlColumnsIndexDataType
+ * @property {string[]} columnNames - Ordered index column names.
+ * @property {string} index_name - Index name.
+ * @property {boolean} is_primary_key - Whether the index is primary.
+ * @property {boolean} is_unique - Whether the index is unique.
+ * @property {string} table_name - Table name.
+ */
 
 export default class VelociousDatabaseDriversPgsqlColumn extends BaseColumnsIndex {
+  /**
+   * Runs constructor.
+   * @param {import("../base-table.js").default} table - Table.
+   * @param {PgsqlColumnsIndexDataType} data - Grouped index metadata.
+   */
+  constructor(table, data) {
+    super(table, data)
+    this.indexData = data
+  }
+
+  /**
+   * Runs get column names.
+   * @returns {string[]} - Ordered index column names.
+   */
+  getColumnNames() { return this.indexData.columnNames }
+
+  /**
+   * Runs get table data index.
+   * @returns {TableIndex} - Table-data index.
+   */
+  getTableDataIndex() {
+    return new TableIndex(this.getColumnNames(), {
+      name: this.getName(),
+      unique: this.isUnique()
+    })
+  }
 }

--- a/src/database/drivers/pgsql/table.js
+++ b/src/database/drivers/pgsql/table.js
@@ -4,6 +4,51 @@ import BaseTable from "../base-table.js"
 import Column from "./column.js"
 import ColumnsIndex from "./columns-index.js"
 import ForeignKey from "./foreign-key.js"
+import { normalizeIndexMetadataRow } from "../index-metadata.js"
+
+/**
+ * PgsqlGroupedIndexDataType type.
+ * @typedef {object} PgsqlGroupedIndexDataType
+ * @property {string[]} columnNames - Ordered index column names.
+ * @property {string} index_name - Index name.
+ * @property {boolean} is_primary_key - Whether the index is primary.
+ * @property {boolean} is_unique - Whether the index is unique.
+ * @property {string} table_name - Table name.
+ */
+
+/**
+ * Groups ordered PostgreSQL index rows into one metadata value per index.
+ * @param {import("../index-metadata.js").IndexMetadataType[]} indexRows - Ordered index metadata rows.
+ * @returns {PgsqlGroupedIndexDataType[]} - Grouped index metadata.
+ */
+export function groupPgsqlIndexRows(indexRows) {
+  /** @type {Map<string, PgsqlGroupedIndexDataType>} */
+  const indexDataByName = new Map()
+  /** @type {PgsqlGroupedIndexDataType[]} */
+  const groupedIndexData = []
+
+  for (const indexRow of indexRows) {
+    const existingIndexData = indexDataByName.get(indexRow.index_name)
+
+    if (existingIndexData) {
+      existingIndexData.columnNames.push(indexRow.column_name)
+      continue
+    }
+
+    const indexData = {
+      columnNames: [indexRow.column_name],
+      index_name: indexRow.index_name,
+      is_primary_key: indexRow.is_primary_key,
+      is_unique: indexRow.is_unique,
+      table_name: indexRow.table_name
+    }
+
+    indexDataByName.set(indexRow.index_name, indexData)
+    groupedIndexData.push(indexData)
+  }
+
+  return groupedIndexData
+}
 
 export default class VelociousDatabaseDriversPgsqlTable extends BaseTable {
   /**
@@ -100,23 +145,29 @@ export default class VelociousDatabaseDriversPgsqlTable extends BaseTable {
 
       const indexesRows = await this.getDriver().query(`
         SELECT
-          pg_attribute.attname AS column_name,
-          pg_index.indexrelid::regclass as index_name,
-          pg_class.relnamespace::regnamespace as schema_name,
-          pg_class.relname as table_name,
-          pg_index.indisprimary as is_primary_key,
-          pg_index.indisunique as is_unique
+          index_attribute.attname AS column_name,
+          pg_index.indexrelid::regclass AS index_name,
+          pg_class.relname AS table_name,
+          pg_index.indisprimary AS is_primary_key,
+          pg_index.indisunique AS is_unique
         FROM pg_index
         JOIN pg_class ON pg_class.oid = pg_index.indrelid
-        JOIN pg_attribute ON pg_attribute.attrelid = pg_class.oid AND pg_attribute.attnum = ANY(pg_index.indkey)
+        JOIN LATERAL unnest(pg_index.indkey) WITH ORDINALITY AS index_columns(attribute_number, ordinal_position) ON true
+        JOIN pg_attribute AS index_attribute ON index_attribute.attrelid = pg_class.oid AND index_attribute.attnum = index_columns.attribute_number
         WHERE
-          pg_class.relname = ${options.quote(this.getName())}
+          pg_class.relname = ${options.quote(this.getName())} AND
+          index_columns.ordinal_position <= pg_index.indnkeyatts
+        ORDER BY
+          pg_index.indexrelid,
+          index_columns.ordinal_position
       `)
 
       const indexes = []
 
-      for (const indexRow of indexesRows) {
-        const columnsIndex = new ColumnsIndex(this, indexRow)
+      const indexRows = indexesRows.map((indexRow) => normalizeIndexMetadataRow(indexRow))
+
+      for (const indexData of groupPgsqlIndexRows(indexRows)) {
+        const columnsIndex = new ColumnsIndex(this, indexData)
 
         indexes.push(columnsIndex)
       }

--- a/src/database/drivers/sqlite/sql/alter-table.js
+++ b/src/database/drivers/sqlite/sql/alter-table.js
@@ -134,6 +134,16 @@ export default class VelociousDatabaseConnectionDriversSqliteSqlAlterTable exten
 
     for (const currentForeignKey of currentTableData.getForeignKeys()) {
       const alterForeignKey = alterTableData.getForeignKeys().find((foreignKey) => foreignKey.getName() == currentForeignKey.getName())
+
+      if (alterForeignKey?.getDropForeignKey()) {
+        const targetColumnName = columnRenames.get(currentForeignKey.getColumnName()) || currentForeignKey.getColumnName()
+        const targetColumn = targetTableData.getColumns().find((column) => column.getActualName() == targetColumnName)
+
+        if (targetColumn) targetColumn.setForeignKey(undefined)
+
+        continue
+      }
+
       const finalForeignKey = this._renameForeignKeyColumn(alterForeignKey || currentForeignKey, columnRenames)
 
       seenForeignKeyNames.add(finalForeignKey.getName())
@@ -141,10 +151,13 @@ export default class VelociousDatabaseConnectionDriversSqliteSqlAlterTable exten
     }
 
     for (const alterForeignKey of alterTableData.getForeignKeys()) {
+      if (alterForeignKey.getDropForeignKey()) continue
       if (seenForeignKeyNames.has(alterForeignKey.getName())) continue
 
       targetTableData.addForeignKey(this._renameForeignKeyColumn(alterForeignKey, columnRenames))
     }
+
+    const targetColumnNames = new Set(targetTableData.getColumns().map((column) => column.getName()))
 
     for (const currentIndex of currentTableData.getIndexes()) {
       const renamedColumns = currentIndex.getColumns().map((columnName) => {
@@ -152,6 +165,10 @@ export default class VelociousDatabaseConnectionDriversSqliteSqlAlterTable exten
 
         return columnRenames.get(columnName) || columnName
       })
+
+      const indexColumnNames = renamedColumns.map((column) => typeof column == "string" ? column : column.getName())
+
+      if (indexColumnNames.some((columnName) => !targetColumnNames.has(columnName))) continue
 
       targetTableData.addIndex(new TableIndex(renamedColumns, {
         name: currentIndex.getName(),
@@ -177,6 +194,7 @@ export default class VelociousDatabaseConnectionDriversSqliteSqlAlterTable exten
 
     return new TableForeignKey({
       columnName: renamed,
+      dropForeignKey: foreignKey.getDropForeignKey(),
       isNewForeignKey: foreignKey.getIsNewForeignKey(),
       name: foreignKey.getName(),
       referencedColumnName: foreignKey.getReferencedColumnName(),

--- a/src/database/drivers/sqlite/sql/alter-table.js
+++ b/src/database/drivers/sqlite/sql/alter-table.js
@@ -157,7 +157,7 @@ export default class VelociousDatabaseConnectionDriversSqliteSqlAlterTable exten
       targetTableData.addForeignKey(this._renameForeignKeyColumn(alterForeignKey, columnRenames))
     }
 
-    const targetColumnNames = new Set(targetTableData.getColumns().map((column) => column.getName()))
+    const targetColumnNames = new Set(targetTableData.getColumns().map((column) => column.getActualName()))
 
     for (const currentIndex of currentTableData.getIndexes()) {
       const renamedColumns = currentIndex.getColumns().map((columnName) => {

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -289,19 +289,35 @@ export default class VelociousDatabaseMigration {
 
     const resolvedColumnName = columnName || `${inflection.underscore(referenceName)}_id`
     const driver = this.getDriver()
-    const table = await driver.getTableByName(tableName)
+    let maximumRemovals = 0
+    let previousMatchingCount = 0
 
-    if (!table) throw new Error(`Table ${tableName} does not exist`)
+    for (let removalAttempt = 0; ; removalAttempt++) {
+      const table = await driver.getTableByName(tableName)
 
-    const foreignKeys = await table.getForeignKeys()
-    const matchingForeignKeys = foreignKeys.filter((foreignKey) => foreignKey.getColumnName() == resolvedColumnName)
+      if (!table) throw new Error(`Table ${tableName} does not exist`)
 
-    if (matchingForeignKeys.length === 0) {
-      throw new Error(`No foreign key on ${tableName}.${resolvedColumnName}`)
-    }
+      const foreignKeys = await table.getForeignKeys()
+      const matchingForeignKeys = foreignKeys.filter((foreignKey) => foreignKey.getColumnName() == resolvedColumnName)
 
-    for (const foreignKey of matchingForeignKeys) {
-      await driver.removeForeignKey(tableName, foreignKey)
+      if (matchingForeignKeys.length === 0) {
+        if (removalAttempt === 0) throw new Error(`No foreign key on ${tableName}.${resolvedColumnName}`)
+
+        return
+      }
+
+      if (removalAttempt === 0) {
+        maximumRemovals = matchingForeignKeys.length
+      } else if (matchingForeignKeys.length >= previousMatchingCount) {
+        throw new Error(`Foreign key removal did not reduce matches on ${tableName}.${resolvedColumnName}`)
+      }
+
+      if (removalAttempt >= maximumRemovals) {
+        throw new Error(`Foreign key removal exceeded expected matches on ${tableName}.${resolvedColumnName}`)
+      }
+
+      previousMatchingCount = matchingForeignKeys.length
+      await driver.removeForeignKey(tableName, matchingForeignKeys[0])
     }
   }
 

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -271,6 +271,41 @@ export default class VelociousDatabaseMigration {
   }
 
   /**
+   * RemoveForeignKeyArgsType type.
+   * @typedef {object} RemoveForeignKeyArgsType
+   * @property {string} [columnName] - Override the derived foreign-key column name.
+   */
+  /**
+   * Runs remove foreign key.
+   * @param {string} tableName - Table the foreign key lives on.
+   * @param {string} referenceName - Singular reference name used to derive the FK column.
+   * @param {RemoveForeignKeyArgsType} [args] - Optional overrides.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async removeForeignKey(tableName, referenceName, args = {}) {
+    const {columnName, ...restArgs} = args
+
+    restArgsError(restArgs)
+
+    const resolvedColumnName = columnName || `${inflection.underscore(referenceName)}_id`
+    const driver = this.getDriver()
+    const table = await driver.getTableByName(tableName)
+
+    if (!table) throw new Error(`Table ${tableName} does not exist`)
+
+    const foreignKeys = await table.getForeignKeys()
+    const matchingForeignKeys = foreignKeys.filter((foreignKey) => foreignKey.getColumnName() == resolvedColumnName)
+
+    if (matchingForeignKeys.length === 0) {
+      throw new Error(`No foreign key on ${tableName}.${resolvedColumnName}`)
+    }
+
+    for (const foreignKey of matchingForeignKeys) {
+      await driver.removeForeignKey(tableName, foreignKey)
+    }
+  }
+
+  /**
    * Runs add reference.
    * @param {string} tableName - Table name.
    * @param {string} referenceName - Reference name.
@@ -299,15 +334,53 @@ export default class VelociousDatabaseMigration {
   }
 
   /**
+   * RemoveReferenceArgsType type.
+   * @typedef {object} RemoveReferenceArgsType
+   * @property {string} [columnName] - Override the derived reference column name.
+   * @property {string} [indexName] - Explicit generated index name to remove.
+   */
+  /**
    * Runs remove reference.
    * @param {string} tableName - Table name.
    * @param {string} referenceName - Reference name.
+   * @param {RemoveReferenceArgsType} [args] - Optional overrides.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async removeReference(tableName, referenceName) {
-    const columnName = `${inflection.underscore(referenceName)}_id`
+  async removeReference(tableName, referenceName, args = {}) {
+    const {columnName, indexName, ...restArgs} = args
 
-    this.removeColumn(tableName, columnName)
+    restArgsError(restArgs)
+
+    const resolvedColumnName = columnName || `${inflection.underscore(referenceName)}_id`
+    const driver = this.getDriver()
+    const table = await driver.getTableByName(tableName)
+
+    if (!table) throw new Error(`Table ${tableName} does not exist`)
+
+    const foreignKeys = await table.getForeignKeys()
+
+    for (const foreignKey of foreignKeys) {
+      if (foreignKey.getColumnName() != resolvedColumnName) continue
+
+      await driver.removeForeignKey(tableName, foreignKey)
+    }
+
+    const expectedIndexName = indexName || this._removeIndexName(tableName, [resolvedColumnName])
+    const indexes = await table.getIndexes()
+    const generatedIndex = indexes.find((index) => {
+      const indexColumnNames = index.getColumnNames()
+
+      return !index.isPrimaryKey() &&
+        index.getName() == expectedIndexName &&
+        indexColumnNames.length == 1 &&
+        indexColumnNames[0] == resolvedColumnName
+    })
+
+    if (generatedIndex) {
+      await this.removeIndex(tableName, generatedIndex.getName())
+    }
+
+    await this.removeColumn(tableName, resolvedColumnName)
   }
 
   /**

--- a/src/database/query/alter-table-base.js
+++ b/src/database/query/alter-table-base.js
@@ -64,9 +64,15 @@ export default class VelociousDatabaseQueryAlterTableBase extends QueryBase {
     // SQLite's ALTER TABLE does not support adding constraints; the SQLite driver overrides
     // alterTableSQLs entirely (via TableRebuilder) so this base path is never invoked there.
     for (const foreignKey of tableData.getForeignKeys()) {
-      if (!foreignKey.getIsNewForeignKey()) continue
+      if (!foreignKey.getIsNewForeignKey() && !foreignKey.getDropForeignKey()) continue
 
       if (actionCount > 0) sql += ", "
+
+      if (foreignKey.getDropForeignKey()) {
+        sql += this.getDropForeignKeySQL(foreignKey)
+        actionCount++
+        continue
+      }
 
       sql += "ADD"
 
@@ -100,5 +106,18 @@ export default class VelociousDatabaseQueryAlterTableBase extends QueryBase {
     }
 
     return sqls
+  }
+
+  /**
+   * Runs get drop foreign key sql.
+   * @param {import("../table-data/table-foreign-key.js").default} foreignKey - Foreign key to drop.
+   * @returns {string} - SQL fragment that removes the foreign key.
+   */
+  getDropForeignKeySQL(foreignKey) {
+    const name = foreignKey.getName()
+
+    if (!name) throw new Error(`Cannot remove unnamed foreign key on ${foreignKey.getTableName()}.${foreignKey.getColumnName()}`)
+
+    return `DROP CONSTRAINT ${this.getOptions().quoteIndexName(name)}`
   }
 }

--- a/src/database/table-data/table-foreign-key.js
+++ b/src/database/table-data/table-foreign-key.js
@@ -7,16 +7,18 @@ export default class TableForeignKey {
    * Runs constructor.
    * @param {object} args - Options object.
    * @param {string} args.columnName - Column name.
+   * @param {boolean} [args.dropForeignKey] - Whether to drop this foreign key.
    * @param {boolean} [args.isNewForeignKey] - Whether is new foreign key.
    * @param {string} [args.name] - Name.
    * @param {string} args.tableName - Table name.
    * @param {string} args.referencedColumnName - Referenced column name.
    * @param {string} args.referencedTableName - Referenced table name.
    */
-  constructor({columnName, isNewForeignKey, name, tableName, referencedColumnName, referencedTableName, ...restArgs}) {
+  constructor({columnName, dropForeignKey, isNewForeignKey, name, tableName, referencedColumnName, referencedTableName, ...restArgs}) {
     restArgsError(restArgs)
 
     this._columnName = columnName
+    this._dropForeignKey = dropForeignKey
     this._isNewForeignKey = isNewForeignKey
     this._name = name
     this._tableName = tableName
@@ -29,6 +31,12 @@ export default class TableForeignKey {
    * @returns {string} - The column name.
    */
   getColumnName() { return this._columnName }
+
+  /**
+   * Runs get drop foreign key.
+   * @returns {boolean} - Whether this foreign key should be dropped.
+   */
+  getDropForeignKey() { return this._dropForeignKey || false }
 
   /**
    * Runs get is new foreign key.


### PR DESCRIPTION
## Summary
- add metadata-backed `removeForeignKey(...)` migration support
- make `removeReference(...)` await FK, exact generated index, and column removal in safe order
- preserve SQLite schema metadata and provide ordered PostgreSQL/MSSQL index metadata
- document the public rollback helpers and add a changelog fragment

## Verification
- focused `removeForeignKey` spec: 1/1
- focused `removeReference` specs: 3/3
- focused PostgreSQL/MSSQL index-metadata specs: 2/2
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- independent GPT-5.6 Sol review: PASS

## CI
The PR matrix should exercise the browser migration specs against SQLite, MariaDB, PostgreSQL, and MSSQL.