### PR TITLE
Fix MySQL schema dump foreign key ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1301,7 +1301,7 @@ If you need to regenerate missing structure files without rerunning migrations, 
 npx velocious db:schema:dump
 ```
 
-`db:schema:dump` generates a structure SQL file for each configured database identifier under `db/structure-<identifier>.sql`. It only writes files when one or more expected files are missing. The generated file includes the full DDL (tables, indexes, views, triggers, etc.) followed by `INSERT INTO schema_migrations (version) VALUES (...)` for every currently applied migration version. This preserves the migration ledger in the checked-in snapshot so fresh databases loaded from it do not re-run migrations that already shaped the schemas in the file.
+`db:schema:dump` generates a structure SQL file for each configured database identifier under `db/structure-<identifier>.sql`. It only writes files when one or more expected files are missing. The generated file includes the full DDL (tables, indexes, views, triggers, etc.) followed by `INSERT INTO schema_migrations (version) VALUES (...)` for every currently applied migration version. MySQL and MariaDB dumps place same-schema referenced base tables before their dependent tables. The migration ledger preserves applied versions in the checked-in snapshot so fresh databases loaded from it do not re-run migrations that already shaped the schemas in the file.
 
 If you need to load the checked-in structure files for each configured database, use:
 

--- a/changelog.d/20260805072928-mysql-schema-dump-foreign-key-order.md
+++ b/changelog.d/20260805072928-mysql-schema-dump-foreign-key-order.md
@@ -1,0 +1,1 @@
+MySQL and MariaDB schema dumps now place same-schema referenced base tables before their dependent tables.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -130,7 +130,7 @@ await this.migrateLegacyLocalDateTimesToUtcStorage({
 
 ## Structure Snapshots and the Migration Ledger
 
-`db:schema:dump` generates `db/structure-<identifier>.sql` files from the current database state. Each file contains the full DDL for tables, indexes, views, and triggers, followed by `INSERT INTO schema_migrations (version) VALUES (...)` for every applied migration version. This embeds the migration ledger directly in the checked-in snapshot.
+`db:schema:dump` generates `db/structure-<identifier>.sql` files from the current database state. Each file contains the full DDL for tables, indexes, views, and triggers, followed by `INSERT INTO schema_migrations (version) VALUES (...)` for every applied migration version. MySQL and MariaDB dumps place same-schema referenced base tables before their dependent tables. The migration ledger is embedded directly in the checked-in snapshot.
 
 When a fresh database is created from a structure file via `db:schema:load`, those insert rows repopulate the `schema_migrations` table so the loaded database knows exactly which migrations have already been applied. Subsequent `db:migrate` calls see those versions and skip them.
 

--- a/spec/environment-handlers/node-structure-mysql-spec.js
+++ b/spec/environment-handlers/node-structure-mysql-spec.js
@@ -18,18 +18,26 @@ function extractQuotedName(sql) {
  * @param {string} args.version
  * @param {Array<{table_name: string, table_type: string}>} args.tables
  * @param {Record<string, {type: "table" | "view", sql: string}>} args.creates
+ * @param {Array<{referenced_table_name: string, table_name: string}>} [args.foreignKeys]
+ * @param {string[]} [args.queries]
  * @returns {import("../../src/database/drivers/base.js").default}
  */
-function buildMysqlDb({version, tables, creates}) {
+function buildMysqlDb({version, tables, creates, foreignKeys = [], queries = []}) {
   return /** @type {import("../../src/database/drivers/base.js").default} */ (/** @type {unknown} */ ({
     quoteTable(/** @type {string} */ name) {
       return `\`${name}\``
     },
     async query(/** @type {string} */ sql) {
+      queries.push(sql)
+
       if (sql == "SELECT VERSION() AS version") return [{version}]
 
       if (sql.startsWith("SELECT table_name, table_type FROM information_schema.tables")) {
         return tables
+      }
+
+      if (sql.startsWith("SELECT table_name, referenced_table_name FROM information_schema.key_column_usage")) {
+        return foreignKeys
       }
 
       if (sql.startsWith("SHOW CREATE TABLE")) {
@@ -70,6 +78,33 @@ describe("Drivers - structure sql - mysql", () => {
     const result = await new MysqlStructureSql({driver: db}).toSql()
 
     expect(result).toEqual("CREATE TABLE `users` (`id` int);\n\nCREATE VIEW `active_users` AS SELECT 1;\n")
+  })
+
+  it("creates referenced audit lookup tables before dependent audit tables", async () => {
+    const queries = []
+    const db = buildMysqlDb({
+      version: "8.0.33",
+      tables: [
+        {table_name: "audits", table_type: "BASE TABLE"},
+        {table_name: "audit_actions", table_type: "BASE TABLE"},
+        {table_name: "audit_auditable_types", table_type: "BASE TABLE"}
+      ],
+      foreignKeys: [
+        {table_name: "audits", referenced_table_name: "audit_actions"},
+        {table_name: "audits", referenced_table_name: "audit_auditable_types"}
+      ],
+      queries,
+      creates: {
+        audit_actions: {type: "table", sql: "CREATE TABLE `audit_actions` (`id` int)"},
+        audit_auditable_types: {type: "table", sql: "CREATE TABLE `audit_auditable_types` (`id` int)"},
+        audits: {type: "table", sql: "CREATE TABLE `audits` (`id` int, `action_id` int, `auditable_type_id` int, CONSTRAINT `audits_action_id_fk` FOREIGN KEY (`action_id`) REFERENCES `audit_actions` (`id`), CONSTRAINT `audits_auditable_type_id_fk` FOREIGN KEY (`auditable_type_id`) REFERENCES `audit_auditable_types` (`id`))"}
+      }
+    })
+
+    const result = await new MysqlStructureSql({driver: db}).toSql()
+
+    expect(queries).toContain("SELECT table_name, referenced_table_name FROM information_schema.key_column_usage WHERE table_schema = DATABASE() AND referenced_table_schema = DATABASE() AND referenced_table_name IS NOT NULL")
+    expect(result).toEqual("CREATE TABLE `audit_actions` (`id` int);\n\nCREATE TABLE `audit_auditable_types` (`id` int);\n\nCREATE TABLE `audits` (`id` int, `action_id` int, `auditable_type_id` int, CONSTRAINT `audits_action_id_fk` FOREIGN KEY (`action_id`) REFERENCES `audit_actions` (`id`), CONSTRAINT `audits_auditable_type_id_fk` FOREIGN KEY (`auditable_type_id`) REFERENCES `audit_auditable_types` (`id`));\n")
   })
 
   it("treats MariaDB system views as views", async () => {

--- a/spec/environment-handlers/node-structure-mysql-spec.js
+++ b/spec/environment-handlers/node-structure-mysql-spec.js
@@ -107,6 +107,28 @@ describe("Drivers - structure sql - mysql", () => {
     expect(result).toEqual("CREATE TABLE `audit_actions` (`id` int);\n\nCREATE TABLE `audit_auditable_types` (`id` int);\n\nCREATE TABLE `audits` (`id` int, `action_id` int, `auditable_type_id` int, CONSTRAINT `audits_action_id_fk` FOREIGN KEY (`action_id`) REFERENCES `audit_actions` (`id`), CONSTRAINT `audits_auditable_type_id_fk` FOREIGN KEY (`auditable_type_id`) REFERENCES `audit_auditable_types` (`id`));\n")
   })
 
+  it("ignores self-referencing foreign keys when ordering dependent tables", async () => {
+    const db = buildMysqlDb({
+      version: "8.0.33",
+      tables: [
+        {table_name: "account_memberships", table_type: "BASE TABLE"},
+        {table_name: "users", table_type: "BASE TABLE"}
+      ],
+      foreignKeys: [
+        {table_name: "account_memberships", referenced_table_name: "users"},
+        {table_name: "users", referenced_table_name: "users"}
+      ],
+      creates: {
+        account_memberships: {type: "table", sql: "CREATE TABLE `account_memberships` (`id` int, `user_id` int, CONSTRAINT `account_memberships_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))"},
+        users: {type: "table", sql: "CREATE TABLE `users` (`id` int, `manager_id` int, CONSTRAINT `users_manager_id_fk` FOREIGN KEY (`manager_id`) REFERENCES `users` (`id`))"}
+      }
+    })
+
+    const result = await new MysqlStructureSql({driver: db}).toSql()
+
+    expect(result).toEqual("CREATE TABLE `users` (`id` int, `manager_id` int, CONSTRAINT `users_manager_id_fk` FOREIGN KEY (`manager_id`) REFERENCES `users` (`id`));\n\nCREATE TABLE `account_memberships` (`id` int, `user_id` int, CONSTRAINT `account_memberships_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`));\n")
+  })
+
   it("treats MariaDB system views as views", async () => {
     const db = buildMysqlDb({
       version: "10.4.0-MariaDB",

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -786,9 +786,9 @@ export default class BackgroundJobsMain {
         options: message.options || {}
       })
 
-      jsonSocket.send({type: "schedule-replaced", ...result})
       this._notifyEnqueued()
       await this._drain()
+      jsonSocket.send({type: "schedule-replaced", ...result})
     } catch (error) {
       this._handleClientMutationError({
         context: {jobName: message.jobName, scheduleKey: message.scheduleKey, stage: "background-job-replace-scheduled"},
@@ -812,9 +812,9 @@ export default class BackgroundJobsMain {
     try {
       const result = await this.store.cancelScheduled(message.scheduleKey)
 
-      jsonSocket.send({type: "schedule-cancelled", ...result})
       this._notifyEnqueued()
       await this._drain()
+      jsonSocket.send({type: "schedule-cancelled", ...result})
     } catch (error) {
       this._handleClientMutationError({
         context: {scheduleKey: message.scheduleKey, stage: "background-job-cancel-scheduled"},

--- a/src/database/drivers/mysql/structure-sql.js
+++ b/src/database/drivers/mysql/structure-sql.js
@@ -20,6 +20,9 @@ export default class VelociousDatabaseDriversMysqlStructureSql {
     const {driver} = this
     const isMariaDb = await this._isMariaDb()
     const rows = await driver.query("SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = DATABASE() ORDER BY table_type, table_name")
+    const foreignKeyRows = await driver.query("SELECT table_name, referenced_table_name FROM information_schema.key_column_usage WHERE table_schema = DATABASE() AND referenced_table_schema = DATABASE() AND referenced_table_name IS NOT NULL")
+    const baseTableNames = []
+    const views = []
     const statements = []
 
     for (const row of rows) {
@@ -31,22 +34,80 @@ export default class VelociousDatabaseDriversMysqlStructureSql {
       if (!tableName || !tableType) continue
 
       if (tableType == "BASE TABLE") {
-        const createRows = await driver.query(`SHOW CREATE TABLE ${driver.quoteTable(tableName)}`)
-        const rawCreateStatement = this._mysqlCreateStatement(createRows?.[0])
-        const createStatement = rawCreateStatement ? this._stripAutoIncrement(rawCreateStatement) : null
-
-        if (createStatement) statements.push(normalizeSqlStatement(createStatement))
+        baseTableNames.push(tableName)
       } else if (tableType == "VIEW" || (isMariaDb && tableType == "SYSTEM VIEW")) {
-        const createRows = await driver.query(`SHOW CREATE VIEW ${driver.quoteTable(tableName)}`)
-        const createStatement = this._mysqlCreateStatement(createRows?.[0])
-
-        if (createStatement) statements.push(normalizeSqlStatement(createStatement))
+        views.push(tableName)
       }
+    }
+
+    for (const tableName of this._orderBaseTables({foreignKeyRows, tableNames: baseTableNames})) {
+      const createRows = await driver.query(`SHOW CREATE TABLE ${driver.quoteTable(tableName)}`)
+      const rawCreateStatement = this._mysqlCreateStatement(createRows?.[0])
+      const createStatement = rawCreateStatement ? this._stripAutoIncrement(rawCreateStatement) : null
+
+      if (createStatement) statements.push(normalizeSqlStatement(createStatement))
+    }
+
+    for (const tableName of views) {
+      const createRows = await driver.query(`SHOW CREATE VIEW ${driver.quoteTable(tableName)}`)
+      const createStatement = this._mysqlCreateStatement(createRows?.[0])
+
+      if (createStatement) statements.push(normalizeSqlStatement(createStatement))
     }
 
     if (statements.length == 0) return null
 
     return `${statements.join("\n\n")}\n`
+  }
+
+  /**
+   * Orders tables so referenced tables are created before their dependents.
+   * @param {object} args - Options object.
+   * @param {Array<Record<string, ?>>} args.foreignKeyRows - Foreign key metadata rows.
+   * @param {string[]} args.tableNames - Base table names in their existing order.
+   * @returns {string[]} - Ordered table names.
+   */
+  _orderBaseTables({foreignKeyRows, tableNames}) {
+    const pendingTableNames = new Set(tableNames)
+    /** @type {Record<string, Set<string>>} */
+    const dependenciesByTableName = {}
+    const orderedTableNames = []
+
+    for (const tableName of tableNames) {
+      dependenciesByTableName[tableName] = new Set()
+    }
+
+    for (const row of foreignKeyRows) {
+      const tableNameValue = row.table_name || row.TABLE_NAME
+      const referencedTableNameValue = row.referenced_table_name || row.REFERENCED_TABLE_NAME
+      const tableName = tableNameValue ? String(tableNameValue) : ""
+      const referencedTableName = referencedTableNameValue ? String(referencedTableNameValue) : ""
+
+      if (!pendingTableNames.has(tableName) || !pendingTableNames.has(referencedTableName)) continue
+
+      dependenciesByTableName[tableName].add(referencedTableName)
+    }
+
+    while (pendingTableNames.size > 0) {
+      const nextTableName = tableNames.find((tableName) => {
+        if (!pendingTableNames.has(tableName)) return false
+
+        return Array.from(dependenciesByTableName[tableName]).every((dependencyTableName) => !pendingTableNames.has(dependencyTableName))
+      })
+
+      if (!nextTableName) {
+        for (const tableName of tableNames) {
+          if (pendingTableNames.has(tableName)) orderedTableNames.push(tableName)
+        }
+
+        break
+      }
+
+      orderedTableNames.push(nextTableName)
+      pendingTableNames.delete(nextTableName)
+    }
+
+    return orderedTableNames
   }
 
   /**

--- a/src/database/drivers/mysql/structure-sql.js
+++ b/src/database/drivers/mysql/structure-sql.js
@@ -83,7 +83,7 @@ export default class VelociousDatabaseDriversMysqlStructureSql {
       const tableName = tableNameValue ? String(tableNameValue) : ""
       const referencedTableName = referencedTableNameValue ? String(referencedTableNameValue) : ""
 
-      if (!pendingTableNames.has(tableName) || !pendingTableNames.has(referencedTableName)) continue
+      if (tableName == referencedTableName || !pendingTableNames.has(tableName) || !pendingTableNames.has(referencedTableName)) continue
 
       dependenciesByTableName[tableName].add(referencedTableName)
     }


### PR DESCRIPTION
## Summary
- order MySQL/MariaDB schema-dump base tables by same-schema foreign-key dependencies
- preserve stable order for unrelated/cyclic tables and existing view output behavior
- document the dump contract and add audit-table regression coverage

## Validation
- `MSSQL_SA_PASSWORD=unused-for-focused-unit-spec VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql npm test -- spec/environment-handlers/node-structure-mysql-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js && npm run lint && npm run typecheck && npm run fallow`