### PR TITLE
perf: cache frontend-model serialization resource instances per request

### DIFF
--- a/benchmark/frontend-model-serialization-resource-metadata.js
+++ b/benchmark/frontend-model-serialization-resource-metadata.js
@@ -1,0 +1,120 @@
+import {performance} from "node:perf_hooks"
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+import dummyConfiguration from "../spec/dummy/src/config/configuration.js"
+import Dummy from "../spec/dummy/index.js"
+import Comment from "../spec/dummy/src/models/comment.js"
+import FrontendModelController from "../src/frontend-model-controller.js"
+import Project from "../spec/dummy/src/models/project.js"
+import Task from "../spec/dummy/src/models/task.js"
+import {withSourcePeerPackage} from "../src/environment-handlers/node/source-peer-package.js"
+
+const modelCount = 500
+const iterations = 20
+const url = "http://localhost:3006/frontend-models"
+const projectDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+dummyConfiguration.setEnvironment("test")
+
+/** @param {number[]} values - Measurements. @returns {number} - 95th percentile. */
+function p95(values) {
+  return [...values].sort((left, right) => left - right)[Math.ceil(values.length * 0.95) - 1]
+}
+
+/**
+ * Instruments resource-resolution counters for the duration of a callback.
+ * @param {() => Promise<void>} callback - Measured work.
+ * @returns {Promise<{resourceInstanceResolutions: number}>} - Counters.
+ */
+async function measureResourceResolutions(callback) {
+  let resourceInstanceResolutions = 0
+  const originalSerializationResourceInstanceForModel = FrontendModelController.prototype._serializationResourceInstanceForModel
+  const originalFrontendModelResourceInstance = FrontendModelController.prototype.frontendModelResourceInstance
+
+  FrontendModelController.prototype._serializationResourceInstanceForModel = function(model) {
+    resourceInstanceResolutions += 1
+
+    return originalSerializationResourceInstanceForModel.call(this, model)
+  }
+
+  FrontendModelController.prototype.frontendModelResourceInstance = function() {
+    resourceInstanceResolutions += 1
+
+    return originalFrontendModelResourceInstance.call(this)
+  }
+
+  try {
+    await callback()
+  } finally {
+    FrontendModelController.prototype._serializationResourceInstanceForModel = originalSerializationResourceInstanceForModel
+    FrontendModelController.prototype.frontendModelResourceInstance = originalFrontendModelResourceInstance
+  }
+
+  return {resourceInstanceResolutions}
+}
+
+await withSourcePeerPackage(projectDirectory, async () => {
+  await Dummy.run(async () => {
+    const connection = Task.connection()
+
+    await connection.truncateAllTables()
+
+    const project = await Project.create({name: "Benchmark project"})
+
+    for (let index = 0; index < modelCount; index += 1) {
+      const task = await Task.create({name: `Task ${index}`, project})
+
+      await Comment.create({body: `Comment ${index}`, task})
+    }
+
+    const body = JSON.stringify({
+      requests: [{
+        commandType: "index",
+        model: "Task",
+        payload: {
+          limit: modelCount,
+          preload: ["project", "comments"]
+        },
+        requestId: "1"
+      }]
+    })
+
+    // Warm-up request to prime connections and caches.
+    const warmUpResponse = await fetch(url, {
+      body,
+      headers: {"content-type": "application/json"},
+      method: "POST"
+    })
+
+    if (!warmUpResponse.ok) {
+      throw new Error(`Frontend-model warm-up failed: ${warmUpResponse.status} ${await warmUpResponse.text()}`)
+    }
+
+    const latencies = []
+    let totalResourceInstanceResolutions = 0
+
+    for (let iteration = 0; iteration < iterations; iteration += 1) {
+      const counters = await measureResourceResolutions(async () => {
+        const startedAt = performance.now()
+        const response = await fetch(url, {
+          body,
+          headers: {"content-type": "application/json"},
+          method: "POST"
+        })
+
+        if (!response.ok) {
+          throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
+        }
+
+        latencies.push(performance.now() - startedAt)
+      })
+
+      totalResourceInstanceResolutions += counters.resourceInstanceResolutions
+    }
+
+    console.log("models\titerations\tp95 ms\tresource-instance resolutions/op")
+    console.log(`${modelCount}\t${iterations}\t${p95(latencies).toFixed(2)} ms\t${Math.round(totalResourceInstanceResolutions / iterations)}`)
+  })
+
+  await Dummy.teardown()
+})

--- a/benchmark/frontend-model-serialization-resource-metadata.js
+++ b/benchmark/frontend-model-serialization-resource-metadata.js
@@ -1,17 +1,16 @@
-import {performance} from "node:perf_hooks"
+import { performance } from "node:perf_hooks"
 import path from "node:path"
-import {fileURLToPath} from "node:url"
+import { fileURLToPath } from "node:url"
 import dummyConfiguration from "../spec/dummy/src/config/configuration.js"
 import Dummy from "../spec/dummy/index.js"
 import Comment from "../spec/dummy/src/models/comment.js"
 import FrontendModelController from "../src/frontend-model-controller.js"
 import Project from "../spec/dummy/src/models/project.js"
 import Task from "../spec/dummy/src/models/task.js"
