### PR TITLE
Add MySQL deadlock retry diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1904,6 +1904,11 @@ Genuinely unexpected frontend-model command failures reach this bus too. The fro
 
 Unexpected inbound decoded WebSocket dispatch failures emit one `framework-error` and one matching `all-error`. Established expected client-flow errors remain excluded from both events.
 
+MySQL/MariaDB transaction deadlock retries emit a structured `database-deadlock-retry` event (also
+mirrored to `all-error`) with retry metadata, a redacted SQL fingerprint when available, and a
+best-effort bounded/redacted InnoDB deadlock excerpt. Diagnostic capture never joins the retry
+control flow. See [deadlock retry diagnostics](docs/logging.md#deadlock-retry-diagnostics).
+
 ## Use the Websocket client API (HTTP-like)
 
 ```js

--- a/changelog.d/20260811000000-mysql-deadlock-diagnostics.md
+++ b/changelog.d/20260811000000-mysql-deadlock-diagnostics.md
@@ -1,0 +1,1 @@
+Add safe structured MySQL deadlock retry diagnostics with SQL fingerprints and best-effort InnoDB deadlock summaries that never include SQL, identifiers, or values.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -17,3 +17,27 @@ Model-backed reads use names such as `Task Load`, `Task Count`, and `Task Pluck`
 The source arrow is included only when Velocious can identify application code. Dependency and framework frames, including `node_modules`, are filtered out; if no application frame is available, Velocious logs only the timed SQL line.
 
 Query logs use the same configured logger outputs as other Velocious logs and are skipped when no output emits `info`. Disable them with `logging: {queryLogging: false}` or by removing `info` from your configured levels. Enable them in tests with `logging: {queryLogging: true}` and choose the output you want, such as `console: true` for local debugging or `file: true` for a test log file.
+
+## Deadlock retry diagnostics
+
+When the outer transaction boundary will retry a MySQL/MariaDB deadlock or lock-wait timeout,
+Velocious emits `database-deadlock-retry` on `configuration.getErrorEvents()`. The same payload is
+mirrored to `all-error` with `errorType: "database-deadlock-retry"`.
+
+```js
+configuration.getErrorEvents().on("database-deadlock-retry", ({context}) => {
+  console.warn("Database deadlock retry", context)
+})
+```
+
+The bounded context contains `stage`, `driverType`, `attempt`, `maxAttempts`, and `willRetry`, plus
+the SQL operation and an `fnv1a64:` SQL fingerprint when the deadlock came from the standard query
+path. The fingerprint is computed after SQL comments and literal spellings are normalized; SQL text
+and bound or interpolated values are never included.
+
+For MySQL/MariaDB, Velocious also attempts `SHOW ENGINE INNODB STATUS` on a bounded, separate
+connection. `statusCapture` is `captured` or `failed`; a captured `innodbDeadlockSummary` contains only
+the transaction count and victim transaction ordinal. Raw SQL, identifiers, values, and physical-record
+dumps are discarded. Collection is asynchronous and
+best-effort: capture errors and diagnostic listeners cannot change the existing retry count,
+eligibility, backoff, or error result.

--- a/spec/database/drivers/mysql/deadlock-diagnostics-spec.js
+++ b/spec/database/drivers/mysql/deadlock-diagnostics-spec.js
@@ -1,0 +1,108 @@
+// @ts-check
+
+import EventEmitter from "eventemitter3"
+import MysqlDriver from "../../../../src/database/drivers/mysql/index.js"
+import {describe, expect, it} from "../../../../src/testing/test.js"
+
+const SECRET_SQL = "UPDATE `accounts` SET `token` = 'secret-token-91827' WHERE `email` = 'owner@example.test' AND `balance` = 12345"
+
+function configuration() {
+  const errorEvents = new EventEmitter()
+
+  return /** @type {import("../../../../src/configuration.js").default} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({
+    debug: false,
+    getCurrentRequestTiming: () => undefined,
+    getErrorEvents: () => errorEvents,
+    getQueryLoggingEnabled: () => false
+  }))
+}
+
+class DiagnosticMysqlDriver extends MysqlDriver {
+  attempts = 0
+  captureFailure = false
+
+  /** @returns {Promise<import("../../../../src/database/drivers/base.js").QueryResultType>} - Query result. */
+  async _queryActual(sql) {
+    if (sql == "START TRANSACTION" || sql == "ROLLBACK" || sql == "COMMIT") return []
+
+    this.attempts++
+    if (this.attempts == 1) {
+      const mysqlError = new Error("Deadlock found when trying to get lock")
+      // @ts-expect-error MySQL attaches its symbolic error code at runtime.
+      mysqlError.code = "ER_LOCK_DEADLOCK"
+      throw new Error("Query failed", {cause: mysqlError})
+    }
+
+    return []
+  }
+
+  /** @returns {Promise<string>} - Simulated InnoDB status. */
+  async _captureInnodbDeadlockStatus() {
+    if (this.captureFailure) throw new Error("diagnostic connection password=do-not-report")
+
+    return `LATEST DETECTED DEADLOCK
+*** (1) TRANSACTION:
+TRANSACTION 123, ACTIVE 1 sec
+${SECRET_SQL}
+*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
+RECORD LOCKS space id 8 page no 4 n bits 72 index \`email\` of table \`app\`.\`accounts\` trx id 123 lock_mode X waiting
+Record lock, heap no 2 PHYSICAL RECORD: n_fields 2; compact format
+ 0: len 30; hex 7365637265742d746f6b656e2d3931383237; asc secret-token-91827;;
+*** WE ROLL BACK TRANSACTION (1)
+${"ignored status line\n".repeat(500)}`
+  }
+}
+
+describe("Database - drivers - mysql deadlock diagnostics", {databaseCleaning: {transaction: false, truncate: false}, tags: ["dummy"]}, () => {
+  it("reports bounded redacted context without changing the retry budget", async () => {
+    const appConfiguration = configuration()
+    const driver = new DiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
+    const diagnostics = []
+    const diagnosticReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("database-deadlock-retry", resolve))
+
+    driver.setDesiredSessionTimeZone(null)
+    driver._waitMs = async () => {}
+    appConfiguration.getErrorEvents().on("database-deadlock-retry", (payload) => diagnostics.push(payload))
+
+    await driver.transaction(async () => await driver.query(SECRET_SQL))
+    await diagnosticReported
+
+    expect(driver.attempts).toEqual(2)
+    expect(diagnostics.length).toEqual(1)
+    expect(diagnostics[0].context).toMatchObject({
+      attempt: 1,
+      driverType: "mysql",
+      maxAttempts: 2,
+      stage: "database-deadlock-retry",
+      statusCapture: "captured",
+      willRetry: true
+    })
+    expect(diagnostics[0].context.sqlFingerprint).toMatch(/^fnv1a64:[0-9a-f]{16}$/)
+    expect(diagnostics[0].context.sqlOperation).toEqual("UPDATE")
+    expect(diagnostics[0].context.innodbDeadlockSummary).toEqual({transactions: 1, victimTransaction: 1})
+    expect(JSON.stringify(diagnostics[0])).not.toContain("secret-token-91827")
+    expect(JSON.stringify(diagnostics[0])).not.toContain("owner@example.test")
+    expect(JSON.stringify(diagnostics[0])).not.toContain("12345")
+    expect(JSON.stringify(diagnostics[0])).not.toContain("736563726574")
+  })
+
+  it("keeps retrying when best-effort InnoDB status capture fails", async () => {
+    const appConfiguration = configuration()
+    const driver = new DiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
+    const diagnostics = []
+    const diagnosticReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("database-deadlock-retry", resolve))
+
+    driver.captureFailure = true
+    driver.setDesiredSessionTimeZone(null)
+    driver._waitMs = async () => {}
+    appConfiguration.getErrorEvents().on("database-deadlock-retry", (payload) => diagnostics.push(payload))
+
+    await driver.transaction(async () => await driver.query(SECRET_SQL))
+    await diagnosticReported
+
+    expect(driver.attempts).toEqual(2)
+    expect(diagnostics.length).toEqual(1)
+    expect(diagnostics[0].context.statusCapture).toEqual("failed")
+    expect(JSON.stringify(diagnostics[0])).not.toContain("do-not-report")
+  })
+})

