### PR TITLE
Add duration-aware test sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,26 @@ npx velocious test --groups=4 --group-number=2
 
 # Combine with tags
 npx velocious test --groups=3 --group-number=1 --tag fast
+
+# Prefer recorded file durations when balancing groups
+npx velocious test --groups=4 --group-number=1 --timing-manifest=tmp/test-timings.json
 ```
 
 Files are distributed using a greedy load-balancing algorithm. Each file is
-weighted by its spec directory (`system/` = 20, `frontend-models/` = 10,
+primarily weighted by a positive finite duration from the optional timing
+manifest. Manifest keys are normalized project-relative test paths using `/`
+separators:
+
+```json
+{
+  "spec/system/sign-in-spec.js": 42.7,
+  "spec/controller/accounts-spec.js": 8.1
+}
+```
+
+Files absent from the manifest, unknown files, invalid duration values, and
+unreadable or malformed JSON all fall back to the existing deterministic
+heuristic. The heuristic weights files by spec directory (`system/` = 20, `frontend-models/` = 10,
 `controller/` = 3, default = 1) with a 2x multiplier for `.browser-spec.js`
 files. The heaviest files are assigned first to the group with the least
 accumulated weight, producing balanced wall-clock times across groups.

--- a/changelog.d/20260807183000-duration-aware-test-sharding.md
+++ b/changelog.d/20260807183000-duration-aware-test-sharding.md
@@ -1,0 +1,1 @@
+Added `velocious test --timing-manifest=<path>` so parallel test groups can use recorded per-file durations while retaining deterministic heuristic weights for missing or invalid entries.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -45,6 +45,24 @@ run. Each line shows the duration, full description and `file:line`.
 `TestRunner#getSlowestTests(limit = 10)` exposes the same data programmatically
 (slowest first; `limit` of `0` returns every recorded test).
 
+## Duration-aware parallel sharding
+Pass `--timing-manifest=<path>` together with `--groups` and `--group-number` to
+weight discovered test files by recorded wall-clock duration. The JSON object maps
+normalized project-relative test paths to positive finite numbers:
+
+```json
+{
+  "spec/system/sign-in-spec.js": 42.7,
+  "spec/controller/accounts-spec.js": 8.1
+}
+```
+
+Forward slashes are the portable manifest format; leading `./` and backslashes are
+normalized when reading keys. A valid duration takes precedence over the static
+directory/browser heuristic for that file. Missing paths, unknown paths, non-number,
+non-positive, or non-finite durations fall back per file. Missing, unreadable, or
+malformed JSON manifests also leave the existing deterministic heuristic intact.
+
 ## Avoiding fixed sleeps
 Never `await wait(<fixed ms>)` to let something async settle — it is both slow and
 flaky (too short and it races, too long and it wastes wall-clock). Wait for the real

--- a/spec/cli/commands/test-timing-manifest-spec.js
+++ b/spec/cli/commands/test-timing-manifest-spec.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../src/testing/test.js"
+import {loadTimingManifest} from "../../../src/environment-handlers/node/cli/commands/test.js"
+
+describe("test timing manifest loading", {databaseCleaning: {transaction: true}}, () => {
+  it("loads valid JSON", async () => {
+    const manifest = await loadTimingManifest("package.json")
+
+    expect(manifest.name).toBe("velocious")
+  })
+
+  it("returns undefined for malformed JSON", async () => {
+    expect(await loadTimingManifest("AGENTS.md")).toBe(undefined)
+  })
+
+  it("returns undefined for an unreadable path", async () => {
+    expect(await loadTimingManifest("missing-test-timing-manifest.json")).toBe(undefined)
+  })
+})

--- a/spec/cli/commands/test-timing-manifest-spec.js
+++ b/spec/cli/commands/test-timing-manifest-spec.js
@@ -1,20 +1,24 @@
 // @ts-check
 
+import path from "node:path"
+import {fileURLToPath} from "node:url"
 import {describe, expect, it} from "../../../src/testing/test.js"
 import {loadTimingManifest} from "../../../src/environment-handlers/node/cli/commands/test.js"
 
+const repositoryDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
+
 describe("test timing manifest loading", {databaseCleaning: {transaction: true}}, () => {
   it("loads valid JSON", async () => {
-    const manifest = await loadTimingManifest("package.json")
+    const manifest = await loadTimingManifest(path.join(repositoryDirectory, "package.json"))
 
     expect(manifest.name).toBe("velocious")
   })
 
   it("returns undefined for malformed JSON", async () => {
-    expect(await loadTimingManifest("AGENTS.md")).toBe(undefined)
+    expect(await loadTimingManifest(path.join(repositoryDirectory, "AGENTS.md"))).toBe(undefined)
   })
 
   it("returns undefined for an unreadable path", async () => {
-    expect(await loadTimingManifest("missing-test-timing-manifest.json")).toBe(undefined)
+    expect(await loadTimingManifest(path.join(repositoryDirectory, "missing-test-timing-manifest.json"))).toBe(undefined)
   })
 })

