### PR TITLE
Add operation before-commit guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * In-process driver schema metadata caching (see [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md))
 * Planned local-first shared-resource sync architecture (see [docs/offline-sync.md](docs/offline-sync.md))
 * Selective named database connection checkouts, bounded pool waits, and debugging held connections (see [docs/database-connections.md](docs/database-connections.md))
-* Explicit singular-database operation transactions whose model scopes preserve ownership through records, relationships, lifecycle work, nested savepoints, and commit callbacks (see [docs/operation-scoped-transactions.md](docs/operation-scoped-transactions.md))
+* Explicit singular-database operation transactions whose model scopes preserve ownership through records, relationships, lifecycle work, nested savepoints, pre-commit guards, and commit callbacks (see [docs/operation-scoped-transactions.md](docs/operation-scoped-transactions.md))
 * AbortSignal-driven MySQL/MariaDB query cancellation for raw, model, and cross-tenant aggregate queries (see [docs/database-query-cancellation.md](docs/database-query-cancellation.md))
 * Optional built-in debug endpoint for inspecting server and database connection state (see [docs/debug-endpoint.md](docs/debug-endpoint.md))
 * Optional built-in API manifest endpoint describing every registered frontend-model resource as human- and machine-readable JSON (see [docs/api-manifest-endpoint.md](docs/api-manifest-endpoint.md))
@@ -63,13 +63,23 @@ await configuration.withTransaction({databaseIdentifier: "default", name: "accep
   ticket.setAccepted(true)
   await ticket.save()
 
+  await operation.beforeCommit(async ({operation: guardedOperation}) => {
+    const currentTicket = await guardedOperation
+      .forModel(Ticket)
+      .findByOrFail({id: ticketId})
+
+    if (!currentTicket.acceptanceStillOwnedBy(workerId)) {
+      throw new Error("Ticket acceptance ownership changed")
+    }
+  })
+
   await operation.afterCommit(async () => {
     await publishAcceptedTicket(ticket.id())
   })
 })
 ```
 
-Use operation-bound model scopes and their loaded records throughout the callback. `operation.transaction` adds a nested savepoint, and `operation.connection()` is the deliberate escape hatch for owned raw SQL. Cross-database models, same-identifier tenant switches to another physical database, and operation handles used after the callback are rejected. On shared SQLite/SQL.js pools, unrelated work waits for the operation lease, while admission during an already-open ordinary transaction is rejected. See [operation-scoped transactions](docs/operation-scoped-transactions.md) for pool behavior, after-commit failure semantics, and migration guidance.
+Use operation-bound model scopes and their loaded records throughout the callback. `operation.beforeCommit` runs a final operation-owned guard after callback success but before outer commit or nested savepoint release; a rejection rolls back that frame. `operation.transaction` adds a nested savepoint, and `operation.connection()` is the deliberate escape hatch for owned raw SQL. Cross-database models, same-identifier tenant switches to another physical database, and operation handles used after the callback are rejected. On shared SQLite/SQL.js pools, unrelated work waits for the operation lease, while admission during an already-open ordinary transaction is rejected. See [operation-scoped transactions](docs/operation-scoped-transactions.md) for guard, pool, after-commit failure, and migration semantics.
 
 # Development
 

--- a/changelog.d/20260729055443-operation-before-commit-guards.md
+++ b/changelog.d/20260729055443-operation-before-commit-guards.md
@@ -1,0 +1,1 @@
+Add operation-owned `beforeCommit` guards that run after transaction callback success but before outer commit or nested savepoint release.

--- a/docs/operation-scoped-transactions.md
+++ b/docs/operation-scoped-transactions.md
@@ -13,6 +13,16 @@ const result = await configuration.withTransaction({
   ticket.setAccepted(true)
   await ticket.save()
 
+  await operation.beforeCommit(async ({operation: guardedOperation}) => {
+    const currentTicket = await guardedOperation
+      .forModel(Ticket)
+      .findByOrFail({id: ticket.id()})
+
+    if (!currentTicket.acceptanceStillOwnedBy(workerId)) {
+      throw new Error("Ticket acceptance ownership changed")
+    }
+  })
+
   await operation.afterCommit(async () => {
     await cacheAcceptedTicket(ticket.id())
   })
@@ -62,11 +72,39 @@ await operation.forModel(Task).create({name: "Import"})
 await Task.create({name: "Import"})
 ```
 
-The operation, its query scopes, its connection, and its records are valid for database work only until `withTransaction` resolves or rejects. This includes an operation-owned `afterCommit` callback, which runs before `withTransaction` settles. Retain scalar results such as IDs, not the operation handle. In-memory attributes can still be read from a returned record, but reloading or persisting that operation-bound record after completion raises. Query the model normally after success when a longer-lived record is needed.
+The operation, its query scopes, its connection, and its records are valid for database work only until `withTransaction` resolves or rejects. This includes an operation-owned `beforeCommit` guard and `afterCommit` callback, which run before `withTransaction` settles. Retain scalar results such as IDs, not the operation handle. In-memory attributes can still be read from a returned record, but reloading or persisting that operation-bound record after completion raises. Query the model normally after success when a longer-lived record is needed.
 
