### PR TITLE
Fix withCount cohort filter collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * Gap-less positional lists with automatic reordering via `actsAsList`, including models with numeric, string, or UUID primary keys (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))
 * Async-aware test-data factories with inherited traits, graph-first native association autosave, metadata-aware override precedence, callbacks, sequences, and linting (see [docs/factories.md](docs/factories.md))
-* Per-row association counts via `.withCount(...)`, including safe batching of structurally identical aggregates, on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
+* Per-row association counts via `.withCount(...)`, including cohort-safe intersected filters and safe batching of structurally identical aggregates, on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)`, with compatible projections sharing a roundtrip while preserving declared alias-overwrite order, on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
 * Translated model attributes with current-locale relationship sorting (see [docs/translations.md](docs/translations.md))

--- a/changelog.d/20260803165840-with-count-cohort-filters.md
+++ b/changelog.d/20260803165840-with-count-cohort-filters.md
@@ -1,0 +1,1 @@
+Keep `.withCount(...)` aggregates anchored to the loaded parent IDs and mandatory polymorphic model type when caller `where` filters name the same columns. Conflicting filters now intersect with those cohort restrictions and return zero instead of widening or retargeting the count query.

--- a/docs/with-count.md
+++ b/docs/with-count.md
@@ -52,6 +52,13 @@ Keys in the object form become the attribute name as-is. `true` is
 shorthand for "count this relationship, store under `<name>Count`";
 `{relationship, where}` lets you rename, filter, or both.
 
+The caller-supplied `where` is always combined with Velocious's
+mandatory relationship cohort using `AND`. It cannot replace the
+foreign-key restriction to the parent IDs actually loaded or, for a
+polymorphic relationship, the owning model's type restriction. A
+conflicting foreign-key or polymorphic-type filter therefore returns
+zero instead of widening or retargeting the aggregate.
+
 ## How it runs
 
 After the main query's rows come back, Velocious builds one grouped
@@ -61,8 +68,8 @@ count query per requested entry:
 SELECT foo_id AS parent_id, COUNT(*) AS count_value
 FROM foos
 WHERE foo_id IN (<loaded parent PKs>)
-  [AND <your where clause>]
   [AND <polymorphic type column> = '<parent model name>']
+  [AND <your where clause>]
 GROUP BY foo_id
 ```
 

--- a/spec/database/query/with-count.browser-spec.js
+++ b/spec/database/query/with-count.browser-spec.js
@@ -1,9 +1,13 @@
 import Configuration from "../../../src/configuration.js"
 import Interaction from "../../dummy/src/models/interaction.js"
+import LoggerArrayOutput from "../../../src/logger/outputs/array-output.js"
 import Project from "../../dummy/src/models/project.js"
 import ProjectDetail from "../../dummy/src/models/project-detail.js"
 import RequestTiming from "../../../src/http-server/client/request-timing.js"
 import Task from "../../dummy/src/models/task.js"