--- a/spec/testing/test-filter-parser-spec.js
+++ b/spec/testing/test-filter-parser-spec.js
@@ -5,6 +5,19 @@ import {describe, expect, it} from "../../src/testing/test.js"
 
 describe("parseFilters", {databaseCleaning: {transaction: true}}, () => {
   describe("group splitting flags", () => {
+    it("parses and strips a timing manifest path", () => {
+      const result = parseFilters(["test", "--groups=4", "--group-number=2", "--timing-manifest", "tmp/timings.json", "spec/testing/"])
+
+      expect(result.timingManifestPath).toBe("tmp/timings.json")
+      expect(result.filteredProcessArgs).toEqual(["test", "spec/testing/"])
+    })
+
+    it("parses a timing manifest path with equals syntax", () => {
+      const result = parseFilters(["test", "--timing-manifest=tmp/timings.json"])
+
+      expect(result.timingManifestPath).toBe("tmp/timings.json")
+    })
+
     it("parses --groups and --group-number with = syntax", () => {
       const result = parseFilters(["test", "--groups=4", "--group-number=2"])
 

--- a/spec/testing/test-suite-splitter-spec.js
+++ b/spec/testing/test-suite-splitter-spec.js
@@ -220,4 +220,65 @@ describe("TestSuiteSplitter", {databaseCleaning: {transaction: true}}, () => {
     expect(byPath["/project/spec/controller/routes-spec.js"]).toBe(3)
     expect(byPath["/project/spec/utils/string-spec.js"]).toBe(1)
   })
+
+  it("uses normalized relative timing manifest durations as primary weights", () => {
+    const splitter = new TestSuiteSplitter({
+      groups: 1,
+      groupNumber: 1,
+      testFiles: [
+        "/project/spec/system/slow-spec.js",
+        "/project/spec/utils/measured-spec.js"
+      ],
+      baseDirectory: "/project",
+      timingManifest: {
+        "./spec/system/slow-spec.js": 2,
+        "spec\\utils\\measured-spec.js": 45.5
+      }
+    })
+
+    expect(splitter.computeWeightedFiles()).toEqual([
+      {filePath: "/project/spec/system/slow-spec.js", weight: 2},
+      {filePath: "/project/spec/utils/measured-spec.js", weight: 45.5}
+    ])
+  })
+
+  it("falls back per file for malformed unknown and unusable timing entries", () => {
+    const testFiles = [
+      "/project/spec/system/zero-spec.js",
+      "/project/spec/frontend-models/infinite-spec.js",
+      "/project/spec/controller/text-spec.js",
+      "/project/spec/utils/unknown-spec.js"
+    ]
+    const splitter = new TestSuiteSplitter({
+      groups: 1,
+      groupNumber: 1,
+      testFiles,
+      baseDirectory: "/project",
+      timingManifest: {
+        "spec/system/zero-spec.js": 0,
+        "spec/frontend-models/infinite-spec.js": Infinity,
+        "spec/controller/text-spec.js": "12",
+        "spec/other/not-discovered-spec.js": 100
+      }
+    })
+
+    expect(splitter.computeWeightedFiles()).toEqual([
+      {filePath: testFiles[0], weight: 20},
+      {filePath: testFiles[1], weight: 10},
+      {filePath: testFiles[2], weight: 3},
+      {filePath: testFiles[3], weight: 1}
+    ])
+  })
+
+  it("falls back to heuristics for a malformed manifest root", () => {
+    const splitter = new TestSuiteSplitter({
+      groups: 1,
+      groupNumber: 1,
+      testFiles: ["/project/spec/system/login-spec.js"],
+      baseDirectory: "/project",
+      timingManifest: [20]
+    })
+
+    expect(splitter.computeWeightedFiles()[0].weight).toBe(20)
+  })
 })

--- a/spec/testing/test-suite-splitter-spec.js
+++ b/spec/testing/test-suite-splitter-spec.js
@@ -242,6 +242,22 @@ describe("TestSuiteSplitter", {databaseCleaning: {transaction: true}}, () => {
     ])
   })
 
+  it("uses project-relative timing manifest durations with a configured test subdirectory", () => {
+    const splitter = new TestSuiteSplitter({
+      groups: 1,
+      groupNumber: 1,
+      testFiles: ["/project/spec/system/slow-spec.js"],
+      baseDirectory: "/project/spec",
+      timingManifest: {
+        "spec/system/slow-spec.js": 2
+      }
+    })
+
+    expect(splitter.computeWeightedFiles()).toEqual([
+      {filePath: "/project/spec/system/slow-spec.js", weight: 2}
+    ])
+  })
+
   it("falls back per file for malformed unknown and unusable timing entries", () => {
     const testFiles = [
       "/project/spec/system/zero-spec.js",

--- a/src/environment-handlers/node/cli/commands/test.js
+++ b/src/environment-handlers/node/cli/commands/test.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import BaseCommand from "../../../../cli/base-command.js"
+import fs from "fs/promises"
 import picocolors from "picocolors"
 import TestFilesFinder from "../../../../testing/test-files-finder.js"
 import TestRunner from "../../../../testing/test-runner.js"
@@ -26,7 +27,7 @@ export default class VelociousCliCommandsTest extends BaseCommand {
       directories.push(`${this.directory()}/spec`)
     }
 
-    const {includeTags, excludeTags, examplePatterns, filteredProcessArgs, groups, groupNumber} = parseFilters(this.processArgs || [])
+    const {includeTags, excludeTags, examplePatterns, filteredProcessArgs, groups, groupNumber, timingManifestPath} = parseFilters(this.processArgs || [])
     const testFilesFinder = new TestFilesFinder({directory, directories, processArgs: filteredProcessArgs})
     let testFiles = await testFilesFinder.findTestFiles()
 
@@ -35,7 +36,8 @@ export default class VelociousCliCommandsTest extends BaseCommand {
         throw new Error("Both --groups and --group-number must be provided together")
       }
 
-      const splitter = new TestSuiteSplitter({groups, groupNumber, testFiles, baseDirectory: directory})
+      const timingManifest = await loadTimingManifest(timingManifestPath)
+      const splitter = new TestSuiteSplitter({groups, groupNumber, testFiles, baseDirectory: directory, timingManifest})
 
       testFiles = splitter.getGroupFiles()
       console.log(picocolors.cyan(`Running group ${groupNumber} of ${groups} (${testFiles.length} files)`))
@@ -135,6 +137,23 @@ export default class VelociousCliCommandsTest extends BaseCommand {
       console.log(picocolors.green(`\nTest run succeeded with ${testRunner.getSuccessfulTests()} successful tests`))
       process.exit(0)
     }
+  }
+}
+
+/**
+ * Loads an optional JSON timing manifest. Unreadable or malformed input intentionally falls back to heuristics.
+ * @param {string | undefined} timingManifestPath - Timing manifest path.
+ * @returns {Promise<ReturnType<typeof JSON.parse> | undefined>} - Parsed manifest when readable and valid JSON.
+ */
+export async function loadTimingManifest(timingManifestPath) {
+  if (!timingManifestPath) return undefined
+
+  try {
+    return JSON.parse(await fs.readFile(timingManifestPath, "utf8"))
+  } catch (error) {
+    if (error instanceof Error) return undefined
+
+    throw error
   }
 }
 

--- a/src/testing/test-filter-parser.js
+++ b/src/testing/test-filter-parser.js
@@ -7,6 +7,7 @@
  * @property {string[]} filteredProcessArgs - Remaining process args with filter flags removed.
  * @property {number | undefined} groups - Total number of groups for test splitting.
  * @property {number | undefined} groupNumber - Which group to run (1-indexed).
+ * @property {string | undefined} timingManifestPath - JSON timing manifest path.
  */
 // @ts-check
 
@@ -15,6 +16,7 @@ const EXCLUDE_TAG_FLAGS = new Set(["--exclude-tag", "--skip-tag", "-x"])
 const EXAMPLE_FLAGS = new Set(["--example", "--name", "-e"])
 const GROUPS_FLAGS = new Set(["--groups"])
 const GROUP_NUMBER_FLAGS = new Set(["--group-number"])
+const TIMING_MANIFEST_FLAGS = new Set(["--timing-manifest"])
 
 /**
  * Runs split tags.
@@ -79,6 +81,8 @@ export function parseFilters(processArgs) {
    * Defines groupNumber.
    * @type {number | undefined} */
   let groupNumber
+  /** @type {string | undefined} */
+  let timingManifestPath
 
   let inRestArgs = false
 
@@ -181,6 +185,21 @@ export function parseFilters(processArgs) {
         groupNumber = parseInt(arg.slice("--group-number=".length), 10)
         continue
       }
+
+      if (TIMING_MANIFEST_FLAGS.has(arg)) {
+        const nextValue = processArgs[i + 1]
+
+        if (nextValue && !nextValue.startsWith("-")) {
+          timingManifestPath = nextValue
+          i++
+        }
+        continue
+      }
+
+      if (arg.startsWith("--timing-manifest=")) {
+        timingManifestPath = arg.slice("--timing-manifest=".length)
+        continue
+      }
     }
 
     filteredProcessArgs.push(arg)
@@ -192,6 +211,7 @@ export function parseFilters(processArgs) {
     examplePatterns,
     filteredProcessArgs,
     groups,
-    groupNumber
+    groupNumber,
+    timingManifestPath
   }
 }

--- a/src/testing/test-suite-splitter.js
+++ b/src/testing/test-suite-splitter.js
@@ -46,8 +46,9 @@ export default class TestSuiteSplitter {
    * @param {number} args.groupNumber - Which group to return (1-indexed).
    * @param {string[]} args.testFiles - All discovered test file paths.
    * @param {string} [args.baseDirectory] - Base directory for relative path computation.
+   * @param {ReturnType<typeof JSON.parse>} [args.timingManifest] - Relative test paths mapped to durations.
    */
-  constructor({groups, groupNumber, testFiles, baseDirectory, ...restArgs}) {
+  constructor({groups, groupNumber, testFiles, baseDirectory, timingManifest, ...restArgs}) {
     restArgsError(restArgs)
 
     if (!Number.isInteger(groups) || groups < 1) {
@@ -62,6 +63,7 @@ export default class TestSuiteSplitter {
     this._groupNumber = groupNumber
     this._testFiles = testFiles
     this._baseDirectory = baseDirectory || process.cwd()
+    this._timingManifest = this.normalizeTimingManifest(timingManifest)
   }
 
   /**
@@ -93,7 +95,13 @@ export default class TestSuiteSplitter {
    * @returns {number} - Weight value.
    */
   computeWeight(filePath) {
-    const relativePath = path.relative(this._baseDirectory, filePath).split(path.sep).join("/")
+    const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
+    const duration = this._timingManifest[relativePath]
+
+    if (duration !== undefined) {
+      return duration
+    }
+
     let weight = DEFAULT_WEIGHT
 
     // Extract the type directory from the relative path.
@@ -114,6 +122,37 @@ export default class TestSuiteSplitter {
     }
 
     return weight
+  }
+
+  /**
+   * Keeps only usable positive finite duration entries keyed by normalized relative path.
+   * @param {ReturnType<typeof JSON.parse>} timingManifest - Parsed timing manifest.
+   * @returns {Record<string, number>} - Valid normalized duration weights.
+   */
+  normalizeTimingManifest(timingManifest) {
+    /** @type {Record<string, number>} */
+    const normalized = {}
+
+    if (!timingManifest || typeof timingManifest !== "object" || Array.isArray(timingManifest)) {
+      return normalized
+    }
+
+    for (const [filePath, duration] of Object.entries(timingManifest)) {
+      if (typeof duration === "number" && Number.isFinite(duration) && duration > 0) {
+        normalized[this.normalizeRelativePath(filePath)] = duration
+      }
+    }
+
+    return normalized
+  }
+
+  /**
+   * Normalizes a relative test path to the manifest's portable slash format.
+   * @param {string} filePath - Relative test path.
+   * @returns {string} - Normalized relative test path.
+   */
+  normalizeRelativePath(filePath) {
+    return filePath.replaceAll("\\", "/").replace(/^\.\//, "")
   }
 
   /**

--- a/src/testing/test-suite-splitter.js
+++ b/src/testing/test-suite-splitter.js
@@ -96,7 +96,8 @@ export default class TestSuiteSplitter {
    */
   computeWeight(filePath) {
     const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
-    const duration = this._timingManifest[relativePath]
+    const projectRelativePath = this.normalizeRelativePath(path.join(path.basename(this._baseDirectory), relativePath))
+    const duration = this._timingManifest[relativePath] ?? this._timingManifest[projectRelativePath]
 
     if (duration !== undefined) {
       return duration
@@ -152,7 +153,9 @@ export default class TestSuiteSplitter {
    * @returns {string} - Normalized relative test path.
    */
   normalizeRelativePath(filePath) {
-    return filePath.replaceAll("\\", "/").replace(/^\.\//, "")
+    return filePath
+      .replaceAll("\\", "/")
+      .replace(/^\.\//, "")
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `--timing-manifest` parsing and JSON loading to the test CLI
- prefer valid positive finite per-file durations in `TestSuiteSplitter`, with normalized relative paths
- retain the deterministic directory/browser heuristic per file for missing, malformed, unknown, non-positive, or non-finite timing input
- document the manifest format and add a changelog fragment

## Validation
- `docker version` attempted first; Docker CLI is installed, but the daemon is unavailable because `/var/run/docker.sock` does not exist
- focused Velocious specs attempted with the mandated SQLite configuration and `MSSQL_SA_PASSWORD`; unavailable because the test lifecycle checks out `mssql:1433`, which is not resolvable in this environment (`getaddrinfo ENOTFOUND mssql`)
- direct source assertions for CLI parsing, path normalization, primary duration weights, and heuristic fallback passed
- exact pre-commit gate passed:
  - `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
  - `npm run lint`
  - `npm run typecheck`
  - `npm run fallow`
- `git diff --check`

Related: kaspernj/tensorbuzz#894
