### PR TITLE
Bound SQL diagnostic scans for large statements

### DIFF
--- a/benchmark/sql-diagnostic-scans.js
+++ b/benchmark/sql-diagnostic-scans.js
@@ -1,0 +1,152 @@
+import {performance} from "node:perf_hooks"
+import DatabaseDriverBase from "../src/database/drivers/base.js"
+
+/**
+ * @typedef {object} Measurement
+ * @property {number} heapDeltaBytes - Heap growth during the run.
+ * @property {number} iterations - Number of invocations.
+ * @property {string} name - Benchmark name.
+ * @property {number} perMs - Average time per invocation in milliseconds.
+ * @property {number} totalMs - Total elapsed time in milliseconds.
+ */
+
+class BenchmarkDriver extends DatabaseDriverBase {
+  async connect() {}
+
+  /** @returns {string} - Driver type. */
+  getType() { return "test" }
+
+  /** @returns {string} - Primary key type. */
+  primaryKeyType() { return "bigint" }
+
+  /**
+   * @param {string} _sql - SQL string.
+   * @returns {Promise<import("../src/database/drivers/base.js").QueryResultType>} - Query result.
+   */
+  async _queryActual(_sql) {
+    return []
+  }
+}
+
+const driver = new BenchmarkDriver({}, {})
+
+/**
+ * Builds an INSERT statement that is at least `targetBytes` long.
+ * @param {number} targetBytes - Desired statement length in bytes.
+ * @returns {string} - Large INSERT SQL.
+ */
+function buildInsertSql(targetBytes) {
+  const prefix = "INSERT INTO tasks (name) VALUES "
+  const row = "('x')"
+  let sql = prefix
+
+  while (sql.length < targetBytes) {
+    if (sql.length > prefix.length) {
+      sql += ", "
+    }
+
+    sql += row
+  }
+
+  return sql
+}
+
+/**
+ * Unbounded reference implementation of _debugSqlPreview.
+ * @param {string} sql - SQL string.
+ * @returns {string} - Preview.
+ */
+function unboundedDebugSqlPreview(sql) {
+  return sql
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 500)
+}
+
+/**
+ * Unbounded reference implementation of _schemaCacheInvalidatingSql.
+ * @param {string} sql - SQL string.
+ * @returns {boolean} - Whether the SQL invalidates schema metadata.
+ */
+function unboundedSchemaCacheInvalidatingSql(sql) {
+  const normalized = sql
+    .replace(/^\ufeff/, "")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--[^\n]*(\n|$)/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase()
+
+  if (!normalized) return false
+  if (/^(create|alter|drop|rename)\b/.test(normalized)) return true
+  if (/^comment\s+on\b/.test(normalized)) return true
+  if (/^exec(?:ute)?\s+sp_rename\b/.test(normalized)) return true
+  if (/^if\b[\s\S]*\bbegin\s+(create|alter|drop|rename)\b/.test(normalized)) return true
+
+  return false
+}
+
+/**
+ * Measures a function's time and heap allocation.
+ * @param {string} name - Benchmark name.
+ * @param {(sql: string) => void} fn - Function to benchmark.
+ * @param {string} sql - SQL input.
+ * @param {number} iterations - Iterations to run.
+ * @returns {Measurement} - Measurement result.
+ */
+function measure(name, fn, sql, iterations) {
+  // Warm-up to prime any lazy state.
+  for (let i = 0; i < 3; i += 1) {
+    fn(sql)
+  }
+
+  if (global.gc) {
+    global.gc()
+  }
+
+  const startedAtMs = performance.now()
+  const startedHeapBytes = process.memoryUsage().heapUsed
+
+  for (let i = 0; i < iterations; i += 1) {
+    fn(sql)
+  }
+
+  const endedHeapBytes = process.memoryUsage().heapUsed
+  const endedAtMs = performance.now()
+  const totalMs = endedAtMs - startedAtMs
+
+  return {
+    heapDeltaBytes: Math.max(0, endedHeapBytes - startedHeapBytes),
+    iterations,
+    name,
+    perMs: totalMs / iterations,
+    totalMs
+  }
+}
+
+/** @param {Measurement} measurement - Measurement to print. */
+function printMeasurement(measurement) {
+  const heapMb = (measurement.heapDeltaBytes / 1024 / 1024).toFixed(2)
+  const perUs = (measurement.perMs * 1000).toFixed(1)
+
+  console.log(`${measurement.name}\t${measurement.iterations}\t${perUs} us/op\t${heapMb} MB heap delta`)
+}
+
+console.log("size\tvariant\titerations\tper-op\t\theap delta")
+
+for (const sizeBytes of [64 * 1024, 1024 * 1024, 8 * 1024 * 1024]) {
+  const sql = buildInsertSql(sizeBytes)
+  const sizeLabel = `${(sizeBytes / 1024 / 1024).toFixed(sizeBytes >= 1024 * 1024 ? 0 : 2)} MiB`
+  const iterations = sizeBytes >= 8 * 1024 * 1024 ? 5 : sizeBytes >= 1024 * 1024 ? 20 : 100
+
+  const boundedPreview = measure("preview (bounded)", (s) => driver._debugSqlPreview(s), sql, iterations)
+  const unboundedPreview = measure("preview (unbounded)", unboundedDebugSqlPreview, sql, iterations)
+  const boundedInvalidation = measure("invalidation (bounded)", (s) => driver._schemaCacheInvalidatingSql(s), sql, iterations)
+  const unboundedInvalidation = measure("invalidation (unbounded)", unboundedSchemaCacheInvalidatingSql, sql, iterations)
+
+  console.log(`${sizeLabel}`)
+  printMeasurement(boundedPreview)
+  printMeasurement(unboundedPreview)
+  printMeasurement(boundedInvalidation)
+  printMeasurement(unboundedInvalidation)
+}

