### PR TITLE
Add stable keys for scheduled background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2249,6 +2249,20 @@ await MyJob.performLaterWithOptions({
 
 Until `scheduledAtMs` is reached, the job remains queued but is not eligible for dispatch. The event-driven dispatcher arms its timer for the earliest future job and wakes at that timestamp. Omitting `scheduledAtMs` keeps the immediate-enqueue behavior.
 
+Use a durable stable key when the same logical one-off schedule must be moved or cancelled without retaining its transient job id:
+
+```js
+const result = await MyJob.replaceScheduled({
+  scheduleKey: `event:${eventId}:reminder:24h`,
+  args: [eventId, reminderRevision],
+  options: {scheduledAtMs: reminderAtMs}
+})
+
+await MyJob.cancelScheduled(`event:${eventId}:reminder:24h`)
+```
+
+A queued owner is atomically cancelled during replacement/cancellation. A `previousStatus` or cancellation `outcome` of `"handed_off"` means the worker may already be running; Velocious removes or replaces key ownership but does not claim that JavaScript stopped. Store a generation/revision in application state, pass it to the job, and re-check it immediately before irreversible effects. Stable keys and full result shapes are documented in [Scheduling One-Off Background Jobs](docs/scheduled-background-job-enqueue.md#replacing-or-cancelling-a-logical-schedule).
+
 Set `deduplicateWhileQueued: true` to coalesce an enqueue onto the earliest identical queued job with the same job name, arguments, and queue when that existing job is scheduled no later than the new request. A retry backed off into the future does not suppress a new immediate enqueue, while repeated immediate triggers and equal or later schedules still coalesce.
 
 Select a non-default runtime explicitly with `options: {executionMode: "inline" | "forked" | "spawned"}`.

--- a/changelog.d/20260803174500-stable-schedule-keys.md
+++ b/changelog.d/20260803174500-stable-schedule-keys.md
@@ -1,0 +1,1 @@
+Add durable stable schedule keys for replacing/rescheduling and cancelling logical one-off background jobs. Queued mutations are atomic across processes, handed-off outcomes remain truthful best-effort, dispatcher timers re-arm after every mutation, and terminal dashboard history retains the schedule key without retaining ownership.

--- a/docs/background-jobs-dashboard.md
+++ b/docs/background-jobs-dashboard.md
@@ -70,6 +70,7 @@ Example list response:
     {
       "id": "…",
       "jobName": "FailingJob",
+      "scheduleKey": "event:42:reminder:24h",
       "status": "failed",
       "attempts": 1,
       "maxRetries": 0,
@@ -90,6 +91,8 @@ Example list response:
   "pagination": {"page": 1, "perPage": 25, "total": 1, "totalPages": 1}
 }
 ```
+
+`scheduleKey` is the historical logical schedule key, or `null` for legacy/unkeyed jobs. It remains visible after replacement, cancellation, completion, failure, or orphaning even though terminal jobs no longer own that key.
 
 Velocious jobs don't have Sidekiq-style named queues; they have a `job_name`
 (the job class) and a `status`. The dashboard groups and filters by those.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -16,6 +16,8 @@ Set the runtime explicitly with `executionMode` — `"pooled"` (default), `"inli
 
 For delayed one-off work, see [Scheduling One-Off Background Jobs](scheduled-background-job-enqueue.md). Recurring schedules use the separate `scheduledBackgroundJobs` configuration described in the [README](../README.md#scheduled-jobs).
 
+Logical one-off schedules that may be moved or cancelled can use `replaceScheduled` and `cancelScheduled` with a durable stable key. Queued replacement/cancellation is atomic across processes; a `handed_off` result is explicitly best-effort because running JavaScript is not interrupted. Consumers must pair the API with their own generation/revision check immediately before side effects. See [Replacing or cancelling a logical schedule](scheduled-background-job-enqueue.md#replacing-or-cancelling-a-logical-schedule).
+
 ## Database connection scopes
 
 By default, a job receives the existing Velocious behavior: every active configured database is checked out for the duration of `perform`. Jobs that need a known subset should declare it on the job class:

--- a/docs/scheduled-background-job-enqueue.md
+++ b/docs/scheduled-background-job-enqueue.md
@@ -14,3 +14,51 @@ The job is persisted immediately with status `queued`, but workers cannot receiv
 `scheduledAtMs` must be a non-negative JavaScript safe integer. Invalid values reject the enqueue promise with the validation message. A timestamp in the past, including `0`, is valid and makes the job eligible for immediate dispatch. Omitting the option preserves immediate enqueue behavior.
 
 This option schedules one job once. For recurring jobs, use the [`scheduledBackgroundJobs` configuration](../README.md#scheduled-jobs). For queue limits, retries, worker recovery, and operational behavior, see [Background Jobs](background-jobs.md).
+
+## Replacing or cancelling a logical schedule
+
+Use a stable schedule key when application state may move or remove the desired one-off job. Keys are opaque, non-empty strings of at most 255 characters and are global within the configured background-jobs database:
+
+```js
+const scheduleKey = `event:${eventId}:reminder:24h`
+
+const replacement = await EventReminderJob.replaceScheduled({
+  scheduleKey,
+  args: [eventId, reminderRevision],
+  options: {scheduledAtMs: reminderAtMs}
+})
+
+const cancellation = await EventReminderJob.cancelScheduled(scheduleKey)
+```
+
+`replaceScheduled` always creates a new job id and returns `{jobId, previousJobId, previousStatus}`. If the previous owner is still `queued`, replacement atomically marks it `cancelled`, inserts the new job, and moves key ownership. If it is already `handed_off`, Velocious leaves that lease running and returns `previousStatus: "handed_off"`; the new job still becomes the current owner.
+
+`cancelScheduled` returns `{jobId, outcome}`:
+
+- `"cancelled"` means the queued transition won and the job cannot subsequently be handed off.
+- `"handed_off"` means ownership was removed, but execution may already be running and was not stopped.
+- `"not_found"` means the key has no current owner. Repeating a successful cancellation therefore returns `"not_found"`.
+
+Replacement and cancellation wake the event-driven dispatcher and rebuild its future-job timer, including when a replacement moves earlier or cancellation removes the earliest job. The current owner survives process restarts in framework-managed database state.
+
+Job history keeps `scheduleKey` after replacement, cancellation, completion, failure, or orphaning, while terminal jobs release current ownership. The dashboard API exposes this historical field.
+
+### Fence irreversible effects in the application
+
+Stable-key cancellation is deliberately best-effort once a worker has received a job. Applications must store a generation or revision with the state that controls the schedule, pass it in job arguments, and compare the current value immediately before an irreversible effect:
+
+```js
+export default class EventReminderJob extends VelociousJob {
+  async perform(eventId, expectedRevision) {
+    const event = await Event.find(eventId)
+
+    if (!event || event.reminderRevision() !== expectedRevision || event.cancelled()) return
+
+    await sendReminder(event)
+  }
+}
+```
+
+Commit the new revision before replacing or cancelling the schedule. This protects against a superseded handed-off job completing or retrying after ownership moved. Existing handoff leases still fence worker reports; stable keys do not terminate running JavaScript.
+
+Deploy or restart the upgraded `background-jobs-main` before application processes begin sending these new protocol messages. Legacy `performLater`, `performLaterWithOptions`, and `scheduledAtMs` calls and return values are unchanged.

--- a/spec/background-jobs/stable-schedule-api-spec.js
+++ b/spec/background-jobs/stable-schedule-api-spec.js
@@ -1,11 +1,15 @@
 // @ts-check
 
 import BackgroundJobsClient from "../../src/background-jobs/client.js"
-import { startBackgroundJobsMain } from "../helpers/background-jobs-helper.js"
+import { clearBackgroundJobs, startBackgroundJobsMain } from "../helpers/background-jobs-helper.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import TestJob from "../dummy/src/jobs/test-job.js"
 
-describe("Background jobs - stable schedule API", {databaseCleaning: {truncate: true}}, () => {
+describe("Background jobs - stable schedule API", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  afterEach(async () => {
+    await clearBackgroundJobs()
+  })
+
   it("replaces and cancels a logical schedule through the public job protocol", async () => {
     const {main, store} = await startBackgroundJobsMain()
 

--- a/spec/background-jobs/stable-schedule-api-spec.js
+++ b/spec/background-jobs/stable-schedule-api-spec.js
@@ -1,0 +1,77 @@
+// @ts-check
+
+import BackgroundJobsClient from "../../src/background-jobs/client.js"
+import { startBackgroundJobsMain } from "../helpers/background-jobs-helper.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import TestJob from "../dummy/src/jobs/test-job.js"
+
+describe("Background jobs - stable schedule API", {databaseCleaning: {truncate: true}}, () => {
+  it("replaces and cancels a logical schedule through the public job protocol", async () => {
+    const {main, store} = await startBackgroundJobsMain()
+
+    dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: main.getPort()})
+
+    try {
+      const replacement = await TestJob.replaceScheduled({
+        scheduleKey: "event:51:reminder:24h",
+        args: ["scheduled"],
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 60_000}
+      })
+
+      expect(replacement).toEqual({jobId: replacement.jobId, previousJobId: null, previousStatus: null})
+      expect(await store.getJob(replacement.jobId)).toMatchObject({
+        jobName: "TestJob",
+        scheduleKey: "event:51:reminder:24h",
+        status: "queued"
+      })
+      expect(await TestJob.cancelScheduled("event:51:reminder:24h")).toEqual({
+        jobId: replacement.jobId,
+        outcome: "cancelled"
+      })
+    } finally {
+      await main.stop()
+    }
+  })
+
+  it("preserves legacy enqueue return contracts beside stable schedules", async () => {
+    const {main, store} = await startBackgroundJobsMain()
+
+    dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: main.getPort()})
+
+    try {
+      const jobId = await TestJob.performLaterWithOptions({
+        args: ["legacy"],
+        options: {scheduledAtMs: Date.now() + 60_000}
+      })
+
+      expect(typeof jobId).toEqual("string")
+      expect(await store.getJob(jobId)).toMatchObject({scheduleKey: null, status: "queued"})
+    } finally {
+      await main.stop()
+    }
+  })
+
+  it("exposes raw client methods and returns validation errors safely", async () => {
+    const {main} = await startBackgroundJobsMain()
+    const errorEvents = dummyConfiguration.getErrorEvents()
+    let frameworkErrorCount = 0
+    const onFrameworkError = () => {
+      frameworkErrorCount += 1
+    }
+
+    dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: main.getPort()})
+    errorEvents.on("framework-error", onFrameworkError)
+
+    try {
+      const client = new BackgroundJobsClient({configuration: dummyConfiguration})
+      const replacement = await client.replaceScheduled({scheduleKey: "client:key", jobName: "TestJob", args: []})
+
+      expect(await client.cancelScheduled({scheduleKey: "client:key"})).toEqual({jobId: replacement.jobId, outcome: "cancelled"})
+      await expect(async () => await client.cancelScheduled({scheduleKey: ""})).toThrow(/non-empty string/)
+      expect(frameworkErrorCount).toEqual(0)
+    } finally {
+      errorEvents.off("framework-error", onFrameworkError)
+      await main.stop()
+    }
+  })
+})

--- a/spec/background-jobs/stable-schedule-dispatch-spec.js
+++ b/spec/background-jobs/stable-schedule-dispatch-spec.js
@@ -1,0 +1,113 @@
+// @ts-check
+
+import fs from "fs/promises"
+import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
+import { outputPathFor, startBackgroundJobs, startBackgroundJobsMain, waitForOutputJson } from "../helpers/background-jobs-helper.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import TestJob from "../dummy/src/jobs/test-job.js"
+
+describe("Background jobs - stable schedule dispatch", {databaseCleaning: {truncate: true}}, () => {
+  it("re-arms dispatch when replacement moves a schedule earlier", async () => {
+    const {main, store, worker} = await startBackgroundJobs()
+    const outputPath = await outputPathFor("stable-schedule-rearm")
+    const scheduleKey = "event:52:reminder:24h"
+
+    try {
+      const first = await TestJob.replaceScheduled({
+        scheduleKey,
+        args: ["late", outputPath],
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 5000}
+      })
+      const second = await TestJob.replaceScheduled({
+        scheduleKey,
+        args: ["early", outputPath],
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 100}
+      })
+
+      expect(second).toEqual({jobId: second.jobId, previousJobId: first.jobId, previousStatus: "queued"})
+      expect(await waitForOutputJson({outputPath, timeoutSeconds: 2})).toEqual({message: "early"})
+      expect(await store.getJob(first.jobId)).toMatchObject({status: "cancelled"})
+    } finally {
+      await worker.stop()
+      await main.stop()
+    }
+  })
+
+  it("re-arms after cancellation and never dispatches the cancelled owner", async () => {
+    const {main, worker} = await startBackgroundJobs()
+    const cancelledOutputPath = await outputPathFor("stable-schedule-cancelled")
+    const keptOutputPath = await outputPathFor("stable-schedule-kept")
+
+    try {
+      await TestJob.replaceScheduled({
+        scheduleKey: "event:53:reminder:24h",
+        args: ["cancelled", cancelledOutputPath],
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 1000}
+      })
+      await TestJob.replaceScheduled({
+        scheduleKey: "event:54:reminder:24h",
+        args: ["kept", keptOutputPath],
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 1200}
+      })
+      await main._drain()
+      await timeout({timeout: 500}, async () => {
+        while (main._draining || !main._scheduledTimer) await wait(0.01)
+      })
+
+      const timerBeforeCancellation = main._scheduledTimer
+
+      expect(await TestJob.cancelScheduled("event:53:reminder:24h")).toMatchObject({outcome: "cancelled"})
+      await timeout({timeout: 500}, async () => {
+        while (main._scheduledTimer === timerBeforeCancellation) await wait(0.01)
+      })
+      expect(await waitForOutputJson({outputPath: keptOutputPath, timeoutSeconds: 2})).toEqual({message: "kept"})
+      await expect(async () => await fs.access(cancelledOutputPath)).toThrow(/ENOENT/)
+    } finally {
+      await worker.stop()
+      await main.stop()
+    }
+  })
+
+  it("dispatches the latest durable owner after main restart", async () => {
+    const {main: firstMain} = await startBackgroundJobsMain()
+    const outputPath = await outputPathFor("stable-schedule-restart")
+    const scheduleKey = "event:55:reminder:24h"
+
+    dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: firstMain.getPort()})
+
+    await TestJob.replaceScheduled({
+      scheduleKey,
+      args: ["stale", outputPath],
+      options: {executionMode: "inline", scheduledAtMs: Date.now() + 5000}
+    })
+    await TestJob.replaceScheduled({
+      scheduleKey,
+      args: ["latest", outputPath],
+      options: {executionMode: "inline", scheduledAtMs: Date.now() + 500}
+    })
+    await firstMain.stop()
+
+    const main = new BackgroundJobsMain({
+      closeDatabaseConnectionsOnStop: false,
+      configuration: dummyConfiguration,
+      host: "127.0.0.1",
+      port: 0
+    })
+    let worker
+
+    try {
+      await main.start()
+      dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: main.getPort()})
+      worker = new BackgroundJobsWorker({closeDatabaseConnectionsOnStop: false, configuration: dummyConfiguration})
+      await worker.start()
+
+      expect(await waitForOutputJson({outputPath, timeoutSeconds: 2})).toEqual({message: "latest"})
+    } finally {
+      await worker?.stop()
+      await main.stop()
+    }
+  })
+})

