### PR TITLE
Invalidate initialize promise when connections close

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,7 +955,8 @@ Translated models also get a `currentTranslation` `hasOne` relationship scoped t
 Async class APIs initialize record metadata on first use when a model has not
 already been initialized eagerly. See [docs/model-initialization.md](docs/model-initialization.md)
 for the eager and lazy initialization behavior, including atomic shared bootstrap
-and complete recovery after an eager initialization failure.
+and complete recovery after an eager initialization failure or database-connection
+closure.
 
 ## Lifecycle callbacks
 

--- a/README.md
+++ b/README.md
@@ -956,7 +956,7 @@ Async class APIs initialize record metadata on first use when a model has not
 already been initialized eagerly. See [docs/model-initialization.md](docs/model-initialization.md)
 for the eager and lazy initialization behavior, including atomic shared bootstrap
 and complete recovery after an eager initialization failure or database-connection
-closure.
+closure without overlapping stale and current bootstrap side effects.
 
 ## Lifecycle callbacks
 

--- a/changelog.d/20260813134839-invalidate-initialize-promise.md
+++ b/changelog.d/20260813134839-invalidate-initialize-promise.md
@@ -1,1 +1,1 @@
-Invalidate cached configuration initialization when database connections close so a later `initialize()` reruns model and application bootstrap work.
+Invalidate cached configuration initialization when database connections close so a later `initialize()` reruns model and application bootstrap work after any stale generation settles, without overlapping side effects.

--- a/changelog.d/20260813134839-invalidate-initialize-promise.md
+++ b/changelog.d/20260813134839-invalidate-initialize-promise.md
@@ -1,0 +1,1 @@
+Invalidate cached configuration initialization when database connections close so a later `initialize()` reruns model and application bootstrap work.

--- a/docs/model-initialization.md
+++ b/docs/model-initialization.md
@@ -18,7 +18,11 @@ configuration and model bootstrap. A later `configuration.initialize()` call
 reruns model discovery and application initializers before `isInitialized()`
 becomes true again. Calls that arrive while connections are closing wait for the
 close to finish, and stale initialization work from the previous connection
-generation cannot mark the new generation initialized.
+generation cannot mark the new generation initialized. If that stale work is
+still running after the close, the next generation waits for its model,
+discovery, and application-initializer phases to settle before retrying the
+complete bootstrap. This keeps side-effecting phases serialized while ensuring
+the new generation cannot resolve with uninitialized models.
 
 ## Lazy record APIs
 

--- a/docs/model-initialization.md
+++ b/docs/model-initialization.md
@@ -13,6 +13,13 @@ not finish. This matters for warm background-job children, which remain reusable
 after reporting a bootstrap failure and must not admit later jobs with partial
 record metadata.
 
+`configuration.closeDatabaseConnections()` invalidates the completed
+configuration and model bootstrap. A later `configuration.initialize()` call
+reruns model discovery and application initializers before `isInitialized()`
+becomes true again. Calls that arrive while connections are closing wait for the
+close to finish, and stale initialization work from the previous connection
+generation cannot mark the new generation initialized.
+
 ## Lazy record APIs
 
 Async class methods such as `create`, `count`, `find`, `findBy`, `first`,

