### PR TITLE
Define MySQL pooled session-state hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 * Trusted reverse proxy handling for `request.remoteAddress()` (see [docs/trusted-proxies.md](docs/trusted-proxies.md))
 * In-process driver schema metadata caching (see [docs/schema-metadata-cache.md](docs/schema-metadata-cache.md))
 * Planned local-first shared-resource sync architecture (see [docs/offline-sync.md](docs/offline-sync.md))
-* Selective named database connection checkouts, bounded pool waits, and debugging held connections (see [docs/database-connections.md](docs/database-connections.md))
+* Selective named database connection checkouts, bounded pool waits, debugging held connections, and checkout-scoped MySQL/MariaDB raw session state (see [docs/database-connections.md](docs/database-connections.md))
 * Explicit singular-database operation transactions whose model scopes preserve ownership through records, relationships, lifecycle work, nested savepoints, pre-commit guards, and commit callbacks (see [docs/operation-scoped-transactions.md](docs/operation-scoped-transactions.md))
 * AbortSignal-driven MySQL/MariaDB query cancellation for raw, model, and cross-tenant aggregate queries (see [docs/database-query-cancellation.md](docs/database-query-cancellation.md))
 * Optional built-in debug endpoint for inspecting server and database connection state (see [docs/debug-endpoint.md](docs/debug-endpoint.md))

--- a/changelog.d/20260811143000-mysql-session-state-hygiene.md
+++ b/changelog.d/20260811143000-mysql-session-state-hygiene.md
@@ -1,0 +1,1 @@
+MySQL/MariaDB pooled check-in now disposes the physical session after transaction, advisory-lock, and checkout-name cleanup, preventing arbitrary raw session state from leaking into a later checkout while preserving logical tenant-aware pool reuse.

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -38,6 +38,10 @@ When every allowed connection is checked out, additional checkouts wait for a co
 
 MySQL/MariaDB callers can cancel queued and in-flight statements with an `AbortSignal`, including ORM model queries and cross-tenant aggregates. See [Database Query Cancellation](database-query-cancellation.md) for the API and driver-specific behavior.
 