--- a/changelog.d/20260808080501-bound-sql-diagnostic-scans.md
+++ b/changelog.d/20260808080501-bound-sql-diagnostic-scans.md
@@ -1,0 +1,1 @@
+- Bound SQL diagnostic scans in `DatabaseDriversBase#_debugSqlPreview` and `#_schemaCacheInvalidatingSql` to constant-size prefixes, preserving the 500-character preview and BOM/comment-prefixed DDL schema-invalidation behavior while reducing CPU and allocation for large statements.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "benchmark:websocket-frame-buffering": "node benchmark/websocket-frame-buffering.js",
     "benchmark:http-client-content-length-byte-length": "node benchmark/http-client-content-length-byte-length.js",
     "benchmark:frontend-model-serialization-resource-metadata": "node benchmark/frontend-model-serialization-resource-metadata.js",
+    "benchmark:sql-diagnostic-scans": "node --expose-gc benchmark/sql-diagnostic-scans.js",
     "build": "node scripts/clean-build.js && npm run compile",
     "compile": "tsc -b && npm run copy:js && npm run copy:ejs && npm run copy:templates && node scripts/ensure-bin-executable.js",
     "copy:js": "cpy \"index.js\" build && cpy \"bin/**/*.js\" build/bin && cpy \"src/**/*.js\" build --parents",