+
+/** @typedef {import("../../../src/configuration-types.js").LoggingConfiguration} LoggingConfiguration */
+/** @typedef {Configuration & {_logging?: LoggingConfiguration}} MutableLoggingConfiguration */
 
 describe("Database - query - withCount", {databaseCleaning: {transaction: false, truncate: true}, tags: ["dummy"]}, () => {
   it("attaches counts for a basic hasMany", async () => {
@@ -39,17 +43,75 @@ describe("Database - query - withCount", {databaseCleaning: {transaction: false,
     expect(loaded.readCount("tasksCount")).toEqual(1)
   })
 
-  it("filters the counted association via where", async () => {
-    const project = await Project.create({nameEn: "Filtered", nameDe: "Gefiltert"})
+  it("keeps a non-cohort filter batched across parents", async () => {
+    const projectA = await Project.create({nameEn: "Filtered A", nameDe: "Gefiltert A"})
+    const projectB = await Project.create({nameEn: "Filtered B", nameDe: "Gefiltert B"})
+    const requestTiming = new RequestTiming()
 
-    await Task.create({name: "Done task", project, isDone: true})
-    await Task.create({name: "Open task", project, isDone: false})
+    await Task.create({name: "A done task", project: projectA, isDone: true})
+    await Task.create({name: "A open task", project: projectA, isDone: false})
+    await Task.create({name: "B done task 1", project: projectB, isDone: true})
+    await Task.create({name: "B done task 2", project: projectB, isDone: true})
 
-    const [loaded] = await Project.where({id: project.id()}).withCount({
-      doneTasksCount: {relationship: "tasks", where: {isDone: true}}
-    }).toArray()
+    const loaded = await Configuration.current().getEnvironmentHandler().runWithRequestTiming(requestTiming, async () => {
+      return await Project
+        .where({id: [projectA.id(), projectB.id()]})
+        .order("projects.id ASC")
+        .withCount({
+          doneTasksCount: {relationship: "tasks", where: {isDone: true}}
+        })
+        .toArray()
+    })
 
-    expect(loaded.readCount("doneTasksCount")).toEqual(1)
+    expect(loaded[0].readCount("doneTasksCount")).toEqual(1)
+    expect(loaded[1].readCount("doneTasksCount")).toEqual(2)
+    expect(requestTiming.dbQueryCount).toEqual(2)
+  })
+
+  it("intersects a colliding foreign-key filter with the parent cohort", async () => {
+    const projectA = await Project.create({nameEn: "Cohort A", nameDe: "Kohorte A"})
+    const projectB = await Project.create({nameEn: "Cohort B", nameDe: "Kohorte B"})
+
+    await Task.create({name: "B task", project: projectB})
+
+    const configuration = /** @type {MutableLoggingConfiguration} */ (Configuration.current())
+    const previousLogging = configuration._logging
+    const arrayOutput = new LoggerArrayOutput()
+
+    configuration._logging = {
+      console: false,
+      file: false,
+      outputs: [{output: arrayOutput, levels: ["info"]}],
+      queryLogging: true
+    }
+
+    try {
+      const [loaded] = await Project.where({id: projectA.id()}).withCount({
+        otherProjectTasksCount: {relationship: "tasks", where: {project_id: projectB.id()}}
+      }).toArray()
+
+      expect(loaded.readCount("otherProjectTasksCount")).toEqual(0)
+    } finally {
+      configuration._logging = previousLogging
+    }
+
+    const aggregateLogs = arrayOutput
+      .getLogs()
+      .filter((log) => log.message.includes("COUNT(*) AS count_value"))
+
+    expect(aggregateLogs.length).toEqual(1)
+
+    const aggregateSql = aggregateLogs[0].message
+    const whereStart = aggregateSql.indexOf(" WHERE ")
+    const groupStart = aggregateSql.indexOf(" GROUP BY ", whereStart)
+
+    expect(whereStart >= 0).toBeTrue()
+    expect(groupStart > whereStart).toBeTrue()
+
+    const whereSql = aggregateSql.slice(whereStart, groupStart)
+
+    expect(whereSql.split("project_id").length).toEqual(3)
+    expect(whereSql.includes(" AND ")).toBeTrue()
   })
 
   it("uses one aggregate roundtrip for compatible aliases", async () => {
@@ -171,6 +233,21 @@ describe("Database - query - withCount", {databaseCleaning: {transaction: false,
 
     expect(loadedProject.readCount("interactionsCount")).toEqual(1)
     expect(loadedTask.readCount("interactionsCount")).toEqual(2)
+  })
+
+  it("intersects a colliding polymorphic type filter with the parent type", async () => {
+    const project = await Project.create({nameEn: "Shared id project", nameDe: "Projekt mit gemeinsamer ID"})
+    const task = await Task.create({id: project.id(), name: "Shared id task", project})
+
+    expect(task.id()).toEqual(project.id())
+
+    await Interaction.create({subjectType: "Project", subjectId: project.id(), kind: "Project interaction"})
+
+    const [loadedTask] = await Task.where({id: task.id()}).withCount({
+      projectInteractionsCount: {relationship: "interactions", where: {subject_type: "Project"}}
+    }).toArray()
+
+    expect(loadedTask.readCount("projectInteractionsCount")).toEqual(0)
   })
 
   it(".count() on the parent query ignores withCount", async () => {

--- a/src/database/query/with-count.js
+++ b/src/database/query/with-count.js
@@ -161,22 +161,22 @@ function queryForEntry({entry, modelClass, parentIds, sourceModel}) {
 
   const foreignKey = relationship.getForeignKey()
   /**
-   * Where conditions.
+   * Mandatory cohort conditions.
    * @type {Record<string, ?>} */
-  const whereConditions = {[foreignKey]: parentIds}
+  const mandatoryWhereConditions = {[foreignKey]: parentIds}
 
   if (relationship.getPolymorphic && relationship.getPolymorphic()) {
     const typeColumn = relationship.getPolymorphicTypeColumn()
-    whereConditions[typeColumn] = modelClass.getModelName()
-  }
-
-  if (entry.where) {
-    Object.assign(whereConditions, entry.where)
+    mandatoryWhereConditions[typeColumn] = modelClass.getModelName()
   }
 
   const baseQuery = sourceModel.queryForModel(targetModelClass)
   baseQuery._forceQualifyBaseTable = true
-  baseQuery.where(whereConditions)
+  baseQuery.where(mandatoryWhereConditions)
+
+  if (entry.where) {
+    baseQuery.where(entry.where)
+  }
 
   const countQuery = relationship.applyScope(baseQuery)
 


### PR DESCRIPTION
## Summary

- preserve mandatory loaded-parent foreign-key predicates when `.withCount(...)` receives caller filters on the same column
- preserve mandatory polymorphic owner-type predicates and intersect conflicting caller filters with `AND`
- add deterministic cross-driver regressions, documentation, and changelog coverage

## AwesomeTasks

- https://tasks.diestoeckels.de/tasks/d5596209-1e61-59f8-ae14-c8df96961ab4

## RED evidence

- foreign-key aggregate SQL retained only one `project_id` predicate (`2` segments instead of `3`)
- same-ID polymorphic collision counted a `Project` interaction for a `Task` (`1` instead of `0`)
- corrected deterministic explicit-ID fixture still reproduced the pre-fix polymorphic failure

## Validation

- focused collision examples: **3/3 passed**
- complete `spec/database/query/with-count.browser-spec.js`: **15/15 passed**
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`

All project commands ran inside the fresh task-specific checked-in Docker Compose service. No full local suite, shard, or database matrix was run.

## Review

- independent read-only review initially found one PostgreSQL identity-sequence fixture blocker
- fixture corrected with an explicit shared primary key and revalidated
- terminal current-head review: **PASS**
- reviewed staged patch SHA-256: `dd45701f61b17571fc7a0f7e3f4d18b8ed9e56fbba48e79e66ebf8e7cc29ff8a`