+MySQL/MariaDB raw SQL may intentionally use session-scoped features during one checked-out connection scope. Session variables, temporary tables, prepared statements, and changes such as `SET SESSION sql_mode = ...` remain available to later statements in that same `withConnections` callback. When the callback returns or throws, Velocious first rolls back any transaction left open, releases tracked advisory locks, and clears its checkout label. It then closes the underlying MySQL session instead of attempting unsafe blanket reset SQL. A later checkout can reuse the same logical pool entry and tenant/database identity, but its first query reconnects on a fresh physical session and cannot observe arbitrary state from the prior checkout. If either ordinary cleanup or physical-session disposal fails, the logical connection is removed from the reusable pool and the cleanup error is surfaced.
+
+This boundary does not make session state portable across separate `withConnections` calls. Code that needs a temporary table or another raw session feature must create and consume it within one connection scope.
+
 Velocious adds checkout names and active database annotations to SQL comments while a query is executing. This makes active queries easier to identify in process/activity views such as `SHOW FULL PROCESSLIST`, PostgreSQL `pg_stat_activity.query`, and SQL Server request SQL text:
 
 ```sql
@@ -58,7 +62,7 @@ await configuration.withConnections({name: "report export"}, async (dbs) => {
 
 Nested annotations are joined in order, for example `annotations="report export > invoice batch"`.
 
-For MySQL and MariaDB, Velocious also writes the active checkout name to the session variable `@velocious_connection_checkout_name`. The variable is reset to `NULL` when the connection is checked in, so inspecting server-side connection/session state can identify the code currently using a checked-out connection. MySQL/MariaDB do not expose a reliable dynamically-changeable idle process-list name through the current driver, so process-list checkout names are visible on active queries through the SQL comment.
+For MySQL and MariaDB, Velocious also writes the active checkout name to the session variable `@velocious_connection_checkout_name`. The variable is reset to `NULL` during check-in before the physical session is disposed, so inspecting server-side connection/session state can identify the code currently using a checked-out connection. MySQL/MariaDB do not expose a reliable dynamically-changeable idle process-list name through the current driver, so process-list checkout names are visible on active queries through the SQL comment.
 
 For PostgreSQL, Velocious sets `application_name` to the active checkout name and resets it when the connection is checked in. This exposes the checkout owner in `pg_stat_activity.application_name`, including idle checked-out sessions.
 

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -52,6 +52,49 @@ async function withMysqlConnection(callback) {
 }
 
 describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transaction: true}}, () => {
+  it("waits for the pool end callback before completing close", async () => {
+    const mysql = new DatabaseDriversMysql(mysqlConfig, configuration)
+    let endCallback
+    let closeCompleted = false
+
+    mysql.pool = /** @type {import("mysql").Pool} */ ({
+      end(callback) {
+        endCallback = callback
+      }
+    })
+
+    const closePromise = mysql._close().then(() => {
+      closeCompleted = true
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(closeCompleted).toBe(false)
+    expect(mysql.pool).not.toBe(undefined)
+
+    if (!endCallback) throw new Error("Expected pool end callback")
+    endCallback()
+    await closePromise
+
+    expect(closeCompleted).toBe(true)
+    expect(mysql.pool).toBe(undefined)
+  })
+
+  it("propagates pool end callback failures", async () => {
+    const mysql = new DatabaseDriversMysql(mysqlConfig, configuration)
+    const closeError = new Error("Pool end failed")
+
+    mysql.pool = /** @type {import("mysql").Pool} */ ({
+      end(callback) {
+        callback(closeError)
+      }
+    })
+
+    await expect(async () => {
+      await mysql._close()
+    }).toThrowError("Pool end failed")
+    expect(mysql.pool).not.toBe(undefined)
+  })
+
   it("connects", async () => {
     await withMysqlConnection(async (mysql) => {
       const result = await mysql.query("SELECT \"1\" AS test1, \"2\" AS test2")

--- a/spec/database/drivers/mysql/connection-spec.js
+++ b/spec/database/drivers/mysql/connection-spec.js
@@ -78,6 +78,22 @@ describe("Database - Drivers - Mysql - Connection", {databaseCleaning: {transact
     })
   })
 
+  it("preserves raw state until checkout cleanup and reconnects without it", async () => {
+    await withMysqlConnection(async (mysql) => {
+      const firstSession = await mysql.query("SELECT CONNECTION_ID() AS id")
+
+      await mysql.query("SET @velocious_raw_session_hygiene = 'checkout-owned'")
+      expect(await mysql.query("SELECT @velocious_raw_session_hygiene AS value")).toEqual([{value: "checkout-owned"}])
+
+      await mysql.cleanupSessionStateAfterCheckout()
+
+      const secondSession = await mysql.query("SELECT CONNECTION_ID() AS id, @velocious_raw_session_hygiene AS value")
+
+      expect(secondSession[0].id).not.toEqual(firstSession[0].id)
+      expect(secondSession[0].value).toBe(null)
+    })
+  })
+
   it("does not tag checkout-name session variable queries with process-list comments", async () => {
     const mysql = new QueryCapturingMysqlDriver(mysqlConfig, configuration)
 

--- a/spec/database/pool/async-tracked-multi-connection-mysql-checkout-name-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-mysql-checkout-name-spec.js
@@ -14,11 +14,20 @@ class CheckoutNameCapturingMysqlDriver extends MysqlDriver {
   /** @type {boolean} */
   static failClear = false
 
+  /** @type {boolean} */
+  static failSessionCleanup = false
+
   /** @type {string[]} */
   checkoutNameQueries = []
 
   /** @type {boolean} */
   closed = false
+
+  /** @type {string | undefined} */
+  rawSessionValue = undefined
+
+  /** @type {number} */
+  sessionGeneration = 1
 
   /** @returns {Promise<void>} - Resolves when connected. */
   async connect() {
@@ -28,6 +37,14 @@ class CheckoutNameCapturingMysqlDriver extends MysqlDriver {
   /** @returns {Promise<void>} - Resolves when closed. */
   async close() {
     this.closed = true
+  }
+
+  /** @returns {Promise<void>} - Disposes the physical session while preserving the logical driver. */
+  async cleanupSessionStateAfterCheckout() {
+    if (CheckoutNameCapturingMysqlDriver.failSessionCleanup) throw new Error("Session cleanup failed")
+
+    this.rawSessionValue = undefined
+    this.sessionGeneration++
   }
 
   /**
@@ -81,12 +98,61 @@ async function withMysqlCheckoutNamePool(callback) {
     await callback(pool)
   } finally {
     CheckoutNameCapturingMysqlDriver.failClear = false
+    CheckoutNameCapturingMysqlDriver.failSessionCleanup = false
     await configuration.closeDatabaseConnections()
     await fs.rm(directory, {force: true, recursive: true})
   }
 }
 
-describe("database - pool - async tracked multi connection MySQL checkout names", () => {
+describe("database - pool - async tracked multi connection MySQL checkout names", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("keeps raw session state within a checkout and disposes it before logical connection reuse", async () => {
+    await withMysqlCheckoutNamePool(async (pool) => {
+      let firstConnection
+      let firstSessionGeneration
+
+      try {
+        await pool.withConnection(async (connection) => {
+          firstConnection = /** @type {CheckoutNameCapturingMysqlDriver} */ (connection)
+          firstConnection.rawSessionValue = "checkout-owned"
+          firstSessionGeneration = firstConnection.sessionGeneration
+
+          expect(firstConnection.rawSessionValue).toBe("checkout-owned")
+
+          throw new Error("Raw session callback failed")
+        })
+      } catch (error) {
+        expect(forcedError(error).message).toBe("Raw session callback failed")
+      }
+
+      const secondConnection = /** @type {CheckoutNameCapturingMysqlDriver} */ (await pool.checkout())
+
+      expect(secondConnection).toBe(firstConnection)
+      expect(secondConnection.rawSessionValue).toBe(undefined)
+      expect(secondConnection.sessionGeneration).toBe(firstSessionGeneration + 1)
+
+      await pool.checkin(secondConnection)
+    })
+  })
+
+  it("disposes the logical connection when physical session disposal fails", async () => {
+    await withMysqlCheckoutNamePool(async (pool) => {
+      const connection = /** @type {CheckoutNameCapturingMysqlDriver} */ (await pool.checkout())
+
+      CheckoutNameCapturingMysqlDriver.failSessionCleanup = true
+
+      try {
+        await pool.checkin(connection)
+        throw new Error("Check-in unexpectedly succeeded")
+      } catch (error) {
+        expect(forcedError(error).message).toBe("Session cleanup failed")
+      }
+
+      expect(connection.closed).toBe(true)
+      expect(pool.connections).toEqual([])
+      expect(pool.connectionsInUse).toEqual({})
+    })
+  })
+
   it("does not issue checkout-name SQL for an unnamed lease", async () => {
     await withMysqlCheckoutNamePool(async (pool) => {
       const connection = /** @type {CheckoutNameCapturingMysqlDriver} */ (await pool.checkout())

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -234,6 +234,13 @@ export default class VelociousDatabaseDriversBase {
   }
 
   /**
+   * Cleans driver-specific session state before this logical connection is reusable.
+   * Drivers whose physical sessions cannot be safely reset should dispose them here.
+   * @returns {Promise<void>} - Resolves when the next checkout cannot observe prior session state.
+   */
+  async cleanupSessionStateAfterCheckout() {}
+
+  /**
    * Runs add foreign key.
    * @param {string} tableName - Table name.
    * @param {string} columnName - Column name.

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -65,7 +65,19 @@ export default class VelociousDatabaseDriversMysql extends Base{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async _close() {
-    await this.pool?.end()
+    const pool = this.pool
+
+    if (!pool) return
+
+    await new Promise((resolve, reject) => {
+      pool.end((error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(undefined)
+        }
+      })
+    })
     this.pool = undefined
     this.resetCurrentSessionTimeZone()
   }

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -71,6 +71,17 @@ export default class VelociousDatabaseDriversMysql extends Base{
   }
 
   /**
+   * Disposes the physical MySQL session after each logical pool checkout.
+   * MySQL exposes open-ended session state, so reconnecting is safer than trying
+   * to enumerate and reset variables, temporary tables, prepared statements,
+   * SQL modes, and other caller-controlled state.
+   * @returns {Promise<void>} - Resolves after the physical session is closed.
+   */
+  async cleanupSessionStateAfterCheckout() {
+    await this._close()
+  }
+
+  /**
    * Runs set connection checkout name.
    * @param {string | undefined} name - Human-readable name for this active checkout.
    * @returns {Promise<void>} - Resolves when complete.

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -150,6 +150,7 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       await this.rollbackLeftOpenTransaction(connection)
       await connection.releaseHeldAdvisoryLocks()
       await connection.clearConnectionCheckoutName()
+      await connection.cleanupSessionStateAfterCheckout()
     } catch (error) {
       await this.closeCheckedOutConnectionAfterCheckinFailure(connection, id, error)
       throw error


### PR DESCRIPTION
## Summary

- define raw MySQL/MariaDB session state as scoped to one logical checkout
- dispose the physical MySQL session after transaction, advisory-lock, and checkout-name cleanup while retaining the logical tenant-aware pool entry
- close and untrack poisoned logical connections when session disposal fails
- document the contract and add unit plus real-server-gated regressions

## Verification

- `npm test -- spec/database/pool/async-tracked-multi-connection-mysql-checkout-name-spec.js` — 7 successful, 0 failed
- exact CI-equivalent lint gate: copied `configuration.peakflow.sqlite.js`, then `npm run lint`, `npm run typecheck`, `npm run fallow` — passed; tracked configuration restored
- `npm run typecheck` — passed independently
- `npm run lint` — passed independently

## Limitation

The local approved dev container does not resolve the `mariadb` service hostname, so the real-server assertion in `spec/database/drivers/mysql/connection-spec.js` is driver-gated locally and will execute in the MySQL/MariaDB CI shard. The focused pool lifecycle regression runs without a server and covers callback throw, same-checkout state, logical reuse with a fresh session generation, and disposal failure.