### PR TITLE
Share test transactions with background job child runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -2072,6 +2072,8 @@ Tests default to a 60-second timeout. Override per test with `{timeoutSeconds: 5
 
 Request tests share transaction-active, non-tenant database connections with their in-process HTTP handlers. Eligibility is evaluated when each request is dispatched, so a hook can start a transaction and issue a request in the same callback. This makes uncommitted setup visible to handlers while preserving rollback isolation. Without an active transaction, handlers use independent pooled connections, so concurrency and locking tests can opt out of transaction cleanup and exercise production-style connections. Shared connection state is scoped to the test lifecycle and cleared around each test. See [docs/testing-guidelines.md](docs/testing-guidelines.md#request-test-database-connections).
 
+Transactional tests also share active non-tenant connections with real forked, reusable pooled, and spawned background-job child runners through a per-attempt test-only loopback broker. Parent setup and child writes therefore occupy the same physical transaction and roll back together, including background-job persistence. Multiple configured databases route by identifier; tenant-only databases remain excluded. Tests using `{transaction: false, truncate: true}` retain ordinary independent physical connections for concurrency and locking coverage. See [docs/testing-guidelines.md](docs/testing-guidelines.md#request-test-database-connections).
+
 # Writing a request test
 
 First create a test file under something like the following path 'src/routes/accounts/create-test.js' with something like the following content:

--- a/README.md
+++ b/README.md
@@ -2074,6 +2074,8 @@ Request tests share transaction-active, non-tenant database connections with the
 
 Transactional tests also share active non-tenant connections with real forked, reusable pooled, and spawned background-job child runners through a per-attempt test-only loopback broker. Parent setup and child writes therefore occupy the same physical transaction and roll back together, including background-job persistence. Multiple configured databases route by identifier; tenant-only databases remain excluded. Tests using `{transaction: false, truncate: true}` retain ordinary independent physical connections for concurrency and locking coverage. See [docs/testing-guidelines.md](docs/testing-guidelines.md#request-test-database-connections).
 
+Warm pooled children receive the active broker capability per job, discard retained proxy state when the capability changes, and fail closed if a transactional dispatch lacks coordinates. Child transaction/savepoint work holds a FIFO lease on the parent physical connection until the matching root release or rollback.
+
 # Writing a request test
 
 First create a test file under something like the following path 'src/routes/accounts/create-test.js' with something like the following content:

--- a/changelog.d/20260812172000-background-job-test-transaction-broker.md
+++ b/changelog.d/20260812172000-background-job-test-transaction-broker.md
@@ -1,0 +1,1 @@
+Share transactional test database connections with forked, pooled, and spawned background-job child runners so parent rollback cleans up their work together.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -23,6 +23,20 @@ lets concurrency and locking tests opt out of transaction cleanup and exercise
 production-style connection behavior. Shared connection state is scoped to the test
 lifecycle and cleared around tests.
 
+Transactional background-job tests use the same isolation for real child runtimes.
+While a test transaction is active, forked, pooled, and spawned runners route their
+physical database operations through a capability-scoped loopback broker owned by
+that test attempt. This makes parent uncommitted setup visible to the job, makes job
+writes visible to the parent, and lets the normal parent rollback remove both the
+job's application writes and its background-job persistence rows. Only active
+non-tenant database connections are shared, and multiple databases are matched by
+their configured identifiers.
+
+The broker is not enabled for tests that opt out of transaction cleanup. Keep
+`{transaction: false, truncate: true}` on true concurrency and locking coverage so
+child/request work continues to use independent physical connections. Tenant-only
+connections are also intentionally excluded from the initial broker mode.
+
 ## Coverage focus for frontend models
 - Command URL mapping behavior
 - `findBy` and `findByOrFail` real HTTP flows

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -34,10 +34,16 @@ their configured identifiers.
 
 Reusable pooled runners receive broker mode and capability with every job dispatch,
 so a warm child can safely cross test-attempt boundaries. A capability change closes
-the child's retained proxy state before the next job; missing coordinates fail closed
-when that dispatch expects transactional sharing. Concurrent child transactions are
+the child's retained proxy state before the next job; concurrent jobs for that same
+new capability share the one serialized rotation, while genuinely different active
+capabilities are rejected. Missing coordinates fail closed when that dispatch expects
+transactional sharing. Concurrent child transactions are
 leased FIFO for their complete root-savepoint lifetime, rather than interleaving
 savepoints one WebSocket call at a time.
+
+If abandoned savepoint cleanup fails, the broker still releases FIFO waiters and
+drains every child socket and server. The teardown caller then receives the collected
+driver cleanup errors after transport shutdown completes.
 
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -48,7 +48,9 @@ driver cleanup errors after transport shutdown completes.
 The in-process background-jobs main also enters the attempt's shared connection
 context before store work. This keeps enqueue, handoff, and terminal job rows on the
 same parent-owned transaction on async-tracked database pools instead of checking out
-an independently committed connection.
+an independently committed connection. Parent store callbacks and child broker calls
+also share the broker's per-physical-connection queue, preventing overlapping driver
+requests while preserving root-savepoint leases.
 
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -45,6 +45,11 @@ If abandoned savepoint cleanup fails, the broker still releases FIFO waiters and
 drains every child socket and server. The teardown caller then receives the collected
 driver cleanup errors after transport shutdown completes.
 
+The in-process background-jobs main also enters the attempt's shared connection
+context before store work. This keeps enqueue, handoff, and terminal job rows on the
+same parent-owned transaction on async-tracked database pools instead of checking out
+an independently committed connection.
+
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so
 child/request work continues to use independent physical connections. Tenant-only

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -32,6 +32,13 @@ job's application writes and its background-job persistence rows. Only active
 non-tenant database connections are shared, and multiple databases are matched by
 their configured identifiers.
 
+Reusable pooled runners receive broker mode and capability with every job dispatch,
+so a warm child can safely cross test-attempt boundaries. A capability change closes
+the child's retained proxy state before the next job; missing coordinates fail closed
+when that dispatch expects transactional sharing. Concurrent child transactions are
+leased FIFO for their complete root-savepoint lifetime, rather than interleaving
+savepoints one WebSocket call at a time.
+
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so
 child/request work continues to use independent physical connections. Tenant-only

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "sql-escape-string": "^1.1.0",
         "sql.js": "^1.12.0",
         "strftime": "^0.10.2",
-        "typanic": "^1.0.9"
+        "typanic": "^1.0.9",
+        "ws": "^8.21.3"
       },
       "bin": {
         "velocious": "build/bin/velocious.js"
@@ -50,6 +51,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/strftime": "^0.9.8",
+        "@types/ws": "^8.18.1",
         "chokidar-cli": "^3.0.0",
         "cpy-cli": "^7.0.0",
         "esbuild": "^0.28.0",
@@ -4656,6 +4658,16 @@
       "integrity": "sha512-QIvDlGAKyF3YJbT3QZnfC+RIvV5noyDbi+ZJ5rkaSRqxCGrYJefgXm3leZAjtoQOutZe1hCXbAg+p89/Vj4HlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -14002,9 +14014,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "sql-escape-string": "^1.1.0",
     "sql.js": "^1.12.0",
     "strftime": "^0.10.2",
-    "typanic": "^1.0.9"
+    "typanic": "^1.0.9",
+    "ws": "^8.21.3"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -108,6 +109,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/strftime": "^0.9.8",
+    "@types/ws": "^8.18.1",
     "chokidar-cli": "^3.0.0",
     "cpy-cli": "^7.0.0",
     "esbuild": "^0.28.0",

--- a/spec/background-jobs/pooled-runner-broker-identity-spec.js
+++ b/spec/background-jobs/pooled-runner-broker-identity-spec.js
@@ -1,0 +1,40 @@
+// @ts-check
+
+import PooledRunnerBrokerIdentity from "../../src/background-jobs/pooled-runner-broker-identity.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+describe("Pooled runner broker identity", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("shares one pending rotation between concurrent jobs requesting the same identity", async () => {
+    /** @type {() => void} */
+    let releaseClose = () => {}
+    const closeBlocked = new Promise((resolve) => { releaseClose = resolve })
+    let closeCalls = 0
+    const identities = new PooledRunnerBrokerIdentity({closeConnections: async () => {
+      closeCalls++
+      await closeBlocked
+    }})
+    await identities.prepare({capability: "attempt-a", expected: true})
+
+    const first = identities.prepare({capability: "attempt-b", expected: true})
+    const second = identities.prepare({capability: "attempt-b", expected: true})
+    await Promise.resolve()
+    expect(closeCalls).toEqual(1)
+    releaseClose()
+    await Promise.all([first, second])
+
+    expect(identities.current()).toEqual(JSON.stringify({capability: "attempt-b", expected: true}))
+  })
+
+  it("rejects a truly different identity while a rotation is pending", async () => {
+    /** @type {() => void} */
+    let releaseClose = () => {}
+    const closeBlocked = new Promise((resolve) => { releaseClose = resolve })
+    const identities = new PooledRunnerBrokerIdentity({closeConnections: async () => await closeBlocked})
+    await identities.prepare({capability: "attempt-a", expected: true})
+
+    const pending = identities.prepare({capability: "attempt-b", expected: true})
+    await expect(() => identities.prepare({capability: "attempt-c", expected: true})).toThrow(/mix.*capabilit/i)
+    releaseClose()
+    await pending
+  })
+})

--- a/spec/background-jobs/shared-transaction-broker-spec.js
+++ b/spec/background-jobs/shared-transaction-broker-spec.js
@@ -1,0 +1,55 @@
+// @ts-check
+
+import { outputPathFor, startBackgroundJobs, waitForJobCompleted, waitForOutputJson } from "../helpers/background-jobs-helper.js"
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import Project from "../dummy/src/models/project.js"
+import SharedTransactionTestJob from "../dummy/src/jobs/shared-transaction-test-job.js"
+
+const markerPrefix = `shared-transaction-broker-${process.pid}-${Date.now()}`
+/** @type {string[]} */
+const jobIds = []
+
+describe("Background jobs - shared test transaction broker", {tags: ["dummy"], databaseCleaning: {transaction: true, truncate: false}}, () => {
+  it("shares parent rollback state with forked, reused pooled, and spawned child runners", async () => {
+    const parentMarker = `${markerPrefix}-parent`
+    await Project.create({creatingUserReference: parentMarker})
+    const {main, store, worker} = await startBackgroundJobs({workerOptions: {pooledRunnerCount: 1, pooledRunnerMaxJobs: 10}})
+
+    try {
+      const modes = ["forked", "pooled", "pooled", "spawned"]
+      /** @type {number[]} */
+      const pooledPids = []
+
+      for (const [index, executionMode] of modes.entries()) {
+        const childMarker = `${markerPrefix}-child-${index}`
+        const outputPath = await outputPathFor(`shared-transaction-${executionMode}-${index}`)
+        const jobId = await SharedTransactionTestJob.performLaterWithOptions({
+          args: [parentMarker, childMarker, outputPath],
+          options: {executionMode}
+        })
+        jobIds.push(jobId)
+        await waitForJobCompleted({jobId, store, timeoutSeconds: 10})
+        const result = await waitForOutputJson({outputPath, timeoutSeconds: 10})
+
+        expect(result.parentCount).toEqual(1)
+        expect(result.childCount).toEqual(1)
+        expect(await Project.where({creatingUserReference: childMarker}).count()).toEqual(1)
+        if (executionMode === "pooled") pooledPids.push(result.pid)
+      }
+
+      expect(pooledPids).toHaveLength(2)
+      expect(pooledPids[0]).toEqual(pooledPids[1])
+    } finally {
+      await worker.stop({timeoutMs: 3000})
+      await main.stop()
+    }
+  })
+
+  it("sees neither child markers nor background-job rows after parent rollback", async () => {
+    expect(await Project.where({creatingUserReference: ["like", `${markerPrefix}%`]}).count()).toEqual(0)
+    const store = new BackgroundJobsStore({configuration: dummyConfiguration})
+
+    for (const jobId of jobIds) expect(await store.getJob(jobId)).toEqual(undefined)
+  })
+})

--- a/spec/background-jobs/shared-transaction-broker-spec.js
+++ b/spec/background-jobs/shared-transaction-broker-spec.js
@@ -7,6 +7,7 @@ import Project from "../dummy/src/models/project.js"
 import SharedTransactionTestJob from "../dummy/src/jobs/shared-transaction-test-job.js"
 
 const markerPrefix = `shared-transaction-broker-${process.pid}-${Date.now()}`
+const childCompletionTimeoutSeconds = 30
 /** @type {string[]} */
 const jobIds = []
 
@@ -29,8 +30,8 @@ describe("Background jobs - shared test transaction broker", {tags: ["dummy"], d
           options: {executionMode}
         })
         jobIds.push(jobId)
-        await waitForJobCompleted({jobId, store, timeoutSeconds: 10})
-        const result = await waitForOutputJson({outputPath, timeoutSeconds: 10})
+        await waitForJobCompleted({jobId, store, timeoutSeconds: childCompletionTimeoutSeconds})
+        const result = await waitForOutputJson({outputPath, timeoutSeconds: childCompletionTimeoutSeconds})
 
         expect(result.parentCount).toEqual(1)
         expect(result.childCount).toEqual(1)

--- a/spec/background-jobs/shared-transaction-pooled-attempt-reuse-spec.js
+++ b/spec/background-jobs/shared-transaction-pooled-attempt-reuse-spec.js
@@ -1,0 +1,55 @@
+// @ts-check
+
+import { afterAll, beforeAll, describe, expect, it } from "../../src/testing/test.js"
+import { outputPathFor, startBackgroundJobs, waitForJobCompleted, waitForOutputJson } from "../helpers/background-jobs-helper.js"
+import Project from "../dummy/src/models/project.js"
+import SharedTransactionTestJob from "../dummy/src/jobs/shared-transaction-test-job.js"
+
+/** @type {Awaited<ReturnType<typeof startBackgroundJobs>> | undefined} */
+let backgroundJobs
+/** @type {number | undefined} */
+let firstAttemptPid
+const markerPrefix = `shared-transaction-pooled-attempts-${process.pid}-${Date.now()}`
+
+describe("Background jobs - pooled broker attempt reuse", {tags: ["dummy"], databaseCleaning: {transaction: true, truncate: false}}, () => {
+  beforeAll(async () => {
+    backgroundJobs = await startBackgroundJobs({workerOptions: {pooledRunnerCount: 1, pooledRunnerMaxJobs: 10}})
+    backgroundJobs.worker._createPooledChild()
+  })
+
+  afterAll(async () => {
+    if (!backgroundJobs) return
+    await backgroundJobs.worker.stop({timeoutMs: 3000})
+    await backgroundJobs.main.stop()
+  })
+
+  it("uses dispatch-time broker coordinates in a child created before broker activation", async () => {
+    if (!backgroundJobs) throw new Error("Expected background jobs to be started")
+    const parentMarker = `${markerPrefix}-parent-first`
+    const childMarker = `${markerPrefix}-child-first`
+    const outputPath = await outputPathFor("shared-transaction-preexisting-pool")
+    await Project.create({creatingUserReference: parentMarker})
+    const jobId = await SharedTransactionTestJob.performLaterWithOptions({args: [parentMarker, childMarker, outputPath], options: {executionMode: "pooled"}})
+
+    await waitForJobCompleted({jobId, store: backgroundJobs.store, timeoutSeconds: 10})
+    const result = await waitForOutputJson({outputPath, timeoutSeconds: 10})
+    expect(result.parentCount).toEqual(1)
+    expect(result.childCount).toEqual(1)
+    firstAttemptPid = result.pid
+  })
+
+  it("reuses the process with the new attempt capability and no stale fallback", async () => {
+    if (!backgroundJobs || firstAttemptPid === undefined) throw new Error("Expected first pooled attempt to complete")
+    const parentMarker = `${markerPrefix}-parent-second`
+    const childMarker = `${markerPrefix}-child-second`
+    const outputPath = await outputPathFor("shared-transaction-next-attempt")
+    await Project.create({creatingUserReference: parentMarker})
+    const jobId = await SharedTransactionTestJob.performLaterWithOptions({args: [parentMarker, childMarker, outputPath], options: {executionMode: "pooled"}})
+
+    await waitForJobCompleted({jobId, store: backgroundJobs.store, timeoutSeconds: 10})
+    const result = await waitForOutputJson({outputPath, timeoutSeconds: 10})
+    expect(result.pid).toEqual(firstAttemptPid)
+    expect(result.parentCount).toEqual(1)
+    expect(result.childCount).toEqual(1)
+  })
+})

--- a/spec/background-jobs/shared-transaction-pooled-attempt-reuse-spec.js
+++ b/spec/background-jobs/shared-transaction-pooled-attempt-reuse-spec.js
@@ -13,7 +13,7 @@ const markerPrefix = `shared-transaction-pooled-attempts-${process.pid}-${Date.n
 
 describe("Background jobs - pooled broker attempt reuse", {tags: ["dummy"], databaseCleaning: {transaction: true, truncate: false}}, () => {
   beforeAll(async () => {
-    backgroundJobs = await startBackgroundJobs({workerOptions: {pooledRunnerCount: 1, pooledRunnerMaxJobs: 10}})
+    backgroundJobs = await startBackgroundJobs({workerOptions: {pooledRunnerConcurrency: 2, pooledRunnerCount: 1, pooledRunnerMaxJobs: 10}})
     backgroundJobs.worker._createPooledChild()
   })
 
@@ -38,18 +38,23 @@ describe("Background jobs - pooled broker attempt reuse", {tags: ["dummy"], data
     firstAttemptPid = result.pid
   })
 
-  it("reuses the process with the new attempt capability and no stale fallback", async () => {
+  it("runs concurrent jobs sharing the new attempt capability in the reused process", async () => {
     if (!backgroundJobs || firstAttemptPid === undefined) throw new Error("Expected first pooled attempt to complete")
     const parentMarker = `${markerPrefix}-parent-second`
-    const childMarker = `${markerPrefix}-child-second`
-    const outputPath = await outputPathFor("shared-transaction-next-attempt")
+    const childMarkers = [`${markerPrefix}-child-second-a`, `${markerPrefix}-child-second-b`]
+    const outputPaths = await Promise.all([
+      outputPathFor("shared-transaction-next-attempt-a"),
+      outputPathFor("shared-transaction-next-attempt-b")
+    ])
     await Project.create({creatingUserReference: parentMarker})
-    const jobId = await SharedTransactionTestJob.performLaterWithOptions({args: [parentMarker, childMarker, outputPath], options: {executionMode: "pooled"}})
+    const jobIds = await Promise.all(childMarkers.map(async (childMarker, index) => {
+      return await SharedTransactionTestJob.performLaterWithOptions({args: [parentMarker, childMarker, outputPaths[index]], options: {executionMode: "pooled"}})
+    }))
 
-    await waitForJobCompleted({jobId, store: backgroundJobs.store, timeoutSeconds: 10})
-    const result = await waitForOutputJson({outputPath, timeoutSeconds: 10})
-    expect(result.pid).toEqual(firstAttemptPid)
-    expect(result.parentCount).toEqual(1)
-    expect(result.childCount).toEqual(1)
+    await Promise.all(jobIds.map(async (jobId) => await waitForJobCompleted({jobId, store: backgroundJobs.store, timeoutSeconds: 10})))
+    const results = await Promise.all(outputPaths.map(async (outputPath) => await waitForOutputJson({outputPath, timeoutSeconds: 10})))
+    expect(results.map((result) => result.pid)).toEqual([firstAttemptPid, firstAttemptPid])
+    expect(results.map((result) => result.parentCount)).toEqual([1, 1])
+    expect(results.map((result) => result.childCount)).toEqual([1, 1])
   })
 })

--- a/spec/background-jobs/store-test-shared-connection-spec.js
+++ b/spec/background-jobs/store-test-shared-connection-spec.js
@@ -6,6 +6,10 @@ import AsyncTrackedMultiConnectionPool from "../../src/database/pool/async-track
 import DatabaseDriverBase from "../../src/database/drivers/base.js"
 import NodeEnvironmentHandler from "../../src/environment-handlers/node.js"
 import {describe, expect, it} from "../../src/testing/test.js"
+import {
+  clearSharedTransactionCoordinator,
+  setSharedTransactionCoordinator
+} from "../../src/testing/shared-transaction-connection-coordinator.js"
 
 class StoreContextDriver extends DatabaseDriverBase {
   async connect() {}
@@ -31,6 +35,60 @@ describe("BackgroundJobsStore test shared connection", {databaseCleaning: {trans
       const selected = await store._withDb(async (db) => db)
       expect(selected).toBe(parentConnection)
     } finally {
+      pool.clearTestSharedConnection(registration)
+      await pool.checkin(parentConnection)
+      await pool.closeAll()
+    }
+  })
+
+  it("coordinates parent persistence with broker work on the shared physical connection", async () => {
+    const configuration = new Configuration({
+      backgroundJobs: {databaseIdentifier: "default"},
+      database: {test: {default: {driver: StoreContextDriver, poolType: AsyncTrackedMultiConnectionPool, type: "test"}}},
+      environment: "test",
+      environmentHandler: new NodeEnvironmentHandler()
+    })
+    const pool = configuration.getDatabasePool("default")
+    const parentConnection = await pool.checkout()
+    const registration = pool.setTestSharedConnection(parentConnection)
+    const store = new BackgroundJobsStore({configuration})
+    let active = 0
+    let maxActive = 0
+    let coordinatorCalls = 0
+    let queue = Promise.resolve()
+    /** @type {(callback: () => Promise<unknown>) => Promise<unknown>} */
+    const coordinator = async (callback) => {
+      coordinatorCalls++
+      const previous = queue
+      let release = () => {}
+      queue = new Promise((resolve) => { release = resolve })
+      await previous
+      try { return await callback() } finally { release() }
+    }
+    setSharedTransactionCoordinator(parentConnection, coordinator)
+    /** @type {() => void} */
+    let releaseFirst = () => {}
+    const firstBlocked = new Promise((resolve) => { releaseFirst = resolve })
+
+    try {
+      const first = coordinator(async () => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await firstBlocked
+        active--
+      })
+      const second = store._withDb(async () => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        active--
+      })
+      await Promise.resolve()
+      releaseFirst()
+      await Promise.all([first, second])
+      expect(coordinatorCalls).toEqual(2)
+      expect(maxActive).toEqual(1)
+    } finally {
+      clearSharedTransactionCoordinator(parentConnection, coordinator)
       pool.clearTestSharedConnection(registration)
       await pool.checkin(parentConnection)
       await pool.closeAll()

--- a/spec/background-jobs/store-test-shared-connection-spec.js
+++ b/spec/background-jobs/store-test-shared-connection-spec.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
+import Configuration from "../../src/configuration.js"
+import AsyncTrackedMultiConnectionPool from "../../src/database/pool/async-tracked-multi-connection.js"
+import DatabaseDriverBase from "../../src/database/drivers/base.js"
+import NodeEnvironmentHandler from "../../src/environment-handlers/node.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class StoreContextDriver extends DatabaseDriverBase {
+  async connect() {}
+  getType() { return "test" }
+  primaryKeyType() { return "bigint" }
+  queryToSql() { return "" }
+}
+
+describe("BackgroundJobsStore test shared connection", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("runs persistence through the installed test transaction connection", async () => {
+    const configuration = new Configuration({
+      backgroundJobs: {databaseIdentifier: "default"},
+      database: {test: {default: {driver: StoreContextDriver, poolType: AsyncTrackedMultiConnectionPool, type: "test"}}},
+      environment: "test",
+      environmentHandler: new NodeEnvironmentHandler()
+    })
+    const pool = configuration.getDatabasePool("default")
+    const parentConnection = await pool.checkout()
+    const registration = pool.setTestSharedConnection(parentConnection)
+    const store = new BackgroundJobsStore({configuration})
+
+    try {
+      const selected = await store._withDb(async (db) => db)
+      expect(selected).toBe(parentConnection)
+    } finally {
+      pool.clearTestSharedConnection(registration)
+      await pool.checkin(parentConnection)
+      await pool.closeAll()
+    }
+  })
+})

--- a/spec/database/drivers/schema-cache-spec.js
+++ b/spec/database/drivers/schema-cache-spec.js
@@ -2,6 +2,7 @@
 
 import AsyncTrackedMultiConnection from "../../../src/database/pool/async-tracked-multi-connection.js"
 import DatabaseDriverBase from "../../../src/database/drivers/base.js"
+import NodeEnvironmentHandler from "../../../src/environment-handlers/node.js"
 import {describe, expect, it} from "../../../src/testing/test.js"
 
 class SchemaCacheTestDriver extends DatabaseDriverBase {
@@ -35,6 +36,8 @@ class SchemaCacheTestDriver extends DatabaseDriverBase {
  * @returns {import("../../../src/configuration.js").default} - Configuration-shaped object.
  */
 function buildConfiguration(databaseConfig) {
+  const environmentHandler = new NodeEnvironmentHandler()
+
   return /** @type {import("../../../src/configuration.js").default} */ (/** @type {unknown} */ ({
     clearSchemaCachesForReuseKey() {
       // This stub configuration owns no pool registry, so cross-pool invalidation
@@ -45,6 +48,9 @@ function buildConfiguration(databaseConfig) {
     },
     getEnvironment() {
       return "test"
+    },
+    getEnvironmentHandler() {
+      return environmentHandler
     },
     getQueryLoggingEnabled() {
       return false

--- a/spec/dummy/src/jobs/shared-transaction-test-job.js
+++ b/spec/dummy/src/jobs/shared-transaction-test-job.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+import fs from "node:fs/promises"
+import VelociousJob from "../../../../src/background-jobs/job.js"
+import Project from "../models/project.js"
+
+export default class SharedTransactionTestJob extends VelociousJob {
+  static databaseIdentifiers = ["default"]
+
+  /** @param {string} parentMarker - Parent marker. @param {string} childMarker - Child marker. @param {string} outputPath - Result path. */
+  async perform(parentMarker, childMarker, outputPath) {
+    const parentRows = await Project.where({creatingUserReference: parentMarker}).toArray()
+    await Project.create({creatingUserReference: childMarker})
+    const childRows = await Project.where({creatingUserReference: childMarker}).toArray()
+    await fs.writeFile(outputPath, JSON.stringify({childCount: childRows.length, parentCount: parentRows.length, pid: process.pid}))
+  }
+}

--- a/spec/helpers/background-jobs-helper.js
+++ b/spec/helpers/background-jobs-helper.js
@@ -67,10 +67,6 @@ export async function startBackgroundJobsMain({backgroundJobsConfig, waitForWork
 
   const pool = dummyConfiguration.getDatabasePool(store.getDatabaseIdentifier())
 
-  if (pool instanceof AsyncTrackedMultiConnectionPool) {
-    pool.setTestSharedConnection(pool.getCurrentConnection())
-  }
-
   const stoppedServices = new Set()
   if (!waitForWorkerStop) stoppedServices.add("worker")
   let connectionsClosed = false
@@ -81,7 +77,6 @@ export async function startBackgroundJobsMain({backgroundJobsConfig, waitForWork
     connectionsClosed = true
 
     if (pool instanceof AsyncTrackedMultiConnectionPool) {
-      pool.clearTestSharedConnection()
       AsyncTrackedMultiConnectionPool.clearGlobalConnections(dummyConfiguration)
     } else if (pool.getCurrentConnection().insideTransaction()) {
       // TestRunner owns this physical connection and rolls it back after the

--- a/spec/helpers/background-jobs-helper.js
+++ b/spec/helpers/background-jobs-helper.js
@@ -83,6 +83,11 @@ export async function startBackgroundJobsMain({backgroundJobsConfig, waitForWork
     if (pool instanceof AsyncTrackedMultiConnectionPool) {
       pool.clearTestSharedConnection()
       AsyncTrackedMultiConnectionPool.clearGlobalConnections(dummyConfiguration)
+    } else if (pool.getCurrentConnection().insideTransaction()) {
+      // TestRunner owns this physical connection and rolls it back after the
+      // background-job broker has drained. Closing it here would implicitly end
+      // SQLite's transaction before the test lifecycle can roll back child work.
+      return
     } else {
       await dummyConfiguration.closeDatabaseConnections()
       await dummyConfiguration.initializeModels()

--- a/spec/testing/shared-transaction-broker-spec.js
+++ b/spec/testing/shared-transaction-broker-spec.js
@@ -14,6 +14,8 @@ class FakeConnection {
     /** @type {(value?: void) => void} */
     this.resolveCall = () => {}
     this.callStarted = new Promise((resolve) => { this.resolveCall = resolve })
+    this.failRollback = false
+    this.failRelease = false
   }
 
   async query(value) {
@@ -35,8 +37,14 @@ class FakeConnection {
   }
 
   async startSavePoint(name) { this.calls.push(`start:${name}`) }
-  async releaseSavePoint(name) { this.calls.push(`release:${name}`) }
-  async rollbackSavePoint(name) { this.calls.push(`rollback:${name}`) }
+  async releaseSavePoint(name) {
+    this.calls.push(`release:${name}`)
+    if (this.failRelease) throw new Error("release cleanup failed")
+  }
+  async rollbackSavePoint(name) {
+    this.calls.push(`rollback:${name}`)
+    if (this.failRollback) throw new Error("rollback cleanup failed")
+  }
 }
 
 describe("Shared transaction broker protocol", {databaseCleaning: {transaction: false, truncate: false}}, () => {
@@ -192,5 +200,52 @@ describe("Shared transaction broker protocol", {databaseCleaning: {transaction: 
       await client.close()
       await broker.close()
     }
+  })
+
+  it("records disconnected lease cleanup failure without an unhandled rejection and settles FIFO waiters", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const holder = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+    const waiter = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+    /** @type {Array<Error>} */
+    const unhandled = []
+    const onUnhandled = (reason) => unhandled.push(reason instanceof Error ? reason : new Error(String(reason)))
+    process.on("unhandledRejection", onUnhandled)
+
+    await holder.call("rootTransactionStart", ["broken"])
+    const waitingStart = waiter.call("rootTransactionStart", ["waiting"])
+    const waitingResult = waitingStart.then(() => "resolved", () => "rejected")
+    connection.failRollback = true
+    await holder.close()
+    expect(await waitingResult).toEqual("resolved")
+    await waiter.call("rootTransactionRelease", ["waiting"])
+    await expect(() => broker.close()).toThrow(/rollback cleanup failed/i)
+
+    process.removeListener("unhandledRejection", onUnhandled)
+    expect(unhandled).toEqual([])
+    expect(broker.httpServer.listening).toEqual(false)
+    expect(broker.sessions.size).toEqual(0)
+    await waiter.close()
+  })
+
+  it("continues explicit close after lease cleanup failures and rejects only after transport drain", async () => {
+    const firstConnection = new FakeConnection()
+    const secondConnection = new FakeConnection()
+    firstConnection.failRollback = true
+    secondConnection.failRelease = true
+    const broker = await SharedTransactionBroker.start({connections: {first: firstConnection, second: secondConnection}})
+    const first = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "first"})
+    const second = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "second"})
+    await first.call("rootTransactionStart", ["first"])
+    await second.call("rootTransactionStart", ["second"])
+
+    await expect(() => broker.close()).toThrow(/cleanup failed/i)
+
+    expect(firstConnection.calls).toEqual(["start:first", "rollback:first", "release:first"])
+    expect(secondConnection.calls).toEqual(["start:second", "rollback:second", "release:second"])
+    expect(broker.httpServer.listening).toEqual(false)
+    expect(broker.sessions.size).toEqual(0)
+    await first.close()
+    await second.close()
   })
 })

--- a/spec/testing/shared-transaction-broker-spec.js
+++ b/spec/testing/shared-transaction-broker-spec.js
@@ -1,0 +1,123 @@
+// @ts-check
+
+import SharedTransactionBroker from "../../src/testing/shared-transaction-broker.js"
+import SharedTransactionBrokerClient from "../../src/testing/shared-transaction-broker-client.js"
+import { waitForEvent } from "../../src/testing/test.js"
+
+class FakeConnection {
+  constructor() {
+    this.active = 0
+    this.calls = []
+    this.maxActive = 0
+    /** @type {() => void} */
+    this.releaseBlocked = () => {}
+    /** @type {(value?: void) => void} */
+    this.resolveCall = () => {}
+    this.callStarted = new Promise((resolve) => { this.resolveCall = resolve })
+  }
+
+  async query(value) {
+    this.active++
+    this.maxActive = Math.max(this.maxActive, this.active)
+    this.calls.push(value)
+    this.resolveCall()
+    try {
+      if (value === "blocked" || value === "slow") await new Promise((resolve) => { this.releaseBlocked = resolve })
+      if (value === "error") {
+        const error = new Error("driver rejected query")
+        error.code = "EDRIVER"
+        throw error
+      }
+      return [{value}]
+    } finally {
+      this.active--
+    }
+  }
+}
+
+describe("Shared transaction broker protocol", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("rejects unknown capabilities and database identifiers without executing SQL", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const wrongCapability = new SharedTransactionBrokerClient({address: broker.address(), capability: "wrong", databaseIdentifier: "default"})
+    const wrongDatabase = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "missing"})
+
+    try {
+      await expect(() => wrongCapability.call("query", ["select secret"])).toThrow(/capability/i)
+      await expect(() => wrongDatabase.call("query", ["select secret"])).toThrow(/database identifier/i)
+      expect(connection.calls).toEqual([])
+    } finally {
+      await wrongCapability.close()
+      await wrongDatabase.close()
+      await broker.close()
+    }
+  })
+
+  it("correlates concurrent responses and serializes work across websocket sessions", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection, secondary: connection}})
+    const first = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+    const second = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "secondary"})
+
+    try {
+      const slowPromise = first.call("query", ["slow"])
+      await connection.callStarted
+      const secondQueued = waitForEvent(broker, "work-queued", {
+        filter: (event) => event.databaseIdentifier === "secondary"
+      })
+      const fastPromise = second.call("query", ["fast"])
+      await secondQueued
+      connection.releaseBlocked()
+      const [slow, fast] = await Promise.all([slowPromise, fastPromise])
+
+      expect(slow).toEqual([{value: "slow"}])
+      expect(fast).toEqual([{value: "fast"}])
+      expect(connection.maxActive).toEqual(1)
+      expect(connection.calls).toEqual(["slow", "fast"])
+    } finally {
+      await first.close()
+      await second.close()
+      await broker.close()
+    }
+  })
+
+  it("propagates tagged driver errors", async () => {
+    const broker = await SharedTransactionBroker.start({connections: {default: new FakeConnection()}})
+    const client = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+
+    try {
+      let caught
+      try {
+        await client.call("query", ["error"])
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(Error)
+      expect(caught.message).toEqual("driver rejected query")
+      expect(caught.code).toEqual("EDRIVER")
+    } finally {
+      await client.close()
+      await broker.close()
+    }
+  })
+
+  it("rejects pending requests on disconnect and revokes teardown capability", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const address = broker.address()
+    const capability = broker.capability()
+    const client = new SharedTransactionBrokerClient({address: broker.address(), capability, databaseIdentifier: "default"})
+    const pending = client.call("query", ["blocked"])
+
+    await client.connected()
+    await client.close()
+    await expect(() => pending).toThrow(/closed|disconnect/i)
+    connection.releaseBlocked()
+    await broker.close()
+
+    const stale = new SharedTransactionBrokerClient({address, capability, databaseIdentifier: "default"})
+    await expect(() => stale.call("query", ["after teardown"])).toThrow(/connect|closed|refused/i)
+    expect(connection.calls).toEqual(["blocked"])
+    await stale.close()
+  })
+})

--- a/spec/testing/shared-transaction-broker-spec.js
+++ b/spec/testing/shared-transaction-broker-spec.js
@@ -33,6 +33,10 @@ class FakeConnection {
       this.active--
     }
   }
+
+  async startSavePoint(name) { this.calls.push(`start:${name}`) }
+  async releaseSavePoint(name) { this.calls.push(`release:${name}`) }
+  async rollbackSavePoint(name) { this.calls.push(`rollback:${name}`) }
 }
 
 describe("Shared transaction broker protocol", {databaseCleaning: {transaction: false, truncate: false}}, () => {
@@ -119,5 +123,74 @@ describe("Shared transaction broker protocol", {databaseCleaning: {transaction: 
     await expect(() => stale.call("query", ["after teardown"])).toThrow(/connect|closed|refused/i)
     expect(connection.calls).toEqual(["blocked"])
     await stale.close()
+  })
+
+  it("leases a physical connection from root savepoint start through release", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const first = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+    const second = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+
+    try {
+      await first.call("rootTransactionStart", ["first"])
+      const secondStart = second.call("rootTransactionStart", ["second"])
+      await first.call("query", ["first write"])
+      expect(connection.calls).toEqual(["start:first", "first write"])
+      await first.call("rootTransactionRelease", ["first"])
+      await secondStart
+      await second.call("query", ["second write"])
+      await second.call("rootTransactionRollback", ["second"])
+
+      expect(connection.calls).toEqual([
+        "start:first",
+        "first write",
+        "release:first",
+        "start:second",
+        "second write",
+        "rollback:second",
+        "release:second"
+      ])
+    } finally {
+      await first.close()
+      await second.close()
+      await broker.close()
+    }
+  })
+
+  it("rolls back and releases a disconnected root transaction holder", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const first = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+    const second = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+
+    try {
+      await first.call("rootTransactionStart", ["abandoned"])
+      const secondStart = second.call("rootTransactionStart", ["next"])
+      await first.close()
+      await secondStart
+      await second.call("rootTransactionRelease", ["next"])
+      expect(connection.calls).toEqual(["start:abandoned", "rollback:abandoned", "release:abandoned", "start:next", "release:next"])
+    } finally {
+      await second.close()
+      await broker.close()
+    }
+  })
+
+  it("rejects nested root leases and mismatched completion without releasing ownership", async () => {
+    const connection = new FakeConnection()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const client = new SharedTransactionBrokerClient({address: broker.address(), capability: broker.capability(), databaseIdentifier: "default"})
+
+    try {
+      await client.call("rootTransactionStart", ["owned"])
+      await expect(() => client.call("rootTransactionStart", ["nested"])).toThrow(/already active/i)
+      await expect(() => client.call("rootTransactionRelease", ["wrong"])).toThrow(/does not match/i)
+      await client.call("query", ["still owned"])
+      await client.call("rootTransactionRollback", ["owned"])
+      expect(connection.calls).toEqual(["start:owned", "still owned", "rollback:owned", "release:owned"])
+    } finally {
+      await client.close()
+      await broker.close()
+    }
   })
 })

--- a/spec/testing/shared-transaction-codec-spec.js
+++ b/spec/testing/shared-transaction-codec-spec.js
@@ -1,0 +1,49 @@
+// @ts-check
+
+import { decodeBrokerValue, encodeBrokerValue } from "../../src/testing/shared-transaction-codec.js"
+
+describe("Shared transaction broker codec", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("round trips database values without JSON coercion", () => {
+    const original = {
+      bigint: 9007199254740993n,
+      buffer: Buffer.from([0, 1, 2, 255]),
+      date: new Date("2026-08-12T10:20:30.456Z"),
+      infinity: Infinity,
+      nan: NaN,
+      negativeInfinity: -Infinity,
+      nested: [undefined, {value: undefined}],
+      undefined
+    }
+
+    const decoded = decodeBrokerValue(encodeBrokerValue(original))
+
+    expect(decoded.bigint).toEqual(original.bigint)
+    expect(Array.from(decoded.buffer)).toEqual(Array.from(original.buffer))
+    expect(decoded.date.toISOString()).toEqual(original.date.toISOString())
+    expect(decoded.infinity).toEqual(Infinity)
+    expect(Number.isNaN(decoded.nan)).toEqual(true)
+    expect(decoded.negativeInfinity).toEqual(-Infinity)
+    expect(decoded.nested).toEqual(original.nested)
+    expect(Object.hasOwn(decoded, "undefined")).toEqual(true)
+    expect(decoded.undefined).toEqual(undefined)
+  })
+
+  it("round trips driver error identity and causes", () => {
+    const cause = new TypeError("socket closed")
+    cause.code = "ECONNRESET"
+    const error = new Error("query failed", {cause})
+    error.name = "DatabaseError"
+    error.code = "EREQUEST"
+
+    const decoded = decodeBrokerValue(encodeBrokerValue(error))
+
+    expect(decoded).toBeInstanceOf(Error)
+    expect(decoded.name).toEqual("DatabaseError")
+    expect(decoded.message).toEqual("query failed")
+    expect(decoded.code).toEqual("EREQUEST")
+    expect(decoded.stack).toEqual(error.stack)
+    expect(decoded.cause).toBeInstanceOf(TypeError)
+    expect(decoded.cause.message).toEqual("socket closed")
+    expect(decoded.cause.code).toEqual("ECONNRESET")
+  })
+})