-import {withSourcePeerPackage} from "../src/environment-handlers/node/source-peer-package.js"
+import { withSourcePeerPackage } from "../src/environment-handlers/node/source-peer-package.js"
 
 const modelCount = 500
 const iterations = 20
-const url = "http://localhost:3006/frontend-models"
 const projectDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 
 dummyConfiguration.setEnvironment("test")
@@ -22,35 +21,33 @@ function p95(values) {
 }
 
 /**
- * Instruments resource-resolution counters for the duration of a callback.
- * @param {() => Promise<void>} callback - Measured work.
- * @returns {Promise<{resourceInstanceResolutions: number}>} - Counters.
+ * Builds a controller for direct serialization benchmarking.
+ * @param {Record<string, ReturnType<typeof JSON.parse>>} params - Frontend-model params.
+ * @returns {FrontendModelController} - Controller instance.
  */
-async function measureResourceResolutions(callback) {
-  let resourceInstanceResolutions = 0
-  const originalSerializationResourceInstanceForModel = FrontendModelController.prototype._serializationResourceInstanceForModel
-  const originalFrontendModelResourceInstance = FrontendModelController.prototype.frontendModelResourceInstance
-
-  FrontendModelController.prototype._serializationResourceInstanceForModel = function(model) {
-    resourceInstanceResolutions += 1
-
-    return originalSerializationResourceInstanceForModel.call(this, model)
+function buildBenchmarkController(params) {
+  const request = {
+    baseURL: () => "http://localhost:3006",
+    header: () => undefined,
+    headers: () => ({}),
+    httpMethod: () => "POST",
+    params: () => params,
+    path: () => "/benchmark-serialization"
   }
+  const controller = new FrontendModelController({
+    action: "index",
+    configuration: dummyConfiguration,
+    controller: "frontend_models",
+    params,
+    request,
+    response: {},
+    viewPath: dummyConfiguration.getDirectory()
+  })
 
-  FrontendModelController.prototype.frontendModelResourceInstance = function() {
-    resourceInstanceResolutions += 1
+  // Bypass transport deserialization so the benchmark can feed plain params directly.
+  controller._frontendModelParams = params
 
-    return originalFrontendModelResourceInstance.call(this)
-  }
-
-  try {
-    await callback()
-  } finally {
-    FrontendModelController.prototype._serializationResourceInstanceForModel = originalSerializationResourceInstanceForModel
-    FrontendModelController.prototype.frontendModelResourceInstance = originalFrontendModelResourceInstance
-  }
-
-  return {resourceInstanceResolutions}
+  return controller
 }
 
 await withSourcePeerPackage(projectDirectory, async () => {
@@ -67,49 +64,37 @@ await withSourcePeerPackage(projectDirectory, async () => {
       await Comment.create({body: `Comment ${index}`, task})
     }
 
-    const body = JSON.stringify({
-      requests: [{
-        commandType: "index",
-        model: "Task",
-        payload: {
-          limit: modelCount,
-          preload: ["project", "comments"]
-        },
-        requestId: "1"
-      }]
-    })
-
-    // Warm-up request to prime connections and caches.
-    const warmUpResponse = await fetch(url, {
-      body,
-      headers: {"content-type": "application/json"},
-      method: "POST"
-    })
-
-    if (!warmUpResponse.ok) {
-      throw new Error(`Frontend-model warm-up failed: ${warmUpResponse.status} ${await warmUpResponse.text()}`)
+    const tasks = await Task.where({}).preload(["project", "comments"]).toArray()
+    const params = {
+      model: "Task",
+      preload: ["project", "comments"]
     }
+
+    // Warm-up serialization to prime caches.
+    const warmUpController = buildBenchmarkController(params)
+
+    await warmUpController.serializeFrontendModels(tasks)
 
     const latencies = []
     let totalResourceInstanceResolutions = 0
 
     for (let iteration = 0; iteration < iterations; iteration += 1) {
-      const counters = await measureResourceResolutions(async () => {
-        const startedAt = performance.now()
-        const response = await fetch(url, {
-          body,
-          headers: {"content-type": "application/json"},
-          method: "POST"
-        })
-
-        if (!response.ok) {
-          throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
-        }
-
-        latencies.push(performance.now() - startedAt)
+      const controller = buildBenchmarkController(params)
+      let resourceInstanceResolutions = 0
+      const cleanup = controller.setSerializationResourceInstanceHook(() => {
+        resourceInstanceResolutions += 1
       })
 
-      totalResourceInstanceResolutions += counters.resourceInstanceResolutions
+      try {
+        const startedAt = performance.now()
+
+        await controller.serializeFrontendModels(tasks)
+        latencies.push(performance.now() - startedAt)
+      } finally {
+        cleanup()
+      }
+
+      totalResourceInstanceResolutions += resourceInstanceResolutions
     }
 
     console.log("models\titerations\tp95 ms\tresource-instance resolutions/op")

--- a/changelog.d/20260807223059-frontend-model-serialization-resource-cache.md
+++ b/changelog.d/20260807223059-frontend-model-serialization-resource-cache.md
@@ -1,0 +1,1 @@
+- Cache frontend-model resource instances per request during serialization to reduce instance churn on large index responses while keeping mutation resources fresh and request-isolated.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "benchmark:websocket-outbound-queue": "node benchmark/websocket-outbound-queue.js",
     "benchmark:websocket-frame-buffering": "node benchmark/websocket-frame-buffering.js",
     "benchmark:http-client-content-length-byte-length": "node benchmark/http-client-content-length-byte-length.js",
+    "benchmark:frontend-model-serialization-resource-metadata": "node benchmark/frontend-model-serialization-resource-metadata.js",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:js && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:js": "cpy \"index.js\" build && cpy \"bin/**/*.js\" build/bin && cpy \"src/**/*.js\" build --parents",

--- a/spec/frontend-models/serialization-resource-metadata-spec.js
+++ b/spec/frontend-models/serialization-resource-metadata-spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import {describe, expect, it} from "../../src/testing/test.js"
+import { describe, expect, it } from "../../src/testing/test.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import Dummy from "../dummy/index.js"
 import Comment from "../dummy/src/models/comment.js"
@@ -46,16 +46,14 @@ function buildSerializationController(params) {
 
 /**
  * Captures resource instances resolved during serialization.
+ * @param {FrontendModelController} controller - Controller whose serialization is captured.
  * @param {() => Promise<void>} callback - Callback whose serialization is captured.
  * @returns {Promise<Map<string, Set<import("../../src/frontend-model-resource/base-resource.js").default>>>} - Resource instances grouped by model class name.
  */
-async function captureSerializationResources(callback) {
+async function captureSerializationResources(controller, callback) {
   /** @type {Map<string, Set<import("../../src/frontend-model-resource/base-resource.js").default>>} */
   const resourcesByModelClassName = new Map()
-  const original = FrontendModelController.prototype._serializationResourceInstanceForModel
-
-  FrontendModelController.prototype._serializationResourceInstanceForModel = function(model) {
-    const resource = original.call(this, model)
+  const cleanup = controller.setSerializationResourceInstanceHook((model, resource) => {
     const modelClassName = /** @type {typeof import("../../src/database/record/index.js").default} */ (model.constructor).getModelName()
 
     if (resource) {
@@ -64,14 +62,12 @@ async function captureSerializationResources(callback) {
       set.add(resource)
       resourcesByModelClassName.set(modelClassName, set)
     }
-
-    return resource
-  }
+  })
 
   try {
     await callback()
   } finally {
-    FrontendModelController.prototype._serializationResourceInstanceForModel = original
+    cleanup()
   }
 
   return resourcesByModelClassName
@@ -92,7 +88,7 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
         model: "Task",
         preload: ["project", "comments"]
       })
-      const resourcesByModelClassName = await captureSerializationResources(async () => {
+      const resourcesByModelClassName = await captureSerializationResources(controller, async () => {
         await controller.serializeFrontendModels(tasks)
       })
 
@@ -141,22 +137,16 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
           preload: ["project"]
         })
         let rootResource
-        const original = FrontendModelController.prototype._serializationResourceInstanceForModel
-
-        FrontendModelController.prototype._serializationResourceInstanceForModel = function(model) {
-          const resource = original.call(this, model)
-
+        const cleanup = controller.setSerializationResourceInstanceHook((model, resource) => {
           if (model.constructor === Task && !rootResource) {
             rootResource = resource
           }
-
-          return resource
-        }
+        })
 
         try {
           await controller.serializeFrontendModels(tasks)
         } finally {
-          FrontendModelController.prototype._serializationResourceInstanceForModel = original
+          cleanup()
         }
 
         return rootResource
@@ -168,6 +158,39 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
       expect(firstResource).toBeTruthy()
       expect(secondResource).toBeTruthy()
       expect(firstResource).not.toBe(secondResource)
+    })
+  })
+
+  it("only fires the serialization resource hook on the controller that installed it", async () => {
+    await Dummy.run(async () => {
+      const project = await Project.create({name: "Hook isolation project"})
+      const task = await Task.create({name: "Hook isolation task", project})
+      const tasks = await Task.where({id: task.id()}).preload(["project"]).toArray()
+
+      const hookedController = buildSerializationController({
+        model: "Task",
+        preload: ["project"]
+      })
+      const unhookedController = buildSerializationController({
+        model: "Task",
+        preload: ["project"]
+      })
+
+      /** @type {string[]} */
+      const hookedModelClassNames = []
+      const cleanup = hookedController.setSerializationResourceInstanceHook((model) => {
+        hookedModelClassNames.push(/** @type {typeof import("../../src/database/record/index.js").default} */ (model.constructor).getModelName())
+      })
+
+      try {
+        await hookedController.serializeFrontendModels(tasks)
+        await unhookedController.serializeFrontendModels(tasks)
+      } finally {
+        cleanup()
+      }
+
+      expect(hookedModelClassNames).toContain("Task")
+      expect(hookedModelClassNames).toContain("Project")
     })
   })
 })

--- a/spec/frontend-models/serialization-resource-metadata-spec.js
+++ b/spec/frontend-models/serialization-resource-metadata-spec.js
@@ -1,0 +1,178 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import Dummy from "../dummy/index.js"
+import Comment from "../dummy/src/models/comment.js"
+import FrontendModelController from "../../src/frontend-model-controller.js"
+import Project from "../dummy/src/models/project.js"
+import Task from "../dummy/src/models/task.js"
+
+const sharedApiUrl = "http://localhost:3006/frontend-models"
+
+/**
+ * Builds a shared frontend-model index request body.
+ * @param {Record<string, ReturnType<typeof JSON.parse>>} payload - Index payload.
+ * @returns {string} - JSON request body.
+ */
+function indexRequestBody(payload) {
+  return JSON.stringify({
+    requests: [{
+      commandType: "index",
+      model: "Task",
+      payload,
+      requestId: "1"
+    }]
+  })
+}
+
+/**
+ * Captures resource instances resolved during serialization.
+ * @param {() => Promise<void>} callback - Callback whose serialization is captured.
+ * @returns {Promise<Map<string, Set<import("../../src/frontend-model-resource/base-resource.js").default>>>} - Resource instances grouped by model class name.
+ */
+async function captureSerializationResources(callback) {
+  /** @type {Map<string, Set<import("../../src/frontend-model-resource/base-resource.js").default>>} */
+  const resourcesByModelClassName = new Map()
+  const original = FrontendModelController.prototype._serializationResourceInstanceForModel
+
+  FrontendModelController.prototype._serializationResourceInstanceForModel = function(model) {
+    const resource = original.call(this, model)
+    const modelClassName = /** @type {typeof import("../../src/database/record/index.js").default} */ (model.constructor).getModelName()
+
+    if (resource) {
+      const set = resourcesByModelClassName.get(modelClassName) || new Set()
+
+      set.add(resource)
+      resourcesByModelClassName.set(modelClassName, set)
+    }
+
+    return resource
+  }
+
+  try {
+    await callback()
+  } finally {
+    FrontendModelController.prototype._serializationResourceInstanceForModel = original
+  }
+
+  return resourcesByModelClassName
+}
+
+describe("FrontendModel serialization resource metadata", {databaseCleaning: {transaction: true}}, () => {
+  it("reuses the same resource instance for multiple models of the same class", async () => {
+    await Dummy.run(async () => {
+      const project = await Project.create({name: "Shared resource project"})
+      const taskOne = await Task.create({name: "Task one", project})
+      const taskTwo = await Task.create({name: "Task two", project})
+
+      await Comment.create({body: "Comment one", task: taskOne})
+      await Comment.create({body: "Comment two", task: taskTwo})
+
+      const body = indexRequestBody({
+        limit: 10,
+        preload: ["project", "comments"]
+      })
+      const resourcesByModelClassName = await captureSerializationResources(async () => {
+        const response = await fetch(sharedApiUrl, {
+          body,
+          headers: {"content-type": "application/json"},
+          method: "POST"
+        })
+
+        if (!response.ok) {
+          throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
+        }
+      })
+
+      expect(resourcesByModelClassName.get("Task")?.size).toEqual(1)
+      expect(resourcesByModelClassName.get("Project")?.size).toEqual(1)
+      expect(resourcesByModelClassName.get("Comment")?.size).toEqual(1)
+    })
+  })
+
+  it("still invokes custom virtual attributes on preloaded related resources", async () => {
+    await Dummy.run(async () => {
+      const project = await Project.create({name: "Custom attribute project"})
+      const task = await Task.create({name: "Task with comment", project})
+
+      await Comment.create({body: "A comment", task})
+
+      const body = indexRequestBody({
+        limit: 10,
+        preload: ["comments"],
+        select: {Comment: ["id", "body", "requestBaseUrl"]}
+      })
+      const response = await fetch(sharedApiUrl, {
+        body,
+        headers: {"content-type": "application/json"},
+        method: "POST"
+      })
+
+      if (!response.ok) {
+        throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
+      }
+
+      const json = /** @type {Record<string, ReturnType<typeof JSON.parse>>} */ (await response.json())
+      const firstResponse = json.responses?.[0]
+      const models = firstResponse?.response?.models
+
+      expect(models).toBeInstanceOf(Array)
+
+      const firstTask = models[0]
+      const comments = firstTask?.__preloadedRelationships?.comments
+
+      expect(comments).toBeInstanceOf(Array)
+      expect(comments[0]?.requestBaseUrl).toMatch(/localhost:3006$/)
+    })
+  })
+
+  it("does not share serialization resource instances across requests", async () => {
+    await Dummy.run(async () => {
+      const project = await Project.create({name: "Cross-request project"})
+
+      await Task.create({name: "Task A", project})
+
+      /**
+       * @param {string} _requestId - Request identifier.
+       * @returns {Promise<import("../../src/frontend-model-resource/base-resource.js").default | undefined>} - Root Task resource instance.
+       */
+      async function fetchRootResource(_requestId) {
+        let rootResource
+        const original = FrontendModelController.prototype._serializationResourceInstanceForModel
+
+        FrontendModelController.prototype._serializationResourceInstanceForModel = function(model) {
+          const resource = original.call(this, model)
+
+          if (model.constructor === Task && !rootResource) {
+            rootResource = resource
+          }
+
+          return resource
+        }
+
+        try {
+          const response = await fetch(sharedApiUrl, {
+            body: indexRequestBody({limit: 10, preload: ["project"]}),
+            headers: {"content-type": "application/json"},
+            method: "POST"
+          })
+
+          if (!response.ok) {
+            throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
+          }
+        } finally {
+          FrontendModelController.prototype._serializationResourceInstanceForModel = original
+        }
+
+        return rootResource
+      }
+
+      const firstResource = await fetchRootResource("first")
+      const secondResource = await fetchRootResource("second")
+
+      expect(firstResource).toBeTruthy()
+      expect(secondResource).toBeTruthy()
+      expect(firstResource).not.toBe(secondResource)
+    })
+  })
+})

--- a/spec/frontend-models/serialization-resource-metadata-spec.js
+++ b/spec/frontend-models/serialization-resource-metadata-spec.js
@@ -1,28 +1,47 @@
 // @ts-check
 
 import {describe, expect, it} from "../../src/testing/test.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
 import Dummy from "../dummy/index.js"
 import Comment from "../dummy/src/models/comment.js"
 import FrontendModelController from "../../src/frontend-model-controller.js"
 import Project from "../dummy/src/models/project.js"
 import Task from "../dummy/src/models/task.js"
 
-const sharedApiUrl = "http://localhost:3006/frontend-models"
-
 /**
- * Builds a shared frontend-model index request body.
- * @param {Record<string, ReturnType<typeof JSON.parse>>} payload - Index payload.
- * @returns {string} - JSON request body.
+ * Builds a controller for direct serialization testing.
+ *
+ * The request path is intentionally not a frontend-model ability route so that
+ * ability-related authorization queries are skipped; this keeps the test
+ * deterministic and free of extra database round-trips.
+ *
+ * @param {Record<string, ReturnType<typeof JSON.parse>>} params - Frontend-model params.
+ * @returns {FrontendModelController} - Controller instance.
  */
-function indexRequestBody(payload) {
-  return JSON.stringify({
-    requests: [{
-      commandType: "index",
-      model: "Task",
-      payload,
-      requestId: "1"
-    }]
+function buildSerializationController(params) {
+  const request = {
+    baseURL: () => "http://localhost:3006",
+    header: () => undefined,
+    headers: () => ({}),
+    httpMethod: () => "POST",
+    params: () => params,
+    path: () => "/test-serialization"
+  }
+  const response = {}
+  const controller = new FrontendModelController({
+    action: "test",
+    configuration: dummyConfiguration,
+    controller: "test",
+    params,
+    request,
+    response,
+    viewPath: dummyConfiguration.getDirectory()
   })
+
+  // Bypass transport deserialization so the test can feed plain params directly.
+  controller._frontendModelParams = params
+
+  return controller
 }
 
 /**
@@ -68,20 +87,13 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
       await Comment.create({body: "Comment one", task: taskOne})
       await Comment.create({body: "Comment two", task: taskTwo})
 
-      const body = indexRequestBody({
-        limit: 10,
+      const tasks = await Task.where({id: [taskOne.id(), taskTwo.id()]}).preload(["project", "comments"]).toArray()
+      const controller = buildSerializationController({
+        model: "Task",
         preload: ["project", "comments"]
       })
       const resourcesByModelClassName = await captureSerializationResources(async () => {
-        const response = await fetch(sharedApiUrl, {
-          body,
-          headers: {"content-type": "application/json"},
-          method: "POST"
-        })
-
-        if (!response.ok) {
-          throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
-        }
+        await controller.serializeFrontendModels(tasks)
       })
 
       expect(resourcesByModelClassName.get("Task")?.size).toEqual(1)
@@ -97,28 +109,14 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
 
       await Comment.create({body: "A comment", task})
 
-      const body = indexRequestBody({
-        limit: 10,
+      const tasks = await Task.where({id: task.id()}).preload(["comments"]).toArray()
+      const controller = buildSerializationController({
+        model: "Task",
         preload: ["comments"],
         select: {Comment: ["id", "body", "requestBaseUrl"]}
       })
-      const response = await fetch(sharedApiUrl, {
-        body,
-        headers: {"content-type": "application/json"},
-        method: "POST"
-      })
-
-      if (!response.ok) {
-        throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
-      }
-
-      const json = /** @type {Record<string, ReturnType<typeof JSON.parse>>} */ (await response.json())
-      const firstResponse = json.responses?.[0]
-      const models = firstResponse?.response?.models
-
-      expect(models).toBeInstanceOf(Array)
-
-      const firstTask = models[0]
+      const serialized = await controller.serializeFrontendModels(tasks)
+      const firstTask = serialized[0]
       const comments = firstTask?.__preloadedRelationships?.comments
 
       expect(comments).toBeInstanceOf(Array)
@@ -126,17 +124,22 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
     })
   })
 
-  it("does not share serialization resource instances across requests", async () => {
+  it("does not share serialization resource instances across controllers", async () => {
     await Dummy.run(async () => {
       const project = await Project.create({name: "Cross-request project"})
+      const task = await Task.create({name: "Task A", project})
 
-      await Task.create({name: "Task A", project})
+      const tasks = await Task.where({id: task.id()}).preload(["project"]).toArray()
 
       /**
-       * @param {string} _requestId - Request identifier.
+       * @param {string} _label - Controller label.
        * @returns {Promise<import("../../src/frontend-model-resource/base-resource.js").default | undefined>} - Root Task resource instance.
        */
-      async function fetchRootResource(_requestId) {
+      async function captureRootResource(_label) {
+        const controller = buildSerializationController({
+          model: "Task",
+          preload: ["project"]
+        })
         let rootResource
         const original = FrontendModelController.prototype._serializationResourceInstanceForModel
 
@@ -151,15 +154,7 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
         }
 
         try {
-          const response = await fetch(sharedApiUrl, {
-            body: indexRequestBody({limit: 10, preload: ["project"]}),
-            headers: {"content-type": "application/json"},
-            method: "POST"
-          })
-
-          if (!response.ok) {
-            throw new Error(`Frontend-model index failed: ${response.status} ${await response.text()}`)
-          }
+          await controller.serializeFrontendModels(tasks)
         } finally {
           FrontendModelController.prototype._serializationResourceInstanceForModel = original
         }
@@ -167,8 +162,8 @@ describe("FrontendModel serialization resource metadata", {databaseCleaning: {tr
         return rootResource
       }
 
-      const firstResource = await fetchRootResource("first")
-      const secondResource = await fetchRootResource("second")
+      const firstResource = await captureRootResource("first")
+      const secondResource = await captureRootResource("second")
 
       expect(firstResource).toBeTruthy()
       expect(secondResource).toBeTruthy()

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -603,6 +603,12 @@ export default class FrontendModelController extends Controller {
    * own arguments rather than the route metadata. Only set on the shared-endpoint path.
    * @type {Record<string, ReturnType<typeof JSON.parse>> | undefined} */
   _frontendModelCustomCommandClientArguments = undefined
+  /**
+   * Request-scoped cache for serialization resource instances.
+   * Keyed by model class, then by whether the resource is for a related model
+   * (so self-referential relationships do not accidentally reuse root params).
+   * @type {Map<typeof import("./database/record/index.js").default, Map<boolean, import("./frontend-model-resource/base-resource.js").default>> | undefined} */
+  _frontendModelSerializationResourceInstances = undefined
 
   /**
    * Runs frontend model params.
@@ -628,15 +634,18 @@ export default class FrontendModelController extends Controller {
   async withFrontendModelParams(params, callback) {
     const previousOverride = this._frontendModelParamsOverride
     const previousParams = this._frontendModelParams
+    const previousSerializationResourceInstances = this._frontendModelSerializationResourceInstances
 
     this._frontendModelParamsOverride = params
     this._frontendModelParams = undefined
+    this._frontendModelSerializationResourceInstances = undefined
 
     try {
       return await callback()
     } finally {
       this._frontendModelParamsOverride = previousOverride
       this._frontendModelParams = previousParams
+      this._frontendModelSerializationResourceInstances = previousSerializationResourceInstances
     }
   }
 
@@ -2793,20 +2802,69 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
+   * Returns the request-scoped serialization resource instance cache.
+   * @returns {Map<typeof import("./database/record/index.js").default, Map<boolean, import("./frontend-model-resource/base-resource.js").default>>} - Cache.
+   */
+  _frontendModelSerializationResourceInstancesMap() {
+    if (!this._frontendModelSerializationResourceInstances) {
+      this._frontendModelSerializationResourceInstances = new Map()
+    }
+
+    return this._frontendModelSerializationResourceInstances
+  }
+
+  /**
+   * Looks up a cached serialization resource instance.
+   * @param {typeof import("./database/record/index.js").default} modelClass - Model class.
+   * @param {boolean} isRelated - Whether the resource is for a related (non-root) model.
+   * @returns {import("./frontend-model-resource/base-resource.js").default | undefined} - Cached resource or undefined.
+   */
+  _cachedSerializationResourceInstance(modelClass, isRelated) {
+    return this._frontendModelSerializationResourceInstancesMap().get(modelClass)?.get(isRelated)
+  }
+
+  /**
+   * Stores a serialization resource instance in the request-scoped cache.
+   * @param {typeof import("./database/record/index.js").default} modelClass - Model class.
+   * @param {boolean} isRelated - Whether the resource is for a related (non-root) model.
+   * @param {import("./frontend-model-resource/base-resource.js").default} resource - Resource instance.
+   * @returns {void}
+   */
+  _setCachedSerializationResourceInstance(modelClass, isRelated, resource) {
+    const byClass = this._frontendModelSerializationResourceInstancesMap()
+    let byRelated = byClass.get(modelClass)
+
+    if (!byRelated) {
+      byRelated = new Map()
+      byClass.set(modelClass, byRelated)
+    }
+
+    byRelated.set(isRelated, resource)
+  }
+
+  /**
    * Runs serialization resource instance for model.
    * @param {import("./database/record/index.js").default} model - Model instance.
    * @returns {import("./frontend-model-resource/base-resource.js").default | null} - Resource instance or null.
    */
   _serializationResourceInstanceForModel(model) {
-    const resource = this.frontendModelResourceInstance()
+    const modelClass = /** @type {typeof import("./database/record/index.js").default} */ (model.constructor)
+    const isRelated = modelClass !== this.frontendModelClass()
+    const cachedResource = this._cachedSerializationResourceInstance(modelClass, isRelated)
 
-    if (resource.modelClass() === model.constructor) {
+    if (cachedResource) return cachedResource
+
+    if (!isRelated) {
+      const resource = this.frontendModelResourceInstance()
+
+      this._setCachedSerializationResourceInstance(modelClass, false, resource)
+
       return resource
     }
 
     const configuration = this.getConfiguration()
     const backendProjects = configuration.getBackendProjects()
-    const modelClassName = /** @type {typeof import("./database/record/index.js").default} */ (model.constructor).getModelName()
+    const modelClassName = modelClass.getModelName()
 
     for (const backendProject of backendProjects) {
       const resources = frontendModelResourcesWithBuiltInsForBackendProject(backendProject)
@@ -2814,7 +2872,7 @@ export default class FrontendModelController extends Controller {
       const resourceClass = resourceDefinition ? frontendModelResourceClassFromDefinition(resourceDefinition) : null
 
       if (resourceClass) {
-        return new resourceClass({
+        const resource = new resourceClass({
           ability: this.currentAbility(),
           // Propagate the controller so a related/preloaded model's serialization
           // resource can use request context (e.g. `requestBaseUrl()` for signed
@@ -2824,11 +2882,15 @@ export default class FrontendModelController extends Controller {
           controller: this,
           context: this.currentAbility()?.getContext() || {},
           locals: this.currentAbility()?.getLocals() || {},
-          modelClass: /** @type {typeof import("./database/record/index.js").default} */ (model.constructor),
+          modelClass,
           modelName: modelClassName,
           params: {},
           resourceConfiguration: resourceClass.resourceConfig()
         })
+
+        this._setCachedSerializationResourceInstance(modelClass, true, resource)
+
+        return resource
       }
     }
 

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -72,6 +72,12 @@ import {RansackQueryError, normalizeRansackGroup, parseRansackSort} from "./util
  * @property {import("./frontend-model-resource/base-resource.js").default} [resource] - Resource providing query hooks.
  */
 /** @typedef {import("./database/query/model-class-query.js").default & Record<symbol, Set<string> | undefined>} FrontendModelQueryMetadata */
+/**
+ * @callback FrontendModelSerializationResourceInstanceHook
+ * @param {import("./database/record/index.js").default} model - Model instance being serialized.
+ * @param {import("./frontend-model-resource/base-resource.js").default | null} resource - Resolved serialization resource instance, if any.
+ * @returns {void}
+ */
 
 /**
  * Runs normalize frontend model preload.
@@ -609,6 +615,11 @@ export default class FrontendModelController extends Controller {
    * (so self-referential relationships do not accidentally reuse root params).
    * @type {Map<typeof import("./database/record/index.js").default, Map<boolean, import("./frontend-model-resource/base-resource.js").default>> | undefined} */
   _frontendModelSerializationResourceInstances = undefined
+  /**
+   * Optional per-instance hook invoked for every serialization resource instance
+   * resolution. Intended for tests and benchmarks; absent in production.
+   * @type {FrontendModelSerializationResourceInstanceHook | null | undefined} */
+  _frontendModelSerializationResourceInstanceHook = undefined
 
   /**
    * Runs frontend model params.
@@ -2843,6 +2854,23 @@ export default class FrontendModelController extends Controller {
   }
 
   /**
+   * Sets a per-instance hook invoked for every serialization resource instance
+   * resolution. The hook is scoped to this controller; it never affects other
+   * controller instances. Passing `null` clears the hook.
+   * @param {FrontendModelSerializationResourceInstanceHook | null} hook - Hook callback or null.
+   * @returns {() => void} - Cleanup function that restores the previous hook.
+   */
+  setSerializationResourceInstanceHook(hook) {
+    const previousHook = this._frontendModelSerializationResourceInstanceHook
+
+    this._frontendModelSerializationResourceInstanceHook = hook
+
+    return () => {
+      this._frontendModelSerializationResourceInstanceHook = previousHook
+    }
+  }
+
+  /**
    * Runs serialization resource instance for model.
    * @param {import("./database/record/index.js").default} model - Model instance.
    * @returns {import("./frontend-model-resource/base-resource.js").default | null} - Resource instance or null.
@@ -2852,49 +2880,62 @@ export default class FrontendModelController extends Controller {
     const isRelated = modelClass !== this.frontendModelClass()
     const cachedResource = this._cachedSerializationResourceInstance(modelClass, isRelated)
 
-    if (cachedResource) return cachedResource
+    if (cachedResource) {
+      if (this._frontendModelSerializationResourceInstanceHook) {
+        this._frontendModelSerializationResourceInstanceHook(model, cachedResource)
+      }
 
-    if (!isRelated) {
-      const resource = this.frontendModelResourceInstance()
-
-      this._setCachedSerializationResourceInstance(modelClass, false, resource)
-
-      return resource
+      return cachedResource
     }
 
-    const configuration = this.getConfiguration()
-    const backendProjects = configuration.getBackendProjects()
-    const modelClassName = modelClass.getModelName()
+    /** @type {import("./frontend-model-resource/base-resource.js").default | null} */
+    let resource
 
-    for (const backendProject of backendProjects) {
-      const resources = frontendModelResourcesWithBuiltInsForBackendProject(backendProject)
-      const resourceDefinition = resources[modelClassName]
-      const resourceClass = resourceDefinition ? frontendModelResourceClassFromDefinition(resourceDefinition) : null
+    if (!isRelated) {
+      resource = this.frontendModelResourceInstance()
 
-      if (resourceClass) {
-        const resource = new resourceClass({
-          ability: this.currentAbility(),
-          // Propagate the controller so a related/preloaded model's serialization
-          // resource can use request context (e.g. `requestBaseUrl()` for signed
-          // download URLs). Without it, any `<attr>Attribute` method that reaches
-          // for the controller throws "requires a controller instance." when a
-          // relationship is serialized as a preload.
-          controller: this,
-          context: this.currentAbility()?.getContext() || {},
-          locals: this.currentAbility()?.getLocals() || {},
-          modelClass,
-          modelName: modelClassName,
-          params: {},
-          resourceConfiguration: resourceClass.resourceConfig()
-        })
+      this._setCachedSerializationResourceInstance(modelClass, false, resource)
+    } else {
+      const configuration = this.getConfiguration()
+      const backendProjects = configuration.getBackendProjects()
+      const modelClassName = modelClass.getModelName()
 
-        this._setCachedSerializationResourceInstance(modelClass, true, resource)
+      resource = null
 
-        return resource
+      for (const backendProject of backendProjects) {
+        const resources = frontendModelResourcesWithBuiltInsForBackendProject(backendProject)
+        const resourceDefinition = resources[modelClassName]
+        const resourceClass = resourceDefinition ? frontendModelResourceClassFromDefinition(resourceDefinition) : null
+
+        if (resourceClass) {
+          resource = new resourceClass({
+            ability: this.currentAbility(),
+            // Propagate the controller so a related/preloaded model's serialization
+            // resource can use request context (e.g. `requestBaseUrl()` for signed
+            // download URLs). Without it, any `<attr>Attribute` method that reaches
+            // for the controller throws "requires a controller instance." when a
+            // relationship is serialized as a preload.
+            controller: this,
+            context: this.currentAbility()?.getContext() || {},
+            locals: this.currentAbility()?.getLocals() || {},
+            modelClass,
+            modelName: modelClassName,
+            params: {},
+            resourceConfiguration: resourceClass.resourceConfig()
+          })
+
+          this._setCachedSerializationResourceInstance(modelClass, true, resource)
+
+          break
+        }
       }
     }
 
-    return null
+    if (this._frontendModelSerializationResourceInstanceHook) {
+      this._frontendModelSerializationResourceInstanceHook(model, resource)
+    }
+
+    return resource
   }
 
   /**


### PR DESCRIPTION
Implements task ef8f307e-5536-53b6-8d36-da0379b4d8dc.

## What changed
- Added a focused benchmark for a large frontend-model index response.
- Added RED-GREEN specs proving resource-instance reuse within a request and no cross-request sharing.
- Added request-scoped caching of frontend-model resource instances during serialization, with separate cache entries for root vs. related models.
- Kept mutation paths fresh by not caching frontendModelResourceInstance() itself.

## Evidence
- Benchmark (500 tasks + project + comments, 20 iterations):
  - Before: ~6006 resource-instance resolutions/op, p95 ~406 ms
  - After: ~3007 resource-instance resolutions/op, p95 ~400 ms
- Focused specs pass:
  - spec/frontend-model-resource/base-resource-spec.js
  - spec/frontend-models/serialization-resource-metadata-spec.js
  - spec/frontend-models/base.http-integration-spec.js (50 tests)
- Lint/typecheck/fallow: green

## Safety
- Caching is scoped to the per-request controller instance.
- withFrontendModelParams clears/restores the cache so temporary param overrides cannot leak stale resources.
- Related models use a separate cache slot from the root model, so self-referential relationships do not accidentally reuse root request params.