-## Nested work and commit callbacks
+## Pre-commit guards, nested work, and commit callbacks
+
+`operation.beforeCommit(callback)` registers an operation-owned guard on the current transaction or savepoint frame. The callback receives an object containing the same active `operation`, so it can re-read operation-owned model state without switching connections:
+
+```js
+await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+  const ScannerDevices = operation.forModel(ScannerDevice)
+  const scannerDevice = await ScannerDevices.findByOrFail({id: scannerDeviceId})
+
+  scannerDevice.setStatus("reported")
+  await scannerDevice.save()
+
+  await operation.beforeCommit(async ({operation: guardedOperation}) => {
+    const currentScannerDevice = await guardedOperation
+      .forModel(ScannerDevice)
+      .findByOrFail({id: scannerDeviceId})
+
+    if (!currentScannerDevice.statusReportOwnedBy(reportToken)) {
+      throw scannerStatusInvalidatedError
+    }
+  })
+})
+```
+
+Velocious runs the guard after that frame's transaction callback resolves successfully and immediately before the outer `COMMIT` or nested savepoint release. If the guard throws or rejects, the existing rollback path rolls back the frame, discards its `afterCommit` callbacks, and propagates the guard error. A transaction callback that rejects never runs its guards. Each registered guard runs once for each successful callback attempt; if an outer deadlock retry reruns the transaction callback, that callback registers a fresh guard for the new attempt.
+
+Always await `beforeCommit` registration inside the transaction callback. Registration requires an active transaction frame and an active operation handle, and therefore cannot move the check past durability. The guard keeps the operation's pinned connection, tenant configuration, and exclusive shared-pool lease. Start model work through the callback's `operation`; unrelated Single-pool work continues waiting until the operation commits or rolls back.
 
 `operation.transaction(callback)` creates a savepoint on the same connection. A rejected nested callback rolls back to its savepoint; a successful nested callback remains part of the outer transaction and is still rolled back if the outer callback rejects.
+
+Each nested frame owns its guards. A successful nested callback runs its guards before releasing its savepoint. A rejected nested guard rolls back only that savepoint under the same semantics as a rejected nested transaction callback.
 
 `operation.afterCommit(callback)` attaches the callback to the current operation transaction/savepoint frame:
 
@@ -76,7 +114,7 @@ The operation, its query scopes, its connection, and its records are valid for d
 - a callback failure rejects `withTransaction`, but the database is already committed and cannot be rolled back;
 - a deadlock-shaped callback failure is surfaced without retrying the already durable operation.
 
-The framework cannot roll back arbitrary memory or external effects. Update caches, publish external messages, or make irreversible state visible only in `operation.afterCommit`, or after `withTransaction` resolves successfully. An after-commit callback that needs database models must keep using `operation.forModel(...)` or an operation-bound record.
+Use `beforeCommit` for final operation-owned validity or ownership checks that must still be able to roll back database writes. The framework cannot roll back arbitrary memory or external effects. Update caches, publish external messages, or make irreversible state visible only in `operation.afterCommit`, or after `withTransaction` resolves successfully. An after-commit callback that needs database models must keep using `operation.forModel(...)` or an operation-bound record.
 
 ## Raw SQL
 
@@ -124,8 +162,9 @@ For consumers such as ticket-app #10495:
 1. Wrap the singular-database unit of work in `configuration.withTransaction({databaseIdentifier}, callback)`.
 2. Replace static model entry points inside the callback with scopes created by `operation.forModel`.
 3. Keep using records and relationships loaded from those scopes; they propagate ownership.
-4. Move cache publication and other irreversible effects into `operation.afterCommit`, or perform them after the outer promise resolves.
-5. Return IDs or plain result data. Do not retain and reuse the operation, its connection, its scopes, or operation-bound records for later database work.
-6. Split cross-database changes into explicit separate operations with application-level compensation; one operation intentionally rejects them.
+4. Register final ownership or validity checks with `operation.beforeCommit(async ({operation}) => ...)` when they must run after the main callback but still be able to abort the commit.
+5. Move cache publication and other irreversible effects into `operation.afterCommit`, or perform them after the outer promise resolves.
+6. Return IDs or plain result data. Do not retain and reuse the operation, its connection, its scopes, or operation-bound records for later database work.
+7. Split cross-database changes into explicit separate operations with application-level compensation; one operation intentionally rejects them.
 
 See [Database Connections](database-connections.md) for ordinary non-transactional connection scopes and pool diagnostics.