--- a/spec/testing/shared-transaction-pooled-job-context-spec.js
+++ b/spec/testing/shared-transaction-pooled-job-context-spec.js
@@ -1,0 +1,44 @@
+// @ts-check
+
+import {
+  runWithSharedTransactionBrokerConfig,
+  sharedTransactionBrokerConfig
+} from "../../src/testing/shared-transaction-proxy-driver.js"
+
+describe("Shared transaction pooled job context", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("selects broker coordinates per sequential job instead of retaining the child bootstrap environment", async () => {
+    const first = {address: "ws://127.0.0.1:1001", capability: "first", databaseIdentifiers: ["default"], expected: true}
+    const second = {address: "ws://127.0.0.1:1002", capability: "second", databaseIdentifiers: ["default"], expected: true}
+
+    await runWithSharedTransactionBrokerConfig(first, async () => {
+      expect(sharedTransactionBrokerConfig("default")).toEqual({address: first.address, capability: first.capability})
+    })
+    await runWithSharedTransactionBrokerConfig(second, async () => {
+      expect(sharedTransactionBrokerConfig("default")).toEqual({address: second.address, capability: second.capability})
+    })
+  })
+
+  it("fails closed when a pooled job expects sharing but has no broker coordinates", async () => {
+    await expect(() => runWithSharedTransactionBrokerConfig({expected: true}, async () => {
+      sharedTransactionBrokerConfig("default")
+    })).toThrow(/expected.*broker/i)
+  })
+
+  it("does not fall back to immutable child environment inside a per-job context", async () => {
+    const previous = process.env.VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER
+    process.env.VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER = Buffer.from(JSON.stringify({
+      address: "ws://127.0.0.1:1000",
+      capability: "stale",
+      databaseIdentifiers: ["default"]
+    })).toString("base64url")
+
+    try {
+      await expect(() => runWithSharedTransactionBrokerConfig({expected: true}, async () => {
+        sharedTransactionBrokerConfig("default")
+      })).toThrow(/expected.*broker/i)
+    } finally {
+      if (previous === undefined) delete process.env.VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER
+      else process.env.VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER = previous
+    }
+  })
+})

