### PR TITLE
Fix SQLite advisory lock declaration emission

### DIFF
--- a/changelog.d/20260811120000-sqlite-advisory-lock-declaration.md
+++ b/changelog.d/20260811120000-sqlite-advisory-lock-declaration.md
@@ -1,0 +1,1 @@
+Fix the emitted SQLite driver declaration so TypeScript consumers can parse the package types.

--- a/spec/utils/package-scripts-spec.js
+++ b/spec/utils/package-scripts-spec.js
@@ -53,6 +53,19 @@ describe("package scripts", {databaseCleaning: {transaction: true}}, () => {
     expect(scripts.prepack).toEqual("npm run build")
   })
 
+  it("emits a valid SQLite base driver declaration", {timeoutSeconds: 180}, async () => {
+    const npmExecutable = process.env.npm_execpath
+
+    if (!npmExecutable) throw new Error("Expected npm_execpath while running the declaration build spec")
+
+    await execFileAsync(process.execPath, [npmExecutable, "run", "build"], {cwd: repositoryDirectory()})
+
+    const declarationPath = path.join(repositoryDirectory(), "build", "src", "database", "drivers", "sqlite", "base.d.ts")
+    const typescriptExecutable = path.join(repositoryDirectory(), "node_modules", "typescript", "bin", "tsc")
+
+    await execFileAsync(process.execPath, [typescriptExecutable, "--ignoreConfig", "--noEmit", "--skipLibCheck", declarationPath])
+  })
+
   it("builds the declared package entry points when installed from Git", {timeoutSeconds: 180}, async () => {
     const temporaryDirectoryParent = path.join(repositoryDirectory(), "tmp")
 

--- a/src/database/drivers/sqlite/base.js
+++ b/src/database/drivers/sqlite/base.js
@@ -20,6 +20,21 @@ import Update from "./sql/update.js"
 
 export default class VelociousDatabaseDriversSqliteBase extends Base {
   /**
+   * Process-wide state for the SQLite advisory lock emulation. Shared across
+   * every SQLite driver instance (native, web, sql.js) because there is no
+   * concept of "connection" to distinguish them at the SQLite level.
+   *
+   * `ownersByName` maps each held lock name to the driver instance that
+   * acquired it so `releaseAdvisoryLock` can reject releases from drivers
+   * that do not own the lock.
+   * @type {{ownersByName: Map<string, VelociousDatabaseDriversSqliteBase>, waitersByName: Map<string, Array<() => void>>}}
+   */
+  static _advisoryLockState = {
+    ownersByName: new Map(),
+    waitersByName: new Map()
+  }
+
+  /**
    * Version major.
    * @type {number | undefined} */
   versionMajor = undefined
@@ -497,19 +512,4 @@ export default class VelociousDatabaseDriversSqliteBase extends Base {
   async isAdvisoryLockHeld(name) {
     return VelociousDatabaseDriversSqliteBase._advisoryLockState.ownersByName.has(name)
   }
-}
-
-/**
- * Process-wide state for the SQLite advisory lock emulation. Shared across
- * every SQLite driver instance (native, web, sql.js) because there is no
- * concept of "connection" to distinguish them at the SQLite level.
- *
- * `ownersByName` maps each held lock name to the driver instance that
- * acquired it so `releaseAdvisoryLock` can reject releases from drivers
- * that do not own the lock.
- * @type {{ownersByName: Map<string, VelociousDatabaseDriversSqliteBase>, waitersByName: Map<string, Array<() => void>>}}
- */
-VelociousDatabaseDriversSqliteBase._advisoryLockState = {
-  ownersByName: new Map(),
-  waitersByName: new Map()
 }


### PR DESCRIPTION
## Summary

- declare the process-wide SQLite advisory-lock state as a static class field
- verify the built SQLite declaration parses with the package TypeScript compiler
- preserve advisory-lock ownership and waiter behavior unchanged

## TDD evidence

RED before the source edit:

```text
build/src/database/drivers/sqlite/base.d.ts(195,26): error TS1005: ';' expected.
export default namespace VelociousDatabaseDriversSqliteBase
```

GREEN after the source edit:

```text
Test run succeeded with 1 successful tests
```

## Checks

- `npm test -- spec/utils/package-scripts-spec.js:56`
- `npm test -- spec/database/record/advisory-locks.browser-spec.js` (6 passed)
- `npm test -- spec/database/drivers/sqlite/node-advisory-locks-spec.js` (5 passed)
- CI-equivalent sqlite-config `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `npm run build`
- TypeScript parse check of `build/src/database/drivers/sqlite/base.d.ts`