--- a/spec/database/drivers/base-before-commit-lifecycle-spec.js
+++ b/spec/database/drivers/base-before-commit-lifecycle-spec.js
@@ -1,0 +1,154 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import DatabaseDriverBase from "../../../src/database/drivers/base.js"
+
+class TransactionLifecycleDriver extends DatabaseDriverBase {
+  /** @type {string[]} */
+  actions = []
+  /** @type {Error | undefined} */
+  commitError = undefined
+  /** @type {Error | undefined} */
+  rollbackError = undefined
+
+  /** @returns {string} - Deterministic savepoint name. */
+  generateSavePointName() {
+    return "before_commit_savepoint"
+  }
+
+  /** @returns {Promise<void>} - Records transaction start. */
+  async _startTransactionAction() {
+    this.actions.push("begin")
+  }
+
+  /** @returns {Promise<void>} - Records transaction commit. */
+  async _commitTransactionAction() {
+    this.actions.push("commit")
+
+    const commitError = this.commitError
+
+    this.commitError = undefined
+    if (commitError) throw commitError
+  }
+
+  /** @returns {Promise<void>} - Records transaction rollback. */
+  async _rollbackTransactionAction() {
+    this.actions.push("rollback")
+
+    const rollbackError = this.rollbackError
+
+    this.rollbackError = undefined
+    if (rollbackError) throw rollbackError
+  }
+
+  /**
+   * Records savepoint start.
+   * @param {string} savePointName - Savepoint name.
+   * @returns {Promise<void>}
+   */
+  async _startSavePointAction(savePointName) {
+    this.actions.push(`savepoint ${savePointName}`)
+  }
+
+  /**
+   * Records savepoint release.
+   * @param {string} savePointName - Savepoint name.
+   * @returns {Promise<void>}
+   */
+  async _releaseSavePointAction(savePointName) {
+    this.actions.push(`release ${savePointName}`)
+  }
+
+  /**
+   * Records savepoint rollback.
+   * @param {string} savePointName - Savepoint name.
+   * @returns {Promise<void>}
+   */
+  async _rollbackSavePointAction(savePointName) {
+    this.actions.push(`rollback ${savePointName}`)
+  }
+}
+
+describe("database driver base - beforeCommit lifecycle", () => {
+  it("shares one guard path for outer commits and nested releases while preserving completion errors", async () => {
+    const driver = new TransactionLifecycleDriver({deadlockMaxRetries: 1}, Configuration.current())
+
+    await driver.transaction(async () => {
+      driver.actions.push("outer callback")
+      await driver.beforeCommit(() => {
+        driver.actions.push("outer guard")
+      })
+
+      await driver.transaction(async () => {
+        driver.actions.push("nested callback")
+        await driver.beforeCommit(() => {
+          driver.actions.push("nested guard")
+        })
+      })
+      driver.actions.push("nested returned")
+    })
+
+    expect(driver.actions).toEqual([
+      "begin",
+      "outer callback",
+      "savepoint before_commit_savepoint",
+      "nested callback",
+      "nested guard",
+      "release before_commit_savepoint",
+      "nested returned",
+      "outer guard",
+      "commit"
+    ])
+
+    const commitError = new Error("COMMIT_FAILED")
+    let commitGuardRuns = 0
+
+    driver.actions = []
+    driver.commitError = commitError
+
+    try {
+      await driver.transaction(async () => {
+        await driver.beforeCommit(() => {
+          commitGuardRuns++
+          driver.actions.push("commit guard")
+        })
+      })
+    } catch (error) {
+      expect(error).toBe(commitError)
+    }
+
+    expect(commitGuardRuns).toEqual(1)
+    expect(driver.actions).toEqual(["begin", "commit guard", "commit", "rollback"])
+
+    const callbackError = new Error("CALLBACK_BEFORE_ROLLBACK_FAILED")
+    const rollbackError = new Error("ROLLBACK_FAILED")
+    let discardedGuardRuns = 0
+
+    driver.actions = []
+    driver.rollbackError = rollbackError
+
+    try {
+      await driver.transaction(async () => {
+        await driver.beforeCommit(() => {
+          discardedGuardRuns++
+        })
+        throw callbackError
+      })
+    } catch (error) {
+      expect(error).toBe(rollbackError)
+    }
+
+    expect(discardedGuardRuns).toEqual(0)
+    expect(driver.actions).toEqual(["begin", "rollback"])
+
+    driver.actions = []
+
+    await driver.transaction(async () => {
+      await driver.beforeCommit(() => {
+        driver.actions.push("fresh guard")
+      })
+    })
+
+    expect(driver.actions).toEqual(["begin", "fresh guard", "commit"])
+  })
+})