--- a/spec/testing/shared-transaction-proxy-cleanup-spec.js
+++ b/spec/testing/shared-transaction-proxy-cleanup-spec.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import MysqlDriver from "../../src/database/drivers/mysql/index.js"
+import NodeEnvironmentHandler from "../../src/environment-handlers/node.js"
+import { createSharedTransactionProxyDriver } from "../../src/testing/shared-transaction-proxy-driver.js"
+import SharedTransactionBroker from "../../src/testing/shared-transaction-broker.js"
+
+describe("Shared transaction proxy checkout cleanup", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("keeps the broker transport usable across inherited MySQL checkout cleanup", async () => {
+    const configuration = new Configuration({database: {test: {}}, environmentHandler: new NodeEnvironmentHandler()})
+    const broker = await SharedTransactionBroker.start({connections: {default: {query: async (sql) => `broker:${sql}`}}})
+    const proxy = createSharedTransactionProxyDriver(MysqlDriver, {type: "mysql"}, configuration, "default", {address: broker.address(), capability: broker.capability()})
+    await proxy.connect()
+
+    try {
+      await proxy.cleanupSessionStateAfterCheckout()
+
+      expect(await proxy.sharedTransactionClient.call("query", ["after checkout"])).toEqual("broker:after checkout")
+    } finally {
+      await proxy.close()
+      await broker.close()
+    }
+  })
+})

--- a/spec/testing/test-runner-non-transactional-request-connections-spec.js
+++ b/spec/testing/test-runner-non-transactional-request-connections-spec.js
@@ -1,12 +1,14 @@
 // @ts-check
 
 import { describe, expect, it } from "../../src/testing/test.js"
