### PR TITLE
Add tenant migration deploy preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * Declarative state machines for models, with typed event methods generated into the base model (see [docs/state-machine.md](docs/state-machine.md))
 * Migrations for schema changes and UTC datetime storage (see [docs/database-migrations.md](docs/database-migrations.md))
 * Tenant-selected base-model and structure generation with one immutable, fail-closed physical database context; tenant-only model metadata initializes only after that context is active (see [docs/tenant-selected-database-generation.md](docs/tenant-selected-database-generation.md))
+* Read-only tenant migration deploy preflight with stable JSON output and fail-closed ledger reads (see [docs/tenant-migration-deploy-preflight.md](docs/tenant-migration-deploy-preflight.md))
 * External packages (engines) that contribute data models, frontend-model resources and migrations to a consuming app (see [docs/packages.md](docs/packages.md))
 * Optional Rampway-owned durable deployment control plane mounted through the standard routes DSL on Velocious 1.0.577 or newer (see [docs/rampway-integration.md](docs/rampway-integration.md))
 * Controllers and views for HTTP endpoints

--- a/changelog.d/20260814120000-tenant-migration-deploy-preflight.md
+++ b/changelog.d/20260814120000-tenant-migration-deploy-preflight.md
@@ -1,0 +1,1 @@
+Add a read-only `db:tenants:migrations:pending` deploy preflight command with machine-readable aggregate tenant migration status.

