### PR TITLE
Add first-class background job rescheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2345,6 +2345,26 @@ await MyJob.performLaterWithOptions({
 
 Until `scheduledAtMs` is reached, the job remains queued but is not eligible for dispatch. The event-driven dispatcher arms its timer for the earliest future job and wakes at that timestamp. Omitting `scheduledAtMs` keeps the immediate-enqueue behavior.
 
+A running job that cannot proceed yet can reschedule its same durable row without
+recording a failure—for example, when a non-blocking lock is busy:
+
+```js
+async perform(accountId) {
+  if (!(await Account.tryAcquireRefreshLock(accountId))) {
+    this.rescheduleIn(30_000)
+  }
+
+  await refreshAccount(accountId)
+}
+```
+
+`rescheduleIn(delayMs)` requires a finite, non-negative safe-integer millisecond
+delay and never returns: it stops the current `perform`, releases its worker and
+concurrency slots, and makes the same job eligible again after the delay. This is
+normal control flow, not failure retry: attempts and failure metadata remain
+unchanged, retries are not consumed, and failure/error events are not emitted.
+See [Rescheduling a running job](docs/background-jobs.md#rescheduling-a-running-job).
+
 Use a durable stable key when the same logical one-off schedule must be moved or cancelled without retaining its transient job id:
 
 ```js

--- a/changelog.d/20260812080500-background-job-reschedule.md
+++ b/changelog.d/20260812080500-background-job-reschedule.md
@@ -1,0 +1,1 @@
+Add `VelociousJob#rescheduleIn(delayMs)` for cleanly snoozing the same running background-job row when work cannot proceed yet. Rescheduling releases worker and durable concurrency capacity, preserves attempts and failure metadata, and does not emit failure/error events or consume retries.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -27,6 +27,37 @@ For delayed one-off work, see [Scheduling One-Off Background Jobs](scheduled-bac
 
 Logical one-off schedules that may be moved or cancelled can use `replaceScheduled` and `cancelScheduled` with a durable stable key. Queued replacement/cancellation is atomic across processes; a `handed_off` result is explicitly best-effort because running JavaScript is not interrupted. Consumers must pair the API with their own generation/revision check immediately before side effects. See [Replacing or cancelling a logical schedule](scheduled-background-job-enqueue.md#replacing-or-cancelling-a-logical-schedule).
 
+## Rescheduling a running job
+
+Use `this.rescheduleIn(delayMs)` when a running job cannot proceed yet but has not
+failed, such as when a non-blocking application lock is already held:
+
+```js
+export default class RefreshAccountJob extends VelociousJob {
+  async perform(accountId) {
+    if (!(await Account.tryAcquireRefreshLock(accountId))) {
+      this.rescheduleIn(30_000)
+    }
+
+    await refreshAccount(accountId)
+  }
+}
+```
+
+The delay must be a finite, non-negative safe integer in milliseconds. The method
+never returns: it ends the current performance, atomically returns the same
+durable job row to `queued`, schedules it relative to the time that transition is
+persisted, and releases both the executing worker slot and any durable concurrency
+reservation. The row keeps its id, arguments, queue, execution mode, stable
+schedule ownership, attempts, and failure metadata.
+
+Rescheduling is normal control flow and is deliberately separate from throwing an
+error. It does not consume `maxRetries`, increment `attempts`, set `lastError`, or
+emit `background-job-failed` / `all-error`. An invalid delay is an ordinary
+programming error and therefore follows normal job failure and retry behavior.
+Independent enqueues remain independent: rescheduling does not insert, merge, or
+delete rows, and `deduplicateWhileQueued` keeps its existing enqueue-time rules.
+
 ## Database connection scopes
 
 By default, a job receives the existing Velocious behavior: every active configured database is checked out for the duration of `perform`. Jobs that need a known subset should declare it on the job class:

--- a/spec/background-jobs/job-reschedule-spec.js
+++ b/spec/background-jobs/job-reschedule-spec.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+import { outputPathFor, startBackgroundJobs, waitForJobCompleted, waitForOutputJson } from "../helpers/background-jobs-helper.js"
+import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+describe("Background jobs - job reschedule", {databaseCleaning: {truncate: true}}, () => {
+  it("reuses the same row later without failure events in inline and pooled modes", async () => {
+    const {main, store, worker} = await startBackgroundJobs({workerOptions: {pooledRunnerCount: 1}})
+    const failures = []
+    const allErrors = []
+    const errorEvents = dummyConfiguration.getErrorEvents()
+    const onFailure = (payload) => failures.push(payload)
+    const onAllError = (payload) => allErrors.push(payload)
+    errorEvents.on("background-job-failed", onFailure)
+    errorEvents.on("all-error", onAllError)
+
+    try {
+      for (const executionMode of ["inline", "pooled"]) {
+        const outputPath = await outputPathFor(`job-reschedule-${executionMode}`)
+        const jobId = await store.enqueue({
+          jobName: "RescheduleTestJob",
+          args: [outputPath, 100],
+          options: {executionMode}
+        })
+
+        await main._drain()
+        await waitForJobCompleted({jobId, store})
+
+        expect(await waitForOutputJson({outputPath})).toEqual({runs: 2})
+        expect(await store.getJob(jobId)).toMatchObject({id: jobId, status: "completed", attempts: 0, lastError: null})
+      }
+
+      expect(failures).toEqual([])
+      expect(allErrors).toEqual([])
+    } finally {
+      errorEvents.off("background-job-failed", onFailure)
+      errorEvents.off("all-error", onAllError)
+      await worker.stop({timeoutMs: 1000})
+      await main.stop()
+    }
+  })
+
+  it("treats an invalid delay as an ordinary job failure", async () => {
+    const {main, store, worker} = await startBackgroundJobs()
+    const outputPath = await outputPathFor("job-reschedule-invalid")
+    const jobId = await store.enqueue({
+      jobName: "RescheduleTestJob",
+      args: [outputPath, -1],
+      options: {executionMode: "inline", maxRetries: 0}
+    })
+
+    try {
+      await main._drain()
+      await waitForOutputJson({outputPath})
+      await timeout({timeout: 2000}, async () => {
+        while ((await store.getJob(jobId))?.status !== "failed") await wait(0.01)
+      })
+
+      expect(await store.getJob(jobId)).toMatchObject({status: "failed", attempts: 1})
+    } finally {
+      await worker.stop({timeoutMs: 1000})
+      await main.stop()
+    }
+  })
+})

--- a/spec/background-jobs/job-runner-reschedule-retry-spec.js
+++ b/spec/background-jobs/job-runner-reschedule-retry-spec.js
@@ -1,0 +1,91 @@
+// @ts-check
+
+import fs from "node:fs/promises"
+import net from "node:net"
+import path from "node:path"
+import {fileURLToPath, pathToFileURL} from "node:url"
+import Configuration, {CurrentConfigurationNotSetError} from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import JsonSocket from "../../src/background-jobs/json-socket.js"
+import runJobPayload from "../../src/background-jobs/job-runner.js"
+import SqliteDriver from "../../src/database/drivers/sqlite/index.js"
+import SingleMultiUsePool from "../../src/database/pool/single-multi-use.js"
+
+/** @returns {string} - Repository root. */
+function repoRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+}
+
+describe("Background jobs - runner reschedule retry", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("retries a transient persistence rejection with the same reschedule outcome and delay", async () => {
+    const directory = path.join(repoRoot(), "tmp", `job-runner-reschedule-${Date.now()}`)
+    await fs.mkdir(path.join(directory, "src", "jobs"), {recursive: true})
+    await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+    const jobPath = pathToFileURL(path.join(repoRoot(), "src", "background-jobs", "job.js")).href
+    await fs.writeFile(path.join(directory, "src", "jobs", "reschedule-job.js"), `import VelociousJob from ${JSON.stringify(jobPath)}
+export default class RescheduleJob extends VelociousJob {
+  async perform() { this.rescheduleIn(1234) }
+}
+`)
+
+    /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobSocketMessage>} */
+    const messages = []
+    const server = net.createServer((socket) => {
+      const jsonSocket = new JsonSocket(socket)
+      jsonSocket.on("message", (message) => {
+        if (message?.type !== "job-reschedule" && message?.type !== "job-failed") return
+        messages.push(message)
+        if (messages.length === 1) {
+          jsonSocket.send({type: "job-update-error", jobId: message.jobId, error: "Transient persistence rejection"})
+        } else {
+          jsonSocket.send({type: "job-updated", jobId: message.jobId})
+        }
+      })
+    })
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("Expected fake main port")
+
+    const configuration = new Configuration({
+      backgroundJobs: {host: "127.0.0.1", port: address.port},
+      database: {test: {default: {driver: SqliteDriver, poolType: SingleMultiUsePool, type: "sqlite", name: "job-runner-reschedule", migrations: false}}},
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    /** @type {Configuration | undefined} */
+    let previousConfiguration
+    try {
+      previousConfiguration = Configuration.current()
+    } catch (error) {
+      if (!(error instanceof CurrentConfigurationNotSetError)) throw error
+    }
+
+    try {
+      configuration.setCurrent()
+      expect(await runJobPayload({
+        id: "job-1",
+        jobName: "RescheduleJob",
+        args: [],
+        handoffId: "handoff-1",
+        handedOffAtMs: 42,
+        workerId: "worker-1"
+      }, {closeConnections: false})).toEqual("rescheduled")
+
+      expect(messages).toEqual([
+        {type: "job-reschedule", jobId: "job-1", delayMs: 1234, handoffId: "handoff-1", handedOffAtMs: 42, workerId: "worker-1"},
+        {type: "job-reschedule", jobId: "job-1", delayMs: 1234, handoffId: "handoff-1", handedOffAtMs: 42, workerId: "worker-1"}
+      ])
+    } finally {
+      previousConfiguration?.setCurrent()
+      await configuration.disconnectBeacon()
+      await configuration.closeDatabaseConnections()
+      await new Promise((resolve) => server.close(() => resolve(undefined)))
+      await fs.rm(directory, {recursive: true, force: true})
+    }
+  })
+})

--- a/spec/background-jobs/main-reschedule-error-spec.js
+++ b/spec/background-jobs/main-reschedule-error-spec.js
@@ -2,7 +2,6 @@
 
 import BackgroundJobsMain from "../../src/background-jobs/main.js"
 import BackgroundJobsStore from "../../src/background-jobs/store.js"
-import JsonSocket from "../../src/background-jobs/json-socket.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 
 class FailingRescheduleStore extends BackgroundJobsStore {
@@ -34,7 +33,7 @@ describe("Background jobs - main reschedule errors", () => {
 
     try {
       await main._handleJobReschedule({
-        jsonSocket: /** @type {JsonSocket} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: (message) => sent.push(message)})),
+        jsonSocket: /** @type {import("../../src/background-jobs/json-socket.js").default} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: (message) => sent.push(message)})),
         message: {type: "job-reschedule", jobId: "job-1", delayMs: 1_000}
       })
     } finally {

--- a/spec/background-jobs/main-reschedule-error-spec.js
+++ b/spec/background-jobs/main-reschedule-error-spec.js
@@ -1,0 +1,49 @@
+// @ts-check
+
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import JsonSocket from "../../src/background-jobs/json-socket.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+class FailingRescheduleStore extends BackgroundJobsStore {
+  /** @returns {Promise<boolean>} - Always rejects like a persistence failure. */
+  async markRescheduled() {
+    throw new Error("Reschedule persistence failed")
+  }
+}
+
+class MainWithFailingRescheduleStore extends BackgroundJobsMain {
+  /** @param {ConstructorParameters<typeof BackgroundJobsMain>[0]} args - Main options. */
+  constructor(args) {
+    super(args)
+    this.store = new FailingRescheduleStore({configuration: args.configuration})
+  }
+}
+
+describe("Background jobs - main reschedule errors", () => {
+  it("reports an unexpected persistence error while retaining the retry response", async () => {
+    const main = new MainWithFailingRescheduleStore({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+    const sent = []
+    const frameworkErrors = []
+    const allErrors = []
+    const errorEvents = dummyConfiguration.getErrorEvents()
+    const onFrameworkError = (payload) => frameworkErrors.push(payload)
+    const onAllError = (payload) => allErrors.push(payload)
+    errorEvents.on("framework-error", onFrameworkError)
+    errorEvents.on("all-error", onAllError)
+
+    try {
+      await main._handleJobReschedule({
+        jsonSocket: /** @type {JsonSocket} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: (message) => sent.push(message)})),
+        message: {type: "job-reschedule", jobId: "job-1", delayMs: 1_000}
+      })
+    } finally {
+      errorEvents.off("framework-error", onFrameworkError)
+      errorEvents.off("all-error", onAllError)
+    }
+
+    expect(sent).toEqual([{type: "job-update-error", jobId: "job-1", error: "Failed to update job"}])
+    expect(frameworkErrors).toMatchObject([{context: {jobId: "job-1", stage: "background-job-reschedule"}, error: {message: "Reschedule persistence failed"}}])
+    expect(allErrors).toMatchObject([{context: {jobId: "job-1", stage: "background-job-reschedule"}, error: {message: "Reschedule persistence failed"}, errorType: "framework-error"}])
+  })
+})

--- a/spec/background-jobs/store-reschedule-spec.js
+++ b/spec/background-jobs/store-reschedule-spec.js
@@ -3,6 +3,19 @@
 import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 
+class DelayedSerializedStore extends BackgroundJobsStore {
+  /** @type {(() => void) | undefined} */
+  beforeNextSerializedMutation
+
+  /** @param {import("../../src/database/drivers/base.js").default} db - Database. @param {Function} callback - Mutation callback. */
+  async _serializedCountMutation(db, callback) {
+    const beforeMutation = this.beforeNextSerializedMutation
+    this.beforeNextSerializedMutation = undefined
+    beforeMutation?.()
+    return await super._serializedCountMutation(db, callback)
+  }
+}
+
 /** @returns {Promise<BackgroundJobsStore>} - Empty background jobs store. */
 async function createStore() {
   dummyConfiguration.setCurrent()
@@ -74,5 +87,26 @@ describe("Background jobs - store reschedule", {databaseCleaning: {truncate: tru
     expect(await store.markRescheduled({jobId, delayMs: 1_000, workerId: "worker-2", ...second})).toEqual(false)
     expect(await store.markRescheduled({jobId: "missing", delayMs: 1_000, workerId: "worker-2", ...second})).toEqual(false)
     expect(await store.getJob(jobId)).toMatchObject({status: "completed", attempts: 0})
+  })
+
+  it("starts the requested delay after waiting to enter the serialized mutation", async () => {
+    dummyConfiguration.setCurrent()
+    const store = new DelayedSerializedStore({configuration: dummyConfiguration})
+    await store.clearAll()
+    const jobId = await store.enqueue({jobName: "RefreshJob", args: [], options: {}})
+    const handoff = await store.markHandedOff({jobId, workerId: "worker-1"})
+    if (!handoff) throw new Error("Expected job handoff")
+    const originalNow = Date.now
+    let now = 1_000_000
+    Date.now = () => now
+    store.beforeNextSerializedMutation = () => { now += 5_000 }
+
+    try {
+      await store.markRescheduled({jobId, delayMs: 10_000, workerId: "worker-1", ...handoff})
+    } finally {
+      Date.now = originalNow
+    }
+
+    expect(await store.getJob(jobId)).toMatchObject({scheduledAtMs: 1_015_000})
   })
 })

--- a/spec/background-jobs/store-reschedule-spec.js
+++ b/spec/background-jobs/store-reschedule-spec.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+
+/** @returns {Promise<BackgroundJobsStore>} - Empty background jobs store. */
+async function createStore() {
+  dummyConfiguration.setCurrent()
+  const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+  await store.clearAll()
+  return store
+}
+
+describe("Background jobs - store reschedule", {databaseCleaning: {truncate: true}}, () => {
+  it("reschedules the same active handoff without recording a failure and releases concurrency", async () => {
+    const store = await createStore()
+    const scheduled = await store.replaceScheduled({
+      scheduleKey: "refresh:account-1",
+      jobName: "RefreshJob",
+      args: ["account-1"],
+      options: {concurrencyKey: "refresh", maxConcurrency: 1}
+    })
+    const waitingId = await store.enqueue({
+      jobName: "RefreshJob",
+      args: ["account-2"],
+      options: {concurrencyKey: "refresh", maxConcurrency: 1}
+    })
+    const handoff = await store.markHandedOff({jobId: scheduled.jobId, workerId: "worker-1"})
+    if (!handoff) throw new Error("Expected the scheduled job handoff")
+    const before = Date.now()
+
+    const accepted = await store.markRescheduled({
+      jobId: scheduled.jobId,
+      delayMs: 60_000,
+      workerId: "worker-1",
+      ...handoff
+    })
+
+    const job = await store.getJob(scheduled.jobId)
+    expect(accepted).toEqual(true)
+    expect(job).toMatchObject({
+      id: scheduled.jobId,
+      args: ["account-1"],
+      attempts: 0,
+      lastError: null,
+      failedAtMs: null,
+      orphanedAtMs: null,
+      scheduleKey: "refresh:account-1",
+      status: "queued"
+    })
+    expect(job?.scheduledAtMs).toBeGreaterThanOrEqual(before + 60_000)
+    expect(await store.nextAvailableJob()).toMatchObject({id: waitingId})
+    expect(await store.nextScheduledJob()).toMatchObject({id: scheduled.jobId})
+    expect(await store.markHandedOff({jobId: waitingId, workerId: "worker-2"})).not.toBeNull()
+  })
+
+  it("ignores stale and terminal reschedule reports without releasing a newer reservation", async () => {
+    const store = await createStore()
+    const jobId = await store.enqueue({
+      jobName: "RefreshJob",
+      args: [],
+      options: {concurrencyKey: "refresh", maxConcurrency: 1}
+    })
+    const first = await store.markHandedOff({jobId, workerId: "worker-1"})
+    if (!first) throw new Error("Expected the first handoff")
+    await store.markReturnedToQueue({jobId, handoffId: first.handoffId})
+    const second = await store.markHandedOff({jobId, workerId: "worker-2"})
+    if (!second) throw new Error("Expected the second handoff")
+
+    expect(await store.markRescheduled({jobId, delayMs: 1_000, workerId: "worker-1", ...first})).toEqual(false)
+    expect(await store.getJob(jobId)).toMatchObject({status: "handed_off", handoffId: second.handoffId})
+
+    await store.markCompleted({jobId, workerId: "worker-2", ...second})
+    expect(await store.markRescheduled({jobId, delayMs: 1_000, workerId: "worker-2", ...second})).toEqual(false)
+    expect(await store.markRescheduled({jobId: "missing", delayMs: 1_000, workerId: "worker-2", ...second})).toEqual(false)
+    expect(await store.getJob(jobId)).toMatchObject({status: "completed", attempts: 0})
+  })
+})

--- a/spec/dummy/src/jobs/reschedule-test-job.js
+++ b/spec/dummy/src/jobs/reschedule-test-job.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+import fs from "node:fs/promises"
+import VelociousJob from "../../../../src/background-jobs/job.js"
+
+export default class RescheduleTestJob extends VelociousJob {
+  /** @param {string} outputPath - Output file. @param {number} delayMs - Reschedule delay. */
+  async perform(outputPath, delayMs) {
+    let runs = 0
+    try {
+      runs = JSON.parse(await fs.readFile(outputPath, "utf8")).runs
+    } catch (error) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error
+    }
+
+    runs += 1
+    await fs.writeFile(outputPath, JSON.stringify({runs}))
+    if (runs === 1) this.rescheduleIn(delayMs)
+  }
+}

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -3,6 +3,7 @@
 import configurationResolver from "../configuration-resolver.js"
 import BackgroundJobRegistry from "./job-registry.js"
 import BackgroundJobsStatusReporter from "./status-reporter.js"
+import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
 
 const BEACON_READY_TIMEOUT_MS = 5000
 
@@ -79,7 +80,7 @@ function runnerProcessTitle(JobClass, payload) {
  * @param {object} [options] - Runner options.
  * @param {boolean} [options.closeConnections] - Whether to gracefully close framework connections after the job.
  * @param {boolean} [options.manageProcessTitle] - Whether to set the per-job process title and restore it afterwards. Off for concurrent pooled runners, where interleaved snapshot/restore of the single process-wide `process.title` would corrupt it; the pooled child owns an aggregate title instead.
- * @returns {Promise<void>} - Resolves when complete.
+ * @returns {Promise<"completed" | "rescheduled">} - Acknowledged outcome.
  */
 export default async function runJobPayload(payload, {closeConnections = true, manageProcessTitle = true} = {}) {
   const configuration = await configurationResolver()
@@ -109,6 +110,22 @@ export default async function runJobPayload(payload, {closeConnections = true, m
         await perform.apply(jobInstance, payload.args || [])
       })
     } catch (error) {
+      if (error instanceof BackgroundJobRescheduleSignal) {
+        if (payload.id) {
+          await reporter.reportWithRetry({
+            jobId: payload.id,
+            status: "rescheduled",
+            delayMs: error.delayMs,
+            handoffId: payload.handoffId,
+            workerId: payload.workerId,
+            handedOffAtMs: payload.handedOffAtMs,
+            maxDurationMs: 30000
+          })
+        }
+
+        return "rescheduled"
+      }
+
       const performedError = error instanceof Error ? error : new Error(String(error))
       if (payload.id) {
         await reporter.reportWithRetry({
@@ -135,6 +152,7 @@ export default async function runJobPayload(payload, {closeConnections = true, m
         maxDurationMs: 30000
       })
     }
+    return "completed"
   } finally {
     // Restore the runner's base title so a lingering/idle runner (or a reused
     // one) doesn't misreport a finished job as still running.

--- a/src/background-jobs/job-runner.js
+++ b/src/background-jobs/job-runner.js
@@ -119,7 +119,8 @@ export default async function runJobPayload(payload, {closeConnections = true, m
             handoffId: payload.handoffId,
             workerId: payload.workerId,
             handedOffAtMs: payload.handedOffAtMs,
-            maxDurationMs: 30000
+            maxDurationMs: 30000,
+            retryPersistErrors: true
           })
         }
 

--- a/src/background-jobs/job.js
+++ b/src/background-jobs/job.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import BackgroundJobsClient from "./client.js"
+import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
 
 /**
  * Base class for background jobs.
@@ -42,6 +43,20 @@ export default class VelociousJob {
    * @type {string | undefined}
    */
   static processTitle = undefined
+
+  /**
+   * Stops this performance and reschedules the same logical job row. This is
+   * normal control flow: it does not count as a failure or consume a retry.
+   * @param {number} delayMs - Non-negative safe-integer delay in milliseconds.
+   * @returns {never} - This method never returns.
+   */
+  rescheduleIn(delayMs) {
+    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+      throw new TypeError("background job reschedule delayMs must be a non-negative safe integer")
+    }
+
+    throw new BackgroundJobRescheduleSignal(delayMs)
+  }
 
   /**
    * Runs job name.

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -601,6 +601,11 @@ export default class BackgroundJobsMain {
 
     if (message?.type === "job-failed") {
       this._handleJobFailed({jsonSocket, message})
+      return
+    }
+
+    if (message?.type === "job-reschedule") {
+      this._handleJobReschedule({jsonSocket, message})
     }
   }
 
@@ -881,6 +886,34 @@ export default class BackgroundJobsMain {
       jsonSocket.send({type: "job-updated", jobId: message.jobId})
     } catch (error) {
       this.logger.error(() => ["Failed to update job completion:", error])
+      jsonSocket.send({type: "job-update-error", jobId: message.jobId, error: "Failed to update job"})
+    }
+  }
+
+  /**
+   * Persists a normal job reschedule outcome and wakes scheduled dispatch.
+   * @param {object} args - Options.
+   * @param {JsonSocket} args.jsonSocket - JSON socket.
+   * @param {import("./types.js").BackgroundJobRescheduleMessage} args.message - Message.
+   * @returns {Promise<void>} - Resolves when handled.
+   */
+  async _handleJobReschedule({jsonSocket, message}) {
+    try {
+      const accepted = await this.store.markRescheduled({
+        jobId: message.jobId,
+        delayMs: message.delayMs,
+        handoffId: message.handoffId,
+        workerId: message.workerId,
+        handedOffAtMs: message.handedOffAtMs
+      })
+      if (accepted && message.handoffId) {
+        this._forgetHandoff({handoffId: message.handoffId, jobId: message.jobId})
+      }
+      jsonSocket.send({type: "job-updated", jobId: message.jobId})
+      this._notifyEnqueued()
+      await this._drain()
+    } catch (error) {
+      this.logger.error(() => ["Failed to update job reschedule:", error])
       jsonSocket.send({type: "job-update-error", jobId: message.jobId, error: "Failed to update job"})
     }
   }

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -913,7 +913,13 @@ export default class BackgroundJobsMain {
       this._notifyEnqueued()
       await this._drain()
     } catch (error) {
-      this.logger.error(() => ["Failed to update job reschedule:", error])
+      const normalizedError = error instanceof Error ? error : new Error(String(error))
+      const payload = {context: {jobId: message.jobId, stage: "background-job-reschedule"}, error: normalizedError}
+      const errorEvents = this.configuration.getErrorEvents()
+
+      this.logger.error(() => ["Failed to update job reschedule:", normalizedError])
+      errorEvents.emit("framework-error", payload)
+      errorEvents.emit("all-error", {...payload, errorType: "framework-error"})
       jsonSocket.send({type: "job-update-error", jobId: message.jobId, error: "Failed to update job"})
     }
   }

--- a/src/background-jobs/pooled-runner-child.js
+++ b/src/background-jobs/pooled-runner-child.js
@@ -65,7 +65,7 @@ function isJobMessage(message) {
  * @param {object} args - Outcome.
  * @param {string} args.jobId - Job id.
  * @param {boolean} args.acknowledged - Whether the terminal report was acknowledged.
- * @param {"completed" | "failed"} [args.status] - Acknowledged terminal status.
+ * @param {"completed" | "failed" | "rescheduled"} [args.status] - Acknowledged outcome.
  * @param {Error} [args.error] - Reporting error when acknowledgement was not obtained.
  * @returns {Promise<void>} - Resolves after IPC accepts the message.
  */
@@ -99,8 +99,8 @@ function sendOutcome({jobId, acknowledged, status, error}) {
  */
 async function runJob(payload) {
   try {
-    await runJobPayload(payload, {closeConnections: false, manageProcessTitle: false})
-    await sendOutcome({jobId: payload.id, acknowledged: true, status: "completed"})
+    const status = await runJobPayload(payload, {closeConnections: false, manageProcessTitle: false})
+    await sendOutcome({jobId: payload.id, acknowledged: true, status})
   } catch (error) {
     if (error instanceof BackgroundJobPerformedFailure) {
       await sendOutcome({jobId: payload.id, acknowledged: true, status: "failed"})

--- a/src/background-jobs/reschedule-signal.js
+++ b/src/background-jobs/reschedule-signal.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+/** Internal control flow raised by `VelociousJob#rescheduleIn`. */
+export default class BackgroundJobRescheduleSignal extends Error {
+  /** @param {number} delayMs - Reschedule delay in milliseconds. */
+  constructor(delayMs) {
+    super(`Reschedule background job in ${delayMs}ms`)
+    this.name = "BackgroundJobRescheduleSignal"
+    this.delayMs = delayMs
+  }
+}

--- a/src/background-jobs/reschedule-signal.js
+++ b/src/background-jobs/reschedule-signal.js
@@ -2,7 +2,10 @@
 
 /** Internal control flow raised by `VelociousJob#rescheduleIn`. */
 export default class BackgroundJobRescheduleSignal extends Error {
-  /** @param {number} delayMs - Reschedule delay in milliseconds. */
+  /**
+   * Creates a reschedule control signal.
+   * @param {number} delayMs - Reschedule delay in milliseconds.
+   */
   constructor(delayMs) {
     super(`Reschedule background job in ${delayMs}ms`)
     this.name = "BackgroundJobRescheduleSignal"

--- a/src/background-jobs/status-reporter.js
+++ b/src/background-jobs/status-reporter.js
@@ -36,14 +36,15 @@ export default class BackgroundJobsStatusReporter {
    * Runs report.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
-   * @param {"completed" | "failed"} args.status - Status.
+   * @param {"completed" | "failed" | "rescheduled"} args.status - Status.
+   * @param {number} [args.delayMs] - Reschedule delay in milliseconds.
    * @param {ReturnType<typeof JSON.parse>} [args.error] - Error.
    * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @param {string} [args.workerId] - Worker id.
    * @returns {Promise<void>} - Resolves when reported.
    */
-  async report({jobId, status, error, handoffId, handedOffAtMs, workerId}) {
+  async report({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId}) {
     const config = this.configuration.getBackgroundJobsConfig()
     const host = this.host || config.host
     const port = typeof this.port === "number" ? this.port : config.port
@@ -57,8 +58,9 @@ export default class BackgroundJobsStatusReporter {
         signal: control.signal,
         onConnect: (jsonSocket) => {
           jsonSocket.send({
-            type: status === "completed" ? "job-complete" : "job-failed",
+            type: status === "completed" ? "job-complete" : status === "rescheduled" ? "job-reschedule" : "job-failed",
             jobId,
+            delayMs,
             handoffId,
             workerId,
             handedOffAtMs,
@@ -83,7 +85,8 @@ export default class BackgroundJobsStatusReporter {
    * Runs report with retry.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
-   * @param {"completed" | "failed"} args.status - Status.
+   * @param {"completed" | "failed" | "rescheduled"} args.status - Status.
+   * @param {number} [args.delayMs] - Reschedule delay in milliseconds.
    * @param {ReturnType<typeof JSON.parse>} [args.error] - Error.
    * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
@@ -92,13 +95,13 @@ export default class BackgroundJobsStatusReporter {
    * @param {boolean} [args.retryPersistErrors] - Retry a `BackgroundJobUpdateError` (main's `job-update-error`, i.e. a transient DB failure while persisting the terminal status) instead of throwing immediately. Off by default so short-lived forked/spawned runners keep failing loudly and exit non-zero to be reclaimed; on for the long-lived worker, which cannot exit-to-reclaim and would otherwise strand the job in `handed_off`.
    * @returns {Promise<void>} - Resolves when reported.
    */
-  async reportWithRetry({jobId, status, error, handoffId, handedOffAtMs, workerId, maxDurationMs, retryPersistErrors = false}) {
+  async reportWithRetry({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId, maxDurationMs, retryPersistErrors = false}) {
     let attempt = 0
     const startTime = Date.now()
 
     while (true) {
       try {
-        await this.report({jobId, status, error, handoffId, handedOffAtMs, workerId})
+        await this.report({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId})
         return
       } catch (error) {
         // A `BackgroundJobUpdateError` means main answered `job-update-error`, which it

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -707,7 +707,7 @@ export default class BackgroundJobsStore {
    */
   async markRescheduled({jobId, delayMs, handoffId, workerId, handedOffAtMs}) {
     await this.ensureReady()
-    const scheduledAtMs = this._rescheduledAtMs(delayMs)
+    this._validateRescheduleDelayMs(delayMs)
 
     return await this._withDb(async (db) => await this._serializedCountMutation(db, async () => {
       const job = await this._getJobRowById(db, jobId)
@@ -716,6 +716,7 @@ export default class BackgroundJobsStore {
       if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return false
 
       await this._lockConcurrencyRow(db, job.concurrencyKey)
+      const scheduledAtMs = this._rescheduledAtMs(delayMs)
       const affectedRows = await this._updateAffectedRows(db, {
         tableName: JOBS_TABLE,
         data: {
@@ -1114,9 +1115,7 @@ export default class BackgroundJobsStore {
    * @returns {number} - Future eligibility timestamp.
    */
   _rescheduledAtMs(delayMs) {
-    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
-      throw VelociousError.safe("background job reschedule delayMs must be a non-negative safe integer")
-    }
+    this._validateRescheduleDelayMs(delayMs)
 
     const scheduledAtMs = Date.now() + delayMs
     if (!Number.isSafeInteger(scheduledAtMs)) {
@@ -1124,6 +1123,17 @@ export default class BackgroundJobsStore {
     }
 
     return scheduledAtMs
+  }
+
+  /**
+   * Validates a public reschedule delay before persistence work begins.
+   * @param {number} delayMs - Delay in milliseconds.
+   * @returns {void}
+   */
+  _validateRescheduleDelayMs(delayMs) {
+    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+      throw VelociousError.safe("background job reschedule delayMs must be a non-negative safe integer")
+    }
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -695,6 +695,47 @@ export default class BackgroundJobsStore {
   }
 
   /**
+   * Returns an active handoff to the queue at a caller-requested future time.
+   * This is normal job control flow: it preserves failure attempts and metadata.
+   * @param {object} args - Options.
+   * @param {string} args.jobId - Job id.
+   * @param {number} args.delayMs - Delay from persistence time in milliseconds.
+   * @param {string} [args.handoffId] - Handoff lease id.
+   * @param {string} [args.workerId] - Worker id.
+   * @param {number} [args.handedOffAtMs] - Handed off timestamp.
+   * @returns {Promise<boolean>} - Whether the fenced report was accepted.
+   */
+  async markRescheduled({jobId, delayMs, handoffId, workerId, handedOffAtMs}) {
+    await this.ensureReady()
+    const scheduledAtMs = this._rescheduledAtMs(delayMs)
+
+    return await this._withDb(async (db) => await this._serializedCountMutation(db, async () => {
+      const job = await this._getJobRowById(db, jobId)
+
+      if (!job) return false
+      if (!this._shouldAcceptReport({job, handoffId, workerId, handedOffAtMs})) return false
+
+      await this._lockConcurrencyRow(db, job.concurrencyKey)
+      const affectedRows = await this._updateAffectedRows(db, {
+        tableName: JOBS_TABLE,
+        data: {
+          status: "queued",
+          scheduled_at_ms: scheduledAtMs,
+          handed_off_at_ms: null,
+          handoff_id: null,
+          worker_id: null
+        },
+        conditions: this._activeHandoffConditions(job)
+      })
+
+      if (affectedRows !== 1) return false
+      await this._releaseConcurrency(db, job.concurrencyKey)
+      await this._recordStatusTransition(db, "handed_off", "queued")
+      return true
+    }))
+  }
+
+  /**
    * Runs mark returned to queue.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
@@ -1065,6 +1106,24 @@ export default class BackgroundJobsStore {
     if (Number.isSafeInteger(scheduledAtMs) && scheduledAtMs >= 0) return scheduledAtMs
 
     throw VelociousError.safe("background job scheduledAtMs must be a non-negative safe integer")
+  }
+
+  /**
+   * Resolves a reschedule delay against persistence time.
+   * @param {number} delayMs - Delay in milliseconds.
+   * @returns {number} - Future eligibility timestamp.
+   */
+  _rescheduledAtMs(delayMs) {
+    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+      throw VelociousError.safe("background job reschedule delayMs must be a non-negative safe integer")
+    }
+
+    const scheduledAtMs = Date.now() + delayMs
+    if (!Number.isSafeInteger(scheduledAtMs)) {
+      throw VelociousError.safe("background job reschedule scheduledAtMs must be a safe integer")
+    }
+
+    return scheduledAtMs
   }
 
   /**

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -99,11 +99,12 @@
  * @typedef {{type: "job", payload: BackgroundJobPayload}} BackgroundJobJobMessage
  * @typedef {{type: "job-complete", jobId: string, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobCompleteMessage
  * @typedef {{type: "job-failed", jobId: string, error?: ReturnType<typeof JSON.parse>, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobFailedMessage
+ * @typedef {{type: "job-reschedule", jobId: string, delayMs: number, handoffId?: string, workerId?: string, handedOffAtMs?: number}} BackgroundJobRescheduleMessage
  * @typedef {{type: "job-updated", jobId: string}} BackgroundJobUpdatedMessage
  * @typedef {{type: "job-update-error", jobId: string, error?: string}} BackgroundJobUpdateErrorMessage
  */
 /**
- * @typedef {BackgroundJobHelloMessage | BackgroundJobReadyMessage | BackgroundJobDrainingMessage | BackgroundJobHeartbeatMessage | BackgroundJobEnqueueMessage | BackgroundJobEnqueuedMessage | BackgroundJobEnqueueErrorMessage | BackgroundJobReplaceScheduledMessage | BackgroundJobScheduleReplacedMessage | BackgroundJobReplaceScheduledErrorMessage | BackgroundJobCancelScheduledMessage | BackgroundJobScheduleCancelledMessage | BackgroundJobCancelScheduledErrorMessage | BackgroundJobJobMessage | BackgroundJobCompleteMessage | BackgroundJobFailedMessage | BackgroundJobUpdatedMessage | BackgroundJobUpdateErrorMessage} BackgroundJobSocketMessage
+ * @typedef {BackgroundJobHelloMessage | BackgroundJobReadyMessage | BackgroundJobDrainingMessage | BackgroundJobHeartbeatMessage | BackgroundJobEnqueueMessage | BackgroundJobEnqueuedMessage | BackgroundJobEnqueueErrorMessage | BackgroundJobReplaceScheduledMessage | BackgroundJobScheduleReplacedMessage | BackgroundJobReplaceScheduledErrorMessage | BackgroundJobCancelScheduledMessage | BackgroundJobScheduleCancelledMessage | BackgroundJobCancelScheduledErrorMessage | BackgroundJobJobMessage | BackgroundJobCompleteMessage | BackgroundJobFailedMessage | BackgroundJobRescheduleMessage | BackgroundJobUpdatedMessage | BackgroundJobUpdateErrorMessage} BackgroundJobSocketMessage
  */
 
 export const nothing = {}

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -9,6 +9,7 @@ import BackgroundJobsStatusReporter from "./status-reporter.js"
 import {randomUUID} from "crypto"
 import {fileURLToPath} from "node:url"
 import shutdownLifecycle from "../utils/shutdown-lifecycle.js"
+import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
 
 /**
  * Per-forked-child timeout bookkeeping.
@@ -574,6 +575,18 @@ export default class BackgroundJobsWorker {
         workerId: payload.workerId || this.workerId
       })
     } catch (error) {
+      if (error instanceof BackgroundJobRescheduleSignal) {
+        this._reportJobResultInBackground({
+          jobId: payload.id,
+          status: "rescheduled",
+          delayMs: error.delayMs,
+          handoffId: payload.handoffId,
+          handedOffAtMs: payload.handedOffAtMs,
+          workerId: payload.workerId || this.workerId
+        })
+        return
+      }
+
       this._reportJobResultInBackground({
         jobId: payload.id,
         status: "failed",
@@ -1233,14 +1246,15 @@ export default class BackgroundJobsWorker {
    * Runs report job result.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
-   * @param {"completed" | "failed"} args.status - Status.
+   * @param {"completed" | "failed" | "rescheduled"} args.status - Status.
+   * @param {number} [args.delayMs] - Reschedule delay in milliseconds.
    * @param {ReturnType<typeof JSON.parse>} [args.error] - Error.
    * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @param {string} [args.workerId] - Worker id.
    * @returns {Promise<void>} - Resolves when reported.
    */
-  async _reportJobResult({jobId, status, error, handoffId, handedOffAtMs, workerId}) {
+  async _reportJobResult({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId}) {
     if (!this.statusReporter) return
 
     try {
@@ -1248,7 +1262,7 @@ export default class BackgroundJobsWorker {
       // long-lived and cannot exit to trigger orphan reclaim, so dropping the
       // completion here would strand the job in `handed_off` forever — fatal for a
       // `max_concurrency: 1` job (a stranded row blocks every future run).
-      await this.statusReporter.reportWithRetry({jobId, status, error, handoffId, handedOffAtMs, workerId, retryPersistErrors: true})
+      await this.statusReporter.reportWithRetry({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId, retryPersistErrors: true})
     } catch (reportError) {
       console.error("Background job status reporting failed:", reportError)
     }
@@ -1260,20 +1274,21 @@ export default class BackgroundJobsWorker {
    * graceful `stop()` can drain in-flight reports before closing the socket.
    * @param {object} args - Options.
    * @param {string} args.jobId - Job id.
-   * @param {"completed" | "failed"} args.status - Status.
+   * @param {"completed" | "failed" | "rescheduled"} args.status - Status.
+   * @param {number} [args.delayMs] - Reschedule delay in milliseconds.
    * @param {ReturnType<typeof JSON.parse>} [args.error] - Error.
    * @param {string} [args.handoffId] - Handoff lease id.
    * @param {number} [args.handedOffAtMs] - Handed off timestamp.
    * @param {string} [args.workerId] - Worker id.
    * @returns {void}
    */
-  _reportJobResultInBackground({jobId, status, error, handoffId, handedOffAtMs, workerId}) {
+  _reportJobResultInBackground({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId}) {
     /**
      * Defines report.
      * @type {Promise<void>} */
     let report
 
-    report = this._reportJobResult({jobId, status, error, handoffId, handedOffAtMs, workerId}).finally(() => {
+    report = this._reportJobResult({jobId, status, delayMs, error, handoffId, handedOffAtMs, workerId}).finally(() => {
       this.inflightReports.delete(report)
     })
 


### PR DESCRIPTION
## Summary
- add a non-returning `this.rescheduleIn(delayMs)` job API backed by a dedicated typed control signal
- persist fenced same-row `handed_off` to scheduled `queued` transitions without attempts, retries, or failure events
- carry reschedule outcomes across inline, pooled, forked, and spawned runner protocols while releasing existing worker and concurrency slots
- document normal-control-flow semantics and add focused store/execution coverage

## RED evidence
- `npm test -- spec/background-jobs/store-reschedule-spec.js` failed with `store.markRescheduled is not a function`
- `npm test -- spec/background-jobs/job-reschedule-spec.js` timed out because the missing API followed ordinary failure behavior and never ran the same row again

## Verification
- `npm test -- spec/background-jobs/store-reschedule-spec.js`
- `npm test -- spec/background-jobs/job-reschedule-spec.js`
- `npm test -- spec/background-jobs/status-reporter-retry-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- restored `spec/dummy/src/config/configuration.js` to its tracked configuration

Task UUID: 0f8a1573-8e8a-57bf-8ce8-ae4543f47c66