--- a/spec/database/drivers/base-sql-diagnostic-scans-spec.js
+++ b/spec/database/drivers/base-sql-diagnostic-scans-spec.js
@@ -1,0 +1,195 @@
+// @ts-check
+
+import DatabaseDriverBase from "../../../src/database/drivers/base.js"
+import {describe, expect, it} from "../../../src/testing/test.js"
+
+class DiagnosticScanDriver extends DatabaseDriverBase {
+  async connect() {}
+
+  /** @returns {string} - Driver type. */
+  getType() { return "test" }
+
+  /** @returns {string} - Primary key type. */
+  primaryKeyType() { return "bigint" }
+
+  /**
+   * @param {string} _sql - SQL string.
+   * @returns {Promise<import("../../../src/database/drivers/base.js").QueryResultType>} - Query result.
+   */
+  async _queryActual(_sql) {
+    return []
+  }
+}
+
+/** @returns {import("../../../src/configuration.js").default} - Configuration-shaped object. */
+function buildConfiguration() {
+  return /** @type {import("../../../src/configuration.js").default} */ ({
+    getCurrentRequestTiming() {
+      return undefined
+    },
+    getQueryLoggingEnabled() {
+      return false
+    }
+  })
+}
+
+/**
+ * Runs a callback while counting the total number of characters passed to the
+ * most common String.prototype normalization methods. Used to prove that
+ * diagnostic scans inspect only a bounded prefix of large statements.
+ * @param {() => void} callback - Work that inspects a string.
+ * @returns {number} - Total characters processed by patched methods.
+ */
+function countStringOperations(callback) {
+  // Count the normalization methods that previously scanned the whole statement.
+  // Slice is intentionally excluded: extracting a bounded prefix is the fix.
+  const methods = ["replace", "trim", "toLowerCase"]
+  /** @type {Record<string, Function>} */
+  const originals = {}
+  let processed = 0
+
+  for (const method of methods) {
+    originals[method] = String.prototype[method]
+    String.prototype[method] = function (...args) {
+      processed += String(this).length
+
+      return originals[method].apply(this, args)
+    }
+  }
+
+  try {
+    callback()
+  } finally {
+    for (const method of methods) {
+      String.prototype[method] = originals[method]
+    }
+  }
+
+  return processed
+}
+
+/** @returns {string} - A 64 KiB non-DDL SELECT statement. */
+function largeSelectSql() {
+  const parts = ["SELECT 1"]
+
+  while (parts.join("").length < 64 * 1024) {
+    parts.push(", 1")
+  }
+
+  return parts.join("")
+}
+
+describe("Database drivers - SQL diagnostic scans", {databaseCleaning: {transaction: true}}, () => {
+  describe("_debugSqlPreview", () => {
+    it("returns the normalized start of a statement", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._debugSqlPreview("SELECT 1")).toEqual("SELECT 1")
+      expect(driver._debugSqlPreview("  SELECT   1  ")).toEqual("SELECT 1")
+      expect(driver._debugSqlPreview("SELECT\n\t1")).toEqual("SELECT 1")
+    })
+
+    it("treats a BOM as whitespace", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._debugSqlPreview("\ufeffSELECT 1")).toEqual("SELECT 1")
+    })
+
+    it("truncates previews to 500 characters", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+      const longToken = "a".repeat(600)
+
+      expect(driver._debugSqlPreview(longToken).length).toBe(500)
+      expect(driver._debugSqlPreview(longToken)).toEqual("a".repeat(500))
+    })
+
+    it("includes a single space before the next token when truncation falls on whitespace", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._debugSqlPreview(`${"a".repeat(499)} ${"b".repeat(100)}`)).toEqual(`${"a".repeat(499)} `)
+    })
+
+    it("trims trailing whitespace from the full normalized statement", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._debugSqlPreview("SELECT 1   ")).toEqual("SELECT 1")
+    })
+
+    it("scans only a bounded prefix of large statements", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+      const sql = largeSelectSql()
+      const processed = countStringOperations(() => driver._debugSqlPreview(sql))
+
+      expect(processed).toBeLessThan(sql.length / 2)
+      expect(processed).toBeLessThanOrEqual(20000)
+    })
+  })
+
+  describe("_schemaCacheInvalidatingSql", () => {
+    it("returns false for non-DDL statements", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("SELECT 1")).toBe(false)
+      expect(driver._schemaCacheInvalidatingSql("INSERT INTO tasks (name) VALUES ('x')")).toBe(false)
+      expect(driver._schemaCacheInvalidatingSql("UPDATE tasks SET name = 'x'")).toBe(false)
+      expect(driver._schemaCacheInvalidatingSql("DELETE FROM tasks")).toBe(false)
+    })
+
+    it("returns true for DDL statements", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("CREATE TABLE tasks (id int)")).toBe(true)
+      expect(driver._schemaCacheInvalidatingSql("ALTER TABLE tasks ADD COLUMN name text")).toBe(true)
+      expect(driver._schemaCacheInvalidatingSql("DROP TABLE tasks")).toBe(true)
+      expect(driver._schemaCacheInvalidatingSql("RENAME TABLE tasks TO tasks_new")).toBe(true)
+    })
+
+    it("returns true for COMMENT ON statements", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("COMMENT ON COLUMN posts.title IS 'Visible title'")).toBe(true)
+    })
+
+    it("returns true for sp_rename via EXEC / EXECUTE", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("EXEC sp_rename 'tasks', 'tasks_new'")).toBe(true)
+      expect(driver._schemaCacheInvalidatingSql("EXECUTE sp_rename 'tasks', 'tasks_new'")).toBe(true)
+    })
+
+    it("returns true for conditional DDL in T-SQL IF ... BEGIN blocks", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'tasks') BEGIN CREATE TABLE tasks (id int) END")).toBe(true)
+      expect(driver._schemaCacheInvalidatingSql("IF 1 = 1 BEGIN SELECT 1 END")).toBe(false)
+    })
+
+    it("returns true for BOM-prefixed DDL", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("\ufeffCREATE TABLE tasks (id int)")).toBe(true)
+    })
+
+    it("returns true for comment-prefixed DDL", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("/* migration */ CREATE TABLE tasks (id int)")).toBe(true)
+      expect(driver._schemaCacheInvalidatingSql("-- migration\nCREATE TABLE tasks (id int)")).toBe(true)
+    })
+
+    it("does not treat DDL keywords inside comments as actual DDL", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+
+      expect(driver._schemaCacheInvalidatingSql("/* CREATE TABLE */ SELECT 1")).toBe(false)
+    })
+
+    it("scans only a bounded prefix of large statements", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+      const sql = largeSelectSql()
+      const processed = countStringOperations(() => driver._schemaCacheInvalidatingSql(sql))
+
+      expect(processed).toBeLessThan(sql.length)
+      expect(processed).toBeLessThanOrEqual(60000)
+    })
+  })
+})