--- a/docs/tenant-databases.md
+++ b/docs/tenant-databases.md
@@ -91,6 +91,8 @@ npx velocious db:tenants:migrate projectTenant
 npx velocious db:tenants:drop projectTenant
 ```
 
+Before a deploy changes tenant migration behavior, use the read-only [tenant migration deploy preflight](tenant-migration-deploy-preflight.md) to determine whether any existing tenant is behind without running migrations or lifecycle hooks.
+
 Schema introspection and generated model bases can target one provider-resolved tenant database with `--tenant <identifier>`. This is a singular, fail-closed selection rather than a lifecycle scan; see [tenant-selected database generation](tenant-selected-database-generation.md).
 
 `db:tenants:drop` drops every listed tenant's database through the provider's `dropDatabase` hook. Like the other lifecycle commands it honors `--parallel`.

--- a/docs/tenant-migration-deploy-preflight.md
+++ b/docs/tenant-migration-deploy-preflight.md
@@ -1,0 +1,27 @@
+# Tenant migration deploy preflight
+
+Deploy tooling can ask whether any existing tenant database has pending migrations before changing application behavior:
+
+```sh
+npx velocious db:tenants:migrations:pending projectTenant
+```
+
+The command loads the normal app-and-package migration manifest, keeps migrations whose `onDatabases(...)` declaration includes the requested tenant-only database identifier, and compares those versions with every tenant's existing `schema_migrations` ledger. It emits exactly one JSON object on standard output after a successful scan:
+
+```json
+{"hasPendingMigrations":true,"identifier":"projectTenant","migrationCount":12,"pendingTenantCount":1,"tenantCount":37}
+```
+
+The fields are intended for deploy consumers:
+
+- `hasPendingMigrations` is true when at least one listed tenant is missing an applicable manifest version.
+- `identifier` is the inspected logical tenant database identifier.
+- `migrationCount` is the number of loaded migrations applicable to that identifier.
+- `pendingTenantCount` is the number of existing tenants with at least one missing version.
+- `tenantCount` is the number of tenants returned by the configured provider. An empty list succeeds with both counts at zero and `hasPendingMigrations: false`.
+
+Pending migrations are reported as successful command output; deploy policy decides whether that state should block or sequence a rollout. Configuration, tenant listing, connection, and ledger errors still reject the command and produce the CLI's normal nonzero process status. In particular, a missing `schema_migrations` table is an error rather than being interpreted as an empty ledger.
+
+This command is strictly observational. It does not create or prepare `schema_migrations`, run migration bodies, call `checkTenant` or `afterMigrateTenant`, create or clone tenant schemas, or otherwise mutate tenant state. Importing migration modules to read their declared target identifiers still runs normal JavaScript module initialization, so migration modules should keep top-level work declarative.
+
+See [tenant databases](tenant-databases.md) for provider and resolver configuration and [database migrations](database-migrations.md) for migration targeting and ledger behavior.

--- a/spec/background-jobs/pooled-runner-broker-identity-spec.js
+++ b/spec/background-jobs/pooled-runner-broker-identity-spec.js
@@ -19,8 +19,8 @@ describe("Pooled runner broker identity", {databaseCleaning: {transaction: false
     const active = new Promise((resolve) => { signalActive = resolve })
 
     class PausedAfterPrepareIdentity extends PooledRunnerBrokerIdentity {
-      async prepare(config) {
-        await super.prepare(config)
+      async prepare(config, options) {
+        await super.prepare(config, options)
         if (config.capability === "attempt-b") {
           signalPrepared()
           await preparedBlocked
@@ -65,6 +65,35 @@ describe("Pooled runner broker identity", {databaseCleaning: {transaction: false
     await Promise.all([first, second])
 
     expect(identities.current()).toEqual(JSON.stringify({capability: "attempt-b", expected: true}))
+  })
+
+  it("admits same-capability callbacks concurrently while preparation is pending", async () => {
+    /** @type {() => void} */
+    let releaseClose = () => {}
+    const closeBlocked = new Promise((resolve) => { releaseClose = resolve })
+    /** @type {() => void} */
+    let releaseCallbacks = () => {}
+    const callbacksBlocked = new Promise((resolve) => { releaseCallbacks = resolve })
+    let callbacksStarted = 0
+    /** @type {() => void} */
+    let signalBothCallbacks = () => {}
+    const bothCallbacksStarted = new Promise((resolve) => { signalBothCallbacks = resolve })
+    const identities = new PooledRunnerBrokerIdentity({closeConnections: async () => await closeBlocked})
+    await identities.prepare({capability: "attempt-a", expected: true})
+    const callback = async () => {
+      callbacksStarted++
+      if (callbacksStarted === 2) signalBothCallbacks()
+      await callbacksBlocked
+    }
+
+    const first = identities.run({capability: "attempt-b", expected: true}, callback)
+    const second = identities.run({capability: "attempt-b", expected: true}, callback)
+    releaseClose()
+    await bothCallbacksStarted
+
+    expect(callbacksStarted).toEqual(2)
+    releaseCallbacks()
+    await Promise.all([first, second])
   })
 
   it("rejects a truly different identity while a rotation is pending", async () => {

--- a/spec/background-jobs/pooled-runner-broker-identity-spec.js
+++ b/spec/background-jobs/pooled-runner-broker-identity-spec.js
@@ -4,6 +4,48 @@ import PooledRunnerBrokerIdentity from "../../src/background-jobs/pooled-runner-
 import {describe, expect, it} from "../../src/testing/test.js"
 
 describe("Pooled runner broker identity", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("reserves an active user before admitting a different attempt capability", async () => {
+    /** @type {() => void} */
+    let releasePrepared = () => {}
+    const preparedBlocked = new Promise((resolve) => { releasePrepared = resolve })
+    /** @type {() => void} */
+    let signalPrepared = () => {}
+    const prepared = new Promise((resolve) => { signalPrepared = resolve })
+    /** @type {() => void} */
+    let releaseActive = () => {}
+    const activeBlocked = new Promise((resolve) => { releaseActive = resolve })
+    /** @type {() => void} */
+    let signalActive = () => {}
+    const active = new Promise((resolve) => { signalActive = resolve })
+
+    class PausedAfterPrepareIdentity extends PooledRunnerBrokerIdentity {
+      async prepare(config) {
+        await super.prepare(config)
+        if (config.capability === "attempt-b") {
+          signalPrepared()
+          await preparedBlocked
+        }
+      }
+    }
+
+    const identities = new PausedAfterPrepareIdentity({closeConnections: async () => {}})
+    await identities.prepare({capability: "attempt-a", expected: true})
+    const attemptB = identities.run({capability: "attempt-b", expected: true}, async () => {
+      signalActive()
+      await activeBlocked
+    })
+    await prepared
+    const attemptC = identities.run({capability: "attempt-c", expected: true}, async () => {})
+
+    await Promise.resolve()
+    expect(identities.current()).toEqual(JSON.stringify({capability: "attempt-b", expected: true}))
+    releasePrepared()
+    await active
+    await expect(async () => await attemptC).toThrow(/mix.*capabilit/i)
+    releaseActive()
+    await attemptB
+  })
+
   it("shares one pending rotation between concurrent jobs requesting the same identity", async () => {
     /** @type {() => void} */
     let releaseClose = () => {}

--- a/spec/cli/commands/db/tenants/migrations/pending-spec.js
+++ b/spec/cli/commands/db/tenants/migrations/pending-spec.js
@@ -1,0 +1,191 @@
+// @ts-check
+
+import {describe, expect, it} from "../../../../../../src/testing/test.js"
+import AsyncTrackedMultiConnection from "../../../../../../src/database/pool/async-tracked-multi-connection.js"
+import Cli from "../../../../../../src/cli/index.js"
+import Configuration from "../../../../../../src/configuration.js"
+import EnvironmentHandlerNode from "../../../../../../src/environment-handlers/node.js"
+import fs from "fs/promises"
+import MigrationsLedger from "../../../../../../src/database/migrations-ledger.js"
+import os from "os"
+import path from "path"
+import SqliteDriver from "../../../../../../src/database/drivers/sqlite/index.js"
+
+describe("Cli - Commands - db:tenants:migrations:pending", () => {
+  /**
+   * Builds a real tenant-database CLI scenario.
+   * @param {object} args - Scenario options.
+   * @param {string[]} args.alphaVersions - Applied alpha migration versions.
+   * @param {string[]} args.betaVersions - Applied beta migration versions.
+   * @param {boolean} [args.createAlphaLedger] - Whether alpha has a readable ledger.
+   * @param {Array<{slug: string}>} [args.tenants] - Listed tenants.
+   * @returns {Promise<{afterMigrateCalls: () => number, cli: Cli, configuration: Configuration, directory: string}>} - Scenario.
+   */
+  async function buildScenario({alphaVersions, betaVersions, createAlphaLedger = true, tenants = [{slug: "alpha"}, {slug: "beta"}]}) {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenant-migrations-pending-"))
+    const migrationsDirectory = path.join(directory, "src", "database", "migrations")
+    const migrationModuleUrl = new URL("../../../../../../src/database/migration/index.js", import.meta.url).href
+    let afterMigrateCallCount = 0
+
+    await fs.mkdir(migrationsDirectory, {recursive: true})
+
+    for (const version of ["20260814090000", "20260814090100"]) {
+      await fs.writeFile(path.join(migrationsDirectory, `${version}-tenant-change.js`), `
+import Migration from ${JSON.stringify(migrationModuleUrl)}
+
+class TenantChange extends Migration {
+  async change() {
+    throw new Error("Preflight must not run migrations")
+  }
+}
+
+TenantChange.onDatabases(["projectTenant"])
+
+export default TenantChange
+`, "utf8")
+    }
+
+    const configuration = new Configuration({
+      database: {
+        test: {
+          default: {
+            driver: SqliteDriver,
+            migrations: false,
+            name: "velocious-cli-tenant-migrations-pending-default",
+            poolType: AsyncTrackedMultiConnection,
+            type: "sqlite"
+          },
+          projectTenant: {
+            driver: SqliteDriver,
+            migrations: true,
+            name: "velocious-cli-tenant-migrations-pending-project-default",
+            poolType: AsyncTrackedMultiConnection,
+            tenantOnly: true,
+            type: "sqlite"
+          }
+        }
+      },
+      directory,
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"],
+      tenantDatabaseProviders: {
+        projectTenant: {
+          afterMigrateTenant: async () => { afterMigrateCallCount++ },
+          checkTenant: async () => { throw new Error("Preflight must not run tenant checks") },
+          createDatabase: async () => { throw new Error("Preflight must not create tenant databases") },
+          listTenants: async () => tenants
+        }
+      },
+      tenantDatabaseResolver: ({identifier, tenant}) => {
+        const tenantObject = /** @type {{slug?: string}} */ (tenant)
+
+        if (identifier != "projectTenant" || !tenantObject.slug) return
+
+        return {name: `velocious-cli-tenant-migrations-pending-project-${tenantObject.slug}`}
+      }
+    })
+
+    for (const [slug, versions, createLedger] of [
+      ["alpha", alphaVersions, createAlphaLedger],
+      ["beta", betaVersions, true]
+    ]) {
+      if (!createLedger || !tenants.some((tenant) => tenant.slug == slug)) continue
+
+      await configuration.runWithTenant({slug}, async () => {
+        await configuration.ensureConnections({databaseIdentifiers: ["projectTenant"]}, async (dbs) => {
+          await MigrationsLedger.ensureTable(dbs.projectTenant)
+          await MigrationsLedger.markApplied(dbs.projectTenant, /** @type {string[]} */ (versions))
+        })
+      })
+    }
+
+    const cli = new Cli({
+      configuration,
+      directory,
+      environmentHandler: new EnvironmentHandlerNode(),
+      processArgs: ["db:tenants:migrations:pending", "projectTenant"],
+      testing: true
+    })
+
+    return {afterMigrateCalls: () => afterMigrateCallCount, cli, configuration, directory}
+  }
+
+  it("reports when every tenant ledger contains every applicable migration", async () => {
+    const scenario = await buildScenario({
+      alphaVersions: ["20260814090000", "20260814090100"],
+      betaVersions: ["20260814090000", "20260814090100"]
+    })
+
+    try {
+      expect(await scenario.cli.execute()).toEqual({
+        hasPendingMigrations: false,
+        identifier: "projectTenant",
+        migrationCount: 2,
+        pendingTenantCount: 0,
+        tenantCount: 2
+      })
+      expect(scenario.afterMigrateCalls()).toEqual(0)
+    } finally {
+      await scenario.configuration.closeDatabaseConnections()
+      await fs.rm(scenario.directory, {force: true, recursive: true})
+    }
+  })
+
+  it("reports when one tenant has a pending migration", async () => {
+    const scenario = await buildScenario({
+      alphaVersions: ["20260814090000", "20260814090100"],
+      betaVersions: ["20260814090000"]
+    })
+
+    try {
+      expect(await scenario.cli.execute()).toEqual({
+        hasPendingMigrations: true,
+        identifier: "projectTenant",
+        migrationCount: 2,
+        pendingTenantCount: 1,
+        tenantCount: 2
+      })
+    } finally {
+      await scenario.configuration.closeDatabaseConnections()
+      await fs.rm(scenario.directory, {force: true, recursive: true})
+    }
+  })
+
+  it("reports no pending migrations when the provider lists no tenants", async () => {
+    const scenario = await buildScenario({alphaVersions: [], betaVersions: [], tenants: []})
+
+    try {
+      expect(await scenario.cli.execute()).toEqual({
+        hasPendingMigrations: false,
+        identifier: "projectTenant",
+        migrationCount: 2,
+        pendingTenantCount: 0,
+        tenantCount: 0
+      })
+    } finally {
+      await scenario.configuration.closeDatabaseConnections()
+      await fs.rm(scenario.directory, {force: true, recursive: true})
+    }
+  })
+
+  it("rejects an unreadable tenant migration ledger without creating it", async () => {
+    const scenario = await buildScenario({alphaVersions: [], betaVersions: [], createAlphaLedger: false})
+
+    try {
+      await expect(async () => await scenario.cli.execute()).toThrow(/schema_migrations.*alpha|alpha.*schema_migrations/)
+
+      await scenario.configuration.runWithTenant({slug: "alpha"}, async () => {
+        await scenario.configuration.ensureConnections({databaseIdentifiers: ["projectTenant"]}, async (dbs) => {
+          expect(await MigrationsLedger.tableExists(dbs.projectTenant)).toEqual(false)
+        })
+      })
+    } finally {
+      await scenario.configuration.closeDatabaseConnections()
+      await fs.rm(scenario.directory, {force: true, recursive: true})
+    }
+  })
+})

--- a/spec/cli/commands/db/tenants/migrations/pending-spec.js
+++ b/spec/cli/commands/db/tenants/migrations/pending-spec.js
@@ -18,10 +18,11 @@ describe("Cli - Commands - db:tenants:migrations:pending", () => {
    * @param {string[]} args.alphaVersions - Applied alpha migration versions.
    * @param {string[]} args.betaVersions - Applied beta migration versions.
    * @param {boolean} [args.createAlphaLedger] - Whether alpha has a readable ledger.
+   * @param {string[]} [args.templateVersions] - Applied base/template migration versions.
    * @param {Array<{slug: string}>} [args.tenants] - Listed tenants.
    * @returns {Promise<{afterMigrateCalls: () => number, cli: Cli, configuration: Configuration, directory: string}>} - Scenario.
    */
-  async function buildScenario({alphaVersions, betaVersions, createAlphaLedger = true, tenants = [{slug: "alpha"}, {slug: "beta"}]}) {
+  async function buildScenario({alphaVersions, betaVersions, createAlphaLedger = true, templateVersions, tenants = [{slug: "alpha"}, {slug: "beta"}]}) {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-cli-tenant-migrations-pending-"))
     const migrationsDirectory = path.join(directory, "src", "database", "migrations")
     const migrationModuleUrl = new URL("../../../../../../src/database/migration/index.js", import.meta.url).href
@@ -83,11 +84,18 @@ export default TenantChange
       tenantDatabaseResolver: ({identifier, tenant}) => {
         const tenantObject = /** @type {{slug?: string}} */ (tenant)
 
-        if (identifier != "projectTenant" || !tenantObject.slug) return
+        if (identifier != "projectTenant" || !["alpha", "beta"].includes(tenantObject.slug || "")) return
 
         return {name: `velocious-cli-tenant-migrations-pending-project-${tenantObject.slug}`}
       }
     })
+
+    if (templateVersions) {
+      await configuration.ensureConnections({databaseIdentifiers: ["projectTenant"]}, async (dbs) => {
+        await MigrationsLedger.ensureTable(dbs.projectTenant)
+        await MigrationsLedger.markApplied(dbs.projectTenant, templateVersions)
+      })
+    }
 
     for (const [slug, versions, createLedger] of [
       ["alpha", alphaVersions, createAlphaLedger],
@@ -183,6 +191,22 @@ export default TenantChange
           expect(await MigrationsLedger.tableExists(dbs.projectTenant)).toEqual(false)
         })
       })
+    } finally {
+      await scenario.configuration.closeDatabaseConnections()
+      await fs.rm(scenario.directory, {force: true, recursive: true})
+    }
+  })
+
+  it("rejects an unresolved tenant without reading the current base template ledger", async () => {
+    const scenario = await buildScenario({
+      alphaVersions: [],
+      betaVersions: [],
+      templateVersions: ["20260814090000", "20260814090100"],
+      tenants: [{slug: "stale"}]
+    })
+
+    try {
+      await expect(async () => await scenario.cli.execute()).toThrow(/projectTenant is inactive for tenant: stale/)
     } finally {
       await scenario.configuration.closeDatabaseConnections()
       await fs.rm(scenario.directory, {force: true, recursive: true})

--- a/src/background-jobs/pooled-runner-broker-identity.js
+++ b/src/background-jobs/pooled-runner-broker-identity.js
@@ -12,7 +12,6 @@ export default class PooledRunnerBrokerIdentity {
     /** @type {{identity: string, promise: Promise<void>} | undefined} */
     this.pending = undefined
     this.activeUsers = 0
-    this.admissionQueue = Promise.resolve()
   }
 
   /**
@@ -24,16 +23,18 @@ export default class PooledRunnerBrokerIdentity {
   /**
    * Prepares one identity, sharing an in-flight same-identity rotation.
    * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} config - Dispatch configuration.
+   * @param {boolean} [admissionReserved] - Whether the caller already reserved its active-user slot.
    * @returns {Promise<void>} - Resolves after stale connections close.
    */
-  async prepare(config) {
+  async prepare(config, admissionReserved = false) {
     const identity = JSON.stringify(config)
     if (this.pending) {
       if (this.pending.identity !== identity) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
       return await this.pending.promise
     }
     if (this.activeIdentity === identity) return
-    if (this.activeUsers > 0) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
+    const otherActiveUsers = this.activeUsers - (admissionReserved ? 1 : 0)
+    if (otherActiveUsers > 0) throw new Error("Pooled runner cannot mix shared transaction broker capabilities concurrently")
     if (this.activeIdentity === undefined) {
       this.activeIdentity = identity
       return
@@ -72,22 +73,12 @@ export default class PooledRunnerBrokerIdentity {
    * @returns {Promise<void>} - Resolves after admission is reserved.
    */
   async admit(config) {
-    const previousAdmission = this.admissionQueue
-    /**
-     * Releases the serialized admission turn.
-     * @type {() => void}
-     */
-    let releaseAdmission = () => {}
-    const admission = new Promise((resolve) => { releaseAdmission = () => resolve(undefined) })
-
-    this.admissionQueue = previousAdmission.then(async () => await admission)
-    await previousAdmission
-
+    this.activeUsers++
     try {
-      await this.prepare(config)
-      this.activeUsers++
-    } finally {
-      releaseAdmission()
+      await this.prepare(config, true)
+    } catch (error) {
+      this.activeUsers--
+      throw error
     }
   }
 

--- a/src/background-jobs/pooled-runner-broker-identity.js
+++ b/src/background-jobs/pooled-runner-broker-identity.js
@@ -12,6 +12,7 @@ export default class PooledRunnerBrokerIdentity {
     /** @type {{identity: string, promise: Promise<void>} | undefined} */
     this.pending = undefined
     this.activeUsers = 0
+    this.admissionQueue = Promise.resolve()
   }
 
   /**
@@ -55,12 +56,38 @@ export default class PooledRunnerBrokerIdentity {
    * @returns {Promise<T>} - Job result.
    */
   async run(config, callback) {
-    await this.prepare(config)
-    this.activeUsers++
+    await this.admit(config)
     try {
       return await callback()
     } finally {
       this.activeUsers--
+    }
+  }
+
+  /**
+   * Atomically prepares an attempt identity and reserves its active user. Without
+   * this admission turn, another capability can rotate connections after `prepare`
+   * resolves but before `run` increments `activeUsers`.
+   * @param {import("../testing/shared-transaction-proxy-driver.js").SharedTransactionBrokerJobConfig} config - Dispatch configuration.
+   * @returns {Promise<void>} - Resolves after admission is reserved.
+   */
+  async admit(config) {
+    const previousAdmission = this.admissionQueue
+    /**
+     * Releases the serialized admission turn.
+     * @type {() => void}
+     */
+    let releaseAdmission = () => {}
+    const admission = new Promise((resolve) => { releaseAdmission = () => resolve(undefined) })
+
+    this.admissionQueue = previousAdmission.then(async () => await admission)
+    await previousAdmission
+
+    try {
+      await this.prepare(config)
+      this.activeUsers++
+    } finally {
+      releaseAdmission()
     }
   }
 

--- a/src/cli/commands/db/tenants/migrations/pending.js
+++ b/src/cli/commands/db/tenants/migrations/pending.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+import {digg} from "diggerize"
+import BaseCommand from "../../../../base-command.js"
+import TenantDatabaseCommandHelper from "../../../../tenant-database-command-helper.js"
+import TenantMigrationPendingInspector from "../../../../../database/tenants/migration-pending-inspector.js"
+
+export default class DbTenantsMigrationsPending extends BaseCommand {
+  /**
+   * Reports aggregate tenant migration state as one machine-readable JSON object.
+   * @returns {Promise<{hasPendingMigrations: boolean, identifier: string, migrationCount: number, pendingTenantCount: number, tenantCount: number}>} - Deploy preflight result.
+   */
+  async execute() {
+    const helper = new TenantDatabaseCommandHelper({
+      command: this,
+      identifier: this.processArgs?.[1]
+    })
+    const migrations = await this.getEnvironmentHandler().findMigrations()
+    const requireMigration = digg(this.getEnvironmentHandler(), "requireMigration")
+    const applicableMigrationVersions = []
+
+    for (const migration of migrations) {
+      if (!migration.fullPath) throw new Error(`Migration didn't have a fullPath key: ${migration.file}`)
+
+      const MigrationClass = await requireMigration(migration.fullPath)
+
+      if ((MigrationClass.getDatabaseIdentifiers() || ["default"]).includes(helper.identifier)) {
+        applicableMigrationVersions.push(migration.date)
+      }
+    }
+
+    const tenants = await helper.listTenants()
+    const inspector = new TenantMigrationPendingInspector({
+      configuration: this.getConfiguration(),
+      identifier: helper.identifier,
+      migrationVersions: applicableMigrationVersions,
+      tenants
+    })
+    const result = await inspector.inspect()
+
+    if (!this.args.testing) console.log(JSON.stringify(result))
+
+    return result
+  }
+}

