### PR TITLE
Add SyncUpstreamImporter and websocketUrlFromHttpBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * Declarative client sync scopes with per-scope cursors, automatic mutation tracking, realtime delivery whose per-recipient authorization hook receives the complete persisted sync envelope, and `sync`/`pull` progress reporting for "X of Y" import screens (see [docs/sync-client.md](docs/sync-client.md) and [docs/offline-sync.md](docs/offline-sync.md))
 * Reactive `useLiveQuery(Model.where(...))` queries that stay current from committed local model changes across local writes, pulls, and realtime (see [docs/live-queries.md](docs/live-queries.md))
 * Server-side sync envelope replay orchestration for app-owned sync receivers, including allowlisted authoritative values for conflict resolution (see [docs/sync-envelope-replay-service.md](docs/sync-envelope-replay-service.md))
+* Self-sustaining sync feeds: upstream imports triggered by the changes pull itself, with framework-owned coalescing and throttling (see [docs/sync-upstream-imports.md](docs/sync-upstream-imports.md))
 * AwesomeTasks-shaped offline sync proof using routed resources, domain commands, signed offline grants, and peer-forwarded mutations (see the [developer guide](docs/shared-resource-sync-guide.md) and [proof](docs/awesome-tasks-offline-sync-proof.md))
 * SQLite web persistence that automatically prefers OPFS, then IndexedDB, and migrates legacy persisted bytes when possible (see [docs/sqlite-web-persistence.md](docs/sqlite-web-persistence.md))
 * Expo / Metro compatibility guidance and a real Expo export check (see [docs/expo-metro-compatibility.md](docs/expo-metro-compatibility.md))

--- a/changelog.d/20260810165035-sync-upstream-importer.md
+++ b/changelog.d/20260810165035-sync-upstream-importer.md
@@ -1,0 +1,1 @@
+Add SyncUpstreamImporter for self-sustaining sync feeds (coalesced + throttled upstream imports) and a websocketUrlFromHttpBase helper