--- a/spec/database/operation-scoped-transactions-before-commit-spec.js
+++ b/spec/database/operation-scoped-transactions-before-commit-spec.js
@@ -1,0 +1,362 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import DatabaseDriverBase from "../../src/database/drivers/base.js"
+import Project from "../dummy/src/models/project.js"
+import Task from "../dummy/src/models/task.js"
+
+class TransactionLifecycleDriver extends DatabaseDriverBase {
+  /** @type {string[]} */
+  actions = []
+  /** @type {Error | undefined} */
+  commitError = undefined
+  /** @type {Error | undefined} */
+  rollbackError = undefined
+
+  /** @returns {string} - Deterministic savepoint name. */
+  generateSavePointName() {
+    return "before_commit_savepoint"
+  }
+
+  /** @returns {Promise<void>} - Records transaction start. */
+  async _startTransactionAction() {
+    this.actions.push("begin")
+  }
+
+  /** @returns {Promise<void>} - Records transaction commit. */
+  async _commitTransactionAction() {
+    this.actions.push("commit")
+
+    const commitError = this.commitError
+
+    this.commitError = undefined
+    if (commitError) throw commitError
+  }
+
+  /** @returns {Promise<void>} - Records transaction rollback. */
+  async _rollbackTransactionAction() {
+    this.actions.push("rollback")
+
+    const rollbackError = this.rollbackError
+
+    this.rollbackError = undefined
+    if (rollbackError) throw rollbackError
+  }
+
+  /**
+   * Records savepoint start.
+   * @param {string} savePointName - Savepoint name.
+   * @returns {Promise<void>}
+   */
+  async _startSavePointAction(savePointName) {
+    this.actions.push(`savepoint ${savePointName}`)
+  }
+
+  /**
+   * Records savepoint release.
+   * @param {string} savePointName - Savepoint name.
+   * @returns {Promise<void>}
+   */
+  async _releaseSavePointAction(savePointName) {
+    this.actions.push(`release ${savePointName}`)
+  }
+
+  /**
+   * Records savepoint rollback.
+   * @param {string} savePointName - Savepoint name.
+   * @returns {Promise<void>}
+   */
+  async _rollbackSavePointAction(savePointName) {
+    this.actions.push(`rollback ${savePointName}`)
+  }
+}
+
+describe("database - operation-scoped transactions - beforeCommit guards", {tags: ["dummy"], databaseCleaning: {transaction: false}}, () => {
+  it("runs an outer guard with its operation after callback success and before commit", async () => {
+    const configuration = Configuration.current()
+    const project = await Project.create({name: "Before-commit order project"})
+    /** @type {string[]} */
+    const events = []
+    let lateGuardRuns = 0
+
+    await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+      await operation.forModel(Task).create({name: "Before-commit order task", project})
+      await operation.beforeCommit(async ({operation: guardedOperation}) => {
+        events.push("guard")
+        expect(guardedOperation).toBe(operation)
+        expect(await guardedOperation.forModel(Task).findBy({name: "Before-commit order task"})).toBeDefined()
+      })
+      await operation.afterCommit(async () => {
+        await expect(async () => {
+          await operation.beforeCommit(() => {
+            lateGuardRuns++
+          })
+        }).toThrowError("beforeCommit requires an active transaction")
+        events.push("afterCommit")
+      })
+      events.push("callback")
+    })
+
+    events.push("resolved")
+    expect(events).toEqual(["callback", "guard", "afterCommit", "resolved"])
+    expect(lateGuardRuns).toEqual(0)
+  })
+
+  it("rolls back a rejected outer guard, discards afterCommit, and preserves error identity", async () => {
+    const configuration = Configuration.current()
+    const project = await Project.create({name: "Before-commit rejection project"})
+    const guardError = new Error("BEFORE_COMMIT_REJECTED")
+    let afterCommitRuns = 0
+    let rejected = false
+
+    try {
+      await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+        await operation.forModel(Task).create({name: "Rejected before-commit task", project})
+        await operation.afterCommit(() => {
+          afterCommitRuns++
+        })
+        await operation.beforeCommit(async () => {
+          await Promise.resolve()
+          throw guardError
+        })
+      })
+    } catch (error) {
+      rejected = true
+      expect(error).toBe(guardError)
+    }
+
+    expect(rejected).toBeTrue()
+    expect(await Task.findBy({name: "Rejected before-commit task"})).toBeNull()
+    expect(afterCommitRuns).toEqual(0)
+  })
+
+  it("keeps unrelated shared-connection work outside the operation until guard rollback releases the lease", async () => {
+    const configuration = Configuration.current()
+    const project = await Project.create({name: "Before-commit lease project"})
+    const guardError = new Error("BEFORE_COMMIT_LEASE_ROLLBACK")
+    let unrelatedFinished = false
+    /** @type {Promise<Task> | undefined} */
+    let unrelatedWrite
+
+    try {
+      await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+        await operation.forModel(Task).create({name: "Owned before-commit lease task", project})
+
+        unrelatedWrite = Task
+          .create({name: "Unrelated before-commit lease task", project})
+          .then((task) => {
+            unrelatedFinished = true
+            return task
+          })
+
+        await operation.beforeCommit(async () => {
+          await Promise.resolve()
+          expect(unrelatedFinished).toBeFalse()
+          throw guardError
+        })
+      })
+    } catch (error) {
+      expect(error).toBe(guardError)
+    }
+
+    if (!unrelatedWrite) throw new Error("Unrelated write was not started")
+
+    await unrelatedWrite
+
+    expect(await Task.findBy({name: "Owned before-commit lease task"})).toBeNull()
+    expect(await Task.findBy({name: "Unrelated before-commit lease task"})).toBeDefined()
+  })
+
+  it("runs nested guards before release and rolls back only a rejected nested frame", async () => {
+    const configuration = Configuration.current()
+    const project = await Project.create({name: "Nested before-commit project"})
+    const nestedGuardError = new Error("NESTED_BEFORE_COMMIT_REJECTED")
+    /** @type {string[]} */
+    const events = []
+    let nestedRejectedAfterCommitRuns = 0
+
+    await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+      const Tasks = operation.forModel(Task)
+
+      await Tasks.create({name: "Outer before-commit survivor", project})
+      await operation.afterCommit(() => {
+        events.push("outer afterCommit")
+      })
+
+      await operation.transaction(async () => {
+        await Tasks.create({name: "Nested before-commit survivor", project})
+        await operation.beforeCommit(() => {
+          events.push("nested success guard")
+        })
+        await operation.afterCommit(() => {
+          events.push("nested success afterCommit")
+        })
+        events.push("nested success callback")
+      })
+      events.push("nested success returned")
+
+      try {
+        await operation.transaction(async () => {
+          await Tasks.create({name: "Nested before-commit rollback", project})
+          await operation.afterCommit(() => {
+            nestedRejectedAfterCommitRuns++
+          })
+          await operation.beforeCommit(() => {
+            events.push("nested rejected guard")
+            throw nestedGuardError
+          })
+          events.push("nested rejected callback")
+        })
+      } catch (error) {
+        expect(error).toBe(nestedGuardError)
+        events.push("nested rejection caught")
+      }
+
+      await Tasks.create({name: "Outer after nested rejection", project})
+      await operation.beforeCommit(() => {
+        events.push("outer guard")
+      })
+    })
+
+    expect(events).toEqual([
+      "nested success callback",
+      "nested success guard",
+      "nested success returned",
+      "nested rejected callback",
+      "nested rejected guard",
+      "nested rejection caught",
+      "outer guard",
+      "outer afterCommit",
+      "nested success afterCommit"
+    ])
+    expect(await Task.findBy({name: "Outer before-commit survivor"})).toBeDefined()
+    expect(await Task.findBy({name: "Nested before-commit survivor"})).toBeDefined()
+    expect(await Task.findBy({name: "Nested before-commit rollback"})).toBeNull()
+    expect(await Task.findBy({name: "Outer after nested rejection"})).toBeDefined()
+    expect(nestedRejectedAfterCommitRuns).toEqual(0)
+  })
+
+  it("does not run a guard or mask the exact transaction callback error on callback failure", async () => {
+    const configuration = Configuration.current()
+    const project = await Project.create({name: "Before-commit callback failure project"})
+    const callbackError = new Error("TRANSACTION_CALLBACK_REJECTED")
+    let guardRuns = 0
+    let rejected = false
+
+    try {
+      await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+        await operation.forModel(Task).create({name: "Before-commit callback rollback", project})
+        await operation.beforeCommit(() => {
+          guardRuns++
+        })
+
+        throw callbackError
+      })
+    } catch (error) {
+      rejected = true
+      expect(error).toBe(callbackError)
+    }
+
+    expect(rejected).toBeTrue()
+    expect(guardRuns).toEqual(0)
+    expect(await Task.findBy({name: "Before-commit callback rollback"})).toBeNull()
+  })
+
+  it("shares one guard path for outer commits and nested releases while preserving completion errors", async () => {
+    const driver = new TransactionLifecycleDriver({deadlockMaxRetries: 1}, Configuration.current())
+
+    await driver.transaction(async () => {
+      driver.actions.push("outer callback")
+      await driver.beforeCommit(() => {
+        driver.actions.push("outer guard")
+      })
+
+      await driver.transaction(async () => {
+        driver.actions.push("nested callback")
+        await driver.beforeCommit(() => {
+          driver.actions.push("nested guard")
+        })
+      })
+      driver.actions.push("nested returned")
+    })
+
+    expect(driver.actions).toEqual([
+      "begin",
+      "outer callback",
+      "savepoint before_commit_savepoint",
+      "nested callback",
+      "nested guard",
+      "release before_commit_savepoint",
+      "nested returned",
+      "outer guard",
+      "commit"
+    ])
+
+    const commitError = new Error("COMMIT_FAILED")
+    let commitGuardRuns = 0
+
+    driver.actions = []
+    driver.commitError = commitError
+
+    try {
+      await driver.transaction(async () => {
+        await driver.beforeCommit(() => {
+          commitGuardRuns++
+          driver.actions.push("commit guard")
+        })
+      })
+    } catch (error) {
+      expect(error).toBe(commitError)
+    }
+
+    expect(commitGuardRuns).toEqual(1)
+    expect(driver.actions).toEqual(["begin", "commit guard", "commit", "rollback"])
+
+    const callbackError = new Error("CALLBACK_BEFORE_ROLLBACK_FAILED")
+    const rollbackError = new Error("ROLLBACK_FAILED")
+    let discardedGuardRuns = 0
+
+    driver.actions = []
+    driver.rollbackError = rollbackError
+
+    try {
+      await driver.transaction(async () => {
+        await driver.beforeCommit(() => {
+          discardedGuardRuns++
+        })
+        throw callbackError
+      })
+    } catch (error) {
+      expect(error).toBe(rollbackError)
+    }
+
+    expect(discardedGuardRuns).toEqual(0)
+    expect(driver.actions).toEqual(["begin", "rollback"])
+
+    driver.actions = []
+
+    await driver.transaction(async () => {
+      await driver.beforeCommit(() => {
+        driver.actions.push("fresh guard")
+      })
+    })
+
+    expect(driver.actions).toEqual(["begin", "fresh guard", "commit"])
+  })
+
+  it("rejects beforeCommit registration through an expired operation handle", async () => {
+    const configuration = Configuration.current()
+    /** @type {import("../../src/database/operation.js").default | undefined} */
+    let expiredOperation
+
+    await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
+      expiredOperation = operation
+    })
+
+    if (!expiredOperation) throw new Error("Operation handle was not captured")
+
+    await expect(async () => {
+      await expiredOperation.beforeCommit(() => {})
+    }).toThrowError("Database operation has completed")
+  })
+})