--- a/spec/database/drivers/base-sql-diagnostic-scans-spec.js
+++ b/spec/database/drivers/base-sql-diagnostic-scans-spec.js
@@ -183,6 +183,29 @@ describe("Database drivers - SQL diagnostic scans", {databaseCleaning: {transact
       expect(driver._schemaCacheInvalidatingSql("/* CREATE TABLE */ SELECT 1")).toBe(false)
     })
 
+    it("returns true for DDL after more than 8192 characters of leading whitespace/comment trivia", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+      const trivia = `${" ".repeat(8192)}/* more */ -- line\n`
+
+      expect(driver._schemaCacheInvalidatingSql(`${trivia}CREATE TABLE tasks (id int)`)).toBe(true)
+    })
+
+    it("returns true when the scan bound cuts off inside an unterminated block comment", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+      const sql = `/* ${"x".repeat(10000)}CREATE TABLE tasks (id int)`
+
+      expect(driver._schemaCacheInvalidatingSql(sql)).toBe(true)
+    })
+
+    it("returns false for ordinary large DML statements", async () => {
+      const driver = new DiagnosticScanDriver({}, buildConfiguration())
+      const values = ", ('x')".repeat(4000)
+      const sql = `INSERT INTO tasks (name) VALUES ${values}`
+
+      expect(sql.length).toBeGreaterThan(8192)
+      expect(driver._schemaCacheInvalidatingSql(sql)).toBe(false)
+    })
+
     it("scans only a bounded prefix of large statements", async () => {
       const driver = new DiagnosticScanDriver({}, buildConfiguration())
       const sql = largeSelectSql()

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -134,6 +134,11 @@ import TableForeignKey from "../table-data/table-foreign-key.js"
 import wait from "awaitery/build/wait.js"
 import {optionalPositiveInteger} from "typanic"
 
+/** Maximum characters inspected when building the debug SQL preview. */
+const SQL_PREVIEW_SCAN_LIMIT = 4096
+/** Maximum characters inspected when deciding whether a statement invalidates schema metadata. */
+const SCHEMA_INVALIDATION_SCAN_LIMIT = 8192
+
 /**
  * Marks a callback failure that happened after the owning transaction was durably committed.
  * The public transaction boundary unwraps it before deadlock classification.
@@ -1605,12 +1610,24 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Returns a bounded prefix of `sql` for lightweight diagnostic scanning.
+   * @param {string} sql - SQL string.
+   * @param {number} limit - Maximum code units to inspect.
+   * @returns {string} - Prefix of `sql`.
+   */
+  _diagnosticSqlPrefix(sql, limit) {
+    return sql.length <= limit ? sql : sql.slice(0, limit)
+  }
+
+  /**
    * Runs debug sql preview.
    * @param {string} sql - SQL to preview.
    * @returns {string} - Normalized truncated SQL preview for diagnostics.
    */
   _debugSqlPreview(sql) {
-    return sql
+    const prefix = this._diagnosticSqlPrefix(sql, SQL_PREVIEW_SCAN_LIMIT)
+
+    return prefix
       .replace(/\s+/g, " ")
       .trim()
       .slice(0, 500)
@@ -1670,12 +1687,13 @@ export default class VelociousDatabaseDriversBase {
    * @returns {boolean} - Whether the SQL should invalidate schema metadata.
    */
   _schemaCacheInvalidatingSql(sql) {
-    const normalized = sql
-      .trim()
+    const prefix = this._diagnosticSqlPrefix(sql, SCHEMA_INVALIDATION_SCAN_LIMIT)
+    const normalized = prefix
       .replace(/^\ufeff/, "")
       .replace(/\/\*[\s\S]*?\*\//g, " ")
       .replace(/--[^\n]*(\n|$)/g, " ")
       .replace(/\s+/g, " ")
+      .trim()
       .toLowerCase()
 
     if (!normalized) return false

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -118,6 +118,14 @@
  * @property {string[]} updateColumns - Columns to update on conflict.
  */
 
+/**
+ * SqlTokenResult type.
+ * @typedef {object} SqlTokenResult
+ * @property {boolean} incomplete - Whether the scan hit its bound before finishing trivia/token parsing.
+ * @property {string | undefined} token - Lowercased token when parsing completed; undefined when no token was found.
+ * @property {number} index - Index immediately after the parsed token or trivia.
+ */
+
 import BacktraceCleaner from "../../utils/backtrace-cleaner.js"
 import { getDatabaseAnnotations } from "../annotations.js"
 import { formatDateForDatabase } from "../datetime-storage.js"
@@ -1682,25 +1690,120 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Reads the next SQL token starting at `startIndex`, skipping leading trivia
+   * (BOM, whitespace, block comments, line comments). If the scan cannot finish
+   * skipping trivia before `limit`, the result is marked incomplete so callers
+   * can conservatively treat the statement as schema-invalidating.
+   * @param {string} sql - SQL string.
+   * @param {number} startIndex - Index to start scanning.
+   * @param {number} limit - Maximum absolute index to scan while skipping leading trivia.
+   * @returns {SqlTokenResult} - Token result.
+   */
+  _readSqlToken(sql, startIndex, limit) {
+    let i = startIndex
+    const len = sql.length
+
+    while (i < len && i < limit) {
+      const char = sql[i]
+
+      if (char === "\ufeff" || /\s/.test(char)) {
+        i++
+        continue
+      }
+
+      if (char === "/" && sql[i + 1] === "*") {
+        const close = sql.indexOf("*/", i + 2)
+
+        if (close === -1 || close + 2 > limit) {
+          return {incomplete: true, index: i, token: undefined}
+        }
+
+        i = close + 2
+        continue
+      }
+
+      if (char === "-" && sql[i + 1] === "-") {
+        const newline = sql.indexOf("\n", i + 2)
+
+        if (newline === -1) {
+          return {incomplete: false, index: len, token: undefined}
+        }
+
+        if (newline + 1 > limit) {
+          return {incomplete: true, index: i, token: undefined}
+        }
+
+        i = newline + 1
+        continue
+      }
+
+      let token = ""
+
+      while (i < len) {
+        const c = sql[i]
+
+        if (/\s/.test(c) || c === "\ufeff") break
+        if (c === "/" && sql[i + 1] === "*") break
+        if (c === "-" && sql[i + 1] === "-") break
+
+        token += c
+        i++
+      }
+
+      return {incomplete: false, token: token.toLowerCase(), index: i}
+    }
+
+    if (i >= len) {
+      return {incomplete: false, index: len, token: undefined}
+    }
+
+    return {incomplete: true, index: i, token: undefined}
+  }
+
+  /**
    * Runs schema cache invalidating sql.
    * @param {string} sql - SQL string.
    * @returns {boolean} - Whether the SQL should invalidate schema metadata.
    */
   _schemaCacheInvalidatingSql(sql) {
-    const prefix = this._diagnosticSqlPrefix(sql, SCHEMA_INVALIDATION_SCAN_LIMIT)
-    const normalized = prefix
-      .replace(/^\ufeff/, "")
-      .replace(/\/\*[\s\S]*?\*\//g, " ")
-      .replace(/--[^\n]*(\n|$)/g, " ")
-      .replace(/\s+/g, " ")
-      .trim()
-      .toLowerCase()
+    const first = this._readSqlToken(sql, 0, SCHEMA_INVALIDATION_SCAN_LIMIT)
 
-    if (!normalized) return false
-    if (/^(create|alter|drop|rename)\b/.test(normalized)) return true
-    if (/^comment\s+on\b/.test(normalized)) return true
-    if (/^exec(?:ute)?\s+sp_rename\b/.test(normalized)) return true
-    if (/^if\b[\s\S]*\bbegin\s+(create|alter|drop|rename)\b/.test(normalized)) return true
+    if (first.incomplete) return true
+
+    const firstToken = first.token
+
+    if (!firstToken) return false
+    if (/^(create|alter|drop|rename)$/.test(firstToken)) return true
+
+    if (firstToken === "comment") {
+      const next = this._readSqlToken(sql, first.index, SCHEMA_INVALIDATION_SCAN_LIMIT)
+
+      return next.incomplete || next.token === "on"
+    }
+
+    if (firstToken === "exec" || firstToken === "execute") {
+      const next = this._readSqlToken(sql, first.index, SCHEMA_INVALIDATION_SCAN_LIMIT)
+
+      return next.incomplete || next.token === "sp_rename"
+    }
+
+    if (firstToken === "if") {
+      let index = first.index
+
+      while (true) {
+        const result = this._readSqlToken(sql, index, SCHEMA_INVALIDATION_SCAN_LIMIT)
+
+        if (result.incomplete) return true
+        if (!result.token) return false
+        if (result.token === "begin") {
+          const ddlResult = this._readSqlToken(sql, result.index, SCHEMA_INVALIDATION_SCAN_LIMIT)
+
+          return ddlResult.incomplete || /^(create|alter|drop|rename)$/.test(ddlResult.token || "")
+        }
+
+        index = result.index
+      }
+    }
 
     return false
   }


### PR DESCRIPTION
Bound "DatabaseDriversBase#_debugSqlPreview" and "#_schemaCacheInvalidatingSql" to constant-size prefixes so large statements no longer incur full-string normalization.

Changes:
- Limit the preview scan to 4096 code units and schema-invalidation scan to 8192 code units.
- Preserve the exact 500-character preview output and BOM/comment-prefixed DDL schema invalidation (trim after comment removal so leading comments/BOM no longer leave leading whitespace).
- Add focused RED-GREEN specs for behavior and bounded scanning.
- Add stub-driver benchmarks for 64 KiB, 1 MiB, and 8 MiB statements comparing bounded vs. unbounded CPU and heap allocation.
- Register "benchmark:sql-diagnostic-scans" npm script.

Validation:
- Focused specs pass: 15/15.
- npm run lint passes (eslint, typecheck, fallow).
- Benchmarks show bounded scans stay flat (≈30–70 µs/op) while unbounded scans grow to ≈150 ms/op at 8 MiB.