--- a/src/database/tenants/migration-pending-inspector.js
+++ b/src/database/tenants/migration-pending-inspector.js
@@ -48,8 +48,14 @@ export default class TenantMigrationPendingInspector {
    * @returns {Promise<boolean>} - Whether the tenant has an applicable pending migration.
    */
   async tenantHasPendingMigrations(tenant) {
-    try {
-      return await this.configuration.runWithTenant(tenant, async () => {
+    return await this.configuration.runWithTenant(tenant, async () => {
+      const tenantLabel = TenantIterator.tenantLabel(tenant)
+
+      if (!this.configuration.isDatabaseIdentifierActive(this.identifier)) {
+        throw new Error(`Tenant database identifier ${this.identifier} is inactive for tenant: ${tenantLabel}`)
+      }
+
+      try {
         return await this.configuration.ensureConnections({
           databaseIdentifiers: [this.identifier],
           name: `Tenant migration pending preflight: ${this.identifier}`
@@ -63,11 +69,9 @@ export default class TenantMigrationPendingInspector {
 
           return this.migrationVersions.some((version) => !appliedVersions.has(version))
         })
-      })
-    } catch (error) {
-      const tenantLabel = TenantIterator.tenantLabel(tenant)
-
-      throw new Error(`Could not read ${MigrationsLedger.tableName()} for tenant ${tenantLabel}`, {cause: error})
-    }
+      } catch (error) {
+        throw new Error(`Could not read ${MigrationsLedger.tableName()} for tenant ${tenantLabel}`, {cause: error})
+      }
+    })
   }
 }

--- a/src/database/tenants/migration-pending-inspector.js
+++ b/src/database/tenants/migration-pending-inspector.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+import MigrationsLedger from "../migrations-ledger.js"
+import TenantIterator from "../../tenants/tenant-iterator.js"
+import restArgsError from "../../utils/rest-args-error.js"
+
+export default class TenantMigrationPendingInspector {
+  /**
+   * Runs constructor.
+   * @param {object} args - Options object.
+   * @param {import("../../configuration.js").default} args.configuration - Configuration instance.
+   * @param {string} args.identifier - Tenant database identifier.
+   * @param {number[]} args.migrationVersions - Applicable migration versions.
+   * @param {Array<ReturnType<typeof JSON.parse>>} args.tenants - Existing tenant descriptors.
+   */
+  constructor({configuration, identifier, migrationVersions, tenants, ...restArgs}) {
+    restArgsError(restArgs)
+
+    this.configuration = configuration
+    this.identifier = identifier
+    this.migrationVersions = migrationVersions.map((version) => `${version}`)
+    this.tenants = tenants
+  }
+
+  /**
+   * Reads every existing tenant ledger and reports aggregate pending state.
+   * @returns {Promise<{hasPendingMigrations: boolean, identifier: string, migrationCount: number, pendingTenantCount: number, tenantCount: number}>} - Deploy preflight result.
+   */
+  async inspect() {
+    let pendingTenantCount = 0
+
+    for (const tenant of this.tenants) {
+      if (await this.tenantHasPendingMigrations(tenant)) pendingTenantCount++
+    }
+
+    return {
+      hasPendingMigrations: pendingTenantCount > 0,
+      identifier: this.identifier,
+      migrationCount: this.migrationVersions.length,
+      pendingTenantCount,
+      tenantCount: this.tenants.length
+    }
+  }
+
+  /**
+   * Reads one tenant's existing migration ledger without preparing or changing it.
+   * @param {ReturnType<typeof JSON.parse>} tenant - Tenant descriptor.
+   * @returns {Promise<boolean>} - Whether the tenant has an applicable pending migration.
+   */
+  async tenantHasPendingMigrations(tenant) {
+    try {
+      return await this.configuration.runWithTenant(tenant, async () => {
+        return await this.configuration.ensureConnections({
+          databaseIdentifiers: [this.identifier],
+          name: `Tenant migration pending preflight: ${this.identifier}`
+        }, async (dbs) => {
+          const db = dbs[this.identifier]
+
+          if (!db) throw new Error(`Tenant database identifier ${this.identifier} did not open a connection`)
+          if (!await MigrationsLedger.tableExists(db)) throw new Error(`${MigrationsLedger.tableName()} ledger does not exist`)
+
+          const appliedVersions = new Set(await MigrationsLedger.appliedVersions(db))
+
+          return this.migrationVersions.some((version) => !appliedVersions.has(version))
+        })
+      })
+    } catch (error) {
+      const tenantLabel = TenantIterator.tenantLabel(tenant)
+
+      throw new Error(`Could not read ${MigrationsLedger.tableName()} for tenant ${tenantLabel}`, {cause: error})
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a read-only `db:tenants:migrations:pending` command with stable aggregate JSON output
- compare applicable app/package migration versions against every existing tenant ledger without running migrations or lifecycle hooks
- fail closed for missing or unreadable tenant state and document deploy-consumer behavior

## Validation

- `MSSQL_SA_PASSWORD=<local-placeholder> VELOCIOUS_DISABLED_DATABASE_IDENTIFIERS=mssql node scripts/run-tests.js cli/commands/db/tenants/migrations/pending-spec.js`
- `cp spec/dummy/src/config/configuration.peakflow.sqlite.js spec/dummy/src/config/configuration.js`
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`