--- a/spec/background-jobs/stable-schedule-handoff-race-spec.js
+++ b/spec/background-jobs/stable-schedule-handoff-race-spec.js
@@ -1,0 +1,154 @@
+// @ts-check
+
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import SingleMultiUsePool from "../../src/database/pool/single-multi-use.js"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+/**
+ * Runs a stable-key mutation while an independently serialized store has won
+ * queued-to-handed-off but has not committed yet.
+ * @param {"cancel" | "replace"} mutation - Stable-key mutation.
+ * @returns {Promise<import("../../src/background-jobs/types.js").BackgroundJobCancellationResult | import("../../src/background-jobs/types.js").BackgroundJobReplacementResult>} - Mutation result.
+ */
+async function runHandoffRace(mutation) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-stable-schedule-race-"))
+  const databaseName = "stable-schedule-handoff-race"
+  const databaseOptions = {
+    driver: SqliteDriver,
+    migrations: false,
+    name: databaseName,
+    poolType: SingleMultiUsePool,
+    type: "sqlite"
+  }
+  const configuration = new Configuration({
+    database: {test: {handoff: {...databaseOptions}, mutation: {...databaseOptions}}},
+    directory,
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+  const handoffCanCommit = Promise.withResolvers()
+  const handoffUpdated = Promise.withResolvers()
+  const ownerReadCanContinue = Promise.withResolvers()
+  const raceObserved = Promise.withResolvers()
+  let raceObservation
+
+  class ReadyOnceStore extends BackgroundJobsStore {
+    _raceReady = false
+
+    async ensureReady() {
+      if (this._raceReady) return
+
+      await super.ensureReady()
+      this._raceReady = true
+    }
+  }
+
+  class PausedHandoffStore extends ReadyOnceStore {
+    async _updateAffectedRows(db, args) {
+      const affectedRows = await super._updateAffectedRows(db, args)
+
+      if (affectedRows === 1 && args.data.status === "handed_off") {
+        handoffUpdated.resolve()
+        await handoffCanCommit.promise
+      }
+
+      return affectedRows
+    }
+  }
+
+  class ObservedMutationStore extends ReadyOnceStore {
+    async _getJobRowById(db, jobId) {
+      const job = await super._getJobRowById(db, jobId)
+
+      if (!raceObservation && job?.status === "queued") {
+        raceObservation = "owner-read"
+        raceObserved.resolve(raceObservation)
+        await ownerReadCanContinue.promise
+      }
+
+      return job
+    }
+
+    async _lockCountRevision(db) {
+      if (!raceObservation) {
+        raceObservation = "count-lock"
+        raceObserved.resolve(raceObservation)
+      }
+
+      await super._lockCountRevision(db)
+    }
+  }
+
+  const setupStore = new BackgroundJobsStore({configuration, databaseIdentifier: "mutation"})
+  const handoffStore = new PausedHandoffStore({configuration, databaseIdentifier: "handoff"})
+  const mutationStore = new ObservedMutationStore({configuration, databaseIdentifier: "mutation"})
+
+  try {
+    await setupStore.clearAll()
+    await handoffStore.ensureReady()
+    await mutationStore.ensureReady()
+    const scheduleKey = `event:handoff-race:${mutation}`
+    const scheduled = await setupStore.replaceScheduled({scheduleKey, jobName: "EventReminderJob", args: [mutation]})
+    const handoffPromise = handoffStore.markHandedOff({jobId: scheduled.jobId, workerId: "race-worker"})
+
+    await Promise.race([
+      handoffUpdated.promise,
+      handoffPromise.then((handoff) => {
+        if (!handoff) throw new Error("Competing store didn't hand off the queued owner")
+      })
+    ])
+
+    const mutationPromise = (mutation === "cancel"
+      ? mutationStore.cancelScheduled(scheduleKey)
+      : mutationStore.replaceScheduled({scheduleKey, jobName: "EventReminderJob", args: ["replacement"]}))
+      .then((result) => ({result}), (error) => ({error}))
+    const observed = await raceObserved.promise
+
+    handoffCanCommit.resolve()
+    const handoff = await handoffPromise
+
+    if (!handoff) throw new Error("Expected competing handoff to win")
+
+    ownerReadCanContinue.resolve()
+    const mutationOutcome = await mutationPromise
+
+    if ("error" in mutationOutcome) throw mutationOutcome.error
+
+    expect(observed).toEqual("count-lock")
+
+    return mutationOutcome.result
+  } finally {
+    handoffCanCommit.resolve()
+    ownerReadCanContinue.resolve()
+    await configuration.closeDatabaseConnections()
+    dummyConfiguration.setCurrent()
+    await dummyConfiguration.initializeModels()
+    await fs.rm(directory, {force: true, recursive: true})
+  }
+}
+
+describe("Background jobs - stable schedule handoff races", {databaseCleaning: {transaction: false}}, () => {
+  it("reports handed_off when cancellation loses to an independent store handoff", async () => {
+    const result = await runHandoffRace("cancel")
+
+    expect(result).toMatchObject({outcome: "handed_off"})
+    expect(result.jobId).not.toBeNull()
+  })
+
+  it("reports handed_off when replacement loses to an independent store handoff", async () => {
+    const result = await runHandoffRace("replace")
+
+    expect(result).toMatchObject({previousStatus: "handed_off"})
+    expect(result.previousJobId).not.toBeNull()
+  })
+})

--- a/spec/background-jobs/stable-schedule-handoff-race-spec.js
+++ b/spec/background-jobs/stable-schedule-handoff-race-spec.js
@@ -3,6 +3,7 @@
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
+import BackgroundJobRecord from "../../src/background-jobs/job-record.js"
 import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import Configuration from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
@@ -17,6 +18,9 @@ import dummyConfiguration from "../dummy/src/config/configuration.js"
  * @returns {Promise<import("../../src/background-jobs/types.js").BackgroundJobCancellationResult | import("../../src/background-jobs/types.js").BackgroundJobReplacementResult>} - Mutation result.
  */
 async function runHandoffRace(mutation) {
+  dummyConfiguration.setCurrent()
+  await new BackgroundJobsStore({configuration: dummyConfiguration}).ensureReady()
+
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-stable-schedule-race-"))
   const databaseName = "stable-schedule-handoff-race"
   const databaseOptions = {
@@ -138,6 +142,14 @@ async function runHandoffRace(mutation) {
 }
 
 describe("Background jobs - stable schedule handoff races", {databaseCleaning: {transaction: false}}, () => {
+  it("keeps the initialized background job record on its configured database", async () => {
+    const databaseIdentifier = BackgroundJobRecord.getConfiguredDatabaseIdentifier()
+
+    await runHandoffRace("cancel")
+
+    expect(BackgroundJobRecord.getConfiguredDatabaseIdentifier()).toEqual(databaseIdentifier)
+  })
+
   it("reports handed_off when cancellation loses to an independent store handoff", async () => {
     const result = await runHandoffRace("cancel")
 

--- a/spec/background-jobs/stable-schedule-store-spec.js
+++ b/spec/background-jobs/stable-schedule-store-spec.js
@@ -78,6 +78,16 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
 
     await pool.withConnection({name: "Background jobs remove stable schedule schema"}, async (db) => {
       await db.dropTable("background_job_schedule_keys", {cascade: true, ifExists: true})
+      const jobsTable = await db.getTableByNameOrFail("background_jobs")
+
+      for (const index of await jobsTable.getIndexes()) {
+        if (!index.getColumnNames().includes("schedule_key")) continue
+
+        for (const sql of await db.removeIndexSQLs({name: index.getName(), tableName: "background_jobs"})) {
+          await db.query(sql)
+        }
+      }
+
       const tableData = new TableData("background_jobs")
 
       tableData.addColumn("schedule_key", {dropColumn: true})

--- a/spec/background-jobs/stable-schedule-store-spec.js
+++ b/spec/background-jobs/stable-schedule-store-spec.js
@@ -1,0 +1,303 @@
+// @ts-check
+
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import TableData from "../../src/database/table-data/index.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+/** @returns {Promise<BackgroundJobsStore>} - Empty background jobs store. */
+async function createClearedStore() {
+  dummyConfiguration.setCurrent()
+  const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+  await store.clearAll()
+
+  return store
+}
+
+/**
+ * @param {BackgroundJobsStore} store - Store.
+ * @param {string} jobId - Job id.
+ * @returns {Promise<import("../../src/background-jobs/types.js").BackgroundJobRow>} - Job.
+ */
+async function getJobOrFail(store, jobId) {
+  const job = await store.getJob(jobId)
+
+  if (!job) throw new Error(`Expected background job to exist: ${jobId}`)
+
+  return job
+}
+
+describe("Background jobs - stable schedule store", {databaseCleaning: {truncate: true}}, () => {
+  it("locks the durable count revision before a mutation reads job state", async () => {
+    const calls = []
+
+    class LockOrderStore extends BackgroundJobsStore {
+      async _lockCountRevision() {
+        calls.push("lock")
+      }
+
+      async _transactionResult(_db, callback) {
+        return await callback()
+      }
+    }
+
+    const store = new LockOrderStore({configuration: dummyConfiguration})
+
+    await store._serializedCountMutation(/** @type {import("../../src/database/drivers/base.js").default} */ ({}), async () => {
+      calls.push("read")
+    })
+
+    expect(calls).toEqual(["lock", "read"])
+  })
+
+  it("creates durable stable schedule ownership schema", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+    await store.ensureReady()
+
+    const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
+
+    await pool.withConnection({name: "Background jobs stable schedule schema"}, async (db) => {
+      const jobsTable = await db.getTableByNameOrFail("background_jobs")
+      const scheduleKeyColumn = await jobsTable.getColumnByName("schedule_key")
+      const scheduleKeysTable = await db.getTableByName("background_job_schedule_keys")
+
+      expect(scheduleKeyColumn?.getName()).toEqual("schedule_key")
+      expect(scheduleKeysTable?.getName()).toEqual("background_job_schedule_keys")
+    })
+  })
+
+  it("idempotently upgrades an existing background jobs schema", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+    await store.ensureReady()
+
+    const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
+
+    await pool.withConnection({name: "Background jobs remove stable schedule schema"}, async (db) => {
+      await db.dropTable("background_job_schedule_keys", {cascade: true, ifExists: true})
+      const tableData = new TableData("background_jobs")
+
+      tableData.addColumn("schedule_key", {dropColumn: true})
+      for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+      db.clearSchemaCache()
+    })
+
+    await store.ensureReady()
+    await store.ensureReady()
+
+    await pool.withConnection({name: "Background jobs inspect upgraded stable schedule schema"}, async (db) => {
+      const jobsTable = await db.getTableByNameOrFail("background_jobs")
+
+      expect((await jobsTable.getColumnByName("schedule_key"))?.getName()).toEqual("schedule_key")
+      expect((await db.getTableByName("background_job_schedule_keys"))?.getName()).toEqual("background_job_schedule_keys")
+    })
+  })
+
+  it("atomically replaces the queued owner while retaining keyed history", async () => {
+    const store = await createClearedStore()
+    const first = await store.replaceScheduled({
+      scheduleKey: "event:42:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [42, 1],
+      options: {scheduledAtMs: Date.now() + 60_000}
+    })
+    const second = await store.replaceScheduled({
+      scheduleKey: "event:42:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [42, 2],
+      options: {scheduledAtMs: Date.now() + 120_000}
+    })
+
+    expect(first).toEqual({jobId: first.jobId, previousJobId: null, previousStatus: null})
+    expect(second).toEqual({jobId: second.jobId, previousJobId: first.jobId, previousStatus: "queued"})
+    expect(await getJobOrFail(store, first.jobId)).toMatchObject({
+      scheduleKey: "event:42:reminder:24h",
+      status: "cancelled"
+    })
+    expect(await getJobOrFail(store, second.jobId)).toMatchObject({
+      args: [42, 2],
+      scheduleKey: "event:42:reminder:24h",
+      status: "queued"
+    })
+
+    const ownerRows = await store._withDb(async (db) =>
+      await db.newQuery().from("background_job_schedule_keys").where({schedule_key: "event:42:reminder:24h"}).results()
+    )
+
+    expect(ownerRows).toMatchObject([{job_id: second.jobId}])
+  })
+
+  it("cancels the queued owner and preserves its keyed history", async () => {
+    const store = await createClearedStore()
+    const replacement = await store.replaceScheduled({
+      scheduleKey: "event:43:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [43, 1],
+      options: {scheduledAtMs: Date.now() + 60_000}
+    })
+
+    expect(await store.cancelScheduled("event:43:reminder:24h")).toEqual({
+      jobId: replacement.jobId,
+      outcome: "cancelled"
+    })
+    expect(await getJobOrFail(store, replacement.jobId)).toMatchObject({
+      scheduleKey: "event:43:reminder:24h",
+      status: "cancelled"
+    })
+    expect(await store.cancelScheduled("event:43:reminder:24h")).toEqual({jobId: null, outcome: "not_found"})
+  })
+
+  it("reports handed-off replacement without claiming the running job stopped", async () => {
+    const store = await createClearedStore()
+    const first = await store.replaceScheduled({
+      scheduleKey: "event:44:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [44, 1]
+    })
+
+    const firstHandoff = await store.markHandedOff({jobId: first.jobId, workerId: "worker-1"})
+
+    if (!firstHandoff) throw new Error("Expected replaced job handoff")
+
+    const second = await store.replaceScheduled({
+      scheduleKey: "event:44:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [44, 2]
+    })
+
+    expect(second).toEqual({jobId: second.jobId, previousJobId: first.jobId, previousStatus: "handed_off"})
+    expect(await getJobOrFail(store, first.jobId)).toMatchObject({status: "handed_off"})
+    expect(await getJobOrFail(store, second.jobId)).toMatchObject({status: "queued"})
+
+    expect(await store.markFailed({jobId: first.jobId, error: "retry", workerId: "worker-1", ...firstHandoff})).toMatchObject({status: "queued"})
+
+    const ownerAfterSupersededRetry = await store._withDb(async (db) =>
+      await db.newQuery().from("background_job_schedule_keys").where({schedule_key: "event:44:reminder:24h"}).results()
+    )
+
+    expect(ownerAfterSupersededRetry).toMatchObject([{job_id: second.jobId}])
+  })
+
+  it("detaches a handed-off owner without claiming execution stopped", async () => {
+    const store = await createClearedStore()
+    const replacement = await store.replaceScheduled({
+      scheduleKey: "event:45:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [45]
+    })
+
+    expect(await store.markHandedOff({jobId: replacement.jobId, workerId: "worker-1"})).not.toBeNull()
+    expect(await store.cancelScheduled("event:45:reminder:24h")).toEqual({
+      jobId: replacement.jobId,
+      outcome: "handed_off"
+    })
+    expect(await getJobOrFail(store, replacement.jobId)).toMatchObject({status: "handed_off"})
+  })
+
+  it("conditionally releases ownership when jobs become terminal", async () => {
+    const store = await createClearedStore()
+    const first = await store.replaceScheduled({
+      scheduleKey: "event:46:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [46, 1]
+    })
+    const firstHandoff = await store.markHandedOff({jobId: first.jobId, workerId: "worker-1"})
+
+    if (!firstHandoff) throw new Error("Expected first handoff")
+
+    const second = await store.replaceScheduled({
+      scheduleKey: "event:46:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [46, 2]
+    })
+
+    expect(await store.markCompleted({jobId: first.jobId, workerId: "worker-1", ...firstHandoff})).toEqual(true)
+
+    const ownerAfterOldCompletion = await store._withDb(async (db) =>
+      await db.newQuery().from("background_job_schedule_keys").where({schedule_key: "event:46:reminder:24h"}).results()
+    )
+
+    expect(ownerAfterOldCompletion).toMatchObject([{job_id: second.jobId}])
+
+    const secondHandoff = await store.markHandedOff({jobId: second.jobId, workerId: "worker-2"})
+
+    if (!secondHandoff) throw new Error("Expected second handoff")
+
+    expect(await store.markCompleted({jobId: second.jobId, workerId: "worker-2", ...secondHandoff})).toEqual(true)
+    const ownerAfterCurrentCompletion = await store._withDb(async (db) =>
+      await db.newQuery().from("background_job_schedule_keys").where({schedule_key: "event:46:reminder:24h"}).results()
+    )
+
+    expect(ownerAfterCurrentCompletion).toEqual([])
+    expect(await store.cancelScheduled("event:46:reminder:24h")).toEqual({jobId: null, outcome: "not_found"})
+    expect(await getJobOrFail(store, second.jobId)).toMatchObject({
+      scheduleKey: "event:46:reminder:24h",
+      status: "completed"
+    })
+  })
+
+  it("retains ownership for retries and releases it after terminal failure", async () => {
+    const store = await createClearedStore()
+    const replacement = await store.replaceScheduled({
+      scheduleKey: "event:48:reminder:24h",
+      jobName: "EventReminderJob",
+      args: [48],
+      options: {maxRetries: 1}
+    })
+    const firstHandoff = await store.markHandedOff({jobId: replacement.jobId, workerId: "worker-1"})
+
+    if (!firstHandoff) throw new Error("Expected first failure handoff")
+
+    expect(await store.markFailed({jobId: replacement.jobId, error: "retry", workerId: "worker-1", ...firstHandoff})).toMatchObject({status: "queued"})
+
+    const ownerDuringRetry = await store._withDb(async (db) =>
+      await db.newQuery().from("background_job_schedule_keys").where({schedule_key: "event:48:reminder:24h"}).results()
+    )
+
+    expect(ownerDuringRetry).toMatchObject([{job_id: replacement.jobId}])
+
+    const secondHandoff = await store.markHandedOff({jobId: replacement.jobId, workerId: "worker-2"})
+
+    if (!secondHandoff) throw new Error("Expected terminal failure handoff")
+
+    expect(await store.markFailed({jobId: replacement.jobId, error: "terminal", workerId: "worker-2", ...secondHandoff})).toMatchObject({
+      scheduleKey: "event:48:reminder:24h",
+      status: "failed"
+    })
+
+    const ownerAfterFailure = await store._withDb(async (db) =>
+      await db.newQuery().from("background_job_schedule_keys").where({schedule_key: "event:48:reminder:24h"}).results()
+    )
+
+    expect(ownerAfterFailure).toEqual([])
+  })
+
+  it("serializes concurrent replacements and persists ownership across store restarts", async () => {
+    const firstStore = await createClearedStore()
+    const secondStore = new BackgroundJobsStore({configuration: dummyConfiguration})
+    const scheduleKey = "event:47:reminder:24h"
+    const replacements = await Promise.all([
+      firstStore.replaceScheduled({scheduleKey, jobName: "EventReminderJob", args: [47, 1]}),
+      secondStore.replaceScheduled({scheduleKey, jobName: "EventReminderJob", args: [47, 2]})
+    ])
+    const jobs = await Promise.all(replacements.map(({jobId}) => getJobOrFail(firstStore, jobId)))
+
+    expect(jobs.map((job) => job.status).sort()).toEqual(["cancelled", "queued"])
+
+    const queuedJob = jobs.find((job) => job.status === "queued")
+
+    if (!queuedJob) throw new Error("Expected one queued replacement")
+
+    expect(await secondStore.cancelScheduled(scheduleKey)).toEqual({jobId: queuedJob.id, outcome: "cancelled"})
+  })
+
+  it("rejects invalid stable schedule keys as client-safe errors", async () => {
+    const store = await createClearedStore()
+
+    await expect(async () => await store.replaceScheduled({scheduleKey: "", jobName: "TestJob", args: []})).toThrow(/non-empty string/)
+    await expect(async () => await store.cancelScheduled("x".repeat(256))).toThrow(/at most 255/)
+  })
+})

--- a/spec/background-jobs/stable-schedule-store-spec.js
+++ b/spec/background-jobs/stable-schedule-store-spec.js
@@ -4,14 +4,11 @@ import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import TableData from "../../src/database/table-data/index.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 
-/** @returns {Promise<BackgroundJobsStore>} - Empty background jobs store. */
-async function createClearedStore() {
+/** @returns {BackgroundJobsStore} - Background jobs store. */
+function createStore() {
   dummyConfiguration.setCurrent()
-  const store = new BackgroundJobsStore({configuration: dummyConfiguration})
 
-  await store.clearAll()
-
-  return store
+  return new BackgroundJobsStore({configuration: dummyConfiguration})
 }
 
 /**
@@ -27,7 +24,15 @@ async function getJobOrFail(store, jobId) {
   return job
 }
 
-describe("Background jobs - stable schedule store", {databaseCleaning: {truncate: true}}, () => {
+describe("Background jobs - stable schedule store", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  beforeEach(async () => {
+    await createStore().clearAll()
+  })
+
+  afterEach(async () => {
+    await createStore().clearAll()
+  })
+
   it("locks the durable count revision before a mutation reads job state", async () => {
     const calls = []
 
@@ -107,7 +112,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("atomically replaces the queued owner while retaining keyed history", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
     const first = await store.replaceScheduled({
       scheduleKey: "event:42:reminder:24h",
       jobName: "EventReminderJob",
@@ -141,7 +146,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("cancels the queued owner and preserves its keyed history", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
     const replacement = await store.replaceScheduled({
       scheduleKey: "event:43:reminder:24h",
       jobName: "EventReminderJob",
@@ -161,7 +166,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("reports handed-off replacement without claiming the running job stopped", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
     const first = await store.replaceScheduled({
       scheduleKey: "event:44:reminder:24h",
       jobName: "EventReminderJob",
@@ -192,7 +197,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("detaches a handed-off owner without claiming execution stopped", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
     const replacement = await store.replaceScheduled({
       scheduleKey: "event:45:reminder:24h",
       jobName: "EventReminderJob",
@@ -208,7 +213,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("conditionally releases ownership when jobs become terminal", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
     const first = await store.replaceScheduled({
       scheduleKey: "event:46:reminder:24h",
       jobName: "EventReminderJob",
@@ -250,7 +255,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("retains ownership for retries and releases it after terminal failure", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
     const replacement = await store.replaceScheduled({
       scheduleKey: "event:48:reminder:24h",
       jobName: "EventReminderJob",
@@ -286,7 +291,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("serializes concurrent replacements and persists ownership across store restarts", async () => {
-    const firstStore = await createClearedStore()
+    const firstStore = createStore()
     const secondStore = new BackgroundJobsStore({configuration: dummyConfiguration})
     const scheduleKey = "event:47:reminder:24h"
     const replacements = await Promise.all([
@@ -305,7 +310,7 @@ describe("Background jobs - stable schedule store", {databaseCleaning: {truncate
   })
 
   it("rejects invalid stable schedule keys as client-safe errors", async () => {
-    const store = await createClearedStore()
+    const store = createStore()
 
     await expect(async () => await store.replaceScheduled({scheduleKey: "", jobName: "TestJob", args: []})).toThrow(/non-empty string/)
     await expect(async () => await store.cancelScheduled("x".repeat(256))).toThrow(/at most 255/)

--- a/spec/background-jobs/web/api-spec.js
+++ b/spec/background-jobs/web/api-spec.js
@@ -199,6 +199,31 @@ describe("Background jobs - web API", {databaseCleaning: {truncate: true}}, () =
     })
   })
 
+  it("retains stable schedule keys in terminal dashboard history", async () => {
+    await Dummy.run(async () => {
+      const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+      await store.clearAll()
+      const replacement = await store.replaceScheduled({
+        scheduleKey: "event:61:reminder:24h",
+        jobName: "TestJob",
+        args: [61]
+      })
+      const handoff = await store.markHandedOff({jobId: replacement.jobId, workerId: "worker-1"})
+
+      if (!handoff) throw new Error("Expected stable scheduled job handoff")
+
+      await store.markCompleted({jobId: replacement.jobId, workerId: "worker-1", ...handoff})
+
+      const response = await fetch(`${API_BASE}/jobs/${replacement.jobId}`, {headers: {Authorization: `Bearer ${TOKEN}`}})
+      const body = await response.json()
+
+      expect(response.status).toEqual(200)
+      expect(body.job.scheduleKey).toEqual("event:61:reminder:24h")
+      expect(body.job.status).toEqual("completed")
+    })
+  })
+
   it("returns 404 for a missing job", async () => {
     await Dummy.run(async () => {
       await seedJobs()

--- a/spec/cli/commands/db/migrate-ensures-framework-schema-spec.js
+++ b/spec/cli/commands/db/migrate-ensures-framework-schema-spec.js
@@ -20,6 +20,7 @@ describe("Cli - Commands - db:migrate framework schema", () => {
       // Drop the framework tables so only db:migrate — via the ensureFrameworkSchema
       // hook — can recreate them (no runtime store boots in this test).
       await dbs.default.withDisabledForeignKeys(async () => {
+        await dbs.default.dropTable("background_job_schedule_keys", {cascade: true, ifExists: true})
         await dbs.default.dropTable("background_job_concurrency", {cascade: true, ifExists: true})
         await dbs.default.dropTable("background_jobs", {cascade: true, ifExists: true})
       })
@@ -35,6 +36,18 @@ describe("Cli - Commands - db:migrate framework schema", () => {
       if (!executionModeColumn) throw new Error("db:migrate didn't create the execution_mode column")
 
       expect(executionModeColumn.getName()).toEqual("execution_mode")
+
+      const scheduleKeyColumn = await backgroundJobsTable.getColumnByName("schedule_key")
+
+      if (!scheduleKeyColumn) throw new Error("db:migrate didn't create the schedule_key column")
+
+      expect(scheduleKeyColumn.getName()).toEqual("schedule_key")
+
+      const scheduleKeysTable = await dbs.default.getTableByName("background_job_schedule_keys")
+
+      if (!scheduleKeysTable) throw new Error("db:migrate didn't create the background_job_schedule_keys table")
+
+      expect(scheduleKeysTable.getName()).toEqual("background_job_schedule_keys")
 
       const concurrencyTable = await dbs.default.getTableByName("background_job_concurrency")
 
@@ -57,6 +70,7 @@ describe("Cli - Commands - db:migrate framework schema", () => {
       // concurrency reconcile — which under `--parallel N` fires once per tenant
       // worker and InnoDB-deadlocks (ER_LOCK_DEADLOCK) on the shared rows.
       await dbs.default.withDisabledForeignKeys(async () => {
+        await dbs.default.dropTable("background_job_schedule_keys", {cascade: true, ifExists: true})
         await dbs.default.dropTable("background_job_concurrency", {cascade: true, ifExists: true})
         await dbs.default.dropTable("background_jobs", {cascade: true, ifExists: true})
       })

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -44,6 +44,7 @@ describe("Cli - Commands - db:migrate", () => {
     const internalTables = new Set([
       "background_job_count_revisions",
       "background_job_concurrency",
+      "background_job_schedule_keys",
       "background_jobs",
       "velocious_attachments",
       "velocious_internal_migrations",

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -6,6 +6,7 @@ import dummyConfiguration from "../../../dummy/src/config/configuration.js"
 import dummyDirectory from "../../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
 import fs from "fs/promises"
+import os from "os"
 import path from "path"
 import uniqunize from "uniqunize"
 
@@ -363,7 +364,7 @@ describe("Cli - Commands - db:migrate", () => {
   })
 
   it("skips writing structure sql by default in test", {databaseCleaning: {transaction: false}}, async () => {
-    const directory = dummyDirectory()
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-db-migrate-without-structure-"))
     const configuration = new Configuration({
       database: dummyConfiguration.database,
       directory,
@@ -382,20 +383,24 @@ describe("Cli - Commands - db:migrate", () => {
       testing: true
     })
 
-    if (cli.getConfiguration().getDatabaseType("default") != "sqlite") {
-      console.warn(`Skipping structure sql disable assertion: default database is ${cli.getConfiguration().getDatabaseType("default")}`)
-      return
+    try {
+      if (cli.getConfiguration().getDatabaseType("default") != "sqlite") {
+        console.warn(`Skipping structure sql disable assertion: default database is ${cli.getConfiguration().getDatabaseType("default")}`)
+        return
+      }
+
+      await cli.getConfiguration().ensureConnections(async () => {
+        const structurePath = path.join(directory, "db", "structure-default.sql")
+
+        await cli.execute()
+
+        await expect(async () => {
+          await fs.readFile(structurePath, "utf8")
+        }).toThrow(/ENOENT/i)
+      })
+    } finally {
+      await cli.getConfiguration().closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
     }
-
-    await cli.getConfiguration().ensureConnections(async () => {
-      const structurePath = path.join(directory, "db", "structure-default.sql")
-
-      await fs.rm(structurePath, {force: true})
-      await cli.execute()
-
-      await expect(async () => {
-        await fs.readFile(structurePath, "utf8")
-      }).toThrow(/ENOENT/i)
-    })
   })
 })

--- a/spec/cli/commands/db/migrate-spec.js
+++ b/spec/cli/commands/db/migrate-spec.js
@@ -295,7 +295,7 @@ describe("Cli - Commands - db:migrate", () => {
   })
 
   it("writes structure sql for sqlite", {databaseCleaning: {transaction: false}}, async () => {
-    const directory = dummyDirectory()
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-db-migrate-with-structure-"))
     const configuration = new Configuration({
       database: dummyConfiguration.database,
       directory,
@@ -317,50 +317,55 @@ describe("Cli - Commands - db:migrate", () => {
       testing: true
     })
 
-    if (cli.getConfiguration().getDatabaseType("default") != "sqlite") {
-      console.warn(`Skipping structure sql assertion: default database is ${cli.getConfiguration().getDatabaseType("default")}`)
-      return
-    }
-
-    await cli.getConfiguration().ensureConnections(async (dbs) => {
-      await cli.execute()
-
-      const structurePath = path.join(directory, "db", "structure-default.sql")
-      const actual = await fs.readFile(structurePath, "utf8")
-      const rows = await dbs.default.query("SELECT type, sql, name FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY name")
-      const tables = []
-      const views = []
-      const indexes = []
-      const triggers = []
-      const others = []
-
-      for (const row of rows) {
-        const rawSql = row.sql || row.SQL
-        const rawType = row.type || row.TYPE
-        const statement = rawSql ? normalizeSqlStatement(String(rawSql)) : ""
-
-        if (!statement) continue
-
-        const normalizedType = rawType ? String(rawType).toLowerCase() : ""
-
-        if (normalizedType === "table") {
-          tables.push(statement)
-        } else if (normalizedType === "view") {
-          views.push(statement)
-        } else if (normalizedType === "index") {
-          indexes.push(statement)
-        } else if (normalizedType === "trigger") {
-          triggers.push(statement)
-        } else {
-          others.push(statement)
-        }
+    try {
+      if (cli.getConfiguration().getDatabaseType("default") != "sqlite") {
+        console.warn(`Skipping structure sql assertion: default database is ${cli.getConfiguration().getDatabaseType("default")}`)
+        return
       }
 
-      const expected = [...tables, ...views, ...indexes, ...triggers, ...others].join("\n\n") + "\n"
-      const ddlOnly = actual.split("\n").filter((l) => !l.startsWith("INSERT INTO schema_migrations")).join("\n")
+      await cli.getConfiguration().ensureConnections(async (dbs) => {
+        await cli.execute()
 
-      expect(ddlOnly).toEqual(expected)
-    })
+        const structurePath = path.join(directory, "db", "structure-default.sql")
+        const actual = await fs.readFile(structurePath, "utf8")
+        const rows = await dbs.default.query("SELECT type, sql, name FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY name")
+        const tables = []
+        const views = []
+        const indexes = []
+        const triggers = []
+        const others = []
+
+        for (const row of rows) {
+          const rawSql = row.sql || row.SQL
+          const rawType = row.type || row.TYPE
+          const statement = rawSql ? normalizeSqlStatement(String(rawSql)) : ""
+
+          if (!statement) continue
+
+          const normalizedType = rawType ? String(rawType).toLowerCase() : ""
+
+          if (normalizedType === "table") {
+            tables.push(statement)
+          } else if (normalizedType === "view") {
+            views.push(statement)
+          } else if (normalizedType === "index") {
+            indexes.push(statement)
+          } else if (normalizedType === "trigger") {
+            triggers.push(statement)
+          } else {
+            others.push(statement)
+          }
+        }
+
+        const expected = [...tables, ...views, ...indexes, ...triggers, ...others].join("\n\n") + "\n"
+        const ddlOnly = actual.split("\n").filter((l) => !l.startsWith("INSERT INTO schema_migrations")).join("\n")
+
+        expect(ddlOnly).toEqual(expected)
+      })
+    } finally {
+      await cli.getConfiguration().closeDatabaseConnections()
+      await fs.rm(directory, {force: true, recursive: true})
+    }
   })
 
   it("skips writing structure sql by default in test", {databaseCleaning: {transaction: false}}, async () => {

--- a/spec/cli/commands/db/rollback-spec.js
+++ b/spec/cli/commands/db/rollback-spec.js
@@ -8,6 +8,7 @@ describe("Cli - Commands - db:rollback", () => {
   const internalTables = new Set([
     "background_job_count_revisions",
     "background_job_concurrency",
+    "background_job_schedule_keys",
     "background_jobs",
     "velocious_attachments",
     "velocious_internal_migrations",

--- a/spec/cli/commands/db/schema/load-spec.js
+++ b/spec/cli/commands/db/schema/load-spec.js
@@ -11,6 +11,59 @@ import os from "os"
 import path from "path"
 
 describe("Cli - Commands - db:schema:load", () => {
+  it("loads the canonical dummy structure without losing framework schema", {databaseCleaning: {transaction: false}}, async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-db-schema-load-canonical-"))
+    const dbDir = path.join(directory, "db")
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            poolType: SingleMultiUsePool,
+            type: "sqlite",
+            name: "schema-load-canonical-test",
+            migrations: true
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode()
+    })
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:schema:load"],
+      testing: true
+    })
+
+    try {
+      await fs.mkdir(dbDir, {recursive: true})
+      await fs.copyFile(
+        path.resolve(import.meta.dirname, "../../../../dummy/db/structure-default.sql"),
+        path.join(dbDir, "structure-default.sql")
+      )
+      await cli.execute()
+
+      await cli.getConfiguration().ensureConnections(async (dbs) => {
+        const backgroundJobsTable = await dbs.default.getTableByNameOrFail("background_jobs")
+        const executionModeColumn = await backgroundJobsTable.getColumnByName("execution_mode")
+
+        if (!executionModeColumn) throw new Error("execution_mode column not found")
+
+        expect(executionModeColumn.getNull()).toEqual(false)
+        expect(await dbs.default.tableExists("background_job_schedule_keys")).toEqual(true)
+        expect(await dbs.default.tableExists("velocious_attachments")).toEqual(true)
+        expect(await dbs.default.tableExists("velocious_server_sequences")).toEqual(true)
+        expect(await dbs.default.tableExists("velocious_sync_scopes")).toEqual(true)
+      })
+    } finally {
+      await cli.getConfiguration().closeDatabaseConnections()
+      await fs.rm(directory, {recursive: true, force: true})
+    }
+  })
+
   it("loads the configured structure sql file into the database", {databaseCleaning: {transaction: false}}, async () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-db-schema-load-"))
     const dbDir = path.join(directory, "db")

--- a/spec/dummy/db/structure-default.sql
+++ b/spec/dummy/db/structure-default.sql
@@ -12,7 +12,9 @@ CREATE TABLE `background_job_concurrency` (`concurrency_key` VARCHAR(255) PRIMAR
 
 CREATE TABLE `background_job_count_revisions` (`key` VARCHAR(255) PRIMARY KEY, `revision` BIGINT NOT NULL);
 
-CREATE TABLE `background_jobs` (`id` VARCHAR(255) PRIMARY KEY, `job_name` VARCHAR(255) NOT NULL, `args_json` TEXT NOT NULL, `execution_mode` VARCHAR(255) NOT NULL, `queue` VARCHAR(255), `max_retries` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `status` VARCHAR(255) NOT NULL, `scheduled_at_ms` BIGINT NOT NULL, `created_at_ms` BIGINT NOT NULL, `handed_off_at_ms` BIGINT, `handoff_id` VARCHAR(255), `completed_at_ms` BIGINT, `failed_at_ms` BIGINT, `orphaned_at_ms` BIGINT, `worker_id` VARCHAR(255), `last_error` TEXT, `concurrency_key` VARCHAR(255), `max_concurrency` INTEGER);
+CREATE TABLE `background_job_schedule_keys` (`schedule_key` VARCHAR(255) PRIMARY KEY, `job_id` VARCHAR(255) NOT NULL);
+
+CREATE TABLE "background_jobs" (`id` VARCHAR(255) PRIMARY KEY, `job_name` VARCHAR(255) NOT NULL, `args_json` TEXT NOT NULL, `execution_mode` VARCHAR(255) NOT NULL, `queue` VARCHAR(255), `max_retries` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `status` VARCHAR(255) NOT NULL, `scheduled_at_ms` BIGINT NOT NULL, `created_at_ms` BIGINT NOT NULL, `handed_off_at_ms` BIGINT, `handoff_id` VARCHAR(255), `completed_at_ms` BIGINT, `failed_at_ms` BIGINT, `orphaned_at_ms` BIGINT, `worker_id` VARCHAR(255), `last_error` TEXT, `concurrency_key` VARCHAR(255), `max_concurrency` INTEGER, `schedule_key` VARCHAR(255));
 
 CREATE TABLE `comments` (`id` INTEGER PRIMARY KEY NOT NULL, `task_id` BIGINT NOT NULL REFERENCES `tasks`(`id`), `body` VARCHAR(255), `created_at` DATETIME, `updated_at` DATETIME);
 
@@ -72,6 +74,8 @@ CREATE UNIQUE INDEX `index_on_authentication_tokens_token` ON `authentication_to
 
 CREATE INDEX `index_on_authentication_tokens_user_id` ON `authentication_tokens` (`user_id`);
 
+CREATE INDEX `index_on_background_job_schedule_keys_job_id` ON `background_job_schedule_keys` (`job_id`);
+
 CREATE INDEX `index_on_background_jobs_concurrency_key` ON `background_jobs` (`concurrency_key`);
 
 CREATE INDEX `index_on_background_jobs_created_at_ms` ON `background_jobs` (`created_at_ms`);
@@ -83,6 +87,8 @@ CREATE INDEX `index_on_background_jobs_job_name` ON `background_jobs` (`job_name
 CREATE INDEX `index_on_background_jobs_orphaned_at_ms` ON `background_jobs` (`orphaned_at_ms`);
 
 CREATE INDEX `index_on_background_jobs_queue` ON `background_jobs` (`queue`);
+
+CREATE INDEX `index_on_background_jobs_schedule_key` ON "background_jobs" (`schedule_key`);
 
 CREATE INDEX `index_on_background_jobs_scheduled_at_ms` ON `background_jobs` (`scheduled_at_ms`);
 

--- a/spec/helpers/background-jobs-helper.js
+++ b/spec/helpers/background-jobs-helper.js
@@ -11,6 +11,19 @@ import AsyncTrackedMultiConnectionPool from "../../src/database/pool/async-track
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 
 /**
+ * Clears only framework background-job persistence.
+ * @returns {Promise<BackgroundJobsStore>} - Cleared background jobs store.
+ */
+export async function clearBackgroundJobs() {
+  dummyConfiguration.setCurrent()
+  const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+  await store.clearAll()
+
+  return store
+}
+
+/**
  * @param {object} [args] - Options.
  * @param {ConstructorParameters<typeof BackgroundJobsWorker>[0]} [args.workerOptions] - Worker constructor options.
  * @returns {Promise<{main: BackgroundJobsMain, store: BackgroundJobsStore, worker: BackgroundJobsWorker}>} - Started background job processes.
@@ -48,11 +61,9 @@ export async function startBackgroundJobs({workerOptions = {}} = {}) {
  * @returns {Promise<{main: BackgroundJobsMain, store: BackgroundJobsStore, stopped: (service: string) => Promise<void>}>} - Started main process and cleared store.
  */
 export async function startBackgroundJobsMain({backgroundJobsConfig, waitForWorkerStop = false} = {}) {
-  dummyConfiguration.setCurrent()
   if (backgroundJobsConfig) dummyConfiguration.setBackgroundJobsConfig(backgroundJobsConfig)
 
-  const store = new BackgroundJobsStore({configuration: dummyConfiguration})
-  await store.clearAll()
+  const store = await clearBackgroundJobs()
 
   const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
 

--- a/spec/helpers/signed-sync-replay-helper.js
+++ b/spec/helpers/signed-sync-replay-helper.js
@@ -88,7 +88,7 @@ export async function buildSignedReplayFixtures({actorDeviceId, actorUserId, gra
       actorUserId,
       certificateId: "cert-1",
       devicePublicKey: deviceKeys.publicKey,
-      expiresAt: "2027-01-01T00:00:00.000Z",
+      expiresAt: "2031-01-01T00:00:00.000Z",
       issuedAt: "2026-08-01T00:00:00.000Z"
     }
   })

--- a/spec/sync/awesome-tasks-offline-peer-sync-end-to-end-spec.js
+++ b/spec/sync/awesome-tasks-offline-peer-sync-end-to-end-spec.js
@@ -16,7 +16,7 @@ import {
   signFixtureMutation
 } from "../helpers/signed-sync-replay-helper.js"
 
-const GRANT_NOW = new Date("2026-08-03T00:00:00.000Z")
+const GRANT_NOW = new Date("2030-01-01T00:00:00.000Z")
 
 /**
  * Builds an in-memory storage adapter for a LocalMutationLog.

--- a/spec/sync/awesome-tasks-signed-offline-sync-spec.js
+++ b/spec/sync/awesome-tasks-signed-offline-sync-spec.js
@@ -20,7 +20,7 @@ describe("AwesomeTasks signed offline and peer-forwarded sync", {databaseCleanin
   it("replays a long-offline signed Task update after verifying device certificate and grant", async () => {
     const project = await Project.create({name: "Signed sync project"})
     const task = await Task.create({name: "Signed task", projectId: project.id()})
-    const grantNow = new Date("2026-08-03T00:00:00.000Z")
+    const grantNow = new Date("2030-01-01T00:00:00.000Z")
     const fixtures = await buildSignedReplayFixtures({
       actorDeviceId: "device-a",
       actorUserId: "user-1",
@@ -123,7 +123,7 @@ describe("AwesomeTasks signed offline and peer-forwarded sync", {databaseCleanin
 
     await TaskBoardCard.create({taskBoardId: board.id(), taskId: task.id(), boardColumnId: "todo", position: 1})
 
-    const grantNow = new Date("2026-08-03T00:00:00.000Z")
+    const grantNow = new Date("2030-01-01T00:00:00.000Z")
     const fixtures = await buildSignedReplayFixtures({
       actorDeviceId: "peer-device",
       actorUserId: "peer-user",
@@ -174,7 +174,7 @@ describe("AwesomeTasks signed offline and peer-forwarded sync", {databaseCleanin
   it("fails closed when actorLookup returns null", async () => {
     const project = await Project.create({name: "Missing actor project"})
     const task = await Task.create({name: "Missing actor task", projectId: project.id()})
-    const grantNow = new Date("2026-08-03T00:00:00.000Z")
+    const grantNow = new Date("2030-01-01T00:00:00.000Z")
     const fixtures = await buildSignedReplayFixtures({
       actorDeviceId: "device-a",
       actorUserId: "unknown-user",
@@ -219,7 +219,7 @@ describe("AwesomeTasks signed offline and peer-forwarded sync", {databaseCleanin
   })
 
   it("keeps concurrent replays on one service from crossing actors or grants", async () => {
-    const grantNow = new Date("2026-08-03T00:00:00.000Z")
+    const grantNow = new Date("2030-01-01T00:00:00.000Z")
 
     /**
      * Builds one actor's fixtures and signed Task mutation.

--- a/spec/sync/awesome-tasks-signed-policy-enforcement-spec.js
+++ b/spec/sync/awesome-tasks-signed-policy-enforcement-spec.js
@@ -77,7 +77,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {NotAModel: {enabled: true, operations: ["update"], policyHash: "sha256-stale"}},
       scopes: {projectId: project.id()}
     })
@@ -98,7 +98,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: {enabled: true, operations: ["destroy"], policyHash: dummySyncManifest().Task.policyHash}},
       scopes: {projectId: project.id()}
     })
@@ -119,7 +119,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: {enabled: true, operations: ["update"], policyHash: dummySyncManifest().Task.policyHash}},
       scopes: {projectId: project.id()}
     })
@@ -140,7 +140,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: {enabled: false, operations: ["update"], policyHash: dummySyncManifest().Task.policyHash}},
       scopes: {projectId: project.id()}
     })
@@ -157,7 +157,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: {enabled: true, operations: ["find"], policyHash: dummySyncManifest().Task.policyHash}},
       scopes: {projectId: project.id()}
     })
@@ -174,7 +174,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: {enabled: true, operations: ["update"], policyHash: "sha256-stale"}},
       scopes: {projectId: project.id()}
     })
@@ -191,7 +191,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: ["update"]},
       scopes: {projectId: project.id()}
     })
@@ -208,7 +208,7 @@ describe("AwesomeTasks signed offline sync policy enforcement", {databaseCleanin
       actorDeviceId: "device-a",
       actorUserId: "user-1",
       grantId: "grant-policy",
-      grantNow: new Date("2026-08-03T00:00:00.000Z"),
+      grantNow: new Date("2030-01-01T00:00:00.000Z"),
       resources: {Task: {enabled: true, operations: ["update"], policyHash: dummySyncManifest().Task.policyHash}},
       scopes: {projectId: project.id()}
     })

--- a/spec/sync/awesome-tasks-signed-scope-authorization-spec.js
+++ b/spec/sync/awesome-tasks-signed-scope-authorization-spec.js
@@ -15,7 +15,7 @@ import {
   signFixtureMutation
 } from "../helpers/signed-sync-replay-helper.js"
 
-const GRANT_NOW = new Date("2026-08-03T00:00:00.000Z")
+const GRANT_NOW = new Date("2030-01-01T00:00:00.000Z")
 
 /**
  * Builds grant fixtures for one actor scoped to a project.

--- a/spec/sync/awesome-tasks-task-board-move-card-spec.js
+++ b/spec/sync/awesome-tasks-task-board-move-card-spec.js
@@ -24,7 +24,7 @@ const ACTOR_ID = "1f6e9a4c-2b3d-4e5f-8a9b-0c1d2e3f4a5b"
  */
 function buildSync({data, id, resourceId, resourceType, syncType}) {
   return {
-    clientUpdatedAt: "2026-08-03T10:00:00.000Z",
+    clientUpdatedAt: "2030-01-01T10:00:00.000Z",
     data,
     id,
     resourceId: String(resourceId),

--- a/spec/sync/awesome-tasks-task-comment-sync-spec.js
+++ b/spec/sync/awesome-tasks-task-comment-sync-spec.js
@@ -22,7 +22,7 @@ const ACTOR_ID = "1f6e9a4c-2b3d-4e5f-8a9b-0c1d2e3f4a5b"
  */
 function buildSync({data, id, resourceId, resourceType = "Task", syncType = "update"}) {
   return {
-    clientUpdatedAt: "2026-08-03T10:00:00.000Z",
+    clientUpdatedAt: "2030-01-01T10:00:00.000Z",
     data,
     id,
     resourceId: String(resourceId),

--- a/spec/sync/sync-publisher-from-configuration-spec.js
+++ b/spec/sync/sync-publisher-from-configuration-spec.js
@@ -51,7 +51,7 @@ function buildFakeServerSyncModel({scopeAttributes} = {}) {
   const rows = []
   let nextId = 1
   let nextServerSequence = 1
-  const persistedUpdatedAt = new Date("2026-08-03T14:00:00.000Z")
+  const persistedUpdatedAt = new Date("2030-01-01T14:00:00.000Z")
   const getAttributeNameToColumnNameMap = () => ({accountId: "account_id", eventId: "event_id"})
 
   return {
@@ -205,7 +205,7 @@ describe("sync publisher from configuration", () => {
         resourceType: "PublishedScan",
         serverSequence: 1,
         syncType: "update",
-        updatedAt: "2026-08-03T14:00:00.000Z"
+        updatedAt: "2030-01-01T14:00:00.000Z"
       }]
     })
   })

--- a/src/background-jobs/client.js
+++ b/src/background-jobs/client.js
@@ -14,6 +14,17 @@ export default class BackgroundJobsClient {
   }
 
   /**
+   * Builds a one-shot client socket request from the resolved configuration.
+   * @returns {Promise<BackgroundJobsSocketRequest>} - Socket request.
+   */
+  async _request() {
+    const configuration = await this.configurationPromise
+    const {host, port} = configuration.getBackgroundJobsConfig()
+
+    return new BackgroundJobsSocketRequest({host, port, role: "client"})
+  }
+
+  /**
    * Runs enqueue.
    * @param {object} args - Options.
    * @param {string} args.jobName - Job name.
@@ -22,9 +33,7 @@ export default class BackgroundJobsClient {
    * @returns {Promise<string>} - Job id.
    */
   async enqueue({jobName, args, options}) {
-    const configuration = await this.configurationPromise
-    const {host, port} = configuration.getBackgroundJobsConfig()
-    const request = new BackgroundJobsSocketRequest({host, port, role: "client"})
+    const request = await this._request()
 
     return await request.run({
       onConnect: (jsonSocket) => {
@@ -43,6 +52,65 @@ export default class BackgroundJobsClient {
 
         if (message?.type === "enqueue-error") {
           reject(new Error(message.error || "Failed to enqueue job"))
+        }
+      }
+    })
+  }
+
+  /**
+   * Atomically replaces the queued owner of a stable schedule key.
+   * @param {object} args - Options.
+   * @param {string} args.scheduleKey - Stable logical schedule key.
+   * @param {string} args.jobName - Job name.
+   * @param {Array<?>} args.args - Job args.
+   * @param {import("./types.js").BackgroundJobOptions} [args.options] - Job options.
+   * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+   */
+  async replaceScheduled({scheduleKey, jobName, args, options}) {
+    const request = await this._request()
+
+    return await request.run({
+      onConnect: (jsonSocket) => {
+        jsonSocket.send({type: "replace-scheduled", scheduleKey, jobName, args, options})
+      },
+      onMessage: ({message, resolve, reject}) => {
+        if (message?.type === "schedule-replaced") {
+          resolve({
+            jobId: message.jobId,
+            previousJobId: message.previousJobId,
+            previousStatus: message.previousStatus
+          })
+          return
+        }
+
+        if (message?.type === "replace-scheduled-error") {
+          reject(new Error(message.error || "Failed to replace scheduled job"))
+        }
+      }
+    })
+  }
+
+  /**
+   * Cancels or detaches the current owner of a stable schedule key.
+   * @param {object} args - Options.
+   * @param {string} args.scheduleKey - Stable logical schedule key.
+   * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+   */
+  async cancelScheduled({scheduleKey}) {
+    const request = await this._request()
+
+    return await request.run({
+      onConnect: (jsonSocket) => {
+        jsonSocket.send({type: "cancel-scheduled", scheduleKey})
+      },
+      onMessage: ({message, resolve, reject}) => {
+        if (message?.type === "schedule-cancelled") {
+          resolve({jobId: message.jobId, outcome: message.outcome})
+          return
+        }
+
+        if (message?.type === "cancel-scheduled-error") {
+          reject(new Error(message.error || "Failed to cancel scheduled job"))
         }
       }
     })

--- a/src/background-jobs/job.js
+++ b/src/background-jobs/job.js
@@ -101,6 +101,36 @@ export default class VelociousJob {
   }
 
   /**
+   * Atomically replaces this job class's queued owner for a stable schedule key.
+   * @param {object} args - Options.
+   * @param {string} args.scheduleKey - Stable logical schedule key.
+   * @param {Array<?>} args.args - Job args.
+   * @param {import("./types.js").BackgroundJobOptions} [args.options] - Job options.
+   * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+   */
+  static async replaceScheduled({scheduleKey, args, options}) {
+    const client = new BackgroundJobsClient()
+
+    return await client.replaceScheduled({
+      scheduleKey,
+      jobName: this.jobName(),
+      args,
+      options: this._withQueue(options)
+    })
+  }
+
+  /**
+   * Cancels or detaches the current owner of a stable schedule key.
+   * @param {string} scheduleKey - Stable logical schedule key.
+   * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+   */
+  static async cancelScheduled(scheduleKey) {
+    const client = new BackgroundJobsClient()
+
+    return await client.cancelScheduled({scheduleKey})
+  }
+
+  /**
    * Runs split args and options.
    * @param {Array<?>} args - Job args.
    * @returns {{jobArgs: Array<?>, jobOptions: import("./types.js").BackgroundJobOptions}} - Split args and options.

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -538,6 +538,16 @@ export default class BackgroundJobsMain {
   _handleClientSocketMessage({jsonSocket, message}) {
     if (message?.type === "enqueue") {
       this._handleEnqueue({jsonSocket, message})
+      return
+    }
+
+    if (message?.type === "replace-scheduled") {
+      this._handleReplaceScheduled({jsonSocket, message})
+      return
+    }
+
+    if (message?.type === "cancel-scheduled") {
+      this._handleCancelScheduled({jsonSocket, message})
     }
   }
 
@@ -749,23 +759,99 @@ export default class BackgroundJobsMain {
       this._notifyEnqueued()
       await this._drain()
     } catch (error) {
-      if (error instanceof VelociousError && error.safeToExpose) {
-        jsonSocket.send({type: "enqueue-error", error: error.message})
-        return
-      }
-
-      const normalizedError = error instanceof Error ? error : new Error(String(error))
-      const payload = {
+      this._handleClientMutationError({
         context: {jobName: message.jobName, stage: "background-job-enqueue"},
-        error: normalizedError
-      }
-      const errorEvents = this.configuration.getErrorEvents()
-
-      this.logger.error(() => ["Failed to enqueue background job:", normalizedError])
-      errorEvents.emit("framework-error", payload)
-      errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
-      jsonSocket.send({type: "enqueue-error", error: "Failed to enqueue job"})
+        error,
+        fallbackMessage: "Failed to enqueue job",
+        jsonSocket,
+        logMessage: "Failed to enqueue background job:",
+        responseType: "enqueue-error"
+      })
     }
+  }
+
+  /**
+   * Handles a stable-key replacement request and re-arms dispatch afterward.
+   * @param {object} args - Options.
+   * @param {JsonSocket} args.jsonSocket - JSON socket.
+   * @param {import("./types.js").BackgroundJobReplaceScheduledMessage} args.message - Message.
+   * @returns {Promise<void>} - Resolves when handled.
+   */
+  async _handleReplaceScheduled({jsonSocket, message}) {
+    try {
+      const result = await this.store.replaceScheduled({
+        scheduleKey: message.scheduleKey,
+        jobName: message.jobName,
+        args: message.args || [],
+        options: message.options || {}
+      })
+
+      jsonSocket.send({type: "schedule-replaced", ...result})
+      this._notifyEnqueued()
+      await this._drain()
+    } catch (error) {
+      this._handleClientMutationError({
+        context: {jobName: message.jobName, scheduleKey: message.scheduleKey, stage: "background-job-replace-scheduled"},
+        error,
+        fallbackMessage: "Failed to replace scheduled job",
+        jsonSocket,
+        logMessage: "Failed to replace scheduled background job:",
+        responseType: "replace-scheduled-error"
+      })
+    }
+  }
+
+  /**
+   * Handles a stable-key cancellation request and re-arms dispatch afterward.
+   * @param {object} args - Options.
+   * @param {JsonSocket} args.jsonSocket - JSON socket.
+   * @param {import("./types.js").BackgroundJobCancelScheduledMessage} args.message - Message.
+   * @returns {Promise<void>} - Resolves when handled.
+   */
+  async _handleCancelScheduled({jsonSocket, message}) {
+    try {
+      const result = await this.store.cancelScheduled(message.scheduleKey)
+
+      jsonSocket.send({type: "schedule-cancelled", ...result})
+      this._notifyEnqueued()
+      await this._drain()
+    } catch (error) {
+      this._handleClientMutationError({
+        context: {scheduleKey: message.scheduleKey, stage: "background-job-cancel-scheduled"},
+        error,
+        fallbackMessage: "Failed to cancel scheduled job",
+        jsonSocket,
+        logMessage: "Failed to cancel scheduled background job:",
+        responseType: "cancel-scheduled-error"
+      })
+    }
+  }
+
+  /**
+   * Returns safe validation failures and reports unexpected client mutations.
+   * @param {object} args - Options.
+   * @param {Record<string, ?>} args.context - Framework-error context.
+   * @param {?} args.error - Mutation failure.
+   * @param {string} args.fallbackMessage - Client-safe fallback message.
+   * @param {JsonSocket} args.jsonSocket - JSON socket.
+   * @param {string} args.logMessage - Error log prefix.
+   * @param {"enqueue-error" | "replace-scheduled-error" | "cancel-scheduled-error"} args.responseType - Response type.
+   * @returns {void}
+   */
+  _handleClientMutationError({context, error, fallbackMessage, jsonSocket, logMessage, responseType}) {
+    if (error instanceof VelociousError && error.safeToExpose) {
+      jsonSocket.send({type: responseType, error: error.message})
+      return
+    }
+
+    const normalizedError = error instanceof Error ? error : new Error(String(error))
+    const payload = {context, error: normalizedError}
+    const errorEvents = this.configuration.getErrorEvents()
+
+    this.logger.error(() => [logMessage, normalizedError])
+    errorEvents.emit("framework-error", payload)
+    errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
+    jsonSocket.send({type: responseType, error: fallbackMessage})
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -1479,10 +1479,9 @@ export default class BackgroundJobsStore {
   }
 
   async _initializeModel() {
-    BackgroundJobRecord.setDatabaseIdentifier(this.getDatabaseIdentifier())
-
     if (BackgroundJobRecord.isInitialized()) return
 
+    BackgroundJobRecord.setDatabaseIdentifier(this.getDatabaseIdentifier())
     const pool = this.configuration.getDatabasePool(this.getDatabaseIdentifier())
 
     await pool.withConnection({name: "Background jobs store initialize model"}, async () => {

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -1,11 +1,25 @@
 // @ts-check
 
-import {randomUUID} from "crypto"
+import {createHash, randomUUID} from "crypto"
 import Logger from "../logger.js"
 import TableData from "../database/table-data/index.js"
 import VelociousError from "../velocious-error.js"
 import BackgroundJobRecord from "./job-record.js"
 import normalizeBackgroundJobError from "./normalize-error.js"
+
+/**
+ * PreparedBackgroundJob type.
+ * @typedef {object} PreparedBackgroundJob
+ * @property {string} argsJson - Serialized arguments.
+ * @property {{concurrencyKey: string, maxConcurrency: number, queueDerived: boolean} | null} concurrency - Resolved concurrency.
+ * @property {number} createdAtMs - Creation timestamp.
+ * @property {import("./types.js").BackgroundJobExecutionMode} executionMode - Execution mode.
+ * @property {string} jobId - New job id.
+ * @property {string} jobName - Job name.
+ * @property {number} maxRetries - Retry cap.
+ * @property {string} queue - Queue name.
+ * @property {number} scheduledAtMs - Eligibility timestamp.
+ */
 
 const MIGRATIONS_TABLE = "velocious_internal_migrations"
 const MIGRATION_SCOPE = "background_jobs"
@@ -22,6 +36,7 @@ const DROP_FORKED_COLUMN_MIGRATION_VERSION = "20260719000000"
 const LEGACY_POOLED_HANDOFF_ID_PREFIX = "velocious-pooled:"
 const LEGACY_POOLED_QUEUED_HANDOFF_ID = `${LEGACY_POOLED_HANDOFF_ID_PREFIX}queued`
 const JOBS_TABLE = "background_jobs"
+const SCHEDULE_KEYS_TABLE = "background_job_schedule_keys"
 const CONCURRENCY_TABLE = "background_job_concurrency"
 const COUNTS_REVISION_TABLE = "background_job_count_revisions"
 const COUNTS_REVISION_KEY = "counts"
@@ -153,16 +168,9 @@ export default class BackgroundJobsStore {
   async enqueue({jobName, args, options}) {
     await this.ensureReady()
 
-    const jobId = randomUUID()
-    const now = Date.now()
-    const executionMode = this._normalizeExecutionMode(options)
-    const maxRetries = this._normalizeMaxRetries(options?.maxRetries)
-    const scheduledAtMs = this._normalizeScheduledAtMs(options?.scheduledAtMs, now)
-    const argsJson = JSON.stringify(args || [])
-    const queue = this._normalizeQueue(options)
-    const concurrency = this._resolveConcurrency(options, queue)
+    const preparedJob = this._prepareJob({jobName, args, options})
     /** @type {string} */
-    let resultJobId = jobId
+    let resultJobId = preparedJob.jobId
 
     await this._withDb(async (db) => await this._serializedCountMutation(db, async () => {
       if (options?.deduplicateWhileQueued) {
@@ -174,8 +182,8 @@ export default class BackgroundJobsStore {
           .newQuery()
           .from(JOBS_TABLE)
           .select("id")
-          .where({status: "queued", job_name: jobName, args_json: argsJson, queue})
-          .where(`scheduled_at_ms <= ${db.quote(scheduledAtMs)}`)
+          .where({status: "queued", job_name: jobName, args_json: preparedJob.argsJson, queue: preparedJob.queue})
+          .where(`scheduled_at_ms <= ${db.quote(preparedJob.scheduledAtMs)}`)
           .order("scheduled_at_ms ASC")
           .limit(1)
           .results()
@@ -187,35 +195,148 @@ export default class BackgroundJobsStore {
         }
       }
 
-      if (concurrency) {
-        if (concurrency.queueDerived) {
-          await this._ensureQueueConcurrencyKey(db, concurrency)
-        } else {
-          await this._ensureConcurrencyKey(db, concurrency)
-        }
-      }
-      await db.insert({
-        tableName: JOBS_TABLE,
-        data: {
-          id: jobId,
-          job_name: jobName,
-          args_json: argsJson,
-          execution_mode: executionMode,
-          queue,
-          max_retries: maxRetries,
-          attempts: 0,
-          status: "queued",
-          scheduled_at_ms: scheduledAtMs,
-          created_at_ms: now,
-          concurrency_key: concurrency?.concurrencyKey || null,
-          max_concurrency: concurrency?.maxConcurrency || null,
-          handoff_id: null
-        }
-      })
+      await this._insertPreparedJob(db, {preparedJob, scheduleKey: null})
       await this._recordCountDelta(db, {all: 1, queued: 1})
     }))
 
     return resultJobId
+  }
+
+  /**
+   * Replaces the queued owner of a stable schedule key with a new one-off job.
+   * A handed-off owner is left running and reported truthfully.
+   * @param {object} args - Options.
+   * @param {string} args.scheduleKey - Stable logical schedule key.
+   * @param {string} args.jobName - Job name.
+   * @param {Array<?>} args.args - Arguments.
+   * @param {import("./types.js").BackgroundJobOptions} [args.options] - Options.
+   * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+   */
+  async replaceScheduled({scheduleKey, jobName, args, options}) {
+    await this.ensureReady()
+
+    const normalizedScheduleKey = this._normalizeScheduleKey(scheduleKey)
+    const preparedJob = this._prepareJob({jobName, args, options})
+
+    return await this._withDb(async (db) => {
+      const lockName = this._scheduleKeyLockName(normalizedScheduleKey)
+      const acquired = await db.acquireAdvisoryLock(lockName)
+
+      if (!acquired) throw new Error("Failed to acquire background job schedule-key lock")
+
+      try {
+        return await this._serializedCountMutation(db, async () => {
+          const ownerRows = await db
+            .newQuery()
+            .from(SCHEDULE_KEYS_TABLE)
+            .where({schedule_key: normalizedScheduleKey})
+            .limit(1)
+            .results()
+          const ownerJobId = ownerRows[0] ? String(/** @type {Record<string, ?>} */ (ownerRows[0]).job_id) : null
+          const ownerJob = ownerJobId ? await this._getJobRowById(db, ownerJobId) : null
+          /** @type {import("./types.js").BackgroundJobReplacementPreviousStatus} */
+          let previousStatus = null
+          let previousJobId = null
+
+          if (ownerJob?.status === "queued") {
+            const affectedRows = await this._updateAffectedRows(db, {
+              tableName: JOBS_TABLE,
+              data: {status: "cancelled"},
+              conditions: {id: ownerJob.id, status: "queued"}
+            })
+
+            if (affectedRows === 1) {
+              previousJobId = ownerJob.id
+              previousStatus = "queued"
+            } else {
+              const currentOwnerJob = await this._getJobRowById(db, ownerJob.id)
+
+              if (currentOwnerJob?.status === "handed_off") {
+                previousJobId = currentOwnerJob.id
+                previousStatus = "handed_off"
+              }
+            }
+          } else if (ownerJob?.status === "handed_off") {
+            previousJobId = ownerJob.id
+            previousStatus = "handed_off"
+          }
+
+          await this._insertPreparedJob(db, {preparedJob, scheduleKey: normalizedScheduleKey})
+          await db.upsert({
+            tableName: SCHEDULE_KEYS_TABLE,
+            data: {schedule_key: normalizedScheduleKey, job_id: preparedJob.jobId},
+            conflictColumns: ["schedule_key"],
+            updateColumns: ["job_id"]
+          })
+
+          if (previousStatus !== "queued") await this._recordCountDelta(db, {all: 1, queued: 1})
+
+          return {jobId: preparedJob.jobId, previousJobId, previousStatus}
+        })
+      } finally {
+        await db.releaseAdvisoryLock(lockName)
+      }
+    })
+  }
+
+  /**
+   * Cancels the queued owner of a stable schedule key. A handed-off owner is
+   * detached but not marked stopped because execution may already be running.
+   * @param {string} scheduleKey - Stable logical schedule key.
+   * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+   */
+  async cancelScheduled(scheduleKey) {
+    await this.ensureReady()
+
+    const normalizedScheduleKey = this._normalizeScheduleKey(scheduleKey)
+
+    return await this._withDb(async (db) => {
+      const lockName = this._scheduleKeyLockName(normalizedScheduleKey)
+      const acquired = await db.acquireAdvisoryLock(lockName)
+
+      if (!acquired) throw new Error("Failed to acquire background job schedule-key lock")
+
+      try {
+        return await this._serializedCountMutation(db, async () => {
+          const ownerRows = await db
+            .newQuery()
+            .from(SCHEDULE_KEYS_TABLE)
+            .where({schedule_key: normalizedScheduleKey})
+            .limit(1)
+            .results()
+
+          if (!ownerRows[0]) return {jobId: null, outcome: "not_found"}
+
+          const jobId = String(/** @type {Record<string, ?>} */ (ownerRows[0]).job_id)
+          const job = await this._getJobRowById(db, jobId)
+
+          if (job?.status === "queued") {
+            const affectedRows = await this._updateAffectedRows(db, {
+              tableName: JOBS_TABLE,
+              data: {status: "cancelled"},
+              conditions: {id: job.id, status: "queued"}
+            })
+
+            if (affectedRows === 1) {
+              await this._releaseScheduleOwnership(db, {jobId, scheduleKey: normalizedScheduleKey})
+              await this._recordStatusTransition(db, "queued", "cancelled")
+
+              return {jobId, outcome: "cancelled"}
+            }
+          }
+
+          const currentJob = await this._getJobRowById(db, jobId)
+
+          await this._releaseScheduleOwnership(db, {jobId, scheduleKey: normalizedScheduleKey})
+
+          if (currentJob?.status === "handed_off") return {jobId, outcome: "handed_off"}
+
+          return {jobId: null, outcome: "not_found"}
+        })
+      } finally {
+        await db.releaseAdvisoryLock(lockName)
+      }
+    })
   }
 
   /**
@@ -526,6 +647,7 @@ export default class BackgroundJobsStore {
       })
 
       if (affectedRows !== 1) return false
+      await this._releaseScheduleOwnershipForJob(db, job)
       await this._releaseConcurrency(db, job.concurrencyKey)
       await this._recordStatusTransition(db, "handed_off", "completed")
       return true
@@ -769,6 +891,7 @@ export default class BackgroundJobsStore {
 
     await this._withDb(async (db) => await this._serializedCountMutation(db, async () => {
       const snapshot = await this._countSnapshotOnLockedConnection(db)
+      if (await db.tableExists(SCHEDULE_KEYS_TABLE)) await db.query(`DELETE FROM ${db.quoteTable(SCHEDULE_KEYS_TABLE)}`)
       await db.query(`DELETE FROM ${db.quoteTable(JOBS_TABLE)}`)
       if (await db.tableExists(CONCURRENCY_TABLE)) await db.query(`DELETE FROM ${db.quoteTable(CONCURRENCY_TABLE)}`)
       const deltas = Object.fromEntries(Object.entries(snapshot.counts).map(([key, value]) => [key, -value]))
@@ -791,6 +914,7 @@ export default class BackgroundJobsStore {
       if (job.status === "handed_off") await this._lockConcurrencyRow(db, job.concurrencyKey)
       const affectedRows = await this._updateAffectedRows(db, {tableName: JOBS_TABLE, data: {status: "cancelled"}, conditions: {id: job.id, status: job.status}})
       if (affectedRows !== 1) return false
+      await this._releaseScheduleOwnershipForJob(db, job)
       if (job.status === "handed_off") await this._releaseConcurrency(db, job.concurrencyKey)
       await this._recordStatusTransition(db, job.status, "cancelled")
       return true
@@ -810,6 +934,71 @@ export default class BackgroundJobsStore {
     }
 
     return (retryCount - 3) * 60 * 60 * 1000
+  }
+
+  /**
+   * Normalizes one new job before entering its persistence transaction.
+   * @param {object} args - Job input.
+   * @param {Array<?>} args.args - Job arguments.
+   * @param {string} args.jobName - Job name.
+   * @param {import("./types.js").BackgroundJobOptions} [args.options] - Job options.
+   * @returns {PreparedBackgroundJob} - Prepared job.
+   */
+  _prepareJob({args, jobName, options}) {
+    const createdAtMs = Date.now()
+    const queue = this._normalizeQueue(options)
+
+    return {
+      argsJson: JSON.stringify(args || []),
+      concurrency: this._resolveConcurrency(options, queue),
+      createdAtMs,
+      executionMode: this._normalizeExecutionMode(options),
+      jobId: randomUUID(),
+      jobName,
+      maxRetries: this._normalizeMaxRetries(options?.maxRetries),
+      queue,
+      scheduledAtMs: this._normalizeScheduledAtMs(options?.scheduledAtMs, createdAtMs)
+    }
+  }
+
+  /**
+   * Inserts one prepared queued job, including its concurrency registration.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {object} args - Insert input.
+   * @param {PreparedBackgroundJob} args.preparedJob - Prepared job.
+   * @param {string | null} args.scheduleKey - Historical stable key.
+   * @returns {Promise<void>} - Resolves after insertion.
+   */
+  async _insertPreparedJob(db, {preparedJob, scheduleKey}) {
+    const {concurrency} = preparedJob
+
+    if (concurrency) {
+      if (concurrency.queueDerived) {
+        await this._ensureQueueConcurrencyKey(db, concurrency)
+      } else {
+        await this._ensureConcurrencyKey(db, concurrency)
+      }
+    }
+
+    await db.insert({
+      tableName: JOBS_TABLE,
+      data: {
+        id: preparedJob.jobId,
+        job_name: preparedJob.jobName,
+        args_json: preparedJob.argsJson,
+        execution_mode: preparedJob.executionMode,
+        queue: preparedJob.queue,
+        max_retries: preparedJob.maxRetries,
+        attempts: 0,
+        status: "queued",
+        scheduled_at_ms: preparedJob.scheduledAtMs,
+        created_at_ms: preparedJob.createdAtMs,
+        schedule_key: scheduleKey,
+        concurrency_key: concurrency?.concurrencyKey || null,
+        max_concurrency: concurrency?.maxConcurrency || null,
+        handoff_id: null
+      }
+    })
   }
 
   /**
@@ -836,6 +1025,28 @@ export default class BackgroundJobsStore {
     if (Number.isSafeInteger(scheduledAtMs) && scheduledAtMs >= 0) return scheduledAtMs
 
     throw VelociousError.safe("background job scheduledAtMs must be a non-negative safe integer")
+  }
+
+  /**
+   * Validates a stable schedule key at the public storage boundary.
+   * @param {string} scheduleKey - Stable logical schedule key.
+   * @returns {string} - Validated key.
+   */
+  _normalizeScheduleKey(scheduleKey) {
+    if (typeof scheduleKey === "string" && scheduleKey.length > 0 && scheduleKey.length <= 255) return scheduleKey
+
+    throw VelociousError.safe("background job scheduleKey must be a non-empty string of at most 255 characters")
+  }
+
+  /**
+   * Builds a bounded advisory-lock name for one stable schedule key.
+   * @param {string} scheduleKey - Validated stable schedule key.
+   * @returns {string} - Advisory-lock name.
+   */
+  _scheduleKeyLockName(scheduleKey) {
+    const hash = createHash("sha256").update(scheduleKey).digest("hex").slice(0, 32)
+
+    return `background-jobs:schedule:${hash}`
   }
 
   /**
@@ -900,6 +1111,7 @@ export default class BackgroundJobsStore {
     // row alone, otherwise later callers fail with "no such table".
     if (alreadyApplied && await db.tableExists(JOBS_TABLE)) {
       await this._ensureJobsTableColumns(db)
+      await this._ensureScheduleKeysTable(db)
       await this._ensureConcurrencyTable(db)
       await this._ensureCountRevisionTable(db)
       await this._reconcileQueueConcurrency(db)
@@ -910,6 +1122,7 @@ export default class BackgroundJobsStore {
 
     await this._applyMigrations(db)
     await this._ensureJobsTableColumns(db)
+    await this._ensureScheduleKeysTable(db)
     await this._ensureConcurrencyTable(db)
     await this._ensureCountRevisionTable(db)
     await this._reconcileQueueConcurrency(db)
@@ -981,6 +1194,7 @@ export default class BackgroundJobsStore {
     table.string("status", {null: false, index: true})
     table.bigint("scheduled_at_ms", {null: false, index: true})
     table.bigint("created_at_ms", {null: false, index: true})
+    table.string("schedule_key", {null: true, index: true})
     table.bigint("handed_off_at_ms", {null: true, index: true})
     table.string("handoff_id", {null: true})
     table.bigint("completed_at_ms", {null: true})
@@ -1081,6 +1295,36 @@ export default class BackgroundJobsStore {
     }
 
     await this._ensureQueueColumn(db)
+    await this._ensureScheduleKeyColumn(db)
+  }
+
+  /**
+   * Idempotently adds the historical stable schedule key to existing jobs.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when ensured.
+   */
+  async _ensureScheduleKeyColumn(db) {
+    const lockName = `${MIGRATION_SCOPE}:schedule_key_column`
+    const acquired = await db.acquireAdvisoryLock(lockName)
+
+    if (!acquired) throw new Error("Failed to acquire background jobs schedule-key schema lock")
+
+    try {
+      db.clearSchemaCache()
+      const lockedTable = await db.getTableByNameOrFail(JOBS_TABLE)
+
+      if (!(await lockedTable.getColumnByName("schedule_key"))) {
+        const tableData = new TableData(JOBS_TABLE)
+
+        tableData.string("schedule_key", {null: true, index: true})
+
+        for (const sql of await db.alterTableSQLs(tableData)) await db.query(sql)
+
+        db.clearSchemaCache()
+      }
+    } finally {
+      await db.releaseAdvisoryLock(lockName)
+    }
   }
 
   /**
@@ -1267,6 +1511,33 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Releases ownership only when the key still points at the expected job.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {object} args - Ownership identity.
+   * @param {string} args.jobId - Expected owner job id.
+   * @param {string} args.scheduleKey - Stable schedule key.
+   * @returns {Promise<void>} - Resolves when deleted or already superseded.
+   */
+  async _releaseScheduleOwnership(db, {jobId, scheduleKey}) {
+    await db.delete({
+      tableName: SCHEDULE_KEYS_TABLE,
+      conditions: {job_id: jobId, schedule_key: scheduleKey}
+    })
+  }
+
+  /**
+   * Releases a job's ownership when it has a historical schedule key.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @param {import("./types.js").BackgroundJobRow} job - Terminal job.
+   * @returns {Promise<void>} - Resolves when deleted or not applicable.
+   */
+  async _releaseScheduleOwnershipForJob(db, job) {
+    if (!job.scheduleKey) return
+
+    await this._releaseScheduleOwnership(db, {jobId: job.id, scheduleKey: job.scheduleKey})
+  }
+
+  /**
    * Runs apply failure.
    * @param {object} args - Options.
    * @param {import("../database/drivers/base.js").default} args.db - Database connection.
@@ -1300,6 +1571,7 @@ export default class BackgroundJobsStore {
     })
 
     if (affectedRows !== 1) return null
+    if (!shouldRetry) await this._releaseScheduleOwnershipForJob(db, job)
     await this._releaseConcurrency(db, job.concurrencyKey)
 
     // Return a snapshot of the transition this update just applied rather than re-reading the row.
@@ -1412,6 +1684,7 @@ export default class BackgroundJobsStore {
       args: this._parseArgs(row.args_json),
       executionMode,
       queue: row.queue ? String(row.queue) : DEFAULT_QUEUE,
+      scheduleKey: row.schedule_key ? String(row.schedule_key) : null,
       status: row.status ? String(row.status) : "queued",
       attempts: this._normalizeNumber(row.attempts),
       maxRetries: this._normalizeNumber(row.max_retries),
@@ -1542,6 +1815,34 @@ export default class BackgroundJobsStore {
     table.integer("max_concurrency", {null: false})
     table.integer("active_count", {null: false})
     await db.createTable(table)
+  }
+
+  /**
+   * Ensures the stable schedule-key ownership table exists.
+   * @param {import("../database/drivers/base.js").default} db - Database connection.
+   * @returns {Promise<void>} - Resolves when ready.
+   */
+  async _ensureScheduleKeysTable(db) {
+    if (await db.tableExists(SCHEDULE_KEYS_TABLE)) return
+
+    const lockName = `${MIGRATION_SCOPE}:schedule_keys_table`
+    const acquired = await db.acquireAdvisoryLock(lockName)
+
+    if (!acquired) throw new Error("Failed to acquire background jobs schedule-key table schema lock")
+
+    try {
+      db.clearSchemaCache()
+      if (await db.tableExists(SCHEDULE_KEYS_TABLE)) return
+
+      const table = new TableData(SCHEDULE_KEYS_TABLE, {ifNotExists: true})
+
+      table.string("schedule_key", {primaryKey: true})
+      table.string("job_id", {null: false, index: true})
+      await db.createTable(table)
+      db.clearSchemaCache()
+    } finally {
+      await db.releaseAdvisoryLock(lockName)
+    }
   }
 
   /**
@@ -1691,7 +1992,6 @@ export default class BackgroundJobsStore {
    * @returns {Promise<{counts: Record<string, number>, revision: number, total: number}>} Snapshot.
    */
   async _countSnapshotOnLockedConnection(db) {
-    await this._lockCountRevision(db)
     const rows = await db.newQuery().from(JOBS_TABLE).select("status").select("COUNT(*) AS count").group("status").results()
     const counts = this._emptyCountBuckets()
     let total = 0
@@ -2024,7 +2324,11 @@ export default class BackgroundJobsStore {
     await previous
 
     try {
-      return await this._transactionResult(db, callback)
+      return await this._transactionResult(db, async () => {
+        await this._lockCountRevision(db)
+
+        return await callback()
+      })
     } finally {
       resolveRun()
       if (countMutationChains.get(identifier) === chain) countMutationChains.delete(identifier)

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -35,6 +35,7 @@
  * @property {Array<?>} args - Serialized job arguments.
  * @property {BackgroundJobExecutionMode} executionMode - How the job should run.
  * @property {string} queue - Queue name (defaults to `"default"`).
+ * @property {string | null} scheduleKey - Stable logical schedule key retained for history.
  * @property {string} status - Current job status.
  * @property {number | null} attempts - Failure attempts count.
  * @property {number | null} maxRetries - Max retry attempts.
@@ -49,6 +50,23 @@
  * @property {string | null} lastError - Last failure message.
  * @property {string | null} concurrencyKey - Durable concurrency key.
  * @property {number | null} maxConcurrency - Durable per-key cap.
+ */
+/**
+ * @typedef {"queued" | "handed_off" | null} BackgroundJobReplacementPreviousStatus
+ */
+/**
+ * @typedef {object} BackgroundJobReplacementResult
+ * @property {string} jobId - Newly queued job id.
+ * @property {string | null} previousJobId - Previous active owner's job id.
+ * @property {BackgroundJobReplacementPreviousStatus} previousStatus - Previous owner's observed state.
+ */
+/**
+ * @typedef {"cancelled" | "handed_off" | "not_found"} BackgroundJobCancellationOutcome
+ */
+/**
+ * @typedef {object} BackgroundJobCancellationResult
+ * @property {string | null} jobId - Detached owner's job id, when one was active.
+ * @property {BackgroundJobCancellationOutcome} outcome - Truthful best-effort outcome.
  */
 /**
  * @typedef {object} BackgroundJobFailureEvent
@@ -72,6 +90,12 @@
  * @typedef {{type: "enqueue", jobName: string, args?: Array<?>, options?: BackgroundJobOptions}} BackgroundJobEnqueueMessage
  * @typedef {{type: "enqueued", jobId: string}} BackgroundJobEnqueuedMessage
  * @typedef {{type: "enqueue-error", error?: string}} BackgroundJobEnqueueErrorMessage
+ * @typedef {{type: "replace-scheduled", scheduleKey: string, jobName: string, args?: Array<?>, options?: BackgroundJobOptions}} BackgroundJobReplaceScheduledMessage
+ * @typedef {{type: "schedule-replaced", jobId: string, previousJobId: string | null, previousStatus: BackgroundJobReplacementPreviousStatus}} BackgroundJobScheduleReplacedMessage
+ * @typedef {{type: "replace-scheduled-error", error?: string}} BackgroundJobReplaceScheduledErrorMessage
+ * @typedef {{type: "cancel-scheduled", scheduleKey: string}} BackgroundJobCancelScheduledMessage
+ * @typedef {{type: "schedule-cancelled", jobId: string | null, outcome: BackgroundJobCancellationOutcome}} BackgroundJobScheduleCancelledMessage
+ * @typedef {{type: "cancel-scheduled-error", error?: string}} BackgroundJobCancelScheduledErrorMessage
  * @typedef {{type: "job", payload: BackgroundJobPayload}} BackgroundJobJobMessage
  * @typedef {{type: "job-complete", jobId: string, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobCompleteMessage
  * @typedef {{type: "job-failed", jobId: string, error?: ?, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobFailedMessage
@@ -79,7 +103,7 @@
  * @typedef {{type: "job-update-error", jobId: string, error?: string}} BackgroundJobUpdateErrorMessage
  */
 /**
- * @typedef {BackgroundJobHelloMessage | BackgroundJobReadyMessage | BackgroundJobDrainingMessage | BackgroundJobHeartbeatMessage | BackgroundJobEnqueueMessage | BackgroundJobEnqueuedMessage | BackgroundJobEnqueueErrorMessage | BackgroundJobJobMessage | BackgroundJobCompleteMessage | BackgroundJobFailedMessage | BackgroundJobUpdatedMessage | BackgroundJobUpdateErrorMessage} BackgroundJobSocketMessage
+ * @typedef {BackgroundJobHelloMessage | BackgroundJobReadyMessage | BackgroundJobDrainingMessage | BackgroundJobHeartbeatMessage | BackgroundJobEnqueueMessage | BackgroundJobEnqueuedMessage | BackgroundJobEnqueueErrorMessage | BackgroundJobReplaceScheduledMessage | BackgroundJobScheduleReplacedMessage | BackgroundJobReplaceScheduledErrorMessage | BackgroundJobCancelScheduledMessage | BackgroundJobScheduleCancelledMessage | BackgroundJobCancelScheduledErrorMessage | BackgroundJobJobMessage | BackgroundJobCompleteMessage | BackgroundJobFailedMessage | BackgroundJobUpdatedMessage | BackgroundJobUpdateErrorMessage} BackgroundJobSocketMessage
  */
 
 export const nothing = {}

--- a/src/background-jobs/web/controller.js
+++ b/src/background-jobs/web/controller.js
@@ -199,6 +199,7 @@ export default class VelociousBackgroundJobsWebController extends Controller {
       lastError: job.lastError,
       maxRetries: job.maxRetries,
       orphanedAtMs: job.orphanedAtMs,
+      scheduleKey: job.scheduleKey,
       scheduledAtMs: job.scheduledAtMs,
       status: job.status,
       workerId: job.workerId


### PR DESCRIPTION
## Summary

- add public stable schedule-key APIs for atomically replacing and cancelling logical one-off background jobs
- persist durable schedule ownership while retaining `schedule_key` on historical job rows and reporting handed-off work truthfully
- re-arm dispatch after replacement/cancellation, expose keys in dashboard history, and document the application-facing contract
- add deterministic handoff-race, restart, schema-upgrade, canonical snapshot, API, dispatch, and compatibility coverage

## Validation

- 91 focused/legacy/migration tests passed on current `master`, including deterministic cross-store handoff races
- `npm run build`
- `npm run lint` (ESLint, typecheck, Fallow)
- canonical SQLite `db:schema:load → db:migrate → db:schema:dump` round trip returned byte-identically to the committed snapshot
- `git diff --check`
- independent exact-candidate review: PASS

## Task

AwesomeTasks: `ec4793ba-f5b0-4d43-a224-026dc5090d94`