--- a/spec/database/drivers/mysql/deadlock-diagnostics-spec.js
+++ b/spec/database/drivers/mysql/deadlock-diagnostics-spec.js
@@ -1,25 +1,39 @@
 // @ts-check
 
-import EventEmitter from "eventemitter3"
+import Configuration from "../../../../src/configuration.js"
+import EnvironmentHandlerNode from "../../../../src/environment-handlers/node.js"
 import MysqlDriver from "../../../../src/database/drivers/mysql/index.js"
-import {describe, expect, it} from "../../../../src/testing/test.js"
+import { describe, expect, it } from "../../../../src/testing/test.js"
 
 const SECRET_SQL = "UPDATE `accounts` SET `token` = 'secret-token-91827' WHERE `email` = 'owner@example.test' AND `balance` = 12345"
 
 function configuration() {
-  const errorEvents = new EventEmitter()
-
-  return /** @type {import("../../../../src/configuration.js").default} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({
-    debug: false,
-    getCurrentRequestTiming: () => undefined,
-    getErrorEvents: () => errorEvents,
-    getQueryLoggingEnabled: () => false
-  }))
+  return new Configuration({
+    database: {test: {}},
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
 }
 
 class DiagnosticMysqlDriver extends MysqlDriver {
   attempts = 0
   captureFailure = false
+  diagnosticPipelineFailure = false
+
+  /** @returns {Promise<void>} - Resolves without a real retry delay. */
+  async _waitMs() {}
+
+  /** @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Safe diagnostic context. */
+  async _deadlockDiagnosticContext() {
+    if (this.diagnosticPipelineFailure) throw new Error("simulated diagnostic pipeline failure")
+
+    return await super._deadlockDiagnosticContext()
+  }
 
   /** @returns {Promise<import("../../../../src/database/drivers/base.js").QueryResultType>} - Query result. */
   async _queryActual(sql) {
@@ -53,7 +67,7 @@ ${"ignored status line\n".repeat(500)}`
   }
 }
 
-describe("Database - drivers - mysql deadlock diagnostics", {databaseCleaning: {transaction: false, truncate: false}, tags: ["dummy"]}, () => {
+describe("Database - drivers - mysql deadlock diagnostics", () => {
   it("reports bounded redacted context without changing the retry budget", async () => {
     const appConfiguration = configuration()
     const driver = new DiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
@@ -61,7 +75,6 @@ describe("Database - drivers - mysql deadlock diagnostics", {databaseCleaning: {
     const diagnosticReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("database-deadlock-retry", resolve))
 
     driver.setDesiredSessionTimeZone(null)
-    driver._waitMs = async () => {}
     appConfiguration.getErrorEvents().on("database-deadlock-retry", (payload) => diagnostics.push(payload))
 
     await driver.transaction(async () => await driver.query(SECRET_SQL))
@@ -94,7 +107,6 @@ describe("Database - drivers - mysql deadlock diagnostics", {databaseCleaning: {
 
     driver.captureFailure = true
     driver.setDesiredSessionTimeZone(null)
-    driver._waitMs = async () => {}
     appConfiguration.getErrorEvents().on("database-deadlock-retry", (payload) => diagnostics.push(payload))
 
     await driver.transaction(async () => await driver.query(SECRET_SQL))
@@ -104,5 +116,42 @@ describe("Database - drivers - mysql deadlock diagnostics", {databaseCleaning: {
     expect(diagnostics.length).toEqual(1)
     expect(diagnostics[0].context.statusCapture).toEqual("failed")
     expect(JSON.stringify(diagnostics[0])).not.toContain("do-not-report")
+  })
+
+  it("normalizes comment markers inside quoted literals before fingerprinting", async () => {
+    const fingerprints = []
+
+    for (const token of ["alpha--suffix#one", "beta--suffix#two"]) {
+      const appConfiguration = configuration()
+      const driver = new DiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
+      const diagnosticReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("database-deadlock-retry", resolve))
+
+      driver.setDesiredSessionTimeZone(null)
+      appConfiguration.getErrorEvents().once("database-deadlock-retry", (payload) => fingerprints.push(payload.context.sqlFingerprint))
+      await driver.transaction(async () => await driver.query(`UPDATE accounts SET token = '${token}' WHERE id = 42`))
+      await diagnosticReported
+    }
+
+    expect(fingerprints.length).toEqual(2)
+    expect(fingerprints[0]).toEqual(fingerprints[1])
+  })
+
+  it("surfaces unexpected diagnostic pipeline failures without stopping retries", async () => {
+    const appConfiguration = configuration()
+    const driver = new DiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
+    const frameworkErrors = []
+    const frameworkErrorReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("framework-error", resolve))
+
+    driver.diagnosticPipelineFailure = true
+    driver.setDesiredSessionTimeZone(null)
+    appConfiguration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push(payload))
+
+    await driver.transaction(async () => await driver.query(SECRET_SQL))
+    await frameworkErrorReported
+
+    expect(driver.attempts).toEqual(2)
+    expect(frameworkErrors.length).toEqual(1)
+    expect(frameworkErrors[0].context.stage).toEqual("database-deadlock-retry-diagnostic")
+    expect(frameworkErrors[0].error.message).toEqual("simulated diagnostic pipeline failure")
   })
 })

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -154,12 +154,44 @@ const SCHEMA_INVALIDATION_SCAN_LIMIT = 8192
  * @returns {string} - Bounded fingerprint.
  */
 function sqlFingerprint(sql) {
-  const normalized = sql
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/--[^\r\n]*/g, " ")
-    .replace(/#[^\r\n]*/g, " ")
-    .replace(/'(?:''|\\.|[^'])*'/g, "?")
-    .replace(/"(?:""|\\.|[^"])*"/g, "?")
+  let fingerprintInput = ""
+
+  for (let index = 0; index < sql.length;) {
+    const character = sql[index]
+    const nextCharacter = sql[index + 1]
+
+    if (character == "'" || character == '"') {
+      const quote = character
+      fingerprintInput += "?"
+      index++
+
+      while (index < sql.length) {
+        if (sql[index] == "\\") {
+          index += 2
+        } else if (sql[index] == quote && sql[index + 1] == quote) {
+          index += 2
+        } else if (sql[index] == quote) {
+          index++
+          break
+        } else {
+          index++
+        }
+      }
+    } else if (character == "/" && nextCharacter == "*") {
+      const commentEnd = sql.indexOf("*/", index + 2)
+      fingerprintInput += " "
+      index = commentEnd == -1 ? sql.length : commentEnd + 2
+    } else if ((character == "-" && nextCharacter == "-") || character == "#") {
+      const lineEnd = sql.indexOf("\n", index + 1)
+      fingerprintInput += " "
+      index = lineEnd == -1 ? sql.length : lineEnd + 1
+    } else {
+      fingerprintInput += character
+      index++
+    }
+  }
+
+  const normalized = fingerprintInput
     .replace(/\b(?:0x[0-9a-f]+|\d+(?:\.\d+)?(?:e[+-]?\d+)?)\b/gi, "?")
     .replace(/\s+/g, " ")
     .trim()
@@ -1261,8 +1293,9 @@ export default class VelociousDatabaseDriversBase {
         return await this._runTransactionAttempt(callback, options)
       } catch (error) {
         if (error instanceof VelociousDatabaseAfterCommitCallbackError) throw error.callbackError
+        if (!(error instanceof Error)) throw error
 
-        const retryInfo = error instanceof Error ? this.retryableDatabaseError(error) : {retry: false, reconnect: false}
+        const retryInfo = this.retryableDatabaseError(error)
 
         if (retryInfo.deadlock && attempt < maxAttempts && this._transactionsCount == 0) {
           this._reportDeadlockRetryDiagnostic({attempt, error, maxAttempts})
@@ -1339,7 +1372,23 @@ export default class VelociousDatabaseDriversBase {
           this.logger.warn("Database deadlock retry all-error listener failed", {error: eventError})
         }
       })
-      .catch(() => {})
+      .catch((diagnosticError) => {
+        const normalizedError = diagnosticError instanceof Error
+          ? diagnosticError
+          : new Error("Database deadlock retry diagnostic failed", {cause: diagnosticError})
+        const payload = {
+          context: {stage: "database-deadlock-retry-diagnostic"},
+          error: normalizedError
+        }
+
+        try {
+          const errorEvents = this.configuration.getErrorEvents()
+          errorEvents.emit("framework-error", payload)
+          errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
+        } catch (reportingError) {
+          this.logger.warn("Database deadlock retry diagnostic pipeline failed", {error: normalizedError, reportingError})
+        }
+      })
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -148,6 +148,33 @@ const SQL_PREVIEW_SCAN_LIMIT = 4096
 const SCHEMA_INVALIDATION_SCAN_LIMIT = 8192
 
 /**
+ * Builds a non-reversible, stable SQL fingerprint without retaining SQL text. Literal spelling is
+ * normalized first so the same statement shape produces the same fingerprint across values.
+ * @param {string} sql - SQL to fingerprint.
+ * @returns {string} - Bounded fingerprint.
+ */
+function sqlFingerprint(sql) {
+  const normalized = sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--[^\r\n]*/g, " ")
+    .replace(/#[^\r\n]*/g, " ")
+    .replace(/'(?:''|\\.|[^'])*'/g, "?")
+    .replace(/"(?:""|\\.|[^"])*"/g, "?")
+    .replace(/\b(?:0x[0-9a-f]+|\d+(?:\.\d+)?(?:e[+-]?\d+)?)\b/gi, "?")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase()
+  let hash = 0xcbf29ce484222325n
+
+  for (let index = 0; index < normalized.length; index++) {
+    hash ^= BigInt(normalized.charCodeAt(index))
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n)
+  }
+
+  return `fnv1a64:${hash.toString(16).padStart(16, "0")}`
+}
+
+/**
  * Marks a callback failure that happened after the owning transaction was durably committed.
  * The public transaction boundary unwraps it before deadlock classification.
  */
@@ -208,6 +235,8 @@ export default class VelociousDatabaseDriversBase {
    * Active query.
    * @type {ActiveQueryState | null} */
   _activeQuery = null
+  /** @type {WeakMap<Error, {sqlFingerprint: string, sqlOperation: string}>} */
+  _failedQueryDiagnostics = new WeakMap()
   /** @type {Map<string, number>} */
   _heldAdvisoryLocks = new Map()
   /**
@@ -1236,6 +1265,8 @@ export default class VelociousDatabaseDriversBase {
         const retryInfo = error instanceof Error ? this.retryableDatabaseError(error) : {retry: false, reconnect: false}
 
         if (retryInfo.deadlock && attempt < maxAttempts && this._transactionsCount == 0) {
+          this._reportDeadlockRetryDiagnostic({attempt, error, maxAttempts})
+
           // An explicitly-configured base wins so the tuning knob is effective even on drivers
           // whose classifier supplies its own `waitMs` (MySQL/MariaDB return a fixed 50ms for
           // deadlocks); otherwise honor that classifier hint, then fall back to 50ms.
@@ -1268,6 +1299,55 @@ export default class VelociousDatabaseDriversBase {
    */
   async _waitMs(ms) {
     await wait(ms)
+  }
+
+  /**
+   * Starts best-effort deadlock diagnostics without joining the retry control flow. Subclasses may
+   * add bounded driver-specific context; capture and event-listener failures cannot affect retry.
+   * @param {{attempt: number, error: Error, maxAttempts: number}} args - Retry metadata.
+   * @returns {void}
+   */
+  _reportDeadlockRetryDiagnostic({attempt, error, maxAttempts}) {
+    const queryDiagnostic = this._failedQueryDiagnostics.get(error)
+
+    void this._deadlockDiagnosticContext()
+      .then((driverContext) => {
+        const context = {
+          attempt,
+          driverType: this.getType(),
+          maxAttempts,
+          stage: "database-deadlock-retry",
+          willRetry: true,
+          ...queryDiagnostic,
+          ...driverContext
+        }
+        const payload = {
+          context,
+          error: new Error("Database transaction deadlock will be retried")
+        }
+        const errorEvents = this.configuration.getErrorEvents()
+
+        try {
+          errorEvents.emit("database-deadlock-retry", payload)
+        } catch (eventError) {
+          this.logger.warn("Database deadlock retry diagnostic listener failed", {error: eventError})
+        }
+
+        try {
+          errorEvents.emit("all-error", {...payload, errorType: "database-deadlock-retry"})
+        } catch (eventError) {
+          this.logger.warn("Database deadlock retry all-error listener failed", {error: eventError})
+        }
+      })
+      .catch(() => {})
+  }
+
+  /**
+   * Builds driver-specific deadlock context. The base driver has no server diagnostic source.
+   * @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Safe context fields.
+   */
+  async _deadlockDiagnosticContext() {
+    return {}
   }
 
   /**
@@ -1547,6 +1627,11 @@ export default class VelociousDatabaseDriversBase {
         return await this._queryActualWithLogging({originalSql: sql, querySql}, {...options, logQuery, sourceStack}, requestTiming, tries)
       } catch (error) {
         if (!(error instanceof Error)) throw error
+
+        this._failedQueryDiagnostics.set(error, {
+          sqlFingerprint: sqlFingerprint(sql),
+          sqlOperation: sql.trim().split(/\s+/, 1)[0]?.toUpperCase() || "UNKNOWN"
+        })
 
         // A deliberately-aborted query must never be silently re-run — its
         // connection was destroyed on purpose, so treat it as terminal.

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -31,6 +31,8 @@ import Update from "./sql/update.js"
  * realistic critical section) instead.
  */
 const MYSQL_INDEFINITE_LOCK_TIMEOUT_SECONDS = 60 * 60 * 24 * 365
+const INNODB_DEADLOCK_CAPTURE_TIMEOUT_MS = 250
+const INNODB_DEADLOCK_EXCERPT_MAX_CHARS = 2048
 
 export default class VelociousDatabaseDriversMysql extends Base{
   /** @type {import("mysql").Pool | undefined} */
@@ -367,6 +369,90 @@ export default class VelociousDatabaseDriversMysql extends Base{
       reconnect: shouldReconnect,
       waitMs: 50
     }
+  }
+
+  /**
+   * Adds a redacted, bounded excerpt from MySQL's latest InnoDB deadlock report. Capture uses a
+   * separate short-lived connection so it cannot queue ahead of rollback or the next retry on this
+   * driver's single-connection pool.
+   * @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Safe diagnostic context.
+   */
+  async _deadlockDiagnosticContext() {
+    try {
+      const status = await this._captureInnodbDeadlockStatus()
+
+      return {
+        innodbDeadlockSummary: this._innodbDeadlockSummary(status),
+        statusCapture: "captured"
+      }
+    } catch {
+      return {statusCapture: "failed"}
+    }
+  }
+
+  /**
+   * Captures SHOW ENGINE INNODB STATUS on a bounded throwaway connection.
+   * @returns {Promise<string>} - Raw server status, retained only inside the redaction path.
+   */
+  async _captureInnodbDeadlockStatus() {
+    const poolWithConfig = /** @type {{config?: {connectionConfig?: ReturnType<typeof JSON.parse>}} | undefined} */ (this.pool)
+    const connectionConfig = poolWithConfig?.config?.connectionConfig
+    const captureConfig = connectionConfig || this.connectArgs()
+
+    return await new Promise((resolve, reject) => {
+      let connection
+      let settled = false
+      const finish = (error, status = "") => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        if (connection) connection.destroy()
+        if (error) reject(error)
+        else resolve(status)
+      }
+      const timeout = setTimeout(() => finish(new Error("InnoDB status capture timed out")), INNODB_DEADLOCK_CAPTURE_TIMEOUT_MS)
+
+      try {
+        connection = mysql.createConnection(captureConfig)
+        connection.on("error", (error) => finish(error))
+        connection.query("SHOW ENGINE INNODB STATUS", (error, rows) => {
+          if (error) {
+            finish(error)
+            return
+          }
+
+          const firstRow = Array.isArray(rows) ? rows[0] : undefined
+          const status = firstRow && typeof firstRow.Status == "string" ? firstRow.Status : ""
+
+          finish(undefined, status)
+        })
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error("InnoDB status capture failed"))
+      }
+    })
+  }
+
+  /**
+   * Extracts only fixed-format deadlock counters. The server report contains raw SQL, identifiers,
+   * and physical record data, so no source text is ever included in an application diagnostic.
+   * @param {string} status - SHOW ENGINE INNODB STATUS text.
+   * @returns {{transactions: number, victimTransaction: number | null}} - Structural deadlock summary.
+   */
+  _innodbDeadlockSummary(status) {
+    const deadlockStart = status.indexOf("LATEST DETECTED DEADLOCK")
+    const candidate = deadlockStart >= 0 ? status.slice(deadlockStart) : status
+    let transactions = 0
+    /** @type {number | null} */
+    let victimTransaction = null
+
+    for (const line of candidate.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (/^\*\*\* \(\d+\) TRANSACTION:$/.test(trimmed)) transactions++
+      const victimMatch = /^\*\*\* WE ROLL BACK TRANSACTION \((\d+)\)$/.exec(trimmed)
+      if (victimMatch) victimTransaction = Number(victimMatch[1])
+    }
+
+    return {transactions, victimTransaction}
   }
 
   /**

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -32,7 +32,6 @@ import Update from "./sql/update.js"
  */
 const MYSQL_INDEFINITE_LOCK_TIMEOUT_SECONDS = 60 * 60 * 24 * 365
 const INNODB_DEADLOCK_CAPTURE_TIMEOUT_MS = 250
-const INNODB_DEADLOCK_EXCERPT_MAX_CHARS = 2048
 
 export default class VelociousDatabaseDriversMysql extends Base{
   /** @type {import("mysql").Pool | undefined} */
@@ -400,8 +399,15 @@ export default class VelociousDatabaseDriversMysql extends Base{
     const captureConfig = connectionConfig || this.connectArgs()
 
     return await new Promise((resolve, reject) => {
+      /** @type {import("mysql").Connection | undefined} */
       let connection
       let settled = false
+      /**
+       * Finishes the status capture once and destroys its temporary connection.
+       * @param {Error | undefined} error - Capture error, when present.
+       * @param {string} [status] - Captured status.
+       * @returns {void}
+       */
       const finish = (error, status = "") => {
         if (settled) return
         settled = true


### PR DESCRIPTION
$## Summary
- emit safe structured context when a transaction is retried after a deadlock
- fingerprint normalized SQL without logging literals or bindings
- collect only a bounded structural InnoDB deadlock summary for MySQL/MariaDB
- add focused regression coverage and logging documentation

## Validation
- `git diff --check` passed
- focused spec is deferred to CI: this canonical topic lane has no multi-database test service, and the dummy setup initializes MSSQL before the mocked-driver spec runs

Retry eligibility, counts, backoff, and propagated errors are unchanged.