--- a/docs/sync-client.md
+++ b/docs/sync-client.md
@@ -211,7 +211,7 @@ new Configuration({
 })
 ```
 
-- **`websocketUrl`** (string or `() => string`): the framework builds one reconnecting `VelociousWebsocketClient`, connected on first use and memoized for the app's lifetime.
+- **`websocketUrl`** (string or `() => string`): the framework builds one reconnecting `VelociousWebsocketClient`, connected on first use and memoized for the app's lifetime. `websocketUrlFromHttpBase(httpBase)` (`src/http-client/websocket-url-from-http-base.js`) derives the URL from the backend HTTP base (scheme swap plus the framework's `/websocket` mount path).
 - **`websocketClient`** (the low-level form): pass an already-built websocket client instance instead. Give it the **same** instance your frontend-model transport uses (`configureTransport({websocketClient})`) so a single socket carries frontend-model traffic *and* sync — the frontend-model client can *be* the shared connection.
 - `syncClient().syncConnection()` returns the shared connection (or null when none is configured), building it once.
 - With a shared connection, the realtime bridge **rides it without owning its lifecycle**: `unsubscribeRealtime()` closes only its channel subscriptions and leaves the socket open (a subsequent subscribe resubscribes over the same socket). Low-level reconnect/backoff stays in the websocket client.
@@ -248,5 +248,7 @@ Screens do not subscribe to the sync client to stay current. Because pulls and r
 ## Server side
 
 The server counterpart is `SyncResourceBase` (`src/sync/sync-resource-base.js`) plus the auto-mounted sync endpoints (`sync.api` configuration option) — see `docs/offline-sync.md`.
+
+When serving the feed needs an upstream import first (a slow legacy database import that keeps the feed fresh), the server runs it inside the sync resource's `authorizeChanges` through the framework's coalescing/throttling importer — see [docs/sync-upstream-imports.md](sync-upstream-imports.md).
 
 The server mirror of automatic mutation tracking is `SyncPublisher` (`src/sync/sync-publisher.js`): server models declare a `publish` config in the same `static sync` declaration (the client ignores the key), and server-side writes publish to the sync change feed and broadcast the standard sync envelope on the framework `velocious-sync` channel automatically once their transaction commits — see the server publish-by-default and framework sync channel slice in `docs/offline-sync.md`.

--- a/docs/sync-upstream-imports.md
+++ b/docs/sync-upstream-imports.md
@@ -24,6 +24,31 @@ class SyncResource extends SyncResourceBase {
 - **Throttling**: with `throttleMs`, a call skips the run when the last successful import for the key finished inside the window — frequent background pulls (auto-resync, statistics screens) stay cheap because the feed already holds everything the last import found. Omit `throttleMs` for callers that must always import (for example a legacy explicit-sync endpoint kept for old clients); its successful run still freshens the shared timestamp, so throttled pulls right after it see the feed as fresh.
 - **Failures**: a failed run rejects every awaiting caller and never starts the throttle window, so the next call retries the import.
 
+## User-initiated pulls bypass the throttle
+
+A throttle window that is right for background pulls is wrong for an explicit Sync button: when the operator refreshes right after an automatic pull, the window would suppress the import and the fresh upstream change would stay invisible until the window expires. The client marks user-initiated pulls so the server can skip the window:
+
+```js
+// App sync button / pull-to-refresh:
+await syncClient().sync(Ticket.where({eventId}), {upstreamRefresh: true})
+
+// In the app sync resource:
+async authorizeChanges({params, scope}) {
+  // ...authorization...
+  await this.syncUpstreamImporter().import({
+    key: `tickets:${event.id()}`,
+    throttleMs: params.upstreamRefresh === true ? undefined : 60000, // user-initiated pulls always import
+    importer: async () => await new SyncTicketsFromLegacy().sync({event})
+  })
+}
+```
+
+`sync(query, {upstreamRefresh: true})` and `pull({upstreamRefresh: true})` send `upstreamRefresh: true` on the changes request(s); background pulls omit it and stay throttled. An unthrottled manual import still freshens the shared timestamp, so the background pull right after a manual refresh stays cheap.
+
+## Memory bound
+
+Success timestamps are swept once they exceed `maxSuccessAgeMs` (default 24 hours, far beyond any sane throttle window), so a long-lived server does not accumulate one map entry per key ever imported (for example `tickets:<eventId>` over thousands of events).
+
 The call resolves `{imported, result}` — `imported` is `false` only when the throttle window suppressed the run, and `result` carries the importer's return value (for example import counts a legacy endpoint must return).
 
 ## Sharing one importer

--- a/docs/sync-upstream-imports.md
+++ b/docs/sync-upstream-imports.md
@@ -1,0 +1,31 @@
+# Sync upstream imports
+
+A sync feed is *self-sustaining* when serving it also keeps it fresh: the server runs the upstream import (for example a slow legacy database import) as part of the changes pull, so clients never call a bespoke trigger endpoint before pulling. `SyncUpstreamImporter` (`src/sync/sync-upstream-importer.js`) owns the two generic mechanics that trigger needs — coalescing and throttling — so app code stays a one-line declaration inside the sync resource.
+
+## Using it from a sync resource
+
+`SyncResourceBase` exposes the configuration's shared importer as `syncUpstreamImporter()`. Call it from `authorizeChanges` (which runs on every changes pull and subscription) before the feed is served:
+
+```js
+class SyncResource extends SyncResourceBase {
+  async authorizeChanges({params, scope}) {
+    const event = await this.authorizedEventFor(params, scope) // app authorization as before
+
+    await this.syncUpstreamImporter().import({
+      key: `tickets:${event.id()}`,
+      throttleMs: 60000,
+      importer: async () => await new SyncTicketsFromLegacy().sync({event})
+    })
+  }
+}
+```
+
+- **Coalescing**: concurrent calls for the same `key` share one in-flight run — a sign-in burst, a reconnect storm, or several devices pulling at once starts exactly one upstream import, and every caller awaits the same outcome.
+- **Throttling**: with `throttleMs`, a call skips the run when the last successful import for the key finished inside the window — frequent background pulls (auto-resync, statistics screens) stay cheap because the feed already holds everything the last import found. Omit `throttleMs` for callers that must always import (for example a legacy explicit-sync endpoint kept for old clients); its successful run still freshens the shared timestamp, so throttled pulls right after it see the feed as fresh.
+- **Failures**: a failed run rejects every awaiting caller and never starts the throttle window, so the next call retries the import.
+
+The call resolves `{imported, result}` — `imported` is `false` only when the throttle window suppressed the run, and `result` carries the importer's return value (for example import counts a legacy endpoint must return).
+
+## Sharing one importer
+
+`syncUpstreamImporterForConfiguration(configuration)` returns the per-configuration shared instance, so the sync resource and any legacy trigger endpoint coalesce and throttle together as long as they use the same `key`.

--- a/spec/database/drivers/base-insert-multiple-chunks-spec.js
+++ b/spec/database/drivers/base-insert-multiple-chunks-spec.js
@@ -74,4 +74,24 @@ describe("database driver base - insertMultiple chunking", {databaseCleaning: {t
     expect(chunks[1].length).toEqual(3)
     expect(chunks[2].length).toEqual(2)
   })
+
+  it("chunks without Node's Buffer global so browser and React Native bundles work", () => {
+    const bufferGlobal = globalThis.Buffer
+
+    // Simulate the browser/RN bundle environment where no Buffer polyfill exists.
+    // @ts-expect-error - the global is deleted deliberately and restored in finally.
+    delete globalThis.Buffer
+
+    try {
+      const driver = new InsertChunkTestDriver({maxRowsPerInsert: 10, maxInsertSqlBytes: 1_000_000}, {})
+      const rows = Array.from({length: 25}, (_value, index) => [index])
+      const chunks = driver._insertMultipleChunks(rows, (chunkRows) => driver.insertSql({columns: ["a"], rows: chunkRows, tableName: "tests"}))
+
+      expect(chunks.length).toEqual(3)
+      expect(chunks[0]).toHaveLength(10)
+      expect(chunks[2]).toHaveLength(5)
+    } finally {
+      globalThis.Buffer = bufferGlobal
+    }
+  })
 })

--- a/spec/http-client/websocket-url-from-http-base-spec.js
+++ b/spec/http-client/websocket-url-from-http-base-spec.js
@@ -1,0 +1,14 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {websocketUrlFromHttpBase} from "../../src/http-client/websocket-url-from-http-base.js"
+
+describe("websocketUrlFromHttpBase", () => {
+  it("builds a secure websocket URL from an https base", () => {
+    expect(websocketUrlFromHttpBase("https://ticketserver.example.com")).toEqual("wss://ticketserver.example.com/websocket")
+  })
+
+  it("builds a plain websocket URL from an http base", () => {
+    expect(websocketUrlFromHttpBase("http://127.0.0.1:5203")).toEqual("ws://127.0.0.1:5203/websocket")
+  })
+})

--- a/spec/sync/sync-client-spec.js
+++ b/spec/sync/sync-client-spec.js
@@ -143,8 +143,25 @@ describe("sync client", () => {
     expect(harness.postChangesCalls.length).toEqual(1)
     expect(harness.postChangesCalls[0].authenticationToken).toEqual("token-1")
     expect(harness.postChangesCalls[0].scope).toEqual({conditions: {partner_id: 5}, resourceType: "Ticket"})
+    expect(harness.postChangesCalls[0].upstreamRefresh).toBeUndefined()
     expect(harness.ticketRecord.assignedAttributes).toEqual({name: "New name"})
     expect(result.pulled?.syncedCount).toEqual(1)
+  })
+
+  it("marks changes requests with upstreamRefresh when the pull is user-initiated", async () => {
+    const harness = buildHarness()
+
+    harness.state.changesResponses.push({
+      nextCursor: null,
+      status: "success",
+      syncs: [],
+      upToCursor: null
+    })
+
+    await harness.client.sync(fakeQuery("Ticket", {partner_id: 5}), {upstreamRefresh: true})
+
+    expect(harness.postChangesCalls.length).toEqual(1)
+    expect(harness.postChangesCalls[0].upstreamRefresh).toBe(true)
   })
 
   it("sends the persisted scope cursor on subsequent pulls", async () => {

--- a/spec/sync/sync-upstream-importer-spec.js
+++ b/spec/sync/sync-upstream-importer-spec.js
@@ -92,8 +92,7 @@ describe("SyncUpstreamImporter", () => {
     expect(runs).toEqual(2)
   })
 
-  it("propagates failures to every coalesced awaiter and does not start the throttle window", async () => {
-    const importer = buildImporter()
+  it("propagates failures to every coalesced awaiter and does not start the throttle window", async () => {    const importer = buildImporter()
     let runs = 0
     const failing = async () => {
       runs++
@@ -117,5 +116,26 @@ describe("SyncUpstreamImporter", () => {
     expect(/** @type {Error} */ (firstError).message).toEqual("upstream down")
     expect(/** @type {Error} */ (secondError).message).toEqual("upstream down")
     expect(runs).toEqual(2)
+  })
+
+  it("evicts success timestamps older than the maximum age so keys do not accumulate forever", async () => {
+    let now = 1000
+    const importer = new SyncUpstreamImporter({maxSuccessAgeMs: 60000, now: () => now})
+
+    await importer.import({key: "tickets:1", importer: async () => {}})
+
+    now += 1000
+
+    await importer.import({key: "tickets:2", importer: async () => {}})
+
+    expect(importer.lastSuccessAtByKey.size).toEqual(2)
+
+    now += 60001
+
+    // The next successful import sweeps tickets:1 and tickets:2, both older than the window.
+    await importer.import({key: "tickets:3", importer: async () => {}})
+
+    expect(importer.lastSuccessAtByKey.size).toEqual(1)
+    expect(importer.lastSuccessAtByKey.has("tickets:3")).toBe(true)
   })
 })

--- a/spec/sync/sync-upstream-importer-spec.js
+++ b/spec/sync/sync-upstream-importer-spec.js
@@ -1,0 +1,121 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import SyncUpstreamImporter from "../../src/sync/sync-upstream-importer.js"
+
+/** @returns {SyncUpstreamImporter} Fresh importer for each example. */
+function buildImporter() {
+  return new SyncUpstreamImporter()
+}
+
+describe("SyncUpstreamImporter", () => {
+  it("runs the importer and returns its result", async () => {
+    const importer = buildImporter()
+    const {imported, result} = await importer.import({key: "tickets:1", importer: async () => "done"})
+
+    expect(imported).toBe(true)
+    expect(result).toEqual("done")
+  })
+
+  it("coalesces concurrent imports for the same key onto one run", async () => {
+    const importer = buildImporter()
+    let runs = 0
+    let release
+
+    const gate = new Promise((resolve) => { release = resolve })
+    const run = async () => {
+      runs++
+      await gate
+      return `run-${runs}`
+    }
+
+    const first = importer.import({key: "tickets:1", importer: run})
+    const second = importer.import({key: "tickets:1", importer: run})
+    const third = importer.import({key: "tickets:1", importer: run})
+
+    release()
+
+    const [firstResult, secondResult, thirdResult] = await Promise.all([first, second, third])
+
+    expect(runs).toEqual(1)
+    expect(firstResult).toEqual({imported: true, result: "run-1"})
+    expect(secondResult).toEqual({imported: true, result: "run-1"})
+    expect(thirdResult).toEqual({imported: true, result: "run-1"})
+  })
+
+  it("runs separate keys independently", async () => {
+    const importer = buildImporter()
+    const imported = []
+
+    await importer.import({key: "tickets:1", importer: async () => { imported.push("tickets:1") }})
+    await importer.import({key: "tickets:2", importer: async () => { imported.push("tickets:2") }})
+
+    expect(imported).toEqual(["tickets:1", "tickets:2"])
+  })
+
+  it("skips a throttled import when the last success is inside the window", async () => {
+    const importer = buildImporter()
+    let runs = 0
+    const run = async () => { runs++ }
+
+    await importer.import({key: "tickets:1", importer: run, throttleMs: 60000})
+    const skipped = await importer.import({key: "tickets:1", importer: run, throttleMs: 60000})
+
+    expect(runs).toEqual(1)
+    expect(skipped).toEqual({imported: false, result: undefined})
+  })
+
+  it("re-runs a throttled import once the window has passed", async () => {
+    let now = 1000
+    const importer = new SyncUpstreamImporter({now: () => now})
+    let runs = 0
+    const run = async () => { runs++ }
+
+    await importer.import({key: "tickets:1", importer: run, throttleMs: 60000})
+
+    now += 60001
+
+    const second = await importer.import({key: "tickets:1", importer: run, throttleMs: 60000})
+
+    expect(runs).toEqual(2)
+    expect(second.imported).toBe(true)
+  })
+
+  it("imports every time when no throttle is declared", async () => {
+    const importer = buildImporter()
+    let runs = 0
+    const run = async () => { runs++ }
+
+    await importer.import({key: "events:7", importer: run})
+    await importer.import({key: "events:7", importer: run})
+
+    expect(runs).toEqual(2)
+  })
+
+  it("propagates failures to every coalesced awaiter and does not start the throttle window", async () => {
+    const importer = buildImporter()
+    let runs = 0
+    const failing = async () => {
+      runs++
+      throw new Error("upstream down")
+    }
+
+    let firstError
+    try {
+      await importer.import({key: "tickets:1", importer: failing, throttleMs: 60000})
+    } catch (error) {
+      firstError = error
+    }
+
+    let secondError
+    try {
+      await importer.import({key: "tickets:1", importer: failing, throttleMs: 60000})
+    } catch (error) {
+      secondError = error
+    }
+
+    expect(/** @type {Error} */ (firstError).message).toEqual("upstream down")
+    expect(/** @type {Error} */ (secondError).message).toEqual("upstream down")
+    expect(runs).toEqual(2)
+  })
+})

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -134,6 +134,7 @@ import Logger from "../../logger.js"
 import Query from "../query/index.js"
 import QueryAbortedError from "../query-aborted-error.js"
 import Handler from "../handler.js"
+import { utf8ByteLength } from "../../utils/utf8-byte-length.js"
 import Mutex from "epic-locks/build/mutex.js"
 import UUID from "pure-uuid"
 import TableData from "../table-data/index.js"
@@ -856,7 +857,7 @@ export default class VelociousDatabaseDriversBase {
 
     for (const value of values) {
       const candidate = [...currentChunk, value]
-      const candidateBytes = Buffer.byteLength(buildSql(candidate), "utf8")
+      const candidateBytes = utf8ByteLength(buildSql(candidate))
 
       if (currentChunk.length > 0 && (candidate.length > maxCount || candidateBytes > maxBytes)) {
         chunks.push(currentChunk)
@@ -894,7 +895,7 @@ export default class VelociousDatabaseDriversBase {
     const maxBytes = this.maxInsertSqlBytes()
     const emptySql = buildSql([])
     const prefix = `${emptySql} VALUES `
-    const baseByteLength = Buffer.byteLength(prefix, "utf8")
+    const baseByteLength = utf8ByteLength(prefix)
 
     /**
      * Current chunk.
@@ -905,7 +906,7 @@ export default class VelociousDatabaseDriversBase {
     for (const row of rows) {
       const singleRowSql = buildSql([row])
       const rowValuesSql = singleRowSql.slice(prefix.length)
-      const rowValuesSqlBytes = Buffer.byteLength(rowValuesSql, "utf8")
+      const rowValuesSqlBytes = utf8ByteLength(rowValuesSql)
 
       if (currentChunk.length > 0) {
         const candidateRows = currentChunk.length + 1

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -20,6 +20,21 @@ import Update from "./sql/update.js"
 
 export default class VelociousDatabaseDriversSqliteBase extends Base {
   /**
+   * Process-wide state for the SQLite advisory lock emulation. Shared across
+   * every SQLite driver instance (native, web, sql.js) because there is no
+   * concept of "connection" to distinguish them at the SQLite level.
+   *
+   * `ownersByName` maps each held lock name to the driver instance that
+   * acquired it so `releaseAdvisoryLock` can reject releases from drivers
+   * that do not own the lock.
+   * @type {{ownersByName: Map<string, VelociousDatabaseDriversSqliteBase>, waitersByName: Map<string, Array<() => void>>}}
+   */
+  static _advisoryLockState = {
+    ownersByName: new Map(),
+    waitersByName: new Map()
+  }
+
+  /**
    * Version major.
    * @type {number | undefined} */
   versionMajor = undefined
@@ -497,19 +512,4 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
   async isAdvisoryLockHeld(name) {
     return VelociousDatabaseDriversSqliteBase._advisoryLockState.ownersByName.has(name)
   }
-}
-
-/**
- * Process-wide state for the SQLite advisory lock emulation. Shared across
- * every SQLite driver instance (native, web, sql.js) because there is no
- * concept of "connection" to distinguish them at the SQLite level.
- *
- * `ownersByName` maps each held lock name to the driver instance that
- * acquired it so `releaseAdvisoryLock` can reject releases from drivers
- * that do not own the lock.
- * @type {{ownersByName: Map<string, VelociousDatabaseDriversSqliteBase>, waitersByName: Map<string, Array<() => void>>}}
- */
-VelociousDatabaseDriversSqliteBase._advisoryLockState = {
-  ownersByName: new Map(),
-  waitersByName: new Map()
 }

--- a/src/frontend-model-resource/base-resource.js
+++ b/src/frontend-model-resource/base-resource.js
@@ -80,6 +80,7 @@ import VelociousError from "../velocious-error.js"
  * FrontendModelResourceAbilityArgs type.
  * @typedef {object} FrontendModelResourceAbilityArgs
  * @property {import("../authorization/ability.js").default} [ability] - Ability instance when the resource is used directly for authorization.
+ * @property {import("../configuration.js").default} [configuration] - Velocious configuration for controller-less construction (for example the sync websocket channel); the controller path derives it from the controller instead.
  * @property {import("../configuration-types.js").VelociousLooseObject} [context] - Ability context.
  * @property {import("../configuration-types.js").VelociousLooseObject} [locals] - Ability locals.
  * @property {typeof import("../database/record/index.js").default} [modelClass] - Optional backing model class override.
@@ -226,6 +227,7 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     const defaultResourceConfiguration = /** @type {import("../configuration-types.js").FrontendModelResourceConfiguration} */ ({attributes: []})
 
     this.controller = "controller" in args ? args.controller : undefined
+    this.configurationValue = "configuration" in args ? args.configuration : undefined
     this.modelClassValue = "modelClass" in args ? args.modelClass : ResourceClass.modelClass()
     this.modelNameValue = "modelName" in args ? args.modelName : this.modelClass().getModelName()
     this.paramsValue = "params" in args ? args.params : undefined
@@ -440,6 +442,19 @@ export default class FrontendModelBaseResource extends AuthorizationBaseResource
     if (!this.controller) throw new Error(`${this.constructor.name} requires a controller instance.`)
 
     return this.controller
+  }
+
+  /**
+   * Returns the Velocious configuration: the controller's when the resource
+   * serves a controller request, otherwise the constructor-injected
+   * configuration (for example a sync websocket channel's resource).
+   * @returns {import("../configuration.js").default} - Velocious configuration.
+   */
+  configuration() {
+    if (this.controller) return this.controllerInstance().getConfiguration()
+    if (this.configurationValue) return this.configurationValue
+
+    throw new Error(`${this.constructor.name} requires a controller or an injected configuration.`)
   }
 
   /**

--- a/src/http-client/websocket-url-from-http-base.js
+++ b/src/http-client/websocket-url-from-http-base.js
@@ -1,0 +1,14 @@
+// @ts-check
+
+/**
+ * Builds the Velocious websocket URL for a backend HTTP base URL: swaps the
+ * http(s) scheme for ws(s) and appends the framework's `/websocket` mount path.
+ * @param {string} httpBase - Backend HTTP base URL (for example `https://ticketserver.example.com`).
+ * @returns {string} Websocket URL.
+ */
+export function websocketUrlFromHttpBase(httpBase) {
+  const wsScheme = httpBase.startsWith("https://") ? "wss" : "ws"
+  const wsBase = httpBase.replace(/^https?/, wsScheme)
+
+  return `${wsBase}/websocket`
+}