+import { SHARED_TRANSACTION_BROKER_ENV } from "../../src/testing/shared-transaction-proxy-driver.js"
 
 describe("TestRunner non-transactional request connections", {
   databaseCleaning: {transaction: false, truncate: true},
   type: "request"
 }, () => {
   it("checks out independent connections for concurrent in-process request handlers", async () => {
+    expect(process.env[SHARED_TRANSACTION_BROKER_ENV]).toBeUndefined()
     const [firstResponse, secondResponse] = await Promise.all([
       fetch("http://localhost:31006/concurrent-connection-identity"),
       fetch("http://localhost:31006/concurrent-connection-identity")

--- a/spec/testing/test-runner-shared-transaction-broker-registration-spec.js
+++ b/spec/testing/test-runner-shared-transaction-broker-registration-spec.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+import Current from "../../src/current.js"
+import TestRunner from "../../src/testing/test-runner.js"
+import { SHARED_TRANSACTION_BROKER_ENV } from "../../src/testing/shared-transaction-proxy-driver.js"
+import { createTenantTestConfiguration } from "../helpers/tenant-test-helpers.js"
+
+describe("TestRunner shared transaction broker registration", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("registers multiple active non-tenant databases and explicitly excludes tenant-only connections", async () => {
+    const {cleanup, configuration} = await createTenantTestConfiguration("velocious-shared-transaction-registration")
+    const testRunner = new TestRunner({configuration, testFiles: []})
+    let previousConfiguration
+
+    try {
+      try {
+        previousConfiguration = Current.configuration()
+      } catch {
+        // No previous configuration.
+      }
+      configuration.setCurrent()
+
+      await configuration.runWithTenant({slug: "alpha"}, async () => {
+        await configuration.ensureConnections(async (dbs) => {
+          for (const connection of Object.values(dbs)) await connection.startTransaction()
+          const registration = await testRunner.startSharedTransactionBroker()
+
+          try {
+            expect(registration).toBeDefined()
+            const serialized = process.env[SHARED_TRANSACTION_BROKER_ENV]
+            if (!serialized) throw new Error("Expected shared transaction broker environment")
+            const childConfig = JSON.parse(Buffer.from(serialized, "base64url").toString("utf8"))
+
+            expect(childConfig.databaseIdentifiers.sort()).toEqual(["analytics", "default"])
+          } finally {
+            await testRunner.stopSharedTransactionBroker(registration)
+            for (const connection of Object.values(dbs)) await connection.rollbackTransaction()
+          }
+        })
+      })
+    } finally {
+      previousConfiguration?.setCurrent()
+      await cleanup()
+    }
+  })
+})

--- a/spec/utils/package-scripts-spec.js
+++ b/spec/utils/package-scripts-spec.js
@@ -66,7 +66,7 @@ describe("package scripts", {databaseCleaning: {transaction: true}}, () => {
     await execFileAsync(process.execPath, [typescriptExecutable, "--ignoreConfig", "--noEmit", "--skipLibCheck", declarationPath])
   })
 
-  it("builds the declared package entry points when installed from Git", {timeoutSeconds: 180}, async () => {
+  it("builds the declared package entry points when installed from Git", {timeoutSeconds: 300}, async () => {
     const temporaryDirectoryParent = path.join(repositoryDirectory(), "tmp")
 
     await fs.mkdir(temporaryDirectoryParent, {recursive: true})
@@ -81,7 +81,9 @@ describe("package scripts", {databaseCleaning: {transaction: true}}, () => {
 
     try {
       await execFileAsync("git", ["clone", "--local", "--no-hardlinks", repositoryDirectory(), sourceDirectory])
-      await fs.copyFile(path.join(repositoryDirectory(), "package.json"), path.join(sourceDirectory, "package.json"))
+      const packageJson = JSON.parse(await fs.readFile(path.join(repositoryDirectory(), "package.json"), "utf8"))
+      packageJson.devDependencies["eslint-plugin-jsdoc-inline-type-casts"] = `file:${path.join(repositoryDirectory(), "node_modules", "eslint-plugin-jsdoc-inline-type-casts")}`
+      await fs.writeFile(path.join(sourceDirectory, "package.json"), JSON.stringify(packageJson, null, 2))
       await execFileAsync("git", [
         "-c", "user.name=Velocious test",
         "-c", "user.email=velocious@example.invalid",
@@ -107,6 +109,7 @@ describe("package scripts", {databaseCleaning: {transaction: true}}, () => {
         "--allow-git=all",
         "--allow-remote=all",
         "--cache", npmCacheDirectory,
+        "--ignore-scripts=false",
         "--no-audit",
         "--no-fund"
       ], {cwd: consumerDirectory})

--- a/src/background-jobs/pooled-runner-broker-identity.js
+++ b/src/background-jobs/pooled-runner-broker-identity.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+export default class PooledRunnerBrokerIdentity {
+  /**
+   * Creates a pooled runner identity coordinator.
+   * @param {{closeConnections: () => Promise<void>}} args - Connection cleanup hook.
+   */
+  constructor({closeConnections}) {
+    this.closeConnections = closeConnections
+    /** @type {string | undefined} */
+    this.activeIdentity = undefined
+    /** @type {{identity: string, promise: Promise<void>} | undefined} */
+    this.pending = undefined
+    this.activeUsers = 0
+  }
+
+  /**
+   * Gets the current prepared identity.
+   * @returns {string | undefined} - Current prepared identity.
+   */
+  current() { return this.activeIdentity }
+
+  /**
+   * Prepares one identity, sharing an in-flight same-identity rotation.
+   * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} config - Dispatch configuration.
+   * @returns {Promise<void>} - Resolves after stale connections close.
+   */
+  async prepare(config) {
+    const identity = JSON.stringify(config)
+    if (this.pending) {
+      if (this.pending.identity !== identity) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
+      return await this.pending.promise
+    }
+    if (this.activeIdentity === identity) return
+    if (this.activeUsers > 0) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
+    if (this.activeIdentity === undefined) {
+      this.activeIdentity = identity
+      return
+    }
+
+    const promise = this.rotate(identity)
+    this.pending = {identity, promise}
+    try {
+      await promise
+    } finally {
+      this.pending = undefined
+    }
+  }
+
+  /**
+   * Runs work while preventing a different identity from replacing its connections.
+   * @template T
+   * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} config - Dispatch configuration.
+   * @param {() => Promise<T>} callback - Job callback.
+   * @returns {Promise<T>} - Job result.
+   */
+  async run(config, callback) {
+    await this.prepare(config)
+    this.activeUsers++
+    try {
+      return await callback()
+    } finally {
+      this.activeUsers--
+    }
+  }
+
+  /**
+   * Rotates retained connection state to an identity.
+   * @param {string} identity - Target identity.
+   * @returns {Promise<void>} - Resolves after rotation.
+   */
+  async rotate(identity) {
+    await this.closeConnections()
+    this.activeIdentity = identity
+  }
+}

--- a/src/background-jobs/pooled-runner-child.js
+++ b/src/background-jobs/pooled-runner-child.js
@@ -3,6 +3,7 @@
 import runJobPayload, { BackgroundJobPerformedFailure } from "./job-runner.js"
 import { closeRunnerConnections, currentConfigurationOrNull } from "./runner-graceful-shutdown.js"
 import setRunnerProcessTitle from "./runner-process-title.js"
+import PooledRunnerBrokerIdentity from "./pooled-runner-broker-identity.js"
 import { runWithSharedTransactionBrokerConfig } from "../testing/shared-transaction-proxy-driver.js"
 
 const BASE_PROCESS_TITLE = "velocious background-jobs-runner"
@@ -34,27 +35,9 @@ async function shutdownRunner(exitCode) {
  * @type {Set<string>}
  */
 const runningJobIds = new Set()
-/** @type {string | undefined} */
-let activeBrokerIdentity
-
-/**
- * Clears retained proxy/direct connections whenever the per-job broker mode or
- * capability changes. Concurrent siblings must share one identity.
- * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} config - Dispatch-time configuration.
- * @returns {Promise<void>} - Resolves after stale connections are closed.
- */
-async function prepareBrokerIdentity(config) {
-  const identity = JSON.stringify(config)
-  if (activeBrokerIdentity === undefined) {
-    activeBrokerIdentity = identity
-    return
-  }
-  if (activeBrokerIdentity === identity) return
-  if (runningJobIds.size > 1) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
-
-  await closeRunnerConnections(currentConfigurationOrNull())
-  activeBrokerIdentity = identity
-}
+const brokerIdentity = new PooledRunnerBrokerIdentity({
+  closeConnections: async () => await closeRunnerConnections(currentConfigurationOrNull())
+})
 
 /**
  * Sets an aggregate process title from the current in-flight count. A child runs
@@ -123,8 +106,9 @@ function sendOutcome({jobId, acknowledged, status, error}) {
 async function runJob(payload, sharedTransactionBroker) {
   try {
     const status = await runWithSharedTransactionBrokerConfig(sharedTransactionBroker, async () => {
-      await prepareBrokerIdentity(sharedTransactionBroker)
-      return await runJobPayload(payload, {closeConnections: false, manageProcessTitle: false})
+      return await brokerIdentity.run(sharedTransactionBroker, async () => {
+        return await runJobPayload(payload, {closeConnections: false, manageProcessTitle: false})
+      })
     })
     await sendOutcome({jobId: payload.id, acknowledged: true, status})
   } catch (error) {

--- a/src/background-jobs/pooled-runner-child.js
+++ b/src/background-jobs/pooled-runner-child.js
@@ -3,6 +3,7 @@
 import runJobPayload, { BackgroundJobPerformedFailure } from "./job-runner.js"
 import { closeRunnerConnections, currentConfigurationOrNull } from "./runner-graceful-shutdown.js"
 import setRunnerProcessTitle from "./runner-process-title.js"
+import { runWithSharedTransactionBrokerConfig } from "../testing/shared-transaction-proxy-driver.js"
 
 const BASE_PROCESS_TITLE = "velocious background-jobs-runner"
 
@@ -33,6 +34,27 @@ async function shutdownRunner(exitCode) {
  * @type {Set<string>}
  */
 const runningJobIds = new Set()
+/** @type {string | undefined} */
+let activeBrokerIdentity
+
+/**
+ * Clears retained proxy/direct connections whenever the per-job broker mode or
+ * capability changes. Concurrent siblings must share one identity.
+ * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} config - Dispatch-time configuration.
+ * @returns {Promise<void>} - Resolves after stale connections are closed.
+ */
+async function prepareBrokerIdentity(config) {
+  const identity = JSON.stringify(config)
+  if (activeBrokerIdentity === undefined) {
+    activeBrokerIdentity = identity
+    return
+  }
+  if (activeBrokerIdentity === identity) return
+  if (runningJobIds.size > 1) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
+
+  await closeRunnerConnections(currentConfigurationOrNull())
+  activeBrokerIdentity = identity
+}
 
 /**
  * Sets an aggregate process title from the current in-flight count. A child runs
@@ -51,11 +73,11 @@ function updateProcessTitle() {
 /**
  * Checks whether an IPC value is a runnable pooled job message.
  * @param {ReturnType<typeof JSON.parse>} message - IPC message.
- * @returns {message is {type: "job", payload: import("./types.js").BackgroundJobPayload & {id: string}}} - Whether this is a valid job message.
+ * @returns {message is {type: "job", payload: import("./types.js").BackgroundJobPayload & {id: string}, sharedTransactionBroker?: import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig}} - Whether this is a valid job message.
  */
 function isJobMessage(message) {
   if (!message || typeof message !== "object") return false
-  const record = /** @type {{type?: ReturnType<typeof JSON.parse>, payload?: ReturnType<typeof JSON.parse>}} */ (message)
+  const record = /** @type {{type?: ReturnType<typeof JSON.parse>, payload?: ReturnType<typeof JSON.parse>, sharedTransactionBroker?: ReturnType<typeof JSON.parse>}} */ (message)
 
   return record.type === "job" && !!record.payload && typeof record.payload === "object" && typeof record.payload.id === "string"
 }
@@ -95,11 +117,15 @@ function sendOutcome({jobId, acknowledged, status, error}) {
  * per-job try/catch) ends the child, which the worker sees as an exit and
  * reclaims for the whole in-flight set.
  * @param {import("./types.js").BackgroundJobPayload & {id: string}} payload - Job payload.
+ * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} sharedTransactionBroker - Per-job broker configuration.
  * @returns {Promise<void>} - Resolves after reporting.
  */
-async function runJob(payload) {
+async function runJob(payload, sharedTransactionBroker) {
   try {
-    const status = await runJobPayload(payload, {closeConnections: false, manageProcessTitle: false})
+    const status = await runWithSharedTransactionBrokerConfig(sharedTransactionBroker, async () => {
+      await prepareBrokerIdentity(sharedTransactionBroker)
+      return await runJobPayload(payload, {closeConnections: false, manageProcessTitle: false})
+    })
     await sendOutcome({jobId: payload.id, acknowledged: true, status})
   } catch (error) {
     if (error instanceof BackgroundJobPerformedFailure) {
@@ -125,7 +151,7 @@ function handleMessage(message) {
 
   runningJobIds.add(message.payload.id)
   updateProcessTitle()
-  void runJob(message.payload)
+  void runJob(message.payload, message.sharedTransactionBroker || {expected: false})
 }
 
 process.on("message", (message) => handleMessage(message))

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -2376,23 +2376,18 @@ export default class BackgroundJobsStore {
    * @returns {Promise<T>} - Callback result.
    */
   async _withDb(callback) {
-    const pool = this.configuration.getDatabasePool(this.getDatabaseIdentifier())
-    let callbackCalled = false
-    /**
-     * Defines result.
-     * @type {T | undefined} */
-    let result
+    const databaseIdentifier = this.getDatabaseIdentifier()
+    const pool = this.configuration.getDatabasePool(databaseIdentifier)
 
-    await pool.withConnection({name: "Background jobs store"}, async (db) => {
-      callbackCalled = true
-      result = await callback(db)
-    })
-
-    if (!callbackCalled) {
-      throw new Error("Background jobs store callback was not invoked")
+    if (!pool.testSharedConnection()) {
+      return await pool.withConnection({name: "Background jobs store"}, callback)
     }
 
-    return /** @type {T} */ (result)
+    return await this.configuration.runWithTestSharedConnectionContexts(async () => {
+      return await this.configuration.ensureConnections({databaseIdentifiers: [databaseIdentifier], name: "Background jobs store"}, async (dbs) => {
+        return await callback(dbs[databaseIdentifier])
+      })
+    })
   }
 
   /**

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -6,6 +6,7 @@ import TableData from "../database/table-data/index.js"
 import VelociousError from "../velocious-error.js"
 import BackgroundJobRecord from "./job-record.js"
 import normalizeBackgroundJobError from "./normalize-error.js"
+import {coordinateSharedTransactionConnection} from "../testing/shared-transaction-connection-coordinator.js"
 
 /**
  * PreparedBackgroundJob type.
@@ -2385,7 +2386,8 @@ export default class BackgroundJobsStore {
 
     return await this.configuration.runWithTestSharedConnectionContexts(async () => {
       return await this.configuration.ensureConnections({databaseIdentifiers: [databaseIdentifier], name: "Background jobs store"}, async (dbs) => {
-        return await callback(dbs[databaseIdentifier])
+        const connection = dbs[databaseIdentifier]
+        return await coordinateSharedTransactionConnection(connection, async () => await callback(connection))
       })
     })
   }

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -693,11 +693,24 @@ export default class BackgroundJobsWorker {
 
       state.inflight.set(payload.id, {payload, resolve, timeoutTimer})
       try {
-        child.send({type: "job", payload})
+        child.send({type: "job", payload, sharedTransactionBroker: this._pooledJobSharedTransactionBrokerConfig()})
       } catch (error) {
         void this._handlePooledChildFailure({child, error})
       }
     })
+  }
+
+  /**
+   * Captures the current test attempt's broker mode at dispatch time. A warm
+   * pooled child must never rely on its immutable fork-time environment.
+   * @returns {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} - Per-job broker configuration.
+   */
+  _pooledJobSharedTransactionBrokerConfig() {
+    const serialized = process.env.VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER
+    if (!serialized) return {expected: false}
+
+    const config = JSON.parse(Buffer.from(serialized, "base64url").toString("utf8"))
+    return {...config, expected: true}
   }
 
   /**

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -792,7 +792,7 @@ export default class BackgroundJobsWorker {
     const config = configuration.getBackgroundJobsConfig()
     const child = fork(POOLED_RUNNER_ENTRY_PATH, [], {
       cwd: configuration.getDirectory(), execArgv: [], stdio: ["ignore", "ignore", "ignore", "ipc"],
-      env: Object.assign({}, process.env, {VELOCIOUS_ENV: configuration.getEnvironment(), VELOCIOUS_BACKGROUND_JOBS_HOST: config.host, VELOCIOUS_BACKGROUND_JOBS_PORT: `${config.port}`})
+      env: Object.assign({}, process.env, {VELOCIOUS_BACKGROUND_JOB_CHILD: "1", VELOCIOUS_ENV: configuration.getEnvironment(), VELOCIOUS_BACKGROUND_JOBS_HOST: config.host, VELOCIOUS_BACKGROUND_JOBS_PORT: `${config.port}`})
     })
     this.pooledChildren.add(child)
     this.inflightProcessChildren.add(child)
@@ -989,6 +989,7 @@ export default class BackgroundJobsWorker {
       execArgv: [],
       stdio: ["ignore", "ignore", "ignore", "ipc"],
       env: Object.assign({}, process.env, {
+        VELOCIOUS_BACKGROUND_JOB_CHILD: "1",
         VELOCIOUS_ENV: configuration.getEnvironment(),
         VELOCIOUS_BACKGROUND_JOBS_HOST: backgroundJobsConfig.host,
         VELOCIOUS_BACKGROUND_JOBS_PORT: `${backgroundJobsConfig.port}`
@@ -1216,6 +1217,7 @@ export default class BackgroundJobsWorker {
       detached: true,
       stdio: "ignore",
       env: Object.assign({}, process.env, {
+        VELOCIOUS_BACKGROUND_JOB_CHILD: "1",
         VELOCIOUS_ENV: configuration.getEnvironment(),
         VELOCIOUS_BACKGROUND_JOBS_HOST: backgroundJobsConfig.host,
         VELOCIOUS_BACKGROUND_JOBS_PORT: `${backgroundJobsConfig.port}`,

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -349,7 +349,15 @@ class VelociousDatabasePoolBase {
 
     if (!DriverClass) throw new Error("No driver class set in database pool or in given config")
 
-    const connection = new DriverClass(config, this.configuration)
+    const sharedConnection = config.tenantOnly
+      ? undefined
+      : await this.configuration.getEnvironmentHandler().createTestSharedTransactionConnection({
+        DriverClass,
+        config,
+        configuration: this.configuration,
+        databaseIdentifier: this.identifier
+      })
+    const connection = sharedConnection || new DriverClass(config, this.configuration)
 
     try {
       await connection.connect()

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -194,6 +194,15 @@ class VelociousDatabasePoolBase {
   }
 
   /**
+   * Returns the connection registered for test-only in-process sharing.
+   * Base pools do not need a separate shared connection.
+   * @returns {import("../drivers/base.js").default | undefined} - Shared connection.
+   */
+  testSharedConnection() {
+    return undefined
+  }
+
+  /**
    * Returns whether the current connection is pinned to an execution context.
    * @returns {boolean} - Whether the current connection can be reused by nested code.
    */

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -20,6 +20,14 @@ import {validateTimeZone} from "../time-zone.js"
 
 export default class VelociousEnvironmentHandlerBase {
   /**
+   * Node test runtimes may replace a physical child connection with a broker
+   * proxy. Other environments never participate in this test-only protocol.
+   * @param {{DriverClass: typeof import("../database/drivers/base.js").default, config: import("../configuration-types.js").DatabaseConfigurationType, configuration: import("../configuration.js").default, databaseIdentifier: string}} _args - Connection details.
+   * @returns {Promise<import("../database/drivers/base.js").default | undefined>} - Optional proxy.
+   */
+  async createTestSharedTransactionConnection(_args) { return undefined }
+
+  /**
    * Mutable ambient tenant used by runtimes without async-context storage.
    * @type {ReturnType<typeof JSON.parse> | undefined}
    */

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -36,6 +36,7 @@ import InitializerFromRequireContext from "../database/initializer-from-require-
 import toImportSpecifier from "../utils/to-import-specifier.js"
 import {validateTimeZone} from "../time-zone.js"
 import AttachmentPathSource from "./node/attachment-path-source.js"
+import { createSharedTransactionProxyDriver, sharedTransactionBrokerConfig } from "../testing/shared-transaction-proxy-driver.js"
 
 /**
  * Defines this typedef.
@@ -63,6 +64,17 @@ function pathWithinAllowedPrefixes(filePath, allowedPathPrefixes) {
 }
 
 export default class VelociousEnvironmentHandlerNode extends Base{
+  /**
+   * Creates a test-only child proxy when TestRunner supplied an active broker.
+   * @param {{DriverClass: typeof import("../database/drivers/base.js").default, config: import("../configuration-types.js").DatabaseConfigurationType, configuration: import("../configuration.js").default, databaseIdentifier: string}} args - Connection details.
+   * @returns {Promise<import("../database/drivers/base.js").default | undefined>} - Optional proxy.
+   */
+  async createTestSharedTransactionConnection({DriverClass, config, configuration, databaseIdentifier}) {
+    const brokerConfig = sharedTransactionBrokerConfig(databaseIdentifier)
+    if (!brokerConfig) return undefined
+    return createSharedTransactionProxyDriver(DriverClass, config, configuration, databaseIdentifier, brokerConfig)
+  }
+
   /**
    * Timezone async local storage.
    * @type {import("node:async_hooks").AsyncLocalStorage<TimezoneStore> | undefined} */

--- a/src/testing/shared-transaction-broker-client.js
+++ b/src/testing/shared-transaction-broker-client.js
@@ -1,0 +1,107 @@
+// @ts-check
+
+import WebSocket from "ws"
+import { decodeBrokerValue, encodeBrokerValue } from "./shared-transaction-codec.js"
+
+export default class SharedTransactionBrokerClient {
+  /**
+   * Creates a broker client.
+   * @param {{address: string, capability: string, databaseIdentifier: string}} args - Broker coordinates.
+   */
+  constructor({address, capability, databaseIdentifier}) {
+    this.capability = capability
+    this.databaseIdentifier = databaseIdentifier
+    this.nextRequestId = 1
+    /** @type {Map<number, {reject: (error: Error) => void, resolve: (value: ReturnType<typeof decodeBrokerValue>) => void}>} */
+    this.pending = new Map()
+    this.socket = new WebSocket(address)
+    this.connectionPromise = new Promise((resolve, reject) => {
+      this.socket.once("open", resolve)
+      this.socket.once("error", reject)
+    })
+    this.socket.on("message", (data) => this.handleMessage(`${data}`))
+    this.socket.once("close", () => this.rejectPending(new Error("Shared transaction broker connection closed")))
+    this.socket.on("error", (error) => this.rejectPending(error))
+  }
+
+  /**
+   * Waits for the websocket to open.
+   * @returns {Promise<void>} - Resolves after the websocket opens.
+   */
+  async connected() { await this.connectionPromise }
+
+  /**
+   * Calls one physical connection operation.
+   * @param {string} method - Broker operation.
+   * @param {Array<ReturnType<typeof JSON.parse>>} args - Operation arguments.
+   * @returns {Promise<ReturnType<typeof decodeBrokerValue>>} - Remote result.
+   */
+  async call(method, args) {
+    await this.connected()
+    if (this.socket.readyState !== WebSocket.OPEN) throw new Error("Shared transaction broker connection is closed")
+    const requestId = this.nextRequestId++
+    const response = new Promise((resolve, reject) => this.pending.set(requestId, {resolve, reject}))
+
+    this.socket.send(JSON.stringify({
+      requestId,
+      capability: this.capability,
+      databaseIdentifier: this.databaseIdentifier,
+      method,
+      args: encodeBrokerValue(args)
+    }), (error) => {
+      if (!error) return
+      const pending = this.pending.get(requestId)
+      this.pending.delete(requestId)
+      pending?.reject(error)
+    })
+
+    return await response
+  }
+
+  /**
+   * Handles a correlated broker response.
+   * @param {string} serialized - Serialized response.
+   * @returns {void} - No return value.
+   */
+  handleMessage(serialized) {
+    const response = /** @type {{requestId: number, result?: import("./shared-transaction-codec.js").EncodedBrokerValue, error?: import("./shared-transaction-codec.js").EncodedBrokerValue}} */ (JSON.parse(serialized))
+    const pending = this.pending.get(response.requestId)
+    if (!pending) return
+    this.pending.delete(response.requestId)
+
+    if (response.error) {
+      const error = decodeBrokerValue(response.error)
+      pending.reject(error instanceof Error ? error : new Error(String(error)))
+    } else if (response.result) {
+      pending.resolve(decodeBrokerValue(response.result))
+    } else {
+      pending.reject(new Error("Invalid shared transaction broker response"))
+    }
+  }
+
+  /**
+   * Rejects every pending call after disconnect.
+   * @param {Error} error - Disconnect error.
+   * @returns {void} - No return value.
+   */
+  rejectPending(error) {
+    for (const {reject} of this.pending.values()) reject(error)
+    this.pending.clear()
+  }
+
+  /**
+   * Closes the client without touching the parent connection.
+   * @returns {Promise<void>} - Resolves after the websocket closes.
+   */
+  async close() {
+    if (this.socket.readyState === WebSocket.CLOSED) return
+    if (this.socket.readyState === WebSocket.CONNECTING) {
+      this.socket.terminate()
+      return
+    }
+    await new Promise((resolve) => {
+      this.socket.once("close", resolve)
+      this.socket.close()
+    })
+  }
+}

--- a/src/testing/shared-transaction-broker.js
+++ b/src/testing/shared-transaction-broker.js
@@ -1,0 +1,160 @@
+// @ts-check
+
+import { randomBytes, timingSafeEqual } from "node:crypto"
+import { createServer } from "node:http"
+import { EventEmitter } from "node:events"
+import { WebSocketServer } from "ws"
+import { decodeBrokerValue, encodeBrokerValue } from "./shared-transaction-codec.js"
+
+const ALLOWED_METHODS = new Set([
+  "query",
+  "affectedRows",
+  "_queryActual",
+  "_affectedRowsActual",
+  "_startTransactionAction",
+  "_commitTransactionAction",
+  "_rollbackTransactionAction",
+  "startSavePoint",
+  "releaseSavePoint",
+  "rollbackSavePoint",
+  "getConnectionScopedValue"
+])
+
+/**
+ * Compares a presented capability without leaking matching prefix timing.
+ * @param {string} provided - Presented capability.
+ * @param {string} expected - Active capability.
+ * @returns {boolean} - Whether the capabilities match.
+ */
+function capabilityMatches(provided, expected) {
+  const providedBytes = Buffer.from(provided)
+  const expectedBytes = Buffer.from(expected)
+  return providedBytes.length === expectedBytes.length && timingSafeEqual(providedBytes, expectedBytes)
+}
+
+export default class SharedTransactionBroker extends EventEmitter {
+  /**
+   * Creates a broker around parent-owned physical connections.
+   * @param {{connections: Record<string, object>}} args - Parent-owned physical connections.
+   */
+  constructor({connections}) {
+    super()
+    this.connections = connections
+    this.secret = randomBytes(32).toString("base64url")
+    this.accepting = true
+    /** @type {Map<object, Promise<void>>} */
+    this.connectionQueues = new Map()
+    /** @type {Set<import("ws").WebSocket>} */
+    this.sessions = new Set()
+    this.httpServer = createServer()
+    this.websocketServer = new WebSocketServer({server: this.httpServer, maxPayload: 16 * 1024 * 1024})
+    this.websocketServer.on("connection", (socket) => {
+      this.sessions.add(socket)
+      socket.once("close", () => this.sessions.delete(socket))
+      socket.on("message", (data) => void this.handleRequest(socket, `${data}`))
+    })
+  }
+
+  /**
+   * Starts a broker on an ephemeral loopback port.
+   * @param {{connections: Record<string, object>}} args - Parent-owned physical connections.
+   * @returns {Promise<SharedTransactionBroker>} - Listening broker.
+   */
+  static async start(args) {
+    const broker = new SharedTransactionBroker(args)
+    await new Promise((resolve, reject) => {
+      broker.httpServer.once("error", reject)
+      broker.httpServer.listen({host: "127.0.0.1", port: 0}, () => resolve(undefined))
+    })
+    return broker
+  }
+
+  /**
+   * Gets the loopback websocket address.
+   * @returns {string} - Loopback websocket address.
+   */
+  address() {
+    const address = this.httpServer.address()
+    if (!address || typeof address === "string") throw new Error("Shared transaction broker is not listening")
+    return `ws://127.0.0.1:${address.port}`
+  }
+
+  /**
+   * Gets the per-attempt unguessable capability.
+   * @returns {string} - Per-attempt unguessable capability.
+   */
+  capability() { return this.secret }
+
+  /**
+   * Validates and handles one request.
+   * @param {import("ws").WebSocket} socket - Calling session.
+   * @param {string} serialized - Request JSON.
+   * @returns {Promise<void>} - Resolves after responding.
+   */
+  async handleRequest(socket, serialized) {
+    let requestId = 0
+    try {
+      const request = /** @type {{requestId: number, capability: string, databaseIdentifier: string, method: string, args: import("./shared-transaction-codec.js").EncodedBrokerValue}} */ (JSON.parse(serialized))
+      requestId = request.requestId
+      if (!this.accepting) throw new Error("Shared transaction broker capability has been revoked")
+      if (!capabilityMatches(request.capability, this.secret)) throw new Error("Unknown shared transaction broker capability")
+      const connection = this.connections[request.databaseIdentifier]
+      if (!connection) throw new Error(`Unknown shared transaction database identifier: ${request.databaseIdentifier}`)
+      if (!ALLOWED_METHODS.has(request.method)) throw new Error(`Unsupported shared transaction broker method: ${request.method}`)
+      const args = decodeBrokerValue(request.args)
+      if (!Array.isArray(args)) throw new TypeError("Shared transaction broker arguments must be an array")
+      this.emit("work-queued", {connection, databaseIdentifier: request.databaseIdentifier, method: request.method})
+      const result = await this.serialize(connection, async () => {
+        if (!this.accepting) throw new Error("Shared transaction broker capability has been revoked")
+        const connectionMethods = /** @type {Record<string, (...methodArgs: Array<ReturnType<typeof JSON.parse>>) => ReturnType<typeof JSON.parse>>} */ (connection)
+        const method = connectionMethods[request.method]
+        if (typeof method !== "function") throw new Error(`Connection does not support shared transaction method: ${request.method}`)
+        return await method.apply(connection, args)
+      })
+      if (socket.readyState === socket.OPEN) socket.send(JSON.stringify({requestId, result: encodeBrokerValue(result)}))
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error(String(error))
+      if (socket.readyState === socket.OPEN) socket.send(JSON.stringify({requestId, error: encodeBrokerValue(normalized)}))
+    }
+  }
+
+  /**
+   * Serializes work by physical connection across all sessions and identifiers.
+   * @template T
+   * @param {object} connection - Parent-owned physical connection.
+   * @param {() => Promise<T>} callback - Work.
+   * @returns {Promise<T>} - Serialized result.
+   */
+  async serialize(connection, callback) {
+    const previous = this.connectionQueues.get(connection) || Promise.resolve()
+    /**
+     * Resolves the current queue entry.
+     * @type {(value?: void) => void}
+     */
+    let release = () => {}
+    const current = new Promise((resolve) => { release = resolve })
+    const queued = previous.then(() => current)
+    this.connectionQueues.set(connection, queued)
+    await previous
+    try {
+      return await callback()
+    } finally {
+      release()
+      if (this.connectionQueues.get(connection) === queued) this.connectionQueues.delete(connection)
+    }
+  }
+
+  /**
+   * Stops admission, revokes capability, rejects clients, and drains active work.
+   * @returns {Promise<void>} - Resolves after transport shutdown.
+   */
+  async close() {
+    if (!this.accepting) return
+    this.accepting = false
+    this.secret = randomBytes(32).toString("base64url")
+    for (const socket of this.sessions) socket.close(1001, "Shared transaction broker closed")
+    await Promise.all(Array.from(this.connectionQueues.values()))
+    await new Promise((resolve) => this.websocketServer.close(() => resolve(undefined)))
+    await new Promise((resolve) => this.httpServer.close(() => resolve(undefined)))
+  }
+}

--- a/src/testing/shared-transaction-broker.js
+++ b/src/testing/shared-transaction-broker.js
@@ -51,13 +51,19 @@ export default class SharedTransactionBroker extends EventEmitter {
     this.connectionStates = new Map()
     /** @type {Set<import("ws").WebSocket>} */
     this.sessions = new Set()
+    /** @type {Map<import("ws").WebSocket, Promise<void>>} */
+    this.sessionCleanup = new Map()
+    /** @type {Array<Error>} */
+    this.cleanupErrors = []
+    /** @type {Promise<void> | undefined} */
+    this.closePromise = undefined
     this.httpServer = createServer()
     this.websocketServer = new WebSocketServer({server: this.httpServer, maxPayload: 16 * 1024 * 1024})
     this.websocketServer.on("connection", (socket) => {
       this.sessions.add(socket)
       socket.once("close", () => {
         this.sessions.delete(socket)
-        void this.releaseDisconnectedLeases(socket)
+        this.scheduleSessionCleanup(socket)
       })
       socket.on("message", (data) => void this.handleRequest(socket, `${data}`))
     })
@@ -259,6 +265,8 @@ export default class SharedTransactionBroker extends EventEmitter {
    * @returns {Promise<void>} - Resolves after all owned leases release.
    */
   async releaseDisconnectedLeases(socket) {
+    /** @type {Array<Error>} */
+    const errors = []
     for (const [connection, state] of this.connectionStates) {
       const lease = state.lease
       if (!lease || lease.socket !== socket) continue
@@ -266,12 +274,34 @@ export default class SharedTransactionBroker extends EventEmitter {
         await this.serializeLease(lease, async () => {
           await this.rollbackRootSavePoint(connection, lease.savePointName)
         })
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)))
       } finally {
         state.lease = undefined
         state.rootSessions.delete(socket)
         lease.release()
       }
     }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, `Shared transaction broker lease cleanup failed: ${errors.map((error) => error.message).join("; ")}`)
+    }
+  }
+
+  /**
+   * Tracks detached socket cleanup and records its failure for close().
+   * @param {import("ws").WebSocket} socket - Closed session.
+   * @returns {Promise<void>} - Settled tracked cleanup.
+   */
+  scheduleSessionCleanup(socket) {
+    const existing = this.sessionCleanup.get(socket)
+    if (existing) return existing
+    const cleanup = this.releaseDisconnectedLeases(socket)
+      .catch((error) => {
+        this.cleanupErrors.push(error instanceof Error ? error : new Error(String(error)))
+      })
+      .finally(() => this.sessionCleanup.delete(socket))
+    this.sessionCleanup.set(socket, cleanup)
+    return cleanup
   }
 
   /**
@@ -282,8 +312,21 @@ export default class SharedTransactionBroker extends EventEmitter {
    */
   async rollbackRootSavePoint(connection, savePointName) {
     const methods = /** @type {{releaseSavePoint: (name: string) => Promise<void>, rollbackSavePoint: (name: string) => Promise<void>}} */ (connection)
-    await methods.rollbackSavePoint(savePointName)
-    await methods.releaseSavePoint(savePointName)
+    /** @type {Array<Error>} */
+    const errors = []
+    try {
+      await methods.rollbackSavePoint(savePointName)
+    } catch (error) {
+      errors.push(error instanceof Error ? error : new Error(String(error)))
+    }
+    try {
+      await methods.releaseSavePoint(savePointName)
+    } catch (error) {
+      errors.push(error instanceof Error ? error : new Error(String(error)))
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, `Shared transaction broker could not clean root savepoint ${savePointName}: ${errors.map((error) => error.message).join("; ")}`)
+    }
   }
 
   /**
@@ -316,13 +359,27 @@ export default class SharedTransactionBroker extends EventEmitter {
    * @returns {Promise<void>} - Resolves after transport shutdown.
    */
   async close() {
-    if (!this.accepting) return
+    if (this.closePromise) return await this.closePromise
+    this.closePromise = this.closeTransport()
+    return await this.closePromise
+  }
+
+  /**
+   * Performs deterministic transport shutdown and reports cleanup failures last.
+   * @returns {Promise<void>} - Resolves after shutdown or rejects with cleanup errors.
+   */
+  async closeTransport() {
     this.accepting = false
     this.secret = randomBytes(32).toString("base64url")
-    for (const socket of this.sessions) await this.releaseDisconnectedLeases(socket)
-    for (const socket of this.sessions) socket.close(1001, "Shared transaction broker closed")
-    await Promise.all(Array.from(this.connectionStates.values()).map((state) => state.queue))
+    const closingSessions = Array.from(this.sessions)
+    await Promise.all(closingSessions.map(async (socket) => await this.scheduleSessionCleanup(socket)))
+    for (const socket of closingSessions) socket.close(1001, "Shared transaction broker closed")
+    await Promise.allSettled(Array.from(this.connectionStates.values()).map((state) => state.queue))
     await new Promise((resolve) => this.websocketServer.close(() => resolve(undefined)))
     await new Promise((resolve) => this.httpServer.close(() => resolve(undefined)))
+    await Promise.all(Array.from(this.sessionCleanup.values()))
+    if (this.cleanupErrors.length > 0) {
+      throw new AggregateError(this.cleanupErrors, `Shared transaction broker cleanup failed: ${this.cleanupErrors.map((error) => error.message).join("; ")}`)
+    }
   }
 }

--- a/src/testing/shared-transaction-broker.js
+++ b/src/testing/shared-transaction-broker.js
@@ -6,6 +6,8 @@ import { EventEmitter } from "node:events"
 import { WebSocketServer } from "ws"
 import { decodeBrokerValue, encodeBrokerValue } from "./shared-transaction-codec.js"
 
+/** @typedef {{queue: Promise<void>, rootSessions: Set<import("ws").WebSocket>, lease?: {operations: Promise<void>, release: () => void, savePointName: string, socket: import("ws").WebSocket}}} ConnectionState */
+
 const ALLOWED_METHODS = new Set([
   "query",
   "affectedRows",
@@ -17,7 +19,10 @@ const ALLOWED_METHODS = new Set([
   "startSavePoint",
   "releaseSavePoint",
   "rollbackSavePoint",
-  "getConnectionScopedValue"
+  "getConnectionScopedValue",
+  "rootTransactionStart",
+  "rootTransactionRelease",
+  "rootTransactionRollback"
 ])
 
 /**
@@ -42,15 +47,18 @@ export default class SharedTransactionBroker extends EventEmitter {
     this.connections = connections
     this.secret = randomBytes(32).toString("base64url")
     this.accepting = true
-    /** @type {Map<object, Promise<void>>} */
-    this.connectionQueues = new Map()
+    /** @type {Map<object, ConnectionState>} */
+    this.connectionStates = new Map()
     /** @type {Set<import("ws").WebSocket>} */
     this.sessions = new Set()
     this.httpServer = createServer()
     this.websocketServer = new WebSocketServer({server: this.httpServer, maxPayload: 16 * 1024 * 1024})
     this.websocketServer.on("connection", (socket) => {
       this.sessions.add(socket)
-      socket.once("close", () => this.sessions.delete(socket))
+      socket.once("close", () => {
+        this.sessions.delete(socket)
+        void this.releaseDisconnectedLeases(socket)
+      })
       socket.on("message", (data) => void this.handleRequest(socket, `${data}`))
     })
   }
@@ -104,10 +112,21 @@ export default class SharedTransactionBroker extends EventEmitter {
       const args = decodeBrokerValue(request.args)
       if (!Array.isArray(args)) throw new TypeError("Shared transaction broker arguments must be an array")
       this.emit("work-queued", {connection, databaseIdentifier: request.databaseIdentifier, method: request.method})
-      const result = await this.serialize(connection, async () => {
+      const result = await this.runConnectionRequest({connection, method: request.method, savePointName: typeof args[0] === "string" ? args[0] : undefined, socket}, async () => {
         if (!this.accepting) throw new Error("Shared transaction broker capability has been revoked")
+        if (request.method === "rootTransactionRollback") {
+          await this.rollbackRootSavePoint(connection, /** @type {string} */ (args[0]))
+          return undefined
+        }
+        const physicalMethod = request.method === "rootTransactionStart"
+          ? "startSavePoint"
+          : request.method === "rootTransactionRelease"
+            ? "releaseSavePoint"
+            : request.method === "rootTransactionRollback"
+              ? "rollbackSavePoint"
+              : request.method
         const connectionMethods = /** @type {Record<string, (...methodArgs: Array<ReturnType<typeof JSON.parse>>) => ReturnType<typeof JSON.parse>>} */ (connection)
-        const method = connectionMethods[request.method]
+        const method = connectionMethods[physicalMethod]
         if (typeof method !== "function") throw new Error(`Connection does not support shared transaction method: ${request.method}`)
         return await method.apply(connection, args)
       })
@@ -119,14 +138,163 @@ export default class SharedTransactionBroker extends EventEmitter {
   }
 
   /**
-   * Serializes work by physical connection across all sessions and identifiers.
-   * @template T
-   * @param {object} connection - Parent-owned physical connection.
-   * @param {() => Promise<T>} callback - Work.
-   * @returns {Promise<T>} - Serialized result.
+   * Gets mutable serialization state for one physical connection.
+   * @param {object} connection - Physical connection.
+   * @returns {ConnectionState} - Connection state.
    */
-  async serialize(connection, callback) {
-    const previous = this.connectionQueues.get(connection) || Promise.resolve()
+  connectionState(connection) {
+    let state = this.connectionStates.get(connection)
+    if (!state) {
+      state = {queue: Promise.resolve(), rootSessions: new Set()}
+      this.connectionStates.set(connection, state)
+    }
+    return state
+  }
+
+  /**
+   * Runs a validated request with root transaction lease semantics.
+   * @template T
+   * @param {{connection: object, method: string, savePointName: string | undefined, socket: import("ws").WebSocket}} args - Request identity.
+   * @param {() => Promise<T>} callback - Physical operation.
+   * @returns {Promise<T>} - Operation result.
+   */
+  async runConnectionRequest({connection, method, savePointName, socket}, callback) {
+    const state = this.connectionState(connection)
+    if (method === "rootTransactionStart") {
+      if (!savePointName) throw new Error("Shared transaction broker root transaction requires a savepoint name")
+      return await this.startRootLease({callback, savePointName, state, socket})
+    }
+    if (method === "rootTransactionRelease" || method === "rootTransactionRollback") {
+      return await this.finishRootLease({callback, savePointName, state, socket})
+    }
+    if (state.lease?.socket === socket) return await this.serializeLease(state.lease, callback)
+    return await this.serialize(state, callback)
+  }
+
+  /**
+   * Acquires the FIFO physical connection lease and holds the queue until end.
+   * @template T
+   * @param {{callback: () => Promise<T>, savePointName: string, state: ConnectionState, socket: import("ws").WebSocket}} args - Lease request.
+   * @returns {Promise<T>} - Root savepoint start result.
+   */
+  async startRootLease({callback, savePointName, state, socket}) {
+    if (state.rootSessions.has(socket)) throw new Error("Shared transaction broker root transaction is already active for this session")
+    state.rootSessions.add(socket)
+    const previous = state.queue
+    /**
+     * Resolves the start response.
+     * @type {(value: T) => void}
+     */
+    let resolveStarted = () => {}
+    /**
+     * Rejects the start response.
+     * @type {(error: Error) => void}
+     */
+    let rejectStarted = () => {}
+    const started = new Promise((resolve, reject) => { resolveStarted = resolve; rejectStarted = reject })
+    /**
+     * Releases the held connection queue.
+     * @type {(value?: void) => void}
+     */
+    let release = () => {}
+    const held = new Promise((resolve) => { release = resolve })
+
+    state.queue = previous.then(async () => {
+      try {
+        if (!this.accepting || socket.readyState !== socket.OPEN) throw new Error("Shared transaction broker root transaction session closed before lease acquisition")
+        const result = await callback()
+        state.lease = {operations: Promise.resolve(), release, savePointName, socket}
+        resolveStarted(result)
+        await held
+      } catch (error) {
+        state.rootSessions.delete(socket)
+        rejectStarted(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+    return await started
+  }
+
+  /**
+   * Finishes the calling session's root lease.
+   * @template T
+   * @param {{callback: () => Promise<T>, savePointName: string | undefined, state: ConnectionState, socket: import("ws").WebSocket}} args - Lease end request.
+   * @returns {Promise<T>} - Savepoint end result.
+   */
+  async finishRootLease({callback, savePointName, state, socket}) {
+    const lease = state.lease
+    if (!lease || lease.socket !== socket) throw new Error("Shared transaction broker session does not own the root transaction lease")
+    if (savePointName !== lease.savePointName) throw new Error("Shared transaction broker root transaction savepoint does not match its lease")
+    try {
+      return await this.serializeLease(lease, callback)
+    } finally {
+      state.lease = undefined
+      state.rootSessions.delete(socket)
+      lease.release()
+    }
+  }
+
+  /**
+   * Serializes operations belonging to the active lease holder.
+   * @template T
+   * @param {{operations: Promise<void>}} lease - Active lease.
+   * @param {() => Promise<T>} callback - Operation.
+   * @returns {Promise<T>} - Result.
+   */
+  async serializeLease(lease, callback) {
+    const previous = lease.operations
+    /**
+     * Releases the holder operation queue.
+     * @type {(value?: void) => void}
+     */
+    let release = () => {}
+    const current = new Promise((resolve) => { release = resolve })
+    lease.operations = previous.then(() => current)
+    await previous
+    try { return await callback() } finally { release() }
+  }
+
+  /**
+   * Rolls back leases abandoned by a disconnected session.
+   * @param {import("ws").WebSocket} socket - Disconnected session.
+   * @returns {Promise<void>} - Resolves after all owned leases release.
+   */
+  async releaseDisconnectedLeases(socket) {
+    for (const [connection, state] of this.connectionStates) {
+      const lease = state.lease
+      if (!lease || lease.socket !== socket) continue
+      try {
+        await this.serializeLease(lease, async () => {
+          await this.rollbackRootSavePoint(connection, lease.savePointName)
+        })
+      } finally {
+        state.lease = undefined
+        state.rootSessions.delete(socket)
+        lease.release()
+      }
+    }
+  }
+
+  /**
+   * Rolls back and removes a root savepoint so it cannot remain beneath the next lease.
+   * @param {object} connection - Parent physical connection.
+   * @param {string} savePointName - Root savepoint name.
+   * @returns {Promise<void>} - Resolves after rollback and release.
+   */
+  async rollbackRootSavePoint(connection, savePointName) {
+    const methods = /** @type {{releaseSavePoint: (name: string) => Promise<void>, rollbackSavePoint: (name: string) => Promise<void>}} */ (connection)
+    await methods.rollbackSavePoint(savePointName)
+    await methods.releaseSavePoint(savePointName)
+  }
+
+  /**
+   * Serializes ordinary non-holder work through the connection FIFO.
+   * @template T
+   * @param {ConnectionState} state - Connection state.
+   * @param {() => Promise<T>} callback - Work.
+   * @returns {Promise<T>} - Work result.
+   */
+  async serialize(state, callback) {
+    const previous = state.queue
     /**
      * Resolves the current queue entry.
      * @type {(value?: void) => void}
@@ -134,13 +302,12 @@ export default class SharedTransactionBroker extends EventEmitter {
     let release = () => {}
     const current = new Promise((resolve) => { release = resolve })
     const queued = previous.then(() => current)
-    this.connectionQueues.set(connection, queued)
+    state.queue = queued
     await previous
     try {
       return await callback()
     } finally {
       release()
-      if (this.connectionQueues.get(connection) === queued) this.connectionQueues.delete(connection)
     }
   }
 
@@ -152,8 +319,9 @@ export default class SharedTransactionBroker extends EventEmitter {
     if (!this.accepting) return
     this.accepting = false
     this.secret = randomBytes(32).toString("base64url")
+    for (const socket of this.sessions) await this.releaseDisconnectedLeases(socket)
     for (const socket of this.sessions) socket.close(1001, "Shared transaction broker closed")
-    await Promise.all(Array.from(this.connectionQueues.values()))
+    await Promise.all(Array.from(this.connectionStates.values()).map((state) => state.queue))
     await new Promise((resolve) => this.websocketServer.close(() => resolve(undefined)))
     await new Promise((resolve) => this.httpServer.close(() => resolve(undefined)))
   }

--- a/src/testing/shared-transaction-broker.js
+++ b/src/testing/shared-transaction-broker.js
@@ -5,6 +5,7 @@ import { createServer } from "node:http"
 import { EventEmitter } from "node:events"
 import { WebSocketServer } from "ws"
 import { decodeBrokerValue, encodeBrokerValue } from "./shared-transaction-codec.js"
+import {clearSharedTransactionCoordinator, setSharedTransactionCoordinator} from "./shared-transaction-connection-coordinator.js"
 
 /** @typedef {{queue: Promise<void>, rootSessions: Set<import("ws").WebSocket>, lease?: {operations: Promise<void>, release: () => void, savePointName: string, socket: import("ws").WebSocket}}} ConnectionState */
 
@@ -57,6 +58,18 @@ export default class SharedTransactionBroker extends EventEmitter {
     this.cleanupErrors = []
     /** @type {Promise<void> | undefined} */
     this.closePromise = undefined
+    /** @type {Map<object, (callback: () => Promise<ReturnType<typeof JSON.parse>>) => Promise<ReturnType<typeof JSON.parse>>>} */
+    this.connectionCoordinators = new Map()
+    for (const connection of new Set(Object.values(connections))) {
+      /**
+       * Serializes parent operations with child broker traffic.
+       * @param {() => Promise<unknown>} callback - Parent operation.
+       * @returns {Promise<unknown>} - Operation result.
+       */
+      const coordinator = async (callback) => await this.serialize(this.connectionState(connection), callback)
+      this.connectionCoordinators.set(connection, coordinator)
+      setSharedTransactionCoordinator(connection, coordinator)
+    }
     this.httpServer = createServer()
     this.websocketServer = new WebSocketServer({server: this.httpServer, maxPayload: 16 * 1024 * 1024})
     this.websocketServer.on("connection", (socket) => {
@@ -378,6 +391,9 @@ export default class SharedTransactionBroker extends EventEmitter {
     await new Promise((resolve) => this.websocketServer.close(() => resolve(undefined)))
     await new Promise((resolve) => this.httpServer.close(() => resolve(undefined)))
     await Promise.all(Array.from(this.sessionCleanup.values()))
+    for (const [connection, coordinator] of this.connectionCoordinators) {
+      clearSharedTransactionCoordinator(connection, coordinator)
+    }
     if (this.cleanupErrors.length > 0) {
       throw new AggregateError(this.cleanupErrors, `Shared transaction broker cleanup failed: ${this.cleanupErrors.map((error) => error.message).join("; ")}`)
     }

--- a/src/testing/shared-transaction-codec.js
+++ b/src/testing/shared-transaction-codec.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+/** @typedef {{[TAG]: string, value?: string | number | boolean | EncodedBrokerValue[] | Record<string, EncodedBrokerValue>}} EncodedBrokerValue */
+
+const TAG = "$velociousSharedTransaction"
+
+/**
+ * Encodes values crossing the test-only shared-transaction transport without
+ * relying on JSON's lossy Date, bigint, non-finite-number, or undefined rules.
+ * @param {ReturnType<typeof JSON.parse> | bigint | Buffer | Date | Error | undefined} value - Runtime value.
+ * @returns {EncodedBrokerValue} - Tagged transport value.
+ */
+export function encodeBrokerValue(value) {
+  if (value === undefined) return {[TAG]: "undefined"}
+  if (value === null) return {[TAG]: "null"}
+  if (typeof value === "bigint") return {[TAG]: "bigint", value: `${value}`}
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) return {[TAG]: "nan"}
+    if (value === Infinity) return {[TAG]: "infinity"}
+    if (value === -Infinity) return {[TAG]: "negative-infinity"}
+    return {[TAG]: "number", value}
+  }
+  if (typeof value === "string" || typeof value === "boolean") return {[TAG]: typeof value, value}
+  if (value instanceof Date) return {[TAG]: "date", value: value.toISOString()}
+  if (Buffer.isBuffer(value)) return {[TAG]: "buffer", value: value.toString("base64")}
+  if (value instanceof Error) {
+    /** @type {Record<string, ReturnType<typeof encodeBrokerValue>>} */
+    const properties = {
+      name: encodeBrokerValue(value.name),
+      message: encodeBrokerValue(value.message),
+      stack: encodeBrokerValue(value.stack)
+    }
+
+    for (const key of Object.keys(value)) {
+      properties[key] = encodeBrokerValue(/** @type {ReturnType<typeof JSON.parse>} */ (value)[key])
+    }
+    if ("code" in value) properties.code = encodeBrokerValue(value.code)
+    if (value.cause !== undefined) properties.cause = encodeBrokerValue(value.cause)
+
+    return {[TAG]: "error", value: properties}
+  }
+  if (Array.isArray(value)) return {[TAG]: "array", value: value.map((entry) => encodeBrokerValue(entry))}
+  if (typeof value === "object") {
+    /** @type {Record<string, ReturnType<typeof encodeBrokerValue>>} */
+    const entries = {}
+    for (const [key, entry] of Object.entries(value)) entries[key] = encodeBrokerValue(entry)
+    return {[TAG]: "object", value: entries}
+  }
+
+  throw new TypeError(`Shared transaction broker cannot encode ${typeof value}`)
+}
+
+/**
+ * Decodes a tagged broker transport value.
+ * @param {EncodedBrokerValue} encoded - Tagged transport value.
+ * @returns {ReturnType<typeof JSON.parse> | bigint | Buffer | Date | Error | undefined} - Runtime value.
+ */
+export function decodeBrokerValue(encoded) {
+  if (!encoded || typeof encoded !== "object" || typeof encoded[TAG] !== "string") {
+    throw new TypeError("Invalid shared transaction broker value")
+  }
+
+  switch (encoded[TAG]) {
+    case "undefined": return undefined
+    case "null": return null
+    case "bigint": return BigInt(/** @type {string} */ (encoded.value))
+    case "nan": return NaN
+    case "infinity": return Infinity
+    case "negative-infinity": return -Infinity
+    case "number":
+    case "string":
+    case "boolean": return encoded.value
+    case "date": return new Date(/** @type {string} */ (encoded.value))
+    case "buffer": return Buffer.from(/** @type {string} */ (encoded.value), "base64")
+    case "array": return /** @type {EncodedBrokerValue[]} */ (encoded.value).map((entry) => decodeBrokerValue(entry))
+    case "object": return decodeProperties(/** @type {Record<string, EncodedBrokerValue>} */ (encoded.value))
+    case "error": return decodeError(/** @type {Record<string, EncodedBrokerValue>} */ (encoded.value))
+    default: throw new TypeError(`Unknown shared transaction broker value tag: ${encoded[TAG]}`)
+  }
+}
+
+/**
+ * Decodes object properties.
+ * @param {Record<string, EncodedBrokerValue>} properties - Encoded properties.
+ * @returns {Record<string, ReturnType<typeof decodeBrokerValue>>} - Decoded properties.
+ */
+function decodeProperties(properties) {
+  /** @type {Record<string, ReturnType<typeof decodeBrokerValue>>} */
+  const decoded = {}
+  for (const [key, value] of Object.entries(properties)) decoded[key] = decodeBrokerValue(value)
+  return decoded
+}
+
+/**
+ * Reconstructs an error from its tagged properties.
+ * @param {Record<string, EncodedBrokerValue>} properties - Encoded error properties.
+ * @returns {Error} - Decoded error.
+ */
+function decodeError(properties) {
+  const decoded = decodeProperties(properties)
+  const ErrorClass = decoded.name === "TypeError" ? TypeError : Error
+  const error = new ErrorClass(/** @type {string} */ (decoded.message), decoded.cause === undefined ? undefined : {cause: decoded.cause})
+
+  for (const [key, value] of Object.entries(decoded)) {
+    if (key === "message" || key === "cause") continue
+    /** @type {Record<string, ReturnType<typeof decodeBrokerValue>>} */ (error)[key] = value
+  }
+
+  return error
+}

--- a/src/testing/shared-transaction-connection-coordinator.js
+++ b/src/testing/shared-transaction-connection-coordinator.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+/** @type {WeakMap<object, (callback: () => Promise<unknown>) => Promise<unknown>>} */
+const coordinators = new WeakMap()
+
+/**
+ * Registers test-only serialization owned by the active broker.
+ * @param {object} connection - Parent physical connection.
+ * @param {(callback: () => Promise<unknown>) => Promise<unknown>} coordinator - Serializer.
+ * @returns {void}
+ */
+export function setSharedTransactionCoordinator(connection, coordinator) {
+  coordinators.set(connection, coordinator)
+}
+
+/**
+ * Removes a broker-owned coordinator without disturbing a replacement.
+ * @param {object} connection - Parent physical connection.
+ * @param {(callback: () => Promise<unknown>) => Promise<unknown>} coordinator - Expected serializer.
+ * @returns {void}
+ */
+export function clearSharedTransactionCoordinator(connection, coordinator) {
+  if (coordinators.get(connection) === coordinator) coordinators.delete(connection)
+}
+
+/**
+ * Runs parent work through broker serialization when registered.
+ * @template T
+ * @param {object} connection - Parent physical connection.
+ * @param {() => Promise<T>} callback - Parent operation.
+ * @returns {Promise<T>} - Operation result.
+ */
+export async function coordinateSharedTransactionConnection(connection, callback) {
+  const coordinator = coordinators.get(connection)
+
+  if (!coordinator) return await callback()
+  return /** @type {T} */ (await coordinator(callback))
+}

--- a/src/testing/shared-transaction-proxy-driver.js
+++ b/src/testing/shared-transaction-proxy-driver.js
@@ -1,9 +1,26 @@
+/** @typedef {{address?: string, capability?: string, databaseIdentifiers?: string[], expected: boolean}} SharedTransactionBrokerJobConfig */
+
 // @ts-check
 
 import SharedTransactionBrokerClient from "./shared-transaction-broker-client.js"
+import { AsyncLocalStorage } from "node:async_hooks"
 
 export const SHARED_TRANSACTION_BROKER_ENV = "VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER"
 export const BACKGROUND_JOB_CHILD_ENV = "VELOCIOUS_BACKGROUND_JOB_CHILD"
+
+/** @type {AsyncLocalStorage<SharedTransactionBrokerJobConfig>} */
+const pooledJobBrokerConfig = new AsyncLocalStorage()
+
+/**
+ * Runs one pooled job with dispatch-time broker configuration.
+ * @template T
+ * @param {SharedTransactionBrokerJobConfig} config - Per-job broker mode and coordinates.
+ * @param {() => T} callback - Job callback.
+ * @returns {T} - Callback result.
+ */
+export function runWithSharedTransactionBrokerConfig(config, callback) {
+  return pooledJobBrokerConfig.run(config, callback)
+}
 
 /**
  * Escapes a PostgreSQL literal without requiring a live child connection.
@@ -35,15 +52,33 @@ function pgEscapeLiteral(value) {
  * @returns {{address: string, capability: string} | undefined} - Broker coordinates.
  */
 export function sharedTransactionBrokerConfig(databaseIdentifier) {
+  const contextualConfig = pooledJobBrokerConfig.getStore()
+  if (contextualConfig) return validatedBrokerConfig(contextualConfig, databaseIdentifier)
   if (process.env[BACKGROUND_JOB_CHILD_ENV] !== "1") return undefined
+
   const serialized = process.env[SHARED_TRANSACTION_BROKER_ENV]
   if (!serialized) return undefined
 
-  const config = /** @type {{address?: ReturnType<typeof JSON.parse>, capability?: ReturnType<typeof JSON.parse>, databaseIdentifiers?: ReturnType<typeof JSON.parse>}} */ (JSON.parse(Buffer.from(serialized, "base64url").toString("utf8")))
+  return validatedBrokerConfig(JSON.parse(Buffer.from(serialized, "base64url").toString("utf8")), databaseIdentifier)
+}
+
+/**
+ * Validates dispatch-time broker configuration and fails closed when expected.
+ * @param {SharedTransactionBrokerJobConfig} config - Candidate configuration.
+ * @param {string} databaseIdentifier - Logical database identifier.
+ * @returns {{address: string, capability: string} | undefined} - Broker coordinates.
+ */
+function validatedBrokerConfig(config, databaseIdentifier) {
+  if (config.expected && (!config.address || !config.capability || !config.databaseIdentifiers)) {
+    throw new Error("Transactional pooled job expected shared transaction broker coordinates")
+  }
+  if (!config.expected) return undefined
   if (typeof config.address !== "string" || typeof config.capability !== "string" || !Array.isArray(config.databaseIdentifiers)) {
     throw new Error("Invalid shared transaction broker child configuration")
   }
-  if (!config.databaseIdentifiers.includes(databaseIdentifier)) return undefined
+  if (!config.databaseIdentifiers.includes(databaseIdentifier)) {
+    throw new Error(`Transactional pooled job expected broker database identifier: ${databaseIdentifier}`)
+  }
 
   return {address: config.address, capability: config.capability}
 }
@@ -78,6 +113,12 @@ export function createSharedTransactionProxyDriver(DriverClass, config, configur
      */
     async _close() { await this.sharedTransactionClient.close() }
     /**
+     * Keeps a broker proxy transport alive across logical MySQL checkouts.
+     * Parent TestRunner owns physical session cleanup and rollback.
+     * @returns {Promise<void>} - Resolves without closing the transport.
+     */
+    async cleanupSessionStateAfterCheckout() {}
+    /**
      * Routes a physical query.
      * @param {string} sql - SQL statement.
      * @returns {Promise<import("../database/drivers/base.js").QueryResultType>} - Rows.
@@ -96,7 +137,7 @@ export function createSharedTransactionProxyDriver(DriverClass, config, configur
      */
     async _startTransactionAction() {
       this.sharedTransactionRootSavePoint = this.generateSavePointName()
-      await this.sharedTransactionClient.call("startSavePoint", [this.sharedTransactionRootSavePoint])
+      await this.sharedTransactionClient.call("rootTransactionStart", [this.sharedTransactionRootSavePoint])
     }
 
     /**
@@ -105,7 +146,7 @@ export function createSharedTransactionProxyDriver(DriverClass, config, configur
      */
     async _commitTransactionAction() {
       if (!this.sharedTransactionRootSavePoint) throw new Error("Shared transaction proxy has no root savepoint")
-      await this.sharedTransactionClient.call("releaseSavePoint", [this.sharedTransactionRootSavePoint])
+      await this.sharedTransactionClient.call("rootTransactionRelease", [this.sharedTransactionRootSavePoint])
       this.sharedTransactionRootSavePoint = undefined
     }
 
@@ -115,7 +156,7 @@ export function createSharedTransactionProxyDriver(DriverClass, config, configur
      */
     async _rollbackTransactionAction() {
       if (!this.sharedTransactionRootSavePoint) throw new Error("Shared transaction proxy has no root savepoint")
-      await this.sharedTransactionClient.call("rollbackSavePoint", [this.sharedTransactionRootSavePoint])
+      await this.sharedTransactionClient.call("rootTransactionRollback", [this.sharedTransactionRootSavePoint])
       this.sharedTransactionRootSavePoint = undefined
     }
 

--- a/src/testing/shared-transaction-proxy-driver.js
+++ b/src/testing/shared-transaction-proxy-driver.js
@@ -1,0 +1,164 @@
+// @ts-check
+
+import SharedTransactionBrokerClient from "./shared-transaction-broker-client.js"
+
+export const SHARED_TRANSACTION_BROKER_ENV = "VELOCIOUS_TEST_SHARED_TRANSACTION_BROKER"
+export const BACKGROUND_JOB_CHILD_ENV = "VELOCIOUS_BACKGROUND_JOB_CHILD"
+
+/**
+ * Escapes a PostgreSQL literal without requiring a live child connection.
+ * @param {ReturnType<typeof JSON.parse>} value - PostgreSQL literal value.
+ * @returns {string} - Quoted literal.
+ */
+function pgEscapeLiteral(value) {
+  const string = typeof value === "string" ? value : String(value)
+  let escaped = "'"
+  let hasBackslash = false
+
+  for (const character of string) {
+    if (character === "'") escaped += character
+    if (character === "\\") {
+      escaped += character
+      hasBackslash = true
+    }
+    escaped += character
+  }
+
+  escaped += "'"
+  return hasBackslash ? ` E${escaped}` : escaped
+}
+
+/**
+ * Parses the test-runner-owned child transport configuration when this logical
+ * database is registered for the active attempt.
+ * @param {string} databaseIdentifier - Logical database identifier.
+ * @returns {{address: string, capability: string} | undefined} - Broker coordinates.
+ */
+export function sharedTransactionBrokerConfig(databaseIdentifier) {
+  if (process.env[BACKGROUND_JOB_CHILD_ENV] !== "1") return undefined
+  const serialized = process.env[SHARED_TRANSACTION_BROKER_ENV]
+  if (!serialized) return undefined
+
+  const config = /** @type {{address?: ReturnType<typeof JSON.parse>, capability?: ReturnType<typeof JSON.parse>, databaseIdentifiers?: ReturnType<typeof JSON.parse>}} */ (JSON.parse(Buffer.from(serialized, "base64url").toString("utf8")))
+  if (typeof config.address !== "string" || typeof config.capability !== "string" || !Array.isArray(config.databaseIdentifiers)) {
+    throw new Error("Invalid shared transaction broker child configuration")
+  }
+  if (!config.databaseIdentifiers.includes(databaseIdentifier)) return undefined
+
+  return {address: config.address, capability: config.capability}
+}
+
+/**
+ * Creates a concrete-driver subclass that retains all local SQL/query/model
+ * builders while forwarding only physical connection actions to the parent.
+ * @param {typeof import("../database/drivers/base.js").default} DriverClass - Configured concrete driver.
+ * @param {import("../configuration-types.js").DatabaseConfigurationType} config - Database configuration.
+ * @param {import("../configuration.js").default} configuration - Child configuration.
+ * @param {string} databaseIdentifier - Logical identifier.
+ * @param {{address: string, capability: string}} brokerConfig - Broker coordinates.
+ * @returns {import("../database/drivers/base.js").default} - Unconnected physical proxy.
+ */
+export function createSharedTransactionProxyDriver(DriverClass, config, configuration, databaseIdentifier, brokerConfig) {
+  class SharedTransactionProxyDriver extends DriverClass {
+    constructor() {
+      super(config, configuration)
+      this.sharedTransactionClient = new SharedTransactionBrokerClient({...brokerConfig, databaseIdentifier})
+      /** @type {string | undefined} */
+      this.sharedTransactionRootSavePoint = undefined
+    }
+
+    /**
+     * Connects the proxy transport.
+     * @returns {Promise<void>} - Resolves when connected.
+     */
+    async connect() { await this.sharedTransactionClient.connected() }
+    /**
+     * Closes only the proxy transport.
+     * @returns {Promise<void>} - Resolves when closed.
+     */
+    async _close() { await this.sharedTransactionClient.close() }
+    /**
+     * Routes a physical query.
+     * @param {string} sql - SQL statement.
+     * @returns {Promise<import("../database/drivers/base.js").QueryResultType>} - Rows.
+     */
+    async _queryActual(sql) { return await this.sharedTransactionClient.call("_queryActual", [sql]) }
+    /**
+     * Routes an affected-row query.
+     * @param {string} sql - SQL statement.
+     * @returns {Promise<number>} - Affected rows.
+     */
+    async _affectedRowsActual(sql) { return await this.sharedTransactionClient.call("_affectedRowsActual", [sql]) }
+
+    /**
+     * Starts a child transaction as a parent savepoint.
+     * @returns {Promise<void>} - Resolves when started.
+     */
+    async _startTransactionAction() {
+      this.sharedTransactionRootSavePoint = this.generateSavePointName()
+      await this.sharedTransactionClient.call("startSavePoint", [this.sharedTransactionRootSavePoint])
+    }
+
+    /**
+     * Releases the child transaction savepoint.
+     * @returns {Promise<void>} - Resolves when released.
+     */
+    async _commitTransactionAction() {
+      if (!this.sharedTransactionRootSavePoint) throw new Error("Shared transaction proxy has no root savepoint")
+      await this.sharedTransactionClient.call("releaseSavePoint", [this.sharedTransactionRootSavePoint])
+      this.sharedTransactionRootSavePoint = undefined
+    }
+
+    /**
+     * Rolls back the child transaction savepoint.
+     * @returns {Promise<void>} - Resolves when rolled back.
+     */
+    async _rollbackTransactionAction() {
+      if (!this.sharedTransactionRootSavePoint) throw new Error("Shared transaction proxy has no root savepoint")
+      await this.sharedTransactionClient.call("rollbackSavePoint", [this.sharedTransactionRootSavePoint])
+      this.sharedTransactionRootSavePoint = undefined
+    }
+
+    /**
+     * Escapes a local SQL value.
+     * @param {ReturnType<typeof JSON.parse>} value - SQL value.
+     * @returns {ReturnType<typeof JSON.parse>} - Escaped value.
+     */
+    escape(value) {
+      if (this.getType() !== "pgsql") return super.escape(value)
+      if (typeof value === "number") return value
+      const escaped = pgEscapeLiteral(this._convertValue(value))
+      return escaped.slice(1, -1)
+    }
+
+    /**
+     * Quotes a local SQL value.
+     * @param {ReturnType<typeof JSON.parse>} value - SQL value.
+     * @returns {string | number} - Quoted value.
+     */
+    quote(value) {
+      if (this.getType() !== "pgsql") return super.quote(value)
+      if (typeof value === "number") return value
+      return pgEscapeLiteral(this._convertValue(value))
+    }
+
+    /**
+     * Streams brokered rows through the driver's buffered fallback.
+     * @param {string} sql - SQL statement.
+     * @param {import("../database/drivers/base.js").QueryOptions} [options] - Query options.
+     * @yields {Record<string, ReturnType<typeof JSON.parse>>} - Result rows.
+     */
+    async *queryStream(sql, options = {}) {
+      const rows = await this.query(sql, options)
+      for (const row of rows) yield row
+    }
+
+    /**
+     * Keeps structure SQL on normal brokered statements.
+     * @returns {Promise<boolean>} - Always false.
+     */
+    async execStructureScript() { return false }
+  }
+
+  return new SharedTransactionProxyDriver()
+}

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -613,7 +613,8 @@ export default class TestRunner {
     process.env[SHARED_TRANSACTION_BROKER_ENV] = Buffer.from(JSON.stringify({
       address: broker.address(),
       capability: broker.capability(),
-      databaseIdentifiers
+      databaseIdentifiers,
+      expected: true
     })).toString("base64url")
 
     return {broker, previousEnvironment}

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -12,6 +12,8 @@ import restArgsError from "../utils/rest-args-error.js"
 import {testConfig, testEvents, tests} from "./test.js"
 import {pathToFileURL} from "url"
 import {clearDeliveries} from "../mailer.js"
+import SharedTransactionBroker from "./shared-transaction-broker.js"
+import { SHARED_TRANSACTION_BROKER_ENV } from "./shared-transaction-proxy-driver.js"
 
 /**
  * ConsoleMethodName type.
@@ -586,6 +588,53 @@ export default class TestRunner {
   }
 
   /**
+   * Starts a capability-scoped broker for the active non-tenant physical
+   * transaction connections. No broker/env is installed for truncation-only or
+   * other transaction-disabled attempts.
+   * @returns {Promise<{broker: SharedTransactionBroker, previousEnvironment: string | undefined} | undefined>} - Attempt registration.
+   */
+  async startSharedTransactionBroker() {
+    const configuration = this.getConfiguration()
+    const currentConnections = configuration.getCurrentConnections()
+    /** @type {Record<string, import("../database/drivers/base.js").default>} */
+    const connections = {}
+
+    for (const [identifier, connection] of Object.entries(currentConnections)) {
+      const pool = configuration.getDatabasePool(identifier)
+      if (pool.getConfiguration().tenantOnly || !connection.insideTransaction()) continue
+      connections[identifier] = connection
+    }
+
+    const databaseIdentifiers = Object.keys(connections)
+    if (databaseIdentifiers.length === 0) return undefined
+
+    const broker = await SharedTransactionBroker.start({connections})
+    const previousEnvironment = process.env[SHARED_TRANSACTION_BROKER_ENV]
+    process.env[SHARED_TRANSACTION_BROKER_ENV] = Buffer.from(JSON.stringify({
+      address: broker.address(),
+      capability: broker.capability(),
+      databaseIdentifiers
+    })).toString("base64url")
+
+    return {broker, previousEnvironment}
+  }
+
+  /**
+   * Revokes an attempt broker before database rollback hooks run and restores
+   * the caller's environment so later pooled/spawned children cannot inherit it.
+   * @param {{broker: SharedTransactionBroker, previousEnvironment: string | undefined} | undefined} registration - Attempt registration.
+   */
+  async stopSharedTransactionBroker(registration) {
+    if (!registration) return
+    if (registration.previousEnvironment === undefined) {
+      delete process.env[SHARED_TRANSACTION_BROKER_ENV]
+    } else {
+      process.env[SHARED_TRANSACTION_BROKER_ENV] = registration.previousEnvironment
+    }
+    await registration.broker.close()
+  }
+
+  /**
    * Runs request client.
    * @returns {Promise<RequestClient>} - Resolves with the request client.
    */
@@ -983,6 +1032,8 @@ export default class TestRunner {
           let testLifecycle
           /** @type {{pool: import("../database/pool/base.js").default, registration: import("../database/pool/base.js").TestSharedConnectionRegistration}[]} */
           let testSharedConnectionRegistrations = []
+          /** @type {{broker: SharedTransactionBroker, previousEnvironment: string | undefined} | undefined} */
+          let sharedTransactionBrokerRegistration
           /**
            * Shared mutable flag so the catch block can suppress the
            * `_successfulTests` increment inside the still-detached lifecycle:
@@ -1020,6 +1071,8 @@ export default class TestRunner {
                       await beforeEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
                     }
 
+                    sharedTransactionBrokerRegistration = await this.startSharedTransactionBroker()
+
                     // Record which test is running so an async crash (an unhandled
                     // rejection detached from any await) that fires during or shortly
                     // after this test can be attributed to it in run()'s handler.
@@ -1033,8 +1086,12 @@ export default class TestRunner {
                       this._successfulTests++
                     }
                   } finally {
-                    for (const afterEachData of newAfterEaches) {
-                      await afterEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                    try {
+                      await this.stopSharedTransactionBroker(sharedTransactionBrokerRegistration)
+                    } finally {
+                      for (const afterEachData of newAfterEaches) {
+                        await afterEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                      }
                     }
                   }
                 } finally {
@@ -1080,6 +1137,8 @@ export default class TestRunner {
               // ensureConnections before activateTestSharedConnections() replaces
               // it. Clear it here so the next test checks out a fresh connection.
               // Idempotent when the lifecycle did settle and already cleared.
+              await this.stopSharedTransactionBroker(sharedTransactionBrokerRegistration)
+              sharedTransactionBrokerRegistration = undefined
               this.clearTestSharedConnections(testSharedConnectionRegistrations)
             }
 

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -1073,6 +1073,9 @@ export default class TestRunner {
                     }
 
                     sharedTransactionBrokerRegistration = await this.startSharedTransactionBroker()
+                    if (sharedTransactionBrokerRegistration && testSharedConnectionRegistrations.length === 0) {
+                      testSharedConnectionRegistrations = this.activateTestSharedConnections()
+                    }
 
                     // Record which test is running so an async crash (an unhandled
                     // rejection detached from any await) that fires during or shortly


### PR DESCRIPTION
## Summary

- add a TestRunner-owned, capability-scoped loopback WebSocket broker for active non-tenant test transaction connections
- create driver-compatible child proxies for forked, reusable pooled, and spawned background-job runners, with physical work serialized per parent connection
- preserve tagged database values/errors and fail closed for stale capabilities, unknown database identifiers, and unsupported operations
- stop and drain the broker before existing test rollback so parent setup, child writes, and background-job persistence roll back together
- retain independent physical connections for `{ transaction: false, truncate: true }` concurrency/locking tests

## Tests

- focused broker/codec/registration and fork/pool/spawn transactional integration: 9 passed
- expanded SQLite background-job lifecycle set (DB context, basic, worker shutdown, process title, reschedule): 51 passed
- exact CI-equivalent lint gate with `configuration.peakflow.sqlite.js` copied into place: `npm run lint`, `npm run typecheck`, `npm run fallow` all passed; tracked configuration restored afterward
- cross-driver integration spec is driver-agnostic and will run in the repository SQLite, MariaDB, PostgreSQL, and MSSQL Peakflow matrix; only SQLite services were available locally

## Scope exclusions

- no worker-thread HTTP request tests restored or added
- no tenant routing; tenant-only connections are explicitly excluded
- no fallback to fresh child connections for registered broker databases
- no change to transaction-disabled/truncation concurrency semantics
- no generated output, release, publish, deploy, production, or AwesomeTasks mutation

AwesomeTasks: `fbe13122-dcf7-5dbb-9ab3-f0e9995e886a`