--- a/spec/background-jobs/job-reschedule-spec.js
+++ b/spec/background-jobs/job-reschedule-spec.js
@@ -5,6 +5,49 @@ import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 
+/**
+ * Waits for both pooled executions of a rescheduled job at the worker's durable
+ * acknowledgement boundary. Cold child bootstrap is intentionally outside a
+ * short polling deadline; each captured execution resolves only after main has
+ * persisted the reschedule/completion report.
+ * @param {object} args - Options.
+ * @param {string} args.jobId - Rescheduled job id.
+ * @param {import("../../src/background-jobs/worker.js").default} args.worker - Started worker.
+ * @returns {Promise<void>} - Resolves after both acknowledged executions.
+ */
+function waitForPooledRescheduleExecutions({jobId, worker}) {
+  const jsonSocket = worker.jsonSocket
+  if (!jsonSocket) throw new Error("Background jobs worker socket is not connected")
+
+  return new Promise((resolve, reject) => {
+    let completedExecutions = 0
+    /** @param {ReturnType<typeof JSON.parse>} message - Worker socket message. */
+    const onMessage = (message) => {
+      if (message?.type !== "job" || message.payload?.id !== jobId) return
+
+      const [execution] = worker.inflightPooledJobs
+      if (worker.inflightPooledJobs.size !== 1 || !execution) {
+        jsonSocket.off("message", onMessage)
+        reject(new Error(`Expected one tracked pooled execution for job ${jobId}, found: ${worker.inflightPooledJobs.size}`))
+        return
+      }
+
+      void execution.then(() => {
+        completedExecutions += 1
+        if (completedExecutions !== 2) return
+
+        jsonSocket.off("message", onMessage)
+        resolve(undefined)
+      }, (error) => {
+        jsonSocket.off("message", onMessage)
+        reject(error)
+      })
+    }
+
+    jsonSocket.on("message", onMessage)
+  })
+}
+
 describe("Background jobs - job reschedule", {databaseCleaning: {truncate: true}}, () => {
   it("reuses the same row later without failure events in inline and pooled modes", async () => {
     const {main, store, worker} = await startBackgroundJobs({workerOptions: {pooledRunnerCount: 1}})
@@ -24,9 +67,16 @@ describe("Background jobs - job reschedule", {databaseCleaning: {truncate: true}
           args: [outputPath, 100],
           options: {executionMode}
         })
+        const pooledExecutions = executionMode === "pooled"
+          ? waitForPooledRescheduleExecutions({jobId, worker})
+          : undefined
 
         await main._drain()
-        await waitForJobCompleted({jobId, store})
+        if (pooledExecutions) {
+          await pooledExecutions
+        } else {
+          await waitForJobCompleted({jobId, store})
+        }
 
         expect(await waitForOutputJson({outputPath})).toEqual({runs: 2})
         expect(await store.getJob(jobId)).toMatchObject({id: jobId, status: "completed", attempts: 0, lastError: null})

--- a/spec/background-jobs/shared-transaction-pooled-attempt-reuse-spec.js
+++ b/spec/background-jobs/shared-transaction-pooled-attempt-reuse-spec.js
@@ -10,6 +10,7 @@ let backgroundJobs
 /** @type {number | undefined} */
 let firstAttemptPid
 const markerPrefix = `shared-transaction-pooled-attempts-${process.pid}-${Date.now()}`
+const concurrentPooledTransactionTimeoutSeconds = 30
 
 describe("Background jobs - pooled broker attempt reuse", {tags: ["dummy"], databaseCleaning: {transaction: true, truncate: false}}, () => {
   beforeAll(async () => {
@@ -51,8 +52,8 @@ describe("Background jobs - pooled broker attempt reuse", {tags: ["dummy"], data
       return await SharedTransactionTestJob.performLaterWithOptions({args: [parentMarker, childMarker, outputPaths[index]], options: {executionMode: "pooled"}})
     }))
 
-    await Promise.all(jobIds.map(async (jobId) => await waitForJobCompleted({jobId, store: backgroundJobs.store, timeoutSeconds: 10})))
-    const results = await Promise.all(outputPaths.map(async (outputPath) => await waitForOutputJson({outputPath, timeoutSeconds: 10})))
+    await Promise.all(jobIds.map(async (jobId) => await waitForJobCompleted({jobId, store: backgroundJobs.store, timeoutSeconds: concurrentPooledTransactionTimeoutSeconds})))
+    const results = await Promise.all(outputPaths.map(async (outputPath) => await waitForOutputJson({outputPath, timeoutSeconds: concurrentPooledTransactionTimeoutSeconds})))
     expect(results.map((result) => result.pid)).toEqual([firstAttemptPid, firstAttemptPid])
     expect(results.map((result) => result.parentCount)).toEqual([1, 1])
     expect(results.map((result) => result.childCount)).toEqual([1, 1])

--- a/spec/configuration/initialize-after-close-spec.js
+++ b/spec/configuration/initialize-after-close-spec.js
@@ -1,0 +1,116 @@
+// @ts-check
+
+import fs from "fs/promises"
+import path from "path"
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import repoRoot from "../helpers/repo-root.js"
+
+describe("Configuration - initialize after close", () => {
+  it("reinitializes once per generation after database connections close", async () => {
+    const directory = path.join(repoRoot(), "tmp", `initialize-after-close-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(path.join(directory, "src", "jobs"), {recursive: true})
+    await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+
+    let modelPhases = 0
+    let initializerPhases = 0
+    const configuration = new Configuration({
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => { modelPhases += 1 },
+      initializers: async () => {
+        initializerPhases += 1
+        return {}
+      },
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+
+    try {
+      for (let generation = 1; generation <= 3; generation += 1) {
+        await configuration.initialize({type: "background-jobs-runner"})
+        await configuration.initialize({type: "background-jobs-runner"})
+
+        expect(configuration.isInitialized()).toBe(true)
+        expect(modelPhases).toEqual(generation)
+        expect(initializerPhases).toEqual(generation)
+
+        if (generation < 3) {
+          await configuration.closeDatabaseConnections()
+          expect(configuration.isInitialized()).toBe(false)
+        }
+      }
+    } finally {
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {recursive: true, force: true})
+    }
+  })
+
+  it("waits for an active connection close before starting a new generation", async () => {
+    const directory = path.join(repoRoot(), "tmp", `initialize-during-close-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(path.join(directory, "src", "jobs"), {recursive: true})
+    await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+
+    /** @type {() => void} */
+    let signalCloseStarted = () => {}
+    const closeStarted = new Promise((resolve) => { signalCloseStarted = resolve })
+    /** @type {() => void} */
+    let releaseClose = () => {}
+    const closeRelease = new Promise((resolve) => { releaseClose = resolve })
+    class BlockingClosePool {
+      static clearGlobalConnections() {}
+
+      setCurrent() {}
+
+      async closeAll() {
+        signalCloseStarted()
+        await closeRelease
+      }
+    }
+
+    let modelPhases = 0
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: class {},
+            poolType: BlockingClosePool,
+            type: "fake"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => { modelPhases += 1 },
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+
+    try {
+      configuration.getDatabasePool()
+      await configuration.initialize({type: "background-jobs-runner"})
+
+      const close = configuration.closeDatabaseConnections()
+      await closeStarted
+      const reinitialize = configuration.initialize({type: "background-jobs-runner"})
+
+      expect(modelPhases).toEqual(1)
+
+      releaseClose()
+      await Promise.all([close, reinitialize])
+
+      expect(configuration.isInitialized()).toBe(true)
+      expect(modelPhases).toEqual(2)
+    } finally {
+      releaseClose()
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {recursive: true, force: true})
+    }
+  })
+})

--- a/spec/configuration/initialize-close-races-spec.js
+++ b/spec/configuration/initialize-close-races-spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+
+import fs from "fs/promises"
+import path from "path"
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import repoRoot from "../helpers/repo-root.js"
+
+describe("Configuration - initialize close races", () => {
+  it("retries the current generation after a stale model phase finishes", async () => {
+    const directory = path.join(repoRoot(), "tmp", `initialize-model-close-race-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(path.join(directory, "src", "jobs"), {recursive: true})
+    await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+
+    let modelPhases = 0
+    /** @type {() => void} */
+    let signalFirstModelPhaseStarted = () => {}
+    const firstModelPhaseStarted = new Promise((resolve) => { signalFirstModelPhaseStarted = resolve })
+    /** @type {() => void} */
+    let releaseFirstModelPhase = () => {}
+    const firstModelPhaseRelease = new Promise((resolve) => { releaseFirstModelPhase = resolve })
+    const configuration = new Configuration({
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {
+        modelPhases += 1
+        if (modelPhases !== 1) return
+
+        signalFirstModelPhaseStarted()
+        await firstModelPhaseRelease
+      },
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+
+    const staleInitialize = configuration.initialize({type: "background-jobs-runner"})
+    /** @type {Promise<void> | undefined} */
+    let reinitialize
+
+    try {
+      await firstModelPhaseStarted
+      await configuration.closeDatabaseConnections()
+
+      reinitialize = configuration.initialize({type: "background-jobs-runner"})
+      expect(modelPhases).toEqual(1)
+
+      releaseFirstModelPhase()
+      await Promise.all([staleInitialize, reinitialize])
+
+      expect(configuration.isInitialized()).toBe(true)
+      expect(modelPhases).toEqual(2)
+    } finally {
+      releaseFirstModelPhase()
+      await staleInitialize
+      if (reinitialize) await reinitialize
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {recursive: true, force: true})
+    }
+  })
+
+  it("serializes a new bootstrap behind stale application initializers", async () => {
+    const directory = path.join(repoRoot(), "tmp", `initialize-initializer-close-race-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(path.join(directory, "src", "jobs"), {recursive: true})
+    await fs.writeFile(path.join(directory, "package.json"), JSON.stringify({type: "module"}))
+
+    let activeInitializers = 0
+    let initializerPhases = 0
+    let maximumActiveInitializers = 0
+    let modelPhases = 0
+    /** @type {() => void} */
+    let signalFirstInitializerStarted = () => {}
+    const firstInitializerStarted = new Promise((resolve) => { signalFirstInitializerStarted = resolve })
+    /** @type {() => void} */
+    let releaseFirstInitializer = () => {}
+    const firstInitializerRelease = new Promise((resolve) => { releaseFirstInitializer = resolve })
+    const configuration = new Configuration({
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => { modelPhases += 1 },
+      initializers: async () => {
+        initializerPhases += 1
+        activeInitializers += 1
+        maximumActiveInitializers = Math.max(maximumActiveInitializers, activeInitializers)
+
+        try {
+          if (initializerPhases === 1) {
+            signalFirstInitializerStarted()
+            await firstInitializerRelease
+          }
+        } finally {
+          activeInitializers -= 1
+        }
+
+        return {}
+      },
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+
+    const staleInitialize = configuration.initialize({type: "background-jobs-runner"})
+    /** @type {Promise<void> | undefined} */
+    let reinitialize
+
+    try {
+      await firstInitializerStarted
+      await configuration.closeDatabaseConnections()
+
+      reinitialize = configuration.initialize({type: "background-jobs-runner"})
+      expect(modelPhases).toEqual(1)
+
+      releaseFirstInitializer()
+      await Promise.all([staleInitialize, reinitialize])
+
+      expect(configuration.isInitialized()).toBe(true)
+      expect(modelPhases).toEqual(2)
+      expect(initializerPhases).toEqual(2)
+      expect(maximumActiveInitializers).toEqual(1)
+    } finally {
+      releaseFirstInitializer()
+      await staleInitialize
+      if (reinitialize) await reinitialize
+      await configuration.closeDatabaseConnections()
+      await fs.rm(directory, {recursive: true, force: true})
+    }
+  })
+})

--- a/spec/configuration/initialize-concurrency-spec.js
+++ b/spec/configuration/initialize-concurrency-spec.js
@@ -2,16 +2,11 @@
 
 import fs from "fs/promises"
 import path from "path"
-import {fileURLToPath} from "url"
 
 import Configuration, {CurrentConfigurationNotSetError} from "../../src/configuration.js"
 import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
 import {describe, expect, it} from "../../src/testing/test.js"
-
-/** @returns {string} - Repository root. */
-function repoRoot() {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
-}
+import repoRoot from "../helpers/repo-root.js"
 
 describe("Configuration - concurrent initialize", () => {
   it("bootstraps once when called concurrently and marks initialized only after it completes", async () => {

--- a/spec/helpers/repo-root.js
+++ b/spec/helpers/repo-root.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+import path from "path"
+import {fileURLToPath} from "url"
+
+/** @returns {string} - Repository root. */
+export default function repoRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -302,8 +302,8 @@ export default class VelociousConfiguration {
      */
     this._initializeModelsPromise = undefined
     /**
-     * In-progress `initialize()` promise, memoized so concurrent callers await
-     * the same bootstrap. Reset to undefined if initialization fails.
+     * Current `initialize()` promise, memoized so concurrent callers await the
+     * same bootstrap. Reset when initialization fails or connections close.
      * @type {Promise<void> | undefined}
      */
     this._initializePromise = undefined
@@ -2110,6 +2110,10 @@ export default class VelociousConfiguration {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async initialize({type} = {type: "undefined"}) {
+    if (this._closeDatabaseConnectionsPromise) {
+      await this._closeDatabaseConnectionsPromise
+    }
+
     if (this._isInitialized) return
     // Memoize the in-progress initialization so concurrent callers await the same
     // bootstrap instead of racing. `_isInitialized` was previously set to `true`
@@ -2119,13 +2123,14 @@ export default class VelociousConfiguration {
     // was still awaiting model discovery and initializers. Mirrors connectBeacon.
     if (this._initializePromise) return await this._initializePromise
 
-    this._initializePromise = (async () => {
+    const initializationGeneration = this._modelInitializationGeneration
+    const initializePromise = (async () => {
       await this.initializeModels({type})
 
       // Model initialization can be invalidated by a concurrent connection close.
       // If models are not ready, stop without marking the configuration initialized
       // so the next caller retries a full bootstrap.
-      if (!this._modelsInitialized) return
+      if (this._modelInitializationGeneration !== initializationGeneration || !this._modelsInitialized) return
 
       await this.getEnvironmentHandler().autoDiscoverResources(this)
       this._mergeDiscoveredAbilityResources()
@@ -2147,22 +2152,28 @@ export default class VelociousConfiguration {
         }
       }
 
-      this._isInitialized = true
+      if (this._modelInitializationGeneration === initializationGeneration) {
+        this._isInitialized = true
+      }
     })()
 
+    this._initializePromise = initializePromise
+
     try {
-      await this._initializePromise
+      await initializePromise
     } catch (error) {
       // Let a later call retry a failed initialization instead of every future
       // caller awaiting the same cached rejection.
-      this._initializePromise = undefined
+      if (this._initializePromise === initializePromise) {
+        this._initializePromise = undefined
+      }
       throw error
     }
 
     // If the inner IIFE returned without marking the configuration initialized
     // (e.g. because models were invalidated mid-bootstrap), clear the promise so
     // a later call retries a full bootstrap.
-    if (!this._isInitialized) {
+    if (!this._isInitialized && this._initializePromise === initializePromise) {
       this._initializePromise = undefined
     }
   }
@@ -3325,6 +3336,7 @@ export default class VelociousConfiguration {
 
     /** @type {Set<typeof import("./database/pool/base.js").default>} */
     const constructors = new Set()
+    const initializePromise = this._initializePromise
 
     this._closeDatabaseConnectionsPromise = (async () => {
       try {
@@ -3354,6 +3366,10 @@ export default class VelociousConfiguration {
         this._modelInitializationGeneration += 1
         this._modelsInitialized = false
         this._isInitialized = false
+
+        if (this._initializePromise === initializePromise) {
+          this._initializePromise = undefined
+        }
       }
     })()
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -303,7 +303,8 @@ export default class VelociousConfiguration {
     this._initializeModelsPromise = undefined
     /**
      * Current `initialize()` promise, memoized so concurrent callers await the
-     * same bootstrap. Reset when initialization fails or connections close.
+     * same bootstrap. Retained across a connection close until stale bootstrap
+     * work settles, then cleared by identity before the new generation retries.
      * @type {Promise<void> | undefined}
      */
     this._initializePromise = undefined
@@ -2054,10 +2055,25 @@ export default class VelociousConfiguration {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async initializeModels(args = {type: "server"}) {
-    if (this._modelsInitialized) return
-    if (this._initializeModelsPromise) return await this._initializeModelsPromise
-
     const modelInitializationGeneration = this._modelInitializationGeneration
+
+    if (this._modelsInitialized) return
+    if (this._initializeModelsPromise) {
+      const initializeModelsPromise = this._initializeModelsPromise
+
+      await initializeModelsPromise
+
+      if (this._modelInitializationGeneration === modelInitializationGeneration && !this._modelsInitialized) {
+        if (this._initializeModelsPromise === initializeModelsPromise) {
+          this._initializeModelsPromise = undefined
+        }
+
+        return await this.initializeModels(args)
+      }
+
+      return
+    }
+
     const initializeModelsPromise = (async () => {
       const shouldSkipDummyModelInitialization = process.env.VELOCIOUS_SKIP_DUMMY_MODEL_INITIALIZATION === "1"
         && process.env.VELOCIOUS_BROWSER_TESTS === "true"
@@ -2114,6 +2130,8 @@ export default class VelociousConfiguration {
       await this._closeDatabaseConnectionsPromise
     }
 
+    const initializationGeneration = this._modelInitializationGeneration
+
     if (this._isInitialized) return
     // Memoize the in-progress initialization so concurrent callers await the same
     // bootstrap instead of racing. `_isInitialized` was previously set to `true`
@@ -2121,9 +2139,22 @@ export default class VelociousConfiguration {
     // `pooledRunnerConcurrency > 1` starting several jobs on a cold child) could
     // skip initialization and load models / perform a job while the first call
     // was still awaiting model discovery and initializers. Mirrors connectBeacon.
-    if (this._initializePromise) return await this._initializePromise
+    if (this._initializePromise) {
+      const initializePromise = this._initializePromise
 
-    const initializationGeneration = this._modelInitializationGeneration
+      await initializePromise
+
+      if (this._modelInitializationGeneration === initializationGeneration && !this._isInitialized) {
+        if (this._initializePromise === initializePromise) {
+          this._initializePromise = undefined
+        }
+
+        return await this.initialize({type})
+      }
+
+      return
+    }
+
     const initializePromise = (async () => {
       await this.initializeModels({type})
 
@@ -3336,7 +3367,6 @@ export default class VelociousConfiguration {
 
     /** @type {Set<typeof import("./database/pool/base.js").default>} */
     const constructors = new Set()
-    const initializePromise = this._initializePromise
 
     this._closeDatabaseConnectionsPromise = (async () => {
       try {
@@ -3366,10 +3396,6 @@ export default class VelociousConfiguration {
         this._modelInitializationGeneration += 1
         this._modelsInitialized = false
         this._isInitialized = false
-
-        if (this._initializePromise === initializePromise) {
-          this._initializePromise = undefined
-        }
       }
     })()
 


### PR DESCRIPTION
## Summary

- invalidate the cached configuration initialization promise when database connections close
- fence initialization completion and promise cleanup by lifecycle generation and promise identity
- wait for an active connection close before starting the next initialization generation
- document the reinitialization lifecycle and add deterministic regression coverage

AwesomeTasks: https://tasks.diestoeckels.de/tasks/9dee154f-0fa5-44d1-8e66-dd3ea8069d63

## RED/GREEN

- RED: the new sequential lifecycle spec failed after close because `isInitialized()` remained `false`
- GREEN: initialize-after-close (2), initialize-concurrency (3), and close-database-connections (1) specs all pass

## Checks

- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`