--- a/spec/database/operation-scoped-transactions-before-commit-spec.js
+++ b/spec/database/operation-scoped-transactions-before-commit-spec.js
@@ -1,75 +1,8 @@
 // @ts-check
 
 import Configuration from "../../src/configuration.js"
-import DatabaseDriverBase from "../../src/database/drivers/base.js"
 import Project from "../dummy/src/models/project.js"
 import Task from "../dummy/src/models/task.js"
-
-class TransactionLifecycleDriver extends DatabaseDriverBase {
-  /** @type {string[]} */
-  actions = []
-  /** @type {Error | undefined} */
-  commitError = undefined
-  /** @type {Error | undefined} */
-  rollbackError = undefined
-
-  /** @returns {string} - Deterministic savepoint name. */
-  generateSavePointName() {
-    return "before_commit_savepoint"
-  }
-
-  /** @returns {Promise<void>} - Records transaction start. */
-  async _startTransactionAction() {
-    this.actions.push("begin")
-  }
-
-  /** @returns {Promise<void>} - Records transaction commit. */
-  async _commitTransactionAction() {
-    this.actions.push("commit")
-
-    const commitError = this.commitError
-
-    this.commitError = undefined
-    if (commitError) throw commitError
-  }
-
-  /** @returns {Promise<void>} - Records transaction rollback. */
-  async _rollbackTransactionAction() {
-    this.actions.push("rollback")
-
-    const rollbackError = this.rollbackError
-
-    this.rollbackError = undefined
-    if (rollbackError) throw rollbackError
-  }
-
-  /**
-   * Records savepoint start.
-   * @param {string} savePointName - Savepoint name.
-   * @returns {Promise<void>}
-   */
-  async _startSavePointAction(savePointName) {
-    this.actions.push(`savepoint ${savePointName}`)
-  }
-
-  /**
-   * Records savepoint release.
-   * @param {string} savePointName - Savepoint name.
-   * @returns {Promise<void>}
-   */
-  async _releaseSavePointAction(savePointName) {
-    this.actions.push(`release ${savePointName}`)
-  }
-
-  /**
-   * Records savepoint rollback.
-   * @param {string} savePointName - Savepoint name.
-   * @returns {Promise<void>}
-   */
-  async _rollbackSavePointAction(savePointName) {
-    this.actions.push(`rollback ${savePointName}`)
-  }
-}
 
 describe("database - operation-scoped transactions - beforeCommit guards", {tags: ["dummy"], databaseCleaning: {transaction: false}}, () => {
   it("runs an outer guard with its operation after callback success and before commit", async () => {
@@ -142,12 +75,12 @@ describe("database - operation-scoped transactions - beforeCommit guards", {tags
       await configuration.withTransaction({databaseIdentifier: "default"}, async (operation) => {
         await operation.forModel(Task).create({name: "Owned before-commit lease task", project})
 
-        unrelatedWrite = Task
-          .create({name: "Unrelated before-commit lease task", project})
-          .then((task) => {
-            unrelatedFinished = true
-            return task
-          })
+        unrelatedWrite = configuration.withoutCurrentConnectionContexts(async () => {
+          const task = await Task.create({name: "Unrelated before-commit lease task", project})
+
+          unrelatedFinished = true
+          return task
+        })
 
         await operation.beforeCommit(async () => {
           await Promise.resolve()
@@ -260,88 +193,6 @@ describe("database - operation-scoped transactions - beforeCommit guards", {tags
     expect(rejected).toBeTrue()
     expect(guardRuns).toEqual(0)
     expect(await Task.findBy({name: "Before-commit callback rollback"})).toBeNull()
-  })
-
-  it("shares one guard path for outer commits and nested releases while preserving completion errors", async () => {
-    const driver = new TransactionLifecycleDriver({deadlockMaxRetries: 1}, Configuration.current())
-
-    await driver.transaction(async () => {
-      driver.actions.push("outer callback")
-      await driver.beforeCommit(() => {
-        driver.actions.push("outer guard")
-      })
-
-      await driver.transaction(async () => {
-        driver.actions.push("nested callback")
-        await driver.beforeCommit(() => {
-          driver.actions.push("nested guard")
-        })
-      })
-      driver.actions.push("nested returned")
-    })
-
-    expect(driver.actions).toEqual([
-      "begin",
-      "outer callback",
-      "savepoint before_commit_savepoint",
-      "nested callback",
-      "nested guard",
-      "release before_commit_savepoint",
-      "nested returned",
-      "outer guard",
-      "commit"
-    ])
-
-    const commitError = new Error("COMMIT_FAILED")
-    let commitGuardRuns = 0
-
-    driver.actions = []
-    driver.commitError = commitError
-
-    try {
-      await driver.transaction(async () => {
-        await driver.beforeCommit(() => {
-          commitGuardRuns++
-          driver.actions.push("commit guard")
-        })
-      })
-    } catch (error) {
-      expect(error).toBe(commitError)
-    }
-
-    expect(commitGuardRuns).toEqual(1)
-    expect(driver.actions).toEqual(["begin", "commit guard", "commit", "rollback"])
-
-    const callbackError = new Error("CALLBACK_BEFORE_ROLLBACK_FAILED")
-    const rollbackError = new Error("ROLLBACK_FAILED")
-    let discardedGuardRuns = 0
-
-    driver.actions = []
-    driver.rollbackError = rollbackError
-
-    try {
-      await driver.transaction(async () => {
-        await driver.beforeCommit(() => {
-          discardedGuardRuns++
-        })
-        throw callbackError
-      })
-    } catch (error) {
-      expect(error).toBe(rollbackError)
-    }
-
-    expect(discardedGuardRuns).toEqual(0)
-    expect(driver.actions).toEqual(["begin", "rollback"])
-
-    driver.actions = []
-
-    await driver.transaction(async () => {
-      await driver.beforeCommit(() => {
-        driver.actions.push("fresh guard")
-      })
-    })
-
-    expect(driver.actions).toEqual(["begin", "fresh guard", "commit"])
   })
 
   it("rejects beforeCommit registration through an expired operation handle", async () => {

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -43,6 +43,12 @@
  * @typedef {Array<QueryRowType>} QueryResultType
  */
 /**
+ * TransactionCallbackFrame type.
+ * @typedef {object} TransactionCallbackFrame
+ * @property {Array<() => void | Promise<void>>} afterCommitCallbacks - Callbacks to merge or run after commit.
+ * @property {Array<() => void | Promise<void>>} beforeCommitCallbacks - Guards to run before this frame completes.
+ */
+/**
  * RetryableDatabaseErrorResult type.
  * @typedef {object} RetryableDatabaseErrorResult
  * @property {boolean} retry - Whether the error should be retried.
@@ -171,8 +177,8 @@ export default class VelociousDatabaseDriversBase {
   idSeq = undefined
   /**
    * Narrows the runtime value to the documented type.
-   * @type {Array<Array<() => void | Promise<void>>>} */
-  _afterCommitCallbackFrames
+   * @type {TransactionCallbackFrame[]} */
+  _transactionCallbackFrames
   /**
    * Narrows the runtime value to the documented type.
    * @type {Map<string, Promise<?>>} */
@@ -207,7 +213,7 @@ export default class VelociousDatabaseDriversBase {
     this.configuration = configuration
     this.mutex = new Mutex() // Can be used to lock this instance for exclusive use
     this.logger = new Logger(this)
-    this._afterCommitCallbackFrames = []
+    this._transactionCallbackFrames = []
     this._transactionsCount = 0
     this._transactionsActionsMutex = new Mutex()
     this._schemaCache = new Map()
@@ -1068,14 +1074,15 @@ export default class VelociousDatabaseDriversBase {
    */
   async _runTransactionAttempt(callback, options) {
     const savePointName = this.generateSavePointName()
-    /**
-     * Callback frame.
-     * @type {Array<() => void | Promise<void>>} */
-    const callbackFrame = []
+    /** @type {TransactionCallbackFrame} */
+    const callbackFrame = {
+      afterCommitCallbacks: [],
+      beforeCommitCallbacks: []
+    }
     let transactionStarted = false
     let savePointStarted = false
 
-    this._afterCommitCallbackFrames.push(callbackFrame)
+    this._transactionCallbackFrames.push(callbackFrame)
 
     try {
       if (this._transactionsCount == 0) {
@@ -1088,7 +1095,7 @@ export default class VelociousDatabaseDriversBase {
         savePointStarted = true
       }
     } catch (error) {
-      this._afterCommitCallbackFrames.pop()
+      this._transactionCallbackFrames.pop()
       throw error
     }
 
@@ -1096,6 +1103,7 @@ export default class VelociousDatabaseDriversBase {
 
     try {
       result = await callback()
+      await this._runBeforeCommitCallbacks(callbackFrame)
 
       if (savePointStarted) {
         this.logger.debug("Release savepoint", savePointName)
@@ -1113,47 +1121,66 @@ export default class VelociousDatabaseDriversBase {
         this.logger.debug("Transaction error", error)
       }
 
-      let transactionRolledBack = false
+      try {
+        let transactionRolledBack = false
 
-      if (savePointStarted) {
-        this.logger.debug("Rollback savepoint", savePointName)
-        try {
-          await this.rollbackSavePoint(savePointName, options)
-        } catch (savePointError) {
-          const message = savePointError instanceof Error ? savePointError.message : `${savePointError}`
+        if (savePointStarted) {
+          this.logger.debug("Rollback savepoint", savePointName)
+          try {
+            await this.rollbackSavePoint(savePointName, options)
+          } catch (savePointError) {
+            const message = savePointError instanceof Error ? savePointError.message : `${savePointError}`
 
-          // MySQL sometimes drops savepoints unexpectedly; fall back to rolling back the full transaction
-          if (message.includes("SAVEPOINT") || message.includes("ER_SP_DOES_NOT_EXIST")) {
-            this.logger.debug("Savepoint rollback failed; rolling back entire transaction instead")
-            await this.rollbackTransaction(options)
-            transactionRolledBack = true
-          } else {
-            throw savePointError
+            // MySQL sometimes drops savepoints unexpectedly; fall back to rolling back the full transaction
+            if (message.includes("SAVEPOINT") || message.includes("ER_SP_DOES_NOT_EXIST")) {
+              this.logger.debug("Savepoint rollback failed; rolling back entire transaction instead")
+              await this.rollbackTransaction(options)
+              transactionRolledBack = true
+            } else {
+              throw savePointError
+            }
           }
         }
-      }
 
-      // Only roll back if a transaction is still open. A nested savepoint whose rollback failed
-      // falls back to rolling back the whole transaction (above), which already closed it and
-      // dropped the count to 0; rolling back again here would issue a second ROLLBACK and drive
-      // `_transactionsCount` below zero, which would then defeat the outermost deadlock-retry guard.
-      if (transactionStarted && !transactionRolledBack && this._transactionsCount > 0) {
-        this.logger.debug("Rollback transaction")
-        await this.rollbackTransaction(options)
+        // Only roll back if a transaction is still open. A nested savepoint whose rollback failed
+        // falls back to rolling back the whole transaction (above), which already closed it and
+        // dropped the count to 0; rolling back again here would issue a second ROLLBACK and drive
+        // `_transactionsCount` below zero, which would then defeat the outermost deadlock-retry guard.
+        if (transactionStarted && !transactionRolledBack && this._transactionsCount > 0) {
+          this.logger.debug("Rollback transaction")
+          await this.rollbackTransaction(options)
+        }
+      } finally {
+        this._transactionCallbackFrames.pop()
       }
-
-      this._afterCommitCallbackFrames.pop()
 
       throw error
     }
 
     try {
-      await this._commitAfterCommitCallbackFrame()
+      await this._commitTransactionCallbackFrame()
     } catch (error) {
       throw new VelociousDatabaseAfterCommitCallbackError(error)
     }
 
     return result
+  }
+
+  /**
+   * Registers a guard to run after the current transaction callback succeeds and before its
+   * outer commit or nested savepoint release.
+   * @param {() => void | Promise<void>} callback - Guard callback.
+   * @param {Pick<QueryOptions, "operationOwner">} [options] - Callback ownership.
+   * @returns {Promise<void>} - Resolves when the guard has been registered.
+   */
+  async beforeCommit(callback, options = {}) {
+    await this._waitForOperationLease(options.operationOwner)
+
+    const currentFrame = this._transactionCallbackFrames[this._transactionCallbackFrames.length - 1]
+
+    if (!currentFrame) throw new Error("beforeCommit requires an active transaction")
+
+    currentFrame.beforeCommitCallbacks.push(callback)
   }
 
   /**
@@ -1166,14 +1193,14 @@ export default class VelociousDatabaseDriversBase {
   async afterCommit(callback, options = {}) {
     await this._waitForOperationLease(options.operationOwner)
 
-    const currentFrame = this._afterCommitCallbackFrames[this._afterCommitCallbackFrames.length - 1]
+    const currentFrame = this._transactionCallbackFrames[this._transactionCallbackFrames.length - 1]
 
     if (!currentFrame) {
       await callback()
       return
     }
 
-    currentFrame.push(callback)
+    currentFrame.afterCommitCallbacks.push(callback)
   }
 
   /**
@@ -1241,22 +1268,33 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Runs every guard registered to the transaction frame.
+   * @param {TransactionCallbackFrame} callbackFrame - Frame whose guards are completing.
+   * @returns {Promise<void>} - Resolves when every guard accepts the commit.
+   */
+  async _runBeforeCommitCallbacks(callbackFrame) {
+    for (const callback of callbackFrame.beforeCommitCallbacks) {
+      await callback()
+    }
+  }
+
+  /**
    * Merges committed callbacks into the parent transaction frame or runs them when the outermost commit completes.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async _commitAfterCommitCallbackFrame() {
-    const committedCallbacks = this._afterCommitCallbackFrames.pop()
+  async _commitTransactionCallbackFrame() {
+    const committedFrame = this._transactionCallbackFrames.pop()
 
-    if (!committedCallbacks || committedCallbacks.length === 0) return
+    if (!committedFrame || committedFrame.afterCommitCallbacks.length === 0) return
 
-    const parentFrame = this._afterCommitCallbackFrames[this._afterCommitCallbackFrames.length - 1]
+    const parentFrame = this._transactionCallbackFrames[this._transactionCallbackFrames.length - 1]
 
     if (parentFrame) {
-      parentFrame.push(...committedCallbacks)
+      parentFrame.afterCommitCallbacks.push(...committedFrame.afterCommitCallbacks)
       return
     }
 
-    for (const callback of committedCallbacks) {
+    for (const callback of committedFrame.afterCommitCallbacks) {
       await callback()
     }
   }

--- a/src/database/operation-connection.js
+++ b/src/database/operation-connection.js
@@ -88,6 +88,17 @@ export default class VelociousDatabaseOperationConnection {
   }
 
   /**
+   * Registers an operation-owned before-commit guard.
+   * @param {() => void | Promise<void>} callback - Guard callback.
+   * @returns {Promise<void>} - Resolves after registration.
+   */
+  async beforeCommit(callback) {
+    this._operation.assertActive()
+
+    await this._physicalConnection.beforeCommit(callback, {operationOwner: this._owner})
+  }
+
+  /**
    * Registers an operation-owned after-commit callback.
    * @param {() => void | Promise<void>} callback - Callback.
    * @returns {Promise<void>} - Resolves after registration or execution.

--- a/src/database/operation.js
+++ b/src/database/operation.js
@@ -86,6 +86,16 @@ export default class VelociousDatabaseOperation {
   }
 
   /**
+   * Registers a guard owned by the current transaction/savepoint frame.
+   * @param {(context: {operation: VelociousDatabaseOperation}) => void | Promise<void>} callback - Guard callback.
+   * @returns {Promise<void>} - Resolves after registration.
+   */
+  async beforeCommit(callback) {
+    this.assertActive()
+    await this.connection().beforeCommit(() => callback({operation: this}))
+  }
+
+  /**
    * Runs a nested operation transaction/savepoint.
    * @template T
    * @param {() => Promise<T>} callback - Callback.


### PR DESCRIPTION
## Summary

- add an operation-owned `beforeCommit(async ({operation}) => ...)` guard API
- run guards after callback success and immediately before outer commit or nested savepoint release
- route guard failures through existing rollback/frame cleanup while preserving error identity and transaction ownership
- document lifecycle, nesting, retry, and ticket-app usage

## Why

Ticket-app PR #1478 can invalidate scanner status reporting after its transaction callback completes but before Expo SQLite commits. Velocious 1.0.569 had no transaction-completion guard capable of rolling that write back.

Linked work:
- AwesomeTasks #10592
- ticket-app AwesomeTasks #10495
- ticket-app PR https://github.com/kaspernj/ticket-app/pull/1478

## Validation

- 7 new focused before-commit contracts passed
- 27 directly affected existing transaction/ownership/persistence/auditing tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`
- independent GPT-5.6 Sol / xhigh read-only review: PASS
