### PR TITLE
Fix MSSQL background job test lifecycle

### DIFF
--- a/changelog.d/20260814143000-test-shared-provider-hook-order.md
+++ b/changelog.d/20260814143000-test-shared-provider-hook-order.md
@@ -1,0 +1,1 @@
+Fix transactional tests so long-lived in-process services share the test connection immediately when a setup hook starts its transaction.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -43,7 +43,7 @@ database: {
 }
 ```
 
-## Request test database connections
+## In-process test database connections
 Request tests share only transaction-active, non-tenant database connections with
 in-process request handlers. Handlers can therefore see uncommitted test setup while
 transaction rollback still isolates and cleans up the test.
@@ -80,11 +80,15 @@ drains every child socket and server. The teardown caller then receives the coll
 driver cleanup errors after transport shutdown completes.
 
 The in-process background-jobs main also enters the attempt's shared connection
-context before store work. This keeps enqueue, handoff, and terminal job rows on the
-same parent-owned transaction on async-tracked database pools instead of checking out
-an independently committed connection. Parent store callbacks and child broker calls
-also share the broker's per-physical-connection queue, preventing overlapping driver
-requests while preserving root-savepoint leases.
+context before store work. Dynamic shared-connection providers are installed before
+`beforeEach` hooks for every test type, so the provider becomes eligible at the exact
+point a hook starts its transaction; a long-lived main cannot acquire an independent
+session in a gap between transaction startup and broker activation. This keeps
+enqueue, handoff, and terminal job rows on the same parent-owned transaction on
+async-tracked database pools instead of checking out an independently committed
+connection. Parent store callbacks and child broker calls also share the broker's
+per-physical-connection queue, preventing overlapping driver requests while
+preserving root-savepoint leases.
 
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so

--- a/spec/background-jobs/stable-schedule-dispatch-spec.js
+++ b/spec/background-jobs/stable-schedule-dispatch-spec.js
@@ -92,12 +92,12 @@ describe("Background jobs - stable schedule dispatch", {databaseCleaning: {trunc
       await TestJob.replaceScheduled({
         scheduleKey: "event:53:reminder:24h",
         args: ["cancelled", cancelledOutputPath],
-        options: {executionMode: "inline", scheduledAtMs: Date.now() + 1000}
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 60000}
       })
       await TestJob.replaceScheduled({
         scheduleKey: "event:54:reminder:24h",
         args: ["kept", keptOutputPath],
-        options: {executionMode: "inline", scheduledAtMs: Date.now() + 1200}
+        options: {executionMode: "inline", scheduledAtMs: Date.now() + 120000}
       })
       await main._drain()
       await timeout({timeout: 500}, async () => {
@@ -109,6 +109,11 @@ describe("Background jobs - stable schedule dispatch", {databaseCleaning: {trunc
       expect(await TestJob.cancelScheduled("event:53:reminder:24h")).toMatchObject({outcome: "cancelled"})
       await timeout({timeout: 500}, async () => {
         while (main._scheduledTimer === timerBeforeCancellation) await wait(0.01)
+      })
+      await TestJob.replaceScheduled({
+        scheduleKey: "event:54:reminder:24h",
+        args: ["kept", keptOutputPath],
+        options: {executionMode: "inline", scheduledAtMs: Date.now()}
       })
       expect(await waitForOutputJson({outputPath: keptOutputPath, timeoutSeconds: 2})).toEqual({message: "kept"})
       await expect(async () => await fs.access(cancelledOutputPath)).toThrow(/ENOENT/)

--- a/spec/testing/test-runner-shared-connection-activation-order-spec.js
+++ b/spec/testing/test-runner-shared-connection-activation-order-spec.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import TestRunner from "../../src/testing/test-runner.js"
+
+describe("TestRunner shared connection activation order", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  it("activates dynamic providers before non-request beforeEach hooks", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const order = []
+
+    class ObservedTestRunner extends TestRunner {
+      activateTestSharedConnections() {
+        order.push("activate")
+        return []
+      }
+
+      async startSharedTransactionBroker() {
+        order.push("broker")
+        return undefined
+      }
+    }
+
+    const testRunner = new ObservedTestRunner({configuration, testFiles: []})
+    const tests = {
+      args: {},
+      afterAlls: [],
+      afterEaches: [],
+      beforeAlls: [],
+      beforeEaches: [{callback: async () => { order.push("beforeEach") }}],
+      subs: {},
+      tests: {
+        "runs outside request mode": {
+          args: {},
+          function: async () => { order.push("test") }
+        }
+      }
+    }
+
+    await testRunner.runTests({afterEaches: [], beforeEaches: [], tests, descriptions: [], indentLevel: 0})
+
+    expect(order[0]).toEqual("activate")
+  })
+})

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -1058,12 +1058,12 @@ export default class TestRunner {
               // back). Releasing the lease after each lifecycle also runs the pool's
               // session cleanup before another test can reuse the connection.
               await this.getConfiguration().ensureConnections({name: `Test: ${testDescription}`}, async () => {
-                // Register dynamic candidates before application hooks so transaction
-                // state changes made during a hook are visible to a request dispatched
-                // by that same callback.
-                if (testArgs.type == "request") {
-                  testSharedConnectionRegistrations = this.activateTestSharedConnections()
-                }
+                // Register dynamic candidates before hooks so transaction state changes
+                // made during a hook are immediately visible to any in-process work.
+                // Long-lived services such as a background-jobs main can dispatch DB
+                // work between a transaction-starting hook and broker activation just
+                // as an HTTP request can dispatch work from inside the hook itself.
+                testSharedConnectionRegistrations = this.activateTestSharedConnections()
 
                 try {
                   try {


### PR DESCRIPTION
## Release blocker

Follow-up for the two MSSQL failures on merged PR #1041 (head `3716ec65b82d3edd0084afd9c7a3734619047fd0`, build group `01548186-a099-42a3-afae-5b95fe67e319`).

## Root cause and correction

- The pooled attempt-reuse spec starts its background-jobs main in `beforeAll`, then deliberately reuses it across per-test transaction broker capabilities. `TestRunner` previously installed dynamic shared-connection providers before `beforeEach` only for request tests. In this non-request spec, MSSQL therefore had an interval after the setup hook opened its transaction but before broker activation. Detached main drain work could check out an independent session in that interval; the second attempt then held the count-revision row in its parent transaction while the escaped session waited on the same row, producing the observed 15-second query timeout and poisoned cleanup. Providers are now installed before hooks for every test type and remain dynamically eligible only while the captured connection is in a transaction.
- The stable-schedule cancellation spec scheduled owners only 1.0/1.2 seconds ahead. Valid MSSQL work took about 12.6 seconds, so the worker had already dispatched the supposed cancellation target and released its durable schedule ownership; `not_found` was the correct result for that vanished precondition. The spec now keeps both owners durably future-scheduled while asserting cancellation/timer re-arm, then explicitly moves only the retained owner to `Date.now()` for dispatch. No wait, retry, timeout, assertion, or production scheduler behavior was changed.

## RED / GREEN

RED before production edit:

```text
observed=beforeEach -> broker -> activate -> test
Error: Expected provider activation before beforeEach
```

GREEN after the fix:

```text
observed=activate -> beforeEach -> broker -> activate -> test
Focused specs passed: 19 tests
```

The focused 19-test boundary covers the new activation-order regression plus shared broker registration/protocol, pooled job context, and pooled broker identity.

## Validation

- focused database-free regression/broker boundary: 19 passed
- `npm run lint`: passed after the required Peakflow SQLite config copy
- `npm run typecheck`: passed
- `npm run fallow`: passed
- `npm run build`: passed
- `git diff --check`: passed

The canonical container exposes the MSSQL service but does not provide `MSSQL_SA_PASSWORD` to this shell. Database-backed MSSQL specs were therefore not replaced with guessed credentials or another driver; exact-head CI must exercise those two database boundaries.

## Scope / rollback

Five paths only: runner lifecycle, two focused specs, testing documentation, and changelog. Roll back this commit to restore the prior provider timing and schedule fixture values; no migration, schema, package version, or release side effect is included.