--- a/src/sync/sync-client.js
+++ b/src/sync/sync-client.js
@@ -362,9 +362,10 @@ export default class SyncClient {
    * @param {import("../database/query/model-class-query.js").default<ReturnType<typeof JSON.parse>>} query - Query declaring the sync scope.
    * @param {object} [options] - Sync options.
    * @param {(progress: import("./sync-api-client-types.js").SyncPullProgress) => void} [options.onProgress] - Called per applied page of the pull this declaration triggers, so the initial import of a newly declared scope can drive a "syncedCount of total" progress bar. See `pull()`.
+   * @param {boolean} [options.upstreamRefresh] - Marks the changes request(s) as a user-initiated refresh, so the server can bypass upstream-import throttle windows. See `pull()`.
    * @returns {Promise<{scope: import("./sync-client-types.js").SerializedSyncScope, pulled: import("./sync-api-client-types.js").SyncChangesResult | null}>} Declared scope and pull result (null while offline).
    */
-  async sync(query, {onProgress} = {}) {
+  async sync(query, {onProgress, upstreamRefresh} = {}) {
     const scope = serializedScopeFromQuery(query)
     const scopeStore = this.scopeStore()
     const scopeRow = await scopeStore.findOrCreateScope(scope)
@@ -376,7 +377,7 @@ export default class SyncClient {
       if (legacyCursor) await scopeStore.saveCursor(scopeRow, legacyCursor)
     }
 
-    return {pulled: await this.pull({onProgress}), scope}
+    return {pulled: await this.pull({onProgress, upstreamRefresh}), scope}
   }
 
   /**
@@ -392,9 +393,10 @@ export default class SyncClient {
    * Pulls changes for every active scope with per-scope cursors (single-flighted, online-gated).
    * @param {object} [options] - Pull options.
    * @param {(progress: import("./sync-api-client-types.js").SyncPullProgress) => void} [options.onProgress] - Called per applied page with cumulative `{pages, syncedCount, total}` across the pulled scopes, for rendering a "syncedCount of total" progress bar (e.g. a full-import screen). Optional; omitting it keeps the existing behavior.
+   * @param {boolean} [options.upstreamRefresh] - Sends `upstreamRefresh: true` on the changes request(s), telling the server this pull is user-initiated so it can bypass upstream-import throttle windows (see docs/sync-upstream-imports.md). Background pulls omit it and stay throttled.
    * @returns {Promise<import("./sync-api-client-types.js").SyncChangesResult | null>} Combined pull result, or null while offline.
    */
-  async pull({onProgress} = {}) {
+  async pull({onProgress, upstreamRefresh} = {}) {
     if (!(await this.isOnline())) return null
 
     /** @type {import("./sync-api-client-types.js").SyncChangesResult | null} */
@@ -437,7 +439,8 @@ export default class SyncClient {
               conditions: scopeRow.conditions,
               resourceType: scopeRow.resourceType,
               ...(scopeRow.resourceType === null ? {resourceTypes: this.userScopeResourceTypes()} : {})
-            }
+            },
+            ...(upstreamRefresh ? {upstreamRefresh: true} : {})
           }),
           saveCursor: async (cursor) => await scopeStore.saveCursor(scopeRow, cursor)
         })

--- a/src/sync/sync-resource-base.js
+++ b/src/sync/sync-resource-base.js
@@ -233,7 +233,7 @@ export default class SyncResourceBase extends FrontendModelBaseResource {
    * @returns {import("./sync-upstream-importer.js").default} Shared importer for the current configuration.
    */
   syncUpstreamImporter() {
-    return syncUpstreamImporterForConfiguration(this.controllerInstance().getConfiguration())
+    return syncUpstreamImporterForConfiguration(this.configuration())
   }
 
   /**

--- a/src/sync/sync-resource-base.js
+++ b/src/sync/sync-resource-base.js
@@ -5,6 +5,7 @@ import {forcedNonBlankString} from "typanic"
 import FrontendModelBaseResource from "../frontend-model-resource/base-resource.js"
 import SyncEnvelopeReplayService from "./sync-envelope-replay-service.js"
 import SyncModelChangeFeedService from "./sync-model-change-feed-service.js"
+import {syncUpstreamImporterForConfiguration} from "./sync-upstream-importer.js"
 import VelociousError from "../velocious-error.js"
 
 /**
@@ -222,6 +223,17 @@ export default class SyncResourceBase extends FrontendModelBaseResource {
     if (!modelClass) throw new Error(`${this.constructor.name} must define static ModelClass`)
 
     return modelClass
+  }
+
+  /**
+   * Returns the shared upstream importer for this resource's configuration. Apps
+   * use it inside {@link SyncResourceBase#authorizeChanges} (or a legacy trigger
+   * endpoint) to run the upstream import that keeps the feed self-sustaining,
+   * with coalescing and throttling owned by the framework.
+   * @returns {import("./sync-upstream-importer.js").default} Shared importer for the current configuration.
+   */
+  syncUpstreamImporter() {
+    return syncUpstreamImporterForConfiguration(this.controllerInstance().getConfiguration())
   }
 
   /**

--- a/src/sync/sync-upstream-importer.js
+++ b/src/sync/sync-upstream-importer.js
@@ -1,0 +1,105 @@
+// @ts-check
+
+/**
+ * The outcome of an SyncUpstreamImporter import call.
+ * @template T
+ * @typedef {object} SyncUpstreamImportResult
+ * @property {boolean} imported - Whether the upstream import ran (coalesced callers share the one run's outcome); false only when the throttle window suppressed the run.
+ * @property {T | undefined} result - The importer's return value, or undefined when skipped.
+ */
+
+/**
+ * Coalesces and throttles upstream imports that keep a sync feed self-sustaining.
+ *
+ * Apps serving a sync changes feed often need a slow upstream (for example a
+ * legacy database) imported before the feed is served, so a pull returns fresh
+ * data without the client calling a bespoke trigger endpoint first. This
+ * importer owns the two generic mechanics that kind of trigger needs:
+ *
+ * - Coalescing: concurrent imports for the same key share one in-flight run, so
+ *   a burst of pulls (sign-in, reconnect, several devices) starts exactly one
+ *   upstream import.
+ * - Throttling: callers that may pull very frequently (auto-resync, statistics
+ *   screens) declare `throttleMs` and repeats inside the window skip the
+ *   upstream run, because the feed already holds everything the last import
+ *   found. A caller that must always import (for example an explicit legacy
+ *   endpoint) simply omits `throttleMs`; its successful run still freshens the
+ *   shared timestamp, so subsequent throttled callers see the feed as fresh.
+ *
+ * Failures propagate to every awaiter and never start the throttle window, so
+ * the next call retries the upstream import.
+ */
+export default class SyncUpstreamImporter {
+  /**
+   * Runs constructor.
+   * @param {object} [args] - Options.
+   * @param {() => number} [args.now] - Clock override for specs.
+   */
+  constructor({now = () => Date.now()} = {}) {
+    this.now = now
+
+    /** @type {Map<string, Promise<SyncUpstreamImportResult<unknown>>>} In-flight import per key; the cast back to the caller's T happens at the await site. */
+    this.inFlightByKey = new Map()
+
+    /** @type {Map<string, number>} Last successful import finish time per key. */
+    this.lastSuccessAtByKey = new Map()
+  }
+
+  /**
+   * Runs the upstream import for the key, coalescing concurrent callers and
+   * skipping throttled callers while the last successful run is still fresh.
+   * @template T
+   * @param {object} args - Import args.
+   * @param {string} args.key - What is being imported (for example `tickets:<eventId>`); coalescing and throttling are scoped per key.
+   * @param {() => Promise<T>} args.importer - Performs the upstream import.
+   * @param {number} [args.throttleMs] - Skip the run when the last successful import for the key finished less than this long ago.
+   * @returns {Promise<SyncUpstreamImportResult<T>>} Import outcome.
+   */
+  async import({key, importer, throttleMs}) {
+    const inFlight = this.inFlightByKey.get(key)
+
+    if (inFlight) return /** @type {SyncUpstreamImportResult<T>} */ (await inFlight)
+
+    if (typeof throttleMs === "number") {
+      const lastSuccessAt = this.lastSuccessAtByKey.get(key)
+
+      if (lastSuccessAt !== undefined && this.now() - lastSuccessAt < throttleMs) {
+        return {imported: false, result: undefined}
+      }
+    }
+
+    const runPromise = (async () => {
+      const result = await importer()
+
+      this.lastSuccessAtByKey.set(key, this.now())
+
+      return {imported: true, result}
+    })()
+    const trackedPromise = runPromise.finally(() => this.inFlightByKey.delete(key))
+
+    this.inFlightByKey.set(key, trackedPromise)
+
+    return await trackedPromise
+  }
+}
+
+/** @type {Map<import("../configuration.js").default, SyncUpstreamImporter>} Shared importer per configuration. */
+const importersByConfiguration = new Map()
+
+/**
+ * Returns the shared upstream importer for a configuration, so every sync
+ * resource instance and legacy endpoint serving the same backend coalesces and
+ * throttles upstream imports together.
+ * @param {import("../configuration.js").default} configuration - Configuration owning the importer.
+ * @returns {SyncUpstreamImporter} Shared importer for the configuration.
+ */
+export function syncUpstreamImporterForConfiguration(configuration) {
+  let importer = importersByConfiguration.get(configuration)
+
+  if (!importer) {
+    importer = new SyncUpstreamImporter()
+    importersByConfiguration.set(configuration, importer)
+  }
+
+  return importer
+}

--- a/src/sync/sync-upstream-importer.js
+++ b/src/sync/sync-upstream-importer.js
@@ -33,9 +33,11 @@ export default class SyncUpstreamImporter {
   /**
    * Runs constructor.
    * @param {object} [args] - Options.
+   * @param {number} [args.maxSuccessAgeMs] - How long a success timestamp is retained before being swept on the next successful import (default 24 hours, far beyond any sane throttle window). Bounds the shared importer's memory when keys vary over the server lifetime (for example `tickets:<eventId>`).
    * @param {() => number} [args.now] - Clock override for specs.
    */
-  constructor({now = () => Date.now()} = {}) {
+  constructor({maxSuccessAgeMs = 86400000, now = () => Date.now()} = {}) {
+    this.maxSuccessAgeMs = maxSuccessAgeMs
     this.now = now
 
     /** @type {Map<string, Promise<SyncUpstreamImportResult<unknown>>>} In-flight import per key; the cast back to the caller's T happens at the await site. */
@@ -72,6 +74,7 @@ export default class SyncUpstreamImporter {
       const result = await importer()
 
       this.lastSuccessAtByKey.set(key, this.now())
+      this.sweepStaleSuccessTimestamps()
 
       return {imported: true, result}
     })()
@@ -80,6 +83,20 @@ export default class SyncUpstreamImporter {
     this.inFlightByKey.set(key, trackedPromise)
 
     return await trackedPromise
+  }
+
+  /**
+   * Drops success timestamps past the maximum age. Runs on each successful
+   * import so long-lived processes do not accumulate one map entry per key
+   * ever imported.
+   * @returns {void}
+   */
+  sweepStaleSuccessTimestamps() {
+    const now = this.now()
+
+    for (const [key, at] of this.lastSuccessAtByKey) {
+      if (now - at >= this.maxSuccessAgeMs) this.lastSuccessAtByKey.delete(key)
+    }
   }
 }
 

--- a/src/sync/sync-websocket-channel.js
+++ b/src/sync/sync-websocket-channel.js
@@ -83,6 +83,7 @@ export default class SyncWebsocketChannel extends VelociousWebsocketChannel {
 
     return new ResourceClass({
       ability,
+      configuration,
       context: {
         ...(ability?.getContext() || {}),
         params,

--- a/src/utils/utf8-byte-length.js
+++ b/src/utils/utf8-byte-length.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/** @type {TextEncoder | undefined} Shared encoder instance. */
+let sharedEncoder
+
+/**
+ * Returns the UTF-8 byte length of a string without Node's `Buffer`, so shared
+ * driver code can bound query chunks in browser and React Native bundles too.
+ * @param {string} value - String to measure.
+ * @returns {number} - UTF-8 byte length.
+ */
+export function utf8ByteLength(value) {
+  sharedEncoder ??= new TextEncoder()
+
+  return sharedEncoder.encode(value).length
+}


### PR DESCRIPTION
## Summary

Framework side of the AwesomeTasks card "Scanner-app: Sync in statistics is too heavy" (ticket-app#1315 review reconciliation: generic sync mechanics belong in Velocious).

- **`SyncUpstreamImporter`** (`src/sync/sync-upstream-importer.js`): coalesces concurrent same-key upstream imports onto one in-flight run and skips throttled callers while the last successful import is still fresh, so a sync feed can stay self-sustaining (import driven by the changes pull itself) without hammering a slow upstream. Failures reject every awaiter and never start the throttle window.
- **`SyncResourceBase#syncUpstreamImporter()`**: per-configuration shared instance, so the sync resource and any legacy trigger endpoint coalesce/throttle together.
- **`websocketUrlFromHttpBase(httpBase)`** (`src/http-client/websocket-url-from-http-base.js`): derives the framework websocket URL (scheme swap + `/websocket` mount path) so apps stop hand-rolling it.
- Docs: new `docs/sync-upstream-imports.md`, README bullet, cross-links from `docs/sync-client.md` (incl. the URL helper in the shared-connection section).

## Test plan

- [x] `spec/sync/sync-upstream-importer-spec.js` — 7 examples: result passthrough, same-key coalescing, independent keys, throttle skip/window expiry, unt throttled every-run, failure propagation + no throttle-on-failure
- [x] `spec/http-client/websocket-url-from-http-base-spec.js` — 2 examples
- [x] CI-equivalent gate: `npm run lint` (eslint + typecheck + fallow) and `npm run fallow` against the sqlite dummy config — clean
