### PR TITLE
Add background jobs adapter runtime modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2264,6 +2264,7 @@ You can configure the main host/port in your configuration:
 export default new Configuration({
   // ...
   backgroundJobs: {
+    mode: "background",
     host: "127.0.0.1",
     port: 7331,
     databaseIdentifier: "default",
@@ -2279,6 +2280,16 @@ export default new Configuration({
   }
 })
 ```
+
+`backgroundJobs.mode` is separate from a job's `executionMode`. The default
+`"background"` mode preserves the Node SQL queue, TCP main/worker transport, and
+per-job `"pooled"` execution default. `"inline"` is a platform-neutral,
+non-durable application mode: `performLater` performs immediately and rejects
+queue/scheduling/retry/execution options whose guarantees require durable state.
+Custom persistence can be supplied as a `BackgroundJobsAdapter` instance or
+synchronous factory. See [runtime modes and adapters](docs/background-jobs.md#runtime-modes-and-adapters)
+for the contract, lifecycle, Node TCP/wake behavior, the explicit
+`platform-job.js` browser/Expo entry, and SQL-only compatibility boundaries.
 
 Or via env vars:
 
@@ -2357,7 +2368,7 @@ Queue a job:
 await MyJob.performLater("a", "b")
 ```
 
-Jobs use `executionMode: "forked"` by default. This runs the job in a separate attached Node child process. To run inline:
+Durably queued jobs use `executionMode: "pooled"` by default. To run one inside the worker process instead:
 
 ```js
 await MyJob.performLaterWithOptions({

--- a/changelog.d/20260814150000-background-jobs-adapter.md
+++ b/changelog.d/20260814150000-background-jobs-adapter.md
@@ -1,0 +1,5 @@
+Add a documented background-jobs adapter lifecycle and a platform-neutral,
+non-durable `backgroundJobs.mode: "inline"`, while preserving the existing Node
+SQL/TCP/pooled defaults and durable queue behavior. Node producers retain lazy
+configuration discovery and main-process wake-ups; non-Node bundles use the
+explicit platform job entry, and adapter readiness/close is generation-safe.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -6,6 +6,100 @@ For the mounted inspection API, authoritative tab-count snapshots, and
 WebSocket/Beacon delta contract, see the
 [background-jobs dashboard](background-jobs-dashboard.md).
 
+## Runtime modes and adapters
+
+`backgroundJobs.mode` selects the application-level delivery path and is distinct
+from a durable job's `executionMode`:
+
+- `"background"` (default) enqueues through a background-jobs producer. In Node,
+  the unchanged default is TCP transport to `background-jobs-main`, the built-in
+  SQL adapter, and `executionMode: "pooled"` when a job does not select an
+  execution mode. Existing retries, leases, fencing, scheduling, idempotency,
+  deduplication, concurrency, pruning, and migrations retain their SQL behavior.
+- `"inline"` performs the job immediately in the caller, awaits `perform`, and
+  returns an ephemeral `inline-...` performance id. It does not resolve an
+  adapter, open a main/worker transport, or create durable queue state. Errors
+  propagate to the caller. All `jobOptions` are rejected because their retry,
+  scheduling, queue, concurrency, idempotency, deduplication, and worker-execution
+  semantics require durable state. `replaceScheduled`, `cancelScheduled`, and
+  `rescheduleIn` are rejected for the same reason.
+
+The established `background-jobs/job.js` entry remains the Node entry. It keeps
+lazy `src/config/configuration.js` discovery in fresh producer processes and
+always sends durable mutations over TCP to `background-jobs-main`, including
+when the main uses a custom adapter. This preserves the main's dispatch wake-up
+and event-driven idle-worker behavior.
+
+Browser, Expo, and other non-Node runtimes use the explicit
+`velocious/build/src/background-jobs/platform-job.js` entry. That entry and its
+runtime graph contain no Node configuration resolver, SQL, TCP, filesystem,
+process, main, or worker imports. Its configuration must already be current
+(call `configuration.setCurrent()`). Inline mode needs no adapter. Background
+mode requires an environment handler and explicit adapter that are valid on the
+target platform; this task does not provide a Cloudflare adapter.
+
+### BackgroundJobsAdapter contract
+
+Custom background persistence extends the documented base class:
+
+```js
+import BackgroundJobsAdapter from "velocious/build/src/background-jobs/adapter.js"
+
+class ApplicationJobsAdapter extends BackgroundJobsAdapter {
+  // Implement the lifecycle and queue operations described below.
+}
+
+export default new Configuration({
+  // One caller-provided instance, reused if a later lifecycle resolves it again:
+  backgroundJobs: {adapter: new ApplicationJobsAdapter()}
+
+  // Or a fresh instance per lifecycle:
+  // backgroundJobs: {adapter: ({configuration}) => new ApplicationJobsAdapter({configuration})}
+})
+```
+
+Adapter factories are synchronous. A configuration memoizes one resolved adapter,
+shares one successful `ensureReady()` phase, and atomically acquires that exact
+ready instance for an operation. Close is serialized against acquisition: if
+close claims an adapter while readiness is pending, the acquisition waits for
+close and readies the next lifecycle instead of mutating a closed generation.
+`closeDatabaseConnections()` calls `close()`, and concurrent close calls share
+that close. After close, a factory is invoked again on the next use; a configured
+instance is resolved again, so an instance intended for repeated lifecycles must
+support readiness after close. A stopped main clears its adapter reference and
+acquires the current ready generation again on every `start()`.
+
+The current main/worker architecture requires these adapter operations:
+
+- lifecycle/readiness: `ensureReady`, `health`, and `close`;
+- enqueue and stable schedules: `enqueue`, `replaceScheduled`, and
+  `cancelScheduled`;
+- dequeue and timing: `nextAvailableJob`, `nextScheduledJob`, and
+  `reconcileQueueConcurrency`;
+- start/handoff state: `markHandedOff`, `markReturnedToQueue`, and
+  `handedOffJobsForWorker`;
+- success/failure state: `markCompleted`, `markRescheduled`, `markFailed`, and
+  `markOrphanedJobs`;
+- built-in maintenance: `getJob` and `pruneTerminalJobs`.
+
+Methods that accept worker reports must preserve the existing lease-fencing and
+at-least-once semantics. `health()` returns `{ready: boolean}`; the mounted health
+endpoint reports `503` when an adapter explicitly reports `ready: false`.
+
+The built-in adapter is available at
+`velocious/build/src/background-jobs/sql-adapter.js`. It subclasses the existing
+`BackgroundJobsStore`, so existing direct store imports and every current SQL
+migration/queue semantic remain compatible. The SQL adapter also owns the
+framework-schema migration hook; a custom adapter may override
+`ensureFrameworkSchema({dbs})` when it owns framework persistence, while the base
+implementation is a no-op.
+
+This seam is intentionally bounded. Dashboard list/stats storage and specialized
+mailer delivery-operation SQL remain direct `BackgroundJobsStore` consumers;
+only dashboard health is adapter-aware. Supplying a generic adapter does not make
+those SQL-specific features portable. No Cloudflare Workers implementation or
+package root/export-map alias is included here.
+
 ## Execution modes and pooled runners
 
 New enqueues default to `executionMode: "pooled"`. Each worker owns a local pool of warm Node child processes; a child runs up to `pooledRunnerConcurrency` jobs at a time on its own event loop and is reused for sequential jobs. Completion still flows through the runner's durable status reporter, so the main process and database acknowledgement remain authoritative. Pooled capacity is advertised explicitly and is separate from inline and forked/spawned capacity. The `execution_mode` column is the single source of truth for a job's runtime — pooled rows persist as `execution_mode = "pooled"` directly.

--- a/spec/background-jobs/custom-adapter-wake-spec.js
+++ b/spec/background-jobs/custom-adapter-wake-spec.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+import SqlBackgroundJobsAdapter from "../../src/background-jobs/sql-adapter.js"
+import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import TestJob from "../dummy/src/jobs/test-job.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import {outputPathFor, startBackgroundJobs, waitForJobCompleted, waitForOutputJson} from "../helpers/background-jobs-helper.js"
+
+describe("Background jobs - custom adapter Node wake-up", {databaseCleaning: {truncate: true}}, () => {
+  it("routes an explicit SQL adapter producer through main so an idle worker wakes", async () => {
+    await dummyConfiguration.closeBackgroundJobsAdapter()
+    dummyConfiguration.setBackgroundJobsConfig({
+      adapter: ({configuration}) => new SqlBackgroundJobsAdapter({configuration}),
+      dispatchStrategy: "beacon",
+      mode: "background"
+    })
+
+    const {main, store, worker} = await startBackgroundJobs()
+    const outputPath = await outputPathFor("custom-adapter-wake")
+
+    try {
+      await timeout({timeout: 1000}, async () => {
+        while (main.readyWorkers.size !== 1 || main._draining) await wait(0.01)
+      })
+      await main._drain()
+
+      const jobId = await TestJob.performLater("custom-adapter", outputPath)
+
+      expect(await waitForOutputJson({outputPath, timeoutSeconds: 1})).toEqual({message: "custom-adapter"})
+      await waitForJobCompleted({jobId, store})
+    } finally {
+      await worker.stop()
+      await main.stop()
+      await dummyConfiguration.closeBackgroundJobsAdapter()
+    }
+  })
+})

--- a/spec/background-jobs/job-browser-bundle-spec.js
+++ b/spec/background-jobs/job-browser-bundle-spec.js
@@ -1,0 +1,51 @@
+// @ts-check
+
+import path from "node:path"
+import {fileURLToPath} from "node:url"
+
+import {build} from "esbuild"
+
+import {describe, expect, it} from "../../src/testing/test.js"
+
+describe("Background jobs - public browser bundle", {databaseCleaning: {transaction: true}}, () => {
+  it("bundles the public job runtime without Node-only background-job modules", async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+
+    const result = await build({
+      bundle: true,
+      format: "esm",
+      logLevel: "silent",
+      metafile: true,
+      platform: "browser",
+      stdin: {
+        contents: `
+          import VelociousJob from "./src/background-jobs/platform-job.js"
+          import Configuration from "./src/configuration.js"
+          import BrowserEnvironmentHandler from "./src/environment-handlers/browser.js"
+          globalThis.VelociousJob = VelociousJob
+          globalThis.VelociousConfiguration = Configuration
+          globalThis.VelociousBrowserEnvironmentHandler = BrowserEnvironmentHandler
+        `,
+        loader: "js",
+        resolveDir: repoRoot,
+        sourcefile: "background-jobs-browser-bundle-entry.js"
+      },
+      write: false
+    })
+
+    const inputs = Object.keys(result.metafile.inputs)
+
+    for (const nodeOnlyPath of [
+      "background-jobs/client.js",
+      "background-jobs/job.js",
+      "background-jobs/main.js",
+      "background-jobs/socket-request.js",
+      "background-jobs/store.js",
+      "background-jobs/worker.js",
+      "configuration-resolver.js",
+      "environment-handlers/node.js"
+    ]) {
+      expect(inputs.some((filePath) => filePath.includes(nodeOnlyPath))).toBeFalse()
+    }
+  })
+})

--- a/spec/background-jobs/job-lazy-configuration-process-spec.js
+++ b/spec/background-jobs/job-lazy-configuration-process-spec.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+import {fork} from "node:child_process"
+import timeout from "awaitery/build/timeout.js"
+import dummyDirectory from "../dummy/dummy-directory.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import {lazyConfigurationChildPath} from "../helpers/background-jobs-lazy-configuration-child.js"
+import {outputPathFor, startBackgroundJobs, waitForJobCompleted, waitForOutputJson} from "../helpers/background-jobs-helper.js"
+
+/**
+ * Enqueues from a fresh Node process that has no current configuration.
+ * @param {{outputPath: string, port: number}} args - Child options.
+ * @returns {Promise<string>} - Enqueued job id.
+ */
+async function enqueueFromFreshProcess({outputPath, port}) {
+  return await timeout({timeout: 5000}, async () => await new Promise((resolve, reject) => {
+    const child = fork(lazyConfigurationChildPath, [outputPath], {
+      cwd: dummyDirectory(),
+      env: {
+        ...process.env,
+        MSSQL_SA_PASSWORD: process.env.MSSQL_SA_PASSWORD || "unused",
+        VELOCIOUS_BACKGROUND_JOBS_HOST: "127.0.0.1",
+        VELOCIOUS_BACKGROUND_JOBS_PORT: String(port),
+        VELOCIOUS_DISABLE_MSSQL: "1",
+        VELOCIOUS_LAZY_CONFIGURATION_CHILD: "1"
+      },
+      stdio: ["ignore", "inherit", "inherit", "ipc"]
+    })
+    let settled = false
+
+    child.once("error", reject)
+    child.on("message", (message) => {
+      if (!message || typeof message !== "object") return
+
+      const typedMessage = /** @type {{error?: string, jobId?: string, type?: string}} */ (message)
+
+      if (typedMessage.type === "error") {
+        settled = true
+        reject(new Error(typedMessage.error || "Fresh-process enqueue failed"))
+      } else if (typedMessage.type === "enqueued" && typedMessage.jobId) {
+        settled = true
+        resolve(typedMessage.jobId)
+      }
+    })
+    child.once("exit", (code) => {
+      if (!settled) reject(new Error(`Fresh-process enqueue exited with status ${String(code)}`))
+    })
+  }))
+}
+
+describe("Background jobs - lazy Node configuration", {databaseCleaning: {truncate: true}}, () => {
+  it("preserves VelociousJob configurationResolver lookup in a fresh process", async () => {
+    const {main, store, worker} = await startBackgroundJobs()
+    const outputPath = await outputPathFor("lazy-node-configuration")
+
+    try {
+      const jobId = await enqueueFromFreshProcess({outputPath, port: main.getPort()})
+
+      expect(await waitForOutputJson({outputPath})).toEqual({message: "lazy-configuration"})
+      await waitForJobCompleted({jobId, store})
+    } finally {
+      await worker.stop()
+      await main.stop()
+    }
+  })
+})

--- a/spec/background-jobs/main-adapter-restart-spec.js
+++ b/spec/background-jobs/main-adapter-restart-spec.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
+import SqlBackgroundJobsAdapter from "../../src/background-jobs/sql-adapter.js"
+import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import TestJob from "../dummy/src/jobs/test-job.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+import {outputPathFor, waitForJobCompleted, waitForOutputJson} from "../helpers/background-jobs-helper.js"
+
+describe("Background jobs - main adapter restart", {databaseCleaning: {transaction: false, truncate: true}}, () => {
+  it("acquires a new factory adapter on the same main instance and dispatches with it", async () => {
+    await dummyConfiguration.closeBackgroundJobsAdapter()
+    const adapters = []
+
+    dummyConfiguration.setBackgroundJobsConfig({
+      adapter: ({configuration}) => {
+        const adapter = new SqlBackgroundJobsAdapter({configuration})
+        adapters.push(adapter)
+        return adapter
+      },
+      mode: "background"
+    })
+
+    const main = new BackgroundJobsMain({
+      closeDatabaseConnectionsOnStop: false,
+      configuration: dummyConfiguration,
+      host: "127.0.0.1",
+      port: 0
+    })
+    /** @type {BackgroundJobsWorker | undefined} */
+    let worker
+
+    try {
+      await main.start()
+      expect(main.adapter).toEqual(adapters[0])
+      await main.stop()
+      await dummyConfiguration.closeBackgroundJobsAdapter()
+
+      await main.start()
+
+      expect(adapters.length).toEqual(2)
+      expect(main.adapter).toEqual(adapters[1])
+
+      worker = new BackgroundJobsWorker({
+        closeDatabaseConnectionsOnStop: false,
+        configuration: dummyConfiguration,
+        host: "127.0.0.1",
+        port: main.getPort()
+      })
+      await worker.start()
+      await timeout({timeout: 1000}, async () => {
+        while (main.readyWorkers.size !== 1 || main._draining) await wait(0.01)
+      })
+
+      const outputPath = await outputPathFor("main-adapter-restart")
+      const jobId = await adapters[1].enqueue({
+        jobName: TestJob.jobName(),
+        args: ["restarted", outputPath],
+        options: {executionMode: "inline"}
+      })
+
+      await main._drain()
+      expect(await waitForOutputJson({outputPath})).toEqual({message: "restarted"})
+      await waitForJobCompleted({jobId, store: adapters[1]})
+    } finally {
+      await worker?.stop({timeoutMs: 1000})
+      await main.stop()
+      await dummyConfiguration.closeBackgroundJobsAdapter()
+    }
+  })
+})

--- a/spec/background-jobs/main-adapter-spec.js
+++ b/spec/background-jobs/main-adapter-spec.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import BackgroundJobsClient from "../../src/background-jobs/client.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import SqlBackgroundJobsAdapter from "../../src/background-jobs/sql-adapter.js"
+import BackgroundJobsTestAdapter from "../helpers/background-jobs-test-adapter.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+describe("Background jobs - main adapter", () => {
+  it("keeps the Node SQL persistence and TCP producer defaults", () => {
+    const environmentHandler = new EnvironmentHandlerNode()
+    const configuration = new Configuration({
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler,
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]}
+    })
+    const main = new BackgroundJobsMain({configuration})
+
+    expect(main.adapter).toBeUndefined()
+    expect(configuration.getBackgroundJobsAdapter()).toBeInstanceOf(SqlBackgroundJobsAdapter)
+    expect(environmentHandler.backgroundJobsClient({configuration})).toBeInstanceOf(BackgroundJobsClient)
+  })
+
+  it("uses the configured adapter as its persistence seam", () => {
+    const adapter = new BackgroundJobsTestAdapter()
+    const configuration = new Configuration({
+      backgroundJobs: {adapter},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]}
+    })
+    const main = new BackgroundJobsMain({configuration})
+
+    expect(main.adapter).toBeUndefined()
+    expect(configuration.getBackgroundJobsAdapter()).toEqual(adapter)
+    expect(configuration.getEnvironmentHandler().backgroundJobsClient({configuration})).toBeInstanceOf(BackgroundJobsClient)
+  })
+})

--- a/spec/background-jobs/main-startup-adapter-lifecycle-spec.js
+++ b/spec/background-jobs/main-startup-adapter-lifecycle-spec.js
@@ -1,0 +1,163 @@
+// @ts-check
+
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import BackgroundJobsTestAdapter from "../helpers/background-jobs-test-adapter.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class StartupAdapter extends BackgroundJobsTestAdapter {
+  /**
+   * @param {{ready?: () => Promise<void>, reconcile?: () => Promise<void>}} [args] - Adapter hooks.
+   */
+  constructor({ready, reconcile} = {}) {
+    super({ready})
+    this.reconcile = reconcile
+    this.reconcileCount = 0
+  }
+
+  /** @returns {Promise<void>} - Resolves after reconciliation. */
+  async reconcileQueueConcurrency() {
+    this.reconcileCount++
+    await this.reconcile?.()
+  }
+
+  /** @returns {Promise<null>} - No scheduled work. */
+  async nextScheduledJob() {
+    return null
+  }
+}
+
+class MainWithAssignedStore extends BackgroundJobsMain {
+  /**
+   * @param {ConstructorParameters<typeof BackgroundJobsMain>[0] & {store: StartupAdapter}} args - Main and store options.
+   */
+  constructor({store, ...args}) {
+    super(args)
+    this.store = store
+  }
+}
+
+/**
+ * @param {() => StartupAdapter} adapterFactory - Adapter factory.
+ * @returns {Configuration} - Isolated main configuration.
+ */
+function buildConfiguration(adapterFactory) {
+  return new Configuration({
+    backgroundJobs: {
+      adapter: adapterFactory,
+      retention: {completedTtlMs: null, failedTtlMs: null}
+    },
+    beacon: {inProcess: true},
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]}
+  })
+}
+
+/**
+ * @param {Configuration} configuration - Main configuration.
+ * @returns {BackgroundJobsMain} - Main configured for isolated lifecycle tests.
+ */
+function buildMain(configuration) {
+  return new BackgroundJobsMain({
+    closeDatabaseConnectionsOnStop: false,
+    configuration,
+    host: "127.0.0.1",
+    port: 0
+  })
+}
+
+describe("Background jobs - main startup adapter lifecycle", () => {
+  it("preserves a store assigned by a subclass before start", async () => {
+    const assignedStore = new StartupAdapter()
+    let configuredAdapterCount = 0
+    const configuration = buildConfiguration(() => {
+      configuredAdapterCount++
+      return new StartupAdapter()
+    })
+    const main = new MainWithAssignedStore({
+      closeDatabaseConnectionsOnStop: false,
+      configuration,
+      host: "127.0.0.1",
+      port: 0,
+      store: assignedStore
+    })
+
+    try {
+      await main.start()
+
+      expect(main.store).toEqual(assignedStore)
+      expect(assignedStore.reconcileCount).toEqual(1)
+      expect(configuredAdapterCount).toEqual(0)
+    } finally {
+      await main.stop()
+      await configuration.closeBackgroundJobsAdapter()
+    }
+  })
+
+  it("cleans a failed readiness generation and Beacon before retrying", async () => {
+    const adapters = []
+    const configuration = buildConfiguration(() => {
+      const adapter = new StartupAdapter({
+        ready: adapters.length === 0 ? async () => { throw new Error("startup readiness failed") } : undefined
+      })
+      adapters.push(adapter)
+      return adapter
+    })
+    const main = buildMain(configuration)
+
+    try {
+      await expect(async () => await main.start()).toThrow(/startup readiness failed/)
+
+      expect(configuration.getBeaconClient()).toBeUndefined()
+      expect(main.adapter).toBeUndefined()
+      expect(main.server).toBeUndefined()
+      expect(adapters[0].closeCount).toEqual(1)
+
+      await main.start()
+
+      expect(adapters.length).toEqual(2)
+      expect(main.adapter).toEqual(adapters[1])
+      expect(adapters[1].readyCount).toEqual(1)
+      expect(adapters[1].reconcileCount).toEqual(1)
+    } finally {
+      await main.stop()
+      await configuration.closeBackgroundJobsAdapter()
+    }
+  })
+
+  it("cleans a failed reconcile generation and Beacon before retrying", async () => {
+    const adapters = []
+    const configuration = buildConfiguration(() => {
+      const adapter = new StartupAdapter({
+        reconcile: adapters.length === 0 ? async () => { throw new Error("startup reconcile failed") } : undefined
+      })
+      adapters.push(adapter)
+      return adapter
+    })
+    const main = buildMain(configuration)
+
+    try {
+      await expect(async () => await main.start()).toThrow(/startup reconcile failed/)
+
+      expect(configuration.getBeaconClient()).toBeUndefined()
+      expect(main.adapter).toBeUndefined()
+      expect(main.server).toBeUndefined()
+      expect(adapters[0].closeCount).toEqual(1)
+
+      await main.start()
+
+      expect(adapters.length).toEqual(2)
+      expect(main.adapter).toEqual(adapters[1])
+      expect(adapters[1].readyCount).toEqual(1)
+      expect(adapters[1].reconcileCount).toEqual(1)
+    } finally {
+      await main.stop()
+      await configuration.closeBackgroundJobsAdapter()
+    }
+  })
+})

--- a/spec/background-jobs/runtime-mode-spec.js
+++ b/spec/background-jobs/runtime-mode-spec.js
@@ -1,0 +1,99 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerBase from "../../src/environment-handlers/base.js"
+import VelociousJob from "../../src/background-jobs/platform-job.js"
+import BackgroundJobsTestAdapter from "../helpers/background-jobs-test-adapter.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+class InlineModeJob extends VelociousJob {
+  static databaseIdentifiers = []
+  static performances = []
+
+  async perform(value) {
+    this.constructor.performances.push(value)
+  }
+}
+
+class ReschedulingInlineModeJob extends VelociousJob {
+  static databaseIdentifiers = []
+
+  async perform() {
+    this.rescheduleIn(1)
+  }
+}
+
+/** @returns {Configuration} - Inline-mode configuration. */
+function inlineConfiguration() {
+  return new Configuration({
+    backgroundJobs: {mode: "inline"},
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerBase(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]}
+  })
+}
+
+describe("Background jobs runtime mode", () => {
+  it("performs immediately without resolving a background adapter", async () => {
+    const previousConfiguration = Configuration.current()
+    const configuration = inlineConfiguration()
+    InlineModeJob.performances = []
+    configuration.setCurrent()
+
+    try {
+      const jobId = await InlineModeJob.performLater("inline-value")
+
+      expect(typeof jobId).toEqual("string")
+      expect(InlineModeJob.performances).toEqual(["inline-value"])
+    } finally {
+      previousConfiguration.setCurrent()
+    }
+  })
+
+  it("rejects durable options and stable scheduling in inline mode", async () => {
+    const previousConfiguration = Configuration.current()
+    const configuration = inlineConfiguration()
+    configuration.setCurrent()
+
+    try {
+      await expect(async () => await InlineModeJob.performLaterWithOptions({args: [], options: {scheduledAtMs: 1}})).toThrow(/scheduledAtMs.*inline mode/)
+      await expect(async () => await InlineModeJob.performLaterWithOptions({args: [], options: {executionMode: "inline"}})).toThrow(/executionMode.*inline mode/)
+      await expect(async () => await InlineModeJob.replaceScheduled({scheduleKey: "inline", args: []})).toThrow(/replaceScheduled.*inline mode/)
+      await expect(async () => await InlineModeJob.cancelScheduled("inline")).toThrow(/cancelScheduled.*inline mode/)
+      await expect(async () => await ReschedulingInlineModeJob.performLater()).toThrow(/rescheduleIn.*inline mode/)
+    } finally {
+      previousConfiguration.setCurrent()
+    }
+  })
+
+  it("delegates background mode to a configured adapter", async () => {
+    const previousConfiguration = Configuration.current()
+    const adapter = new BackgroundJobsTestAdapter()
+    const configuration = new Configuration({
+      backgroundJobs: {adapter, mode: "background"},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerBase(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]}
+    })
+    configuration.setCurrent()
+
+    try {
+      expect(await InlineModeJob.performLaterWithOptions({
+        args: ["background-value"],
+        options: {executionMode: "forked"}
+      })).toEqual("adapter-job-id")
+      expect(adapter.calls).toMatchObject([
+        {method: "ensureReady"},
+        {args: {jobName: "InlineModeJob", args: ["background-value"], options: {executionMode: "forked"}}, method: "enqueue"}
+      ])
+    } finally {
+      previousConfiguration.setCurrent()
+    }
+  })
+})

--- a/spec/background-jobs/sql-adapter-spec.js
+++ b/spec/background-jobs/sql-adapter-spec.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+import SqlBackgroundJobsAdapter from "../../src/background-jobs/sql-adapter.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+describe("Background jobs - SQL adapter", {databaseCleaning: {truncate: true}}, () => {
+  it("preserves the store's durable handoff and fenced completion semantics", async () => {
+    const adapter = new SqlBackgroundJobsAdapter({configuration: dummyConfiguration})
+    await adapter.clearAll()
+
+    const jobId = await adapter.enqueue({jobName: "TestJob", args: [], options: {executionMode: "inline"}})
+    const candidate = await adapter.nextAvailableJob()
+    const handoff = await adapter.markHandedOff({jobId, workerId: "sql-adapter-worker"})
+
+    expect(candidate?.id).toEqual(jobId)
+    expect(handoff).toBeTruthy()
+    if (!handoff) throw new Error("Expected SQL adapter handoff")
+
+    expect(await adapter.markCompleted({jobId, workerId: "wrong-worker", ...handoff})).toBeFalse()
+    expect(await adapter.markCompleted({jobId, workerId: "sql-adapter-worker", ...handoff})).toBeTrue()
+    expect((await adapter.getJob(jobId))?.status).toEqual("completed")
+    expect(await adapter.health()).toEqual({ready: true})
+  })
+})

--- a/spec/background-jobs/web/api-spec.js
+++ b/spec/background-jobs/web/api-spec.js
@@ -6,6 +6,7 @@ import Dummy from "../../dummy/index.js"
 import dummyConfiguration from "../../dummy/src/config/configuration.js"
 import dummyDirectory from "../../dummy/dummy-directory.js"
 import EnvironmentHandlerNode from "../../../src/environment-handlers/node.js"
+import BackgroundJobsTestAdapter from "../../helpers/background-jobs-test-adapter.js"
 import fetch from "node-fetch"
 import Request from "../../../src/http-server/client/request.js"
 import Response from "../../../src/http-server/client/response.js"
@@ -41,10 +42,12 @@ async function seedJobs() {
 /**
  * @param {object} args - Options.
  * @param {string} args.at - Mount prefix.
+ * @param {import("../../../src/configuration-types.js").BackgroundJobsConfiguration} [args.backgroundJobs] - Background-jobs configuration.
  * @returns {Configuration} - A throwaway configuration for resolver-level tests.
  */
-function buildResolverConfiguration({at}) {
+function buildResolverConfiguration({at, backgroundJobs}) {
   const configuration = new Configuration({
+    backgroundJobs,
     database: {test: {}},
     directory: dummyDirectory(),
     environment: "test",
@@ -244,8 +247,34 @@ describe("Background jobs - web API", {databaseCleaning: {truncate: true}}, () =
     })
   })
 
+  it("reports adapter unavailability through the health check", async () => {
+    const adapter = new BackgroundJobsTestAdapter()
+    adapter.healthResult = {ready: false}
+    const configuration = buildResolverConfiguration({
+      at: "/velocious/jobs-unready",
+      backgroundJobs: {adapter}
+    })
+
+    const response = await resolveGet({
+      configuration,
+      path: "/velocious/jobs-unready/api/health",
+      remoteAddress: "127.0.0.1"
+    })
+
+    expect(response.getStatusCode()).toEqual(503)
+    expect(JSON.parse(response.getBody())).toEqual({
+      capabilities: {backgroundJobCountDeltas: 1},
+      ok: false,
+      ready: false,
+      service: "velocious-background-jobs"
+    })
+  })
+
   it("falls back to loopback-only access when no auth is configured", async () => {
-    const configuration = buildResolverConfiguration({at: "/velocious/jobs-open"})
+    const configuration = buildResolverConfiguration({
+      at: "/velocious/jobs-open",
+      backgroundJobs: {adapter: new BackgroundJobsTestAdapter()}
+    })
 
     const loopbackResponse = await resolveGet({configuration, path: "/velocious/jobs-open/api/health", remoteAddress: "127.0.0.1"})
 

--- a/spec/background-jobs/worker-shutdown-spec.js
+++ b/spec/background-jobs/worker-shutdown-spec.js
@@ -632,6 +632,7 @@ describe("Background jobs main - shutdown", () => {
     const main = new BackgroundJobsMain({
       closeDatabaseConnectionsOnStop: false,
       configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeBackgroundJobsAdapter: async () => { events.push("close-adapter") },
         closeDatabaseConnections: async () => { events.push("close-db") },
         disconnectBeacon: async () => { events.push("disconnect-beacon") },
         getBackgroundJobsConfig: () => ({
@@ -652,7 +653,7 @@ describe("Background jobs main - shutdown", () => {
 
     await main.stop()
 
-    expect(events).toEqual(["disconnect-beacon", "close-server"])
+    expect(events).toEqual(["disconnect-beacon", "close-server", "close-adapter"])
   })
 
   it("runs the stopped hook after shutdown", async () => {
@@ -661,6 +662,7 @@ describe("Background jobs main - shutdown", () => {
     const main = new BackgroundJobsMain({
       closeDatabaseConnectionsOnStop: false,
       configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeBackgroundJobsAdapter: async () => { events.push("close-adapter") },
         disconnectBeacon: async () => { events.push("disconnect-beacon") },
         getBackgroundJobsConfig: () => ({
           databaseIdentifier: "default",
@@ -675,15 +677,17 @@ describe("Background jobs main - shutdown", () => {
 
     await main.stop()
 
-    expect(events).toEqual(["disconnect-beacon", "stopped"])
+    expect(events).toEqual(["disconnect-beacon", "close-adapter", "stopped"])
   })
 
   it("shares one main stop lifecycle across concurrent and repeated callers", async () => {
     const disconnect = deferred()
+    let adapterCloseCount = 0
     let stoppedCount = 0
     const main = new BackgroundJobsMain({
       closeDatabaseConnectionsOnStop: false,
       configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeBackgroundJobsAdapter: async () => { adapterCloseCount += 1 },
         disconnectBeacon: async () => await disconnect.promise,
         getBackgroundJobsConfig: () => ({
           databaseIdentifier: "default",
@@ -707,15 +711,18 @@ describe("Background jobs main - shutdown", () => {
 
     expect(main.stop()).toBe(firstStop)
     await main.stop()
+    expect(adapterCloseCount).toBe(1)
     expect(stoppedCount).toBe(1)
   })
 
   it("runs the stopped hook after an earlier main shutdown rejection", async () => {
     const shutdownError = new Error("main scheduler stop failed")
+    let adapterCloseCount = 0
     let stoppedCount = 0
     const main = new BackgroundJobsMain({
       closeDatabaseConnectionsOnStop: false,
       configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeBackgroundJobsAdapter: async () => { adapterCloseCount += 1 },
         disconnectBeacon: async () => {},
         getBackgroundJobsConfig: () => ({
           databaseIdentifier: "default",
@@ -734,15 +741,18 @@ describe("Background jobs main - shutdown", () => {
     expect(await captureRejection(main.stop())).toBe(shutdownError)
     expect(stoppedCount).toBe(1)
     expect(await captureRejection(main.stop())).toBe(shutdownError)
+    expect(adapterCloseCount).toBe(1)
     expect(stoppedCount).toBe(1)
   })
 
   it("aggregates main shutdown and stopped-hook failures in lifecycle order", async () => {
     const shutdownError = new Error("main scheduler stop failed")
     const hookError = new Error("main hook failed")
+    let adapterCloseCount = 0
     const main = new BackgroundJobsMain({
       closeDatabaseConnectionsOnStop: false,
       configuration: /** @type {import("../../src/configuration.js").default} */ ({
+        closeBackgroundJobsAdapter: async () => { adapterCloseCount += 1 },
         disconnectBeacon: async () => {},
         getBackgroundJobsConfig: () => ({
           databaseIdentifier: "default",
@@ -763,5 +773,6 @@ describe("Background jobs main - shutdown", () => {
     expect(error).toBeInstanceOf(AggregateError)
     expect(/** @type {AggregateError} */ (error).errors).toEqual([shutdownError, hookError])
     expect(error.cause).toBe(shutdownError)
+    expect(adapterCloseCount).toBe(1)
   })
 })

--- a/spec/configuration/background-jobs-adapter-spec.js
+++ b/spec/configuration/background-jobs-adapter-spec.js
@@ -1,0 +1,109 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import BackgroundJobsTestAdapter from "../helpers/background-jobs-test-adapter.js"
+import {describe, expect, it} from "../../src/testing/test.js"
+
+/**
+ * Creates a manually resolved promise.
+ * @returns {{promise: Promise<void>, resolve: () => void}} - Deferred promise.
+ */
+function deferred() {
+  /** @type {() => void} */
+  let resolve = () => {}
+  const promise = new Promise((actualResolve) => {
+    resolve = actualResolve
+  })
+
+  return {promise, resolve}
+}
+
+/**
+ * @param {import("../../src/configuration-types.js").BackgroundJobsConfiguration} backgroundJobs - Background-jobs configuration.
+ * @returns {Configuration} - Isolated configuration.
+ */
+function buildConfiguration(backgroundJobs) {
+  return new Configuration({
+    backgroundJobs,
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]}
+  })
+}
+
+describe("Background jobs adapter configuration", () => {
+  it("defaults to background mode and resolves an adapter instance once", async () => {
+    const adapter = new BackgroundJobsTestAdapter()
+    const configuration = buildConfiguration({adapter})
+
+    expect(configuration.getBackgroundJobsConfig().mode).toEqual("background")
+    expect(configuration.getBackgroundJobsAdapter()).toEqual(adapter)
+    expect(configuration.getBackgroundJobsAdapter()).toEqual(adapter)
+
+    await configuration.ensureBackgroundJobsAdapterReady()
+    await configuration.ensureBackgroundJobsAdapterReady()
+
+    expect(adapter.readyCount).toEqual(1)
+  })
+
+  it("creates one factory adapter per lifecycle and closes it once", async () => {
+    const adapters = []
+    const configuration = buildConfiguration({
+      adapter: () => {
+        const adapter = new BackgroundJobsTestAdapter()
+        adapters.push(adapter)
+        return adapter
+      }
+    })
+
+    const first = configuration.getBackgroundJobsAdapter()
+    expect(configuration.getBackgroundJobsAdapter()).toEqual(first)
+
+    await configuration.ensureBackgroundJobsAdapterReady()
+    await configuration.closeDatabaseConnections()
+    await configuration.closeBackgroundJobsAdapter()
+
+    expect(adapters.length).toEqual(1)
+    expect(adapters[0].closeCount).toEqual(1)
+    expect(configuration.getBackgroundJobsAdapter()).not.toEqual(first)
+    expect(adapters.length).toEqual(2)
+  })
+
+  it("rejects invalid modes and adapter factories", () => {
+    expect(() => buildConfiguration(/** @type {ReturnType<typeof JSON.parse>} */ ({mode: "worker"})).getBackgroundJobsConfig()).toThrow(/backgroundJobs.mode/)
+    expect(() => buildConfiguration(/** @type {ReturnType<typeof JSON.parse>} */ ({adapter: () => ({})})).getBackgroundJobsAdapter()).toThrow(/BackgroundJobsAdapter/)
+  })
+
+  it("does not return a replaced adapter before that exact generation is ready", async () => {
+    const firstReady = deferred()
+    const adapters = []
+    const configuration = buildConfiguration({
+      adapter: () => {
+        const adapter = new BackgroundJobsTestAdapter({
+          ready: adapters.length === 0 ? async () => await firstReady.promise : undefined
+        })
+        adapters.push(adapter)
+        return adapter
+      }
+    })
+
+    const acquirePromise = configuration.acquireReadyBackgroundJobsAdapter()
+
+    expect(adapters.length).toEqual(1)
+    const closePromise = configuration.closeBackgroundJobsAdapter()
+
+    firstReady.resolve()
+    await closePromise
+
+    const acquiredAdapter = await acquirePromise
+
+    expect(adapters.length).toEqual(2)
+    expect(adapters[0].closeCount).toEqual(1)
+    expect(adapters[1].readyCount).toEqual(1)
+    expect(acquiredAdapter).toEqual(adapters[1])
+  })
+})

--- a/spec/helpers/background-jobs-lazy-configuration-child.js
+++ b/spec/helpers/background-jobs-lazy-configuration-child.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+import {fileURLToPath} from "node:url"
+import TestJob from "../dummy/src/jobs/test-job.js"
+
+export const lazyConfigurationChildPath = fileURLToPath(import.meta.url)
+
+async function run() {
+  const outputPath = process.argv[2]
+
+  if (!outputPath) throw new Error("Expected an output path")
+
+  try {
+    const jobId = await TestJob.performLater("lazy-configuration", outputPath)
+
+    process.send?.({jobId, type: "enqueued"})
+    process.disconnect?.()
+  } catch (error) {
+    process.send?.({error: error instanceof Error ? error.message : String(error), type: "error"})
+    process.disconnect?.()
+    process.exitCode = 1
+  }
+}
+
+if (process.env.VELOCIOUS_LAZY_CONFIGURATION_CHILD === "1") await run()

--- a/spec/helpers/background-jobs-test-adapter.js
+++ b/spec/helpers/background-jobs-test-adapter.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import BackgroundJobsAdapter from "../../src/background-jobs/adapter.js"
+
+export default class BackgroundJobsTestAdapter extends BackgroundJobsAdapter {
+  /**
+   * @param {{ready?: () => Promise<void>}} [args] - Adapter hooks.
+   */
+  constructor({ready} = {}) {
+    super()
+    this.calls = []
+    this.closeCount = 0
+    this.readyCount = 0
+    this.healthResult = {ready: true}
+    this.ready = ready
+  }
+
+  // Framework callback invoked through the BackgroundJobsAdapter contract.
+  // fallow-ignore-next-line unused-class-member
+  async ensureReady() {
+    this.calls.push({method: "ensureReady"})
+    this.readyCount++
+    await this.ready?.()
+  }
+
+  // Framework callback invoked through the BackgroundJobsAdapter contract.
+  // fallow-ignore-next-line unused-class-member
+  async close() {
+    this.calls.push({method: "close"})
+    this.closeCount++
+  }
+
+  // Framework callback invoked through the BackgroundJobsAdapter contract.
+  // fallow-ignore-next-line unused-class-member
+  async health() {
+    this.calls.push({method: "health"})
+    return this.healthResult
+  }
+
+  // Framework callback invoked through the BackgroundJobsAdapter contract.
+  // fallow-ignore-next-line unused-class-member
+  async enqueue(args) {
+    this.calls.push({args, method: "enqueue"})
+    return "adapter-job-id"
+  }
+}

--- a/src/background-jobs/adapter-client.js
+++ b/src/background-jobs/adapter-client.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+/** Platform-neutral producer client for a configured adapter. */
+export default class BackgroundJobsAdapterClient {
+  /**
+   * Creates an adapter-backed producer.
+   * @param {{configuration: import("../configuration.js").default}} args - Client options.
+   */
+  constructor({configuration}) {
+    this.configuration = configuration
+  }
+
+  /**
+   * Enqueues a job through the configured adapter.
+   * @param {{jobName: string, args: Array<ReturnType<typeof JSON.parse>>, options?: import("./types.js").BackgroundJobOptions}} args - Job request.
+   * @returns {Promise<string>} - Job id.
+   */
+  async enqueue(args) {
+    const adapter = await this.configuration.acquireReadyBackgroundJobsAdapter()
+
+    return await adapter.enqueue(args)
+  }
+
+  /**
+   * Replaces a stable schedule through the configured adapter.
+   * @param {{scheduleKey: string, jobName: string, args: Array<ReturnType<typeof JSON.parse>>, options?: import("./types.js").BackgroundJobOptions}} args - Replacement request.
+   * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+   */
+  async replaceScheduled(args) {
+    const adapter = await this.configuration.acquireReadyBackgroundJobsAdapter()
+
+    return await adapter.replaceScheduled(args)
+  }
+
+  /**
+   * Cancels a stable schedule through the configured adapter.
+   * @param {{scheduleKey: string}} args - Cancellation request.
+   * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+   */
+  async cancelScheduled({scheduleKey}) {
+    const adapter = await this.configuration.acquireReadyBackgroundJobsAdapter()
+
+    return await adapter.cancelScheduled(scheduleKey)
+  }
+}

--- a/src/background-jobs/adapter.js
+++ b/src/background-jobs/adapter.js
@@ -1,0 +1,139 @@
+// @ts-check
+
+/**
+ * Platform-neutral persistence and lifecycle contract used by the background-jobs
+ * runtime. Adapters own durable queue state; transport and job execution remain
+ * separate concerns.
+ */
+export default class BackgroundJobsAdapter {
+  /**
+   * Ensures the adapter can accept work.
+   * @returns {Promise<void>} - Resolves when ready.
+   */
+  async ensureReady() { throw new Error("BackgroundJobsAdapter#ensureReady is not implemented") }
+
+  /**
+   * Closes adapter-owned resources.
+   * @returns {Promise<void>} - Resolves after close.
+   */
+  async close() {}
+
+  /**
+   * Reports adapter health.
+   * @returns {Promise<import("./types.js").BackgroundJobsHealth>} - Adapter health.
+   */
+  async health() {
+    return {ready: true}
+  }
+
+  /**
+   * Ensures framework-owned persistence during a migration lifecycle. Non-SQL
+   * adapters may leave this as a no-op.
+   * @param {{dbs: Record<string, import("../database/drivers/base.js").default>}} _args - Migrated databases.
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async ensureFrameworkSchema(_args) {}
+
+  /**
+   * Reconciles configured queue limits.
+   * @returns {Promise<void>} - Resolves after reconciliation.
+   */
+  async reconcileQueueConcurrency() { throw new Error("BackgroundJobsAdapter#reconcileQueueConcurrency is not implemented") }
+
+  /**
+   * Enqueues a job.
+   * @param {{jobName: string, args: Array<ReturnType<typeof JSON.parse>>, options?: import("./types.js").BackgroundJobOptions}} _args - Job request.
+   * @returns {Promise<string>} - Job id.
+   */
+  async enqueue(_args) { throw new Error("BackgroundJobsAdapter#enqueue is not implemented") }
+
+  /**
+   * Replaces the owner of a stable schedule key.
+   * @param {{scheduleKey: string, jobName: string, args: Array<ReturnType<typeof JSON.parse>>, options?: import("./types.js").BackgroundJobOptions}} _args - Replacement request.
+   * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+   */
+  async replaceScheduled(_args) { throw new Error("BackgroundJobsAdapter#replaceScheduled is not implemented") }
+
+  /**
+   * Cancels the owner of a stable schedule key.
+   * @param {string} _scheduleKey - Stable schedule key.
+   * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+   */
+  async cancelScheduled(_scheduleKey) { throw new Error("BackgroundJobsAdapter#cancelScheduled is not implemented") }
+
+  /**
+   * Finds the next eligible job.
+   * @param {{executionMode?: import("./types.js").BackgroundJobExecutionMode | import("./types.js").BackgroundJobExecutionMode[]}} [_args] - Dequeue filters.
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Next eligible job.
+   */
+  async nextAvailableJob(_args = {}) { throw new Error("BackgroundJobsAdapter#nextAvailableJob is not implemented") }
+
+  /**
+   * Finds the soonest future job.
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Soonest future job.
+   */
+  async nextScheduledJob() { throw new Error("BackgroundJobsAdapter#nextScheduledJob is not implemented") }
+
+  /**
+   * Reads one job.
+   * @param {string} _jobId - Job id.
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Job row.
+   */
+  async getJob(_jobId) { throw new Error("BackgroundJobsAdapter#getJob is not implemented") }
+
+  /**
+   * Starts a job by claiming its durable handoff.
+   * @param {{jobId: string, workerId?: string}} _args - Handoff request.
+   * @returns {Promise<import("./types.js").BackgroundJobHandoff | null>} - Claimed handoff.
+   */
+  async markHandedOff(_args) { throw new Error("BackgroundJobsAdapter#markHandedOff is not implemented") }
+
+  /**
+   * Marks a handed-off job successful.
+   * @param {{jobId: string, handoffId?: string, workerId?: string, handedOffAtMs?: number}} _args - Completion report.
+   * @returns {Promise<boolean>} - Whether the fenced report was accepted.
+   */
+  async markCompleted(_args) { throw new Error("BackgroundJobsAdapter#markCompleted is not implemented") }
+
+  /**
+   * Returns a handed-off job to its schedule.
+   * @param {{jobId: string, delayMs: number, handoffId?: string, workerId?: string, handedOffAtMs?: number}} _args - Reschedule report.
+   * @returns {Promise<boolean>} - Whether the fenced report was accepted.
+   */
+  async markRescheduled(_args) { throw new Error("BackgroundJobsAdapter#markRescheduled is not implemented") }
+
+  /**
+   * Returns a handed-off job to the queue.
+   * @param {{jobId: string, handoffId: string}} _args - Handoff release.
+   * @returns {Promise<void>} - Resolves after the job is returned.
+   */
+  async markReturnedToQueue(_args) { throw new Error("BackgroundJobsAdapter#markReturnedToQueue is not implemented") }
+
+  /**
+   * Finds active handoffs for a worker.
+   * @param {{workerId: string}} _args - Worker identity.
+   * @returns {Promise<Array<{jobId: string, handoffId: string}>>} - Active worker handoffs.
+   */
+  async handedOffJobsForWorker(_args) { throw new Error("BackgroundJobsAdapter#handedOffJobsForWorker is not implemented") }
+
+  /**
+   * Marks a handed-off job failed or retryable.
+   * @param {{jobId: string, error: ReturnType<typeof JSON.parse>, handoffId?: string, workerId?: string, handedOffAtMs?: number}} _args - Failure report.
+   * @returns {Promise<import("./types.js").BackgroundJobRow | null>} - Updated job when accepted.
+   */
+  async markFailed(_args) { throw new Error("BackgroundJobsAdapter#markFailed is not implemented") }
+
+  /**
+   * Reclaims expired handoffs.
+   * @param {{orphanedAfterMs?: number}} [_args] - Sweep options.
+   * @returns {Promise<import("./types.js").BackgroundJobRow[]>} - Newly orphaned jobs.
+   */
+  async markOrphanedJobs(_args = {}) { throw new Error("BackgroundJobsAdapter#markOrphanedJobs is not implemented") }
+
+  /**
+   * Prunes terminal jobs past their retention windows.
+   * @param {{completedTtlMs?: number | null, failedTtlMs?: number | null, batchSize?: number}} [_args] - Retention options.
+   * @returns {Promise<number>} - Deleted rows.
+   */
+  async pruneTerminalJobs(_args = {}) { throw new Error("BackgroundJobsAdapter#pruneTerminalJobs is not implemented") }
+}

--- a/src/background-jobs/job-registry.js
+++ b/src/background-jobs/job-registry.js
@@ -3,7 +3,7 @@
 import fs from "fs/promises"
 import path from "path"
 import toImportSpecifier from "../utils/to-import-specifier.js"
-import VelociousJob from "./job.js"
+import VelociousJob from "./platform-job.js"
 
 export default class BackgroundJobRegistry {
   /**

--- a/src/background-jobs/job.js
+++ b/src/background-jobs/job.js
@@ -1,101 +1,31 @@
 // @ts-check
 
-import BackgroundJobsClient from "./client.js"
-import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
+import configurationResolver from "../configuration-resolver.js"
+import PlatformVelociousJob from "./platform-job.js"
+import {
+  cancelScheduledBackgroundJobForConfiguration,
+  enqueueBackgroundJobForConfiguration,
+  replaceScheduledBackgroundJobForConfiguration
+} from "./runtime.js"
 
 /**
- * Base class for background jobs.
- *
- * `TArgs` is the tuple of arguments the subclass's `perform` accepts, so a job that
- * needs arguments declares them as required and typed — for example
- * `class RunBuildJob extends VelociousJob<[string]>` with `async perform(buildId)`.
- * The default empty tuple keeps argument-less jobs (`extends VelociousJob`,
- * `async perform()`) working unchanged.
+ * Node background-job entry. It preserves lazy configuration discovery for
+ * fresh producer processes while the explicit platform entry stays free of
+ * Node-only configuration resolution.
  * @template {Array<ReturnType<typeof JSON.parse>>} [TArgs=[]]
+ * @augments {PlatformVelociousJob<TArgs>}
  */
-export default class VelociousJob {
-  /**
-   * Database identifiers checked out while this job performs. Set an explicit
-   * list to avoid holding unrelated configured database connections, or `[]`
-   * when the job establishes any connections it needs itself. Left undefined,
-   * jobs retain the existing behavior of checking out every active database.
-   * @type {string[] | undefined}
-   */
-  static databaseIdentifiers = undefined
-
-  /**
-   * Queue this job class runs on. Subclasses set e.g. `static queue = "builds"`
-   * to route onto a queue with its own cluster-wide concurrency cap (configured
-   * via `backgroundJobs.queues`). The `{queue}` enqueue option overrides it.
-   * Left undefined, jobs run on the `"default"` queue.
-   * @type {string | undefined}
-   */
-  static queue = undefined
-
-  /**
-   * Optional process title shown for the runner while this job executes.
-   * Velocious sets `process.title` to this for the duration of the job — so
-   * `ps`/`top`/`htop` identify what a runner is doing — and restores the
-   * runner's base title when the job finishes. Left undefined, the runner falls
-   * back to `velocious job-runner: <JobName>`. Set e.g.
-   * `static processTitle = "velocious media transcoder"` to give a job a
-   * custom, human-readable title.
-   * @type {string | undefined}
-   */
-  static processTitle = undefined
-
-  /**
-   * Stops this performance and reschedules the same logical job row. This is
-   * normal control flow: it does not count as a failure or consume a retry.
-   * @param {number} delayMs - Non-negative safe-integer delay in milliseconds.
-   * @returns {never} - This method never returns.
-   */
-  rescheduleIn(delayMs) {
-    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
-      throw new TypeError("background job reschedule delayMs must be a non-negative safe integer")
-    }
-
-    throw new BackgroundJobRescheduleSignal(delayMs)
-  }
-
-  /**
-   * Runs job name.
-   * @returns {string} - Job name.
-   */
-  static jobName() {
-    return this.name
-  }
-
-  /**
-   * Folds this job class's static `queue` into the enqueue options unless the
-   * caller already specified one.
-   * @param {import("./types.js").BackgroundJobOptions | undefined} options - Job options.
-   * @returns {import("./types.js").BackgroundJobOptions} - Options including the resolved queue.
-   */
-  static _withQueue(options) {
-    const merged = options ? {...options} : {}
-
-    if (merged.queue === undefined && typeof this.queue === "string" && this.queue.length > 0) {
-      merged.queue = this.queue
-    }
-
-    return merged
-  }
-
+export default class VelociousJob extends PlatformVelociousJob {
   /**
    * Runs perform later.
    * @param {...ReturnType<typeof JSON.parse>} args - Job args.
    * @returns {Promise<string>} - Job id.
    */
   static async performLater(...args) {
+    const configuration = await configurationResolver()
     const {jobArgs, jobOptions} = this._splitArgsAndOptions(args)
-    const client = new BackgroundJobsClient()
 
-    return await client.enqueue({
-      jobName: this.jobName(),
-      args: jobArgs,
-      options: this._withQueue(jobOptions)
-    })
+    return await enqueueBackgroundJobForConfiguration({configuration, JobClass: this, jobArgs, jobOptions})
   }
 
   /**
@@ -106,13 +36,9 @@ export default class VelociousJob {
    * @returns {Promise<string>} - Job id.
    */
   static async performLaterWithOptions({args, options}) {
-    const client = new BackgroundJobsClient()
+    const configuration = await configurationResolver()
 
-    return await client.enqueue({
-      jobName: this.jobName(),
-      args,
-      options: this._withQueue(options)
-    })
+    return await enqueueBackgroundJobForConfiguration({configuration, JobClass: this, jobArgs: args, jobOptions: options})
   }
 
   /**
@@ -124,14 +50,9 @@ export default class VelociousJob {
    * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
    */
   static async replaceScheduled({scheduleKey, args, options}) {
-    const client = new BackgroundJobsClient()
+    const configuration = await configurationResolver()
 
-    return await client.replaceScheduled({
-      scheduleKey,
-      jobName: this.jobName(),
-      args,
-      options: this._withQueue(options)
-    })
+    return await replaceScheduledBackgroundJobForConfiguration({configuration, JobClass: this, scheduleKey, jobArgs: args, jobOptions: options})
   }
 
   /**
@@ -140,38 +61,8 @@ export default class VelociousJob {
    * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
    */
   static async cancelScheduled(scheduleKey) {
-    const client = new BackgroundJobsClient()
+    const configuration = await configurationResolver()
 
-    return await client.cancelScheduled({scheduleKey})
-  }
-
-  /**
-   * Runs split args and options.
-   * @param {Array<ReturnType<typeof JSON.parse>>} args - Job args.
-   * @returns {{jobArgs: Array<ReturnType<typeof JSON.parse>>, jobOptions: import("./types.js").BackgroundJobOptions}} - Split args and options.
-   */
-  static _splitArgsAndOptions(args) {
-    if (args.length === 0) {
-      return {jobArgs: [], jobOptions: {}}
-    }
-
-    const lastArg = args[args.length - 1]
-    const isOptionsArg = lastArg && typeof lastArg === "object" && !Array.isArray(lastArg) && "jobOptions" in lastArg
-
-    if (isOptionsArg) {
-      const {jobOptions} = /** @type {{jobOptions: import("./types.js").BackgroundJobOptions}} */ (lastArg)
-      return {jobArgs: args.slice(0, -1), jobOptions: jobOptions || {}}
-    }
-
-    return {jobArgs: args, jobOptions: {}}
-  }
-
-  /**
-   * Override in subclasses.
-   * @param {TArgs} _args - Job args (the tuple this job class was parameterized with).
-   * @returns {Promise<void>} - Resolves when complete.
-   */
-  async perform(..._args) {
-    throw new Error("perform not implemented")
+    return await cancelScheduledBackgroundJobForConfiguration({configuration, scheduleKey})
   }
 }

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -169,21 +169,25 @@ export default class BackgroundJobsMain {
   async start() {
     this._stopped = false
     this.stopPromise = undefined
-    this.adapter = undefined
     this.configuration.setCurrent()
-    await this.configuration.initialize({type: "background-jobs-main"})
-    await this.configuration.connectBeacon({peerType: "background-jobs-main"})
-    this.adapter = await this.configuration.acquireReadyBackgroundJobsAdapter()
-    // Queue-cap changes are reconciled against the persisted backlog here, at
-    // main-process startup — the explicit lifecycle for applying queue
-    // configuration changes. The store serializes the adoption/release UPDATEs
-    // across processes with a database advisory lock, so concurrently started
-    // mains cannot interleave them.
-    await this.store.reconcileQueueConcurrency()
-    const server = net.createServer((socket) => this._handleConnection(socket))
-    this.server = server
 
     try {
+      await this.configuration.initialize({type: "background-jobs-main"})
+      await this.configuration.connectBeacon({peerType: "background-jobs-main"})
+
+      if (!this.adapter) {
+        this.adapter = await this.configuration.acquireReadyBackgroundJobsAdapter()
+      }
+
+      // Queue-cap changes are reconciled against the persisted backlog here, at
+      // main-process startup — the explicit lifecycle for applying queue
+      // configuration changes. The store serializes the adoption/release UPDATEs
+      // across processes with a database advisory lock, so concurrently started
+      // mains cannot interleave them.
+      await this.store.reconcileQueueConcurrency()
+      const server = net.createServer((socket) => this._handleConnection(socket))
+      this.server = server
+
       await new Promise((resolve, reject) => {
         server.once("error", reject)
         server.listen(this.port, this.host, () => resolve(undefined))
@@ -238,7 +242,16 @@ export default class BackgroundJobsMain {
       // but this drain covers it).
       await this._drain()
     } catch (error) {
-      await this.stop()
+      try {
+        await this.stop()
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "Background jobs main startup and cleanup failed",
+          {cause: cleanupError}
+        )
+      }
+
       throw error
     }
   }
@@ -267,11 +280,14 @@ export default class BackgroundJobsMain {
           this._closeWorkers()
           this._clearTimers()
           this._disconnectBeaconHandlers()
-          await this.scheduler?.stop()
           try {
-            await this._drainWorkerHandoffAdoptions()
+            await this.scheduler?.stop()
           } finally {
-            await this._stopBeaconAndServer()
+            try {
+              await this._drainWorkerHandoffAdoptions()
+            } finally {
+              await this._stopBeaconAndServer()
+            }
           }
         }
       })
@@ -339,7 +355,11 @@ export default class BackgroundJobsMain {
     try {
       await this._closeServer()
     } finally {
-      if (this.closeDatabaseConnectionsOnStop) await this.configuration.closeDatabaseConnections()
+      if (this.closeDatabaseConnectionsOnStop) {
+        await this.configuration.closeDatabaseConnections()
+      } else {
+        await this.configuration.closeBackgroundJobsAdapter()
+      }
     }
   }
 

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -3,7 +3,6 @@
 import net from "net"
 import JsonSocket from "./json-socket.js"
 import BackgroundJobsScheduler from "./scheduler.js"
-import BackgroundJobsStore from "./store.js"
 import Logger from "../logger.js"
 import PruneTerminalBackgroundJobsJob from "../jobs/prune-terminal-background-jobs.js"
 import VelociousError from "../velocious-error.js"
@@ -78,7 +77,8 @@ export default class BackgroundJobsMain {
     // long is treated as wedged/dead: its leases are released and it is dropped.
     this.workerStaleTimeoutMs = typeof workerStaleTimeoutMs === "number" && workerStaleTimeoutMs >= 1 ? workerStaleTimeoutMs : WORKER_STALE_TIMEOUT_MS
     this.workerLivenessSweepMs = typeof workerLivenessSweepMs === "number" && workerLivenessSweepMs >= 1 ? workerLivenessSweepMs : WORKER_LIVENESS_SWEEP_MS
-    this.store = new BackgroundJobsStore({configuration, databaseIdentifier: config.databaseIdentifier})
+    /** @type {import("./adapter.js").default | undefined} */
+    this.adapter = undefined
     this.logger = new Logger(this)
     /**
      * Narrows the runtime value to the documented type.
@@ -145,16 +145,35 @@ export default class BackgroundJobsMain {
   }
 
   /**
+   * Compatibility alias for integrations that inspect the active main store.
+   * @returns {import("./adapter.js").default} - Adapter acquired by start.
+   */
+  get store() {
+    if (!this.adapter) throw new Error("Background jobs main has not acquired its adapter")
+
+    return this.adapter
+  }
+
+  /**
+   * Preserves the historical subclass seam while keeping one adapter reference.
+   * @param {import("./adapter.js").default} adapter - Adapter to assign.
+   */
+  set store(adapter) {
+    this.adapter = adapter
+  }
+
+  /**
    * Runs start.
    * @returns {Promise<void>} - Resolves when listening.
    */
   async start() {
     this._stopped = false
     this.stopPromise = undefined
+    this.adapter = undefined
     this.configuration.setCurrent()
     await this.configuration.initialize({type: "background-jobs-main"})
     await this.configuration.connectBeacon({peerType: "background-jobs-main"})
-    await this.store.ensureReady()
+    this.adapter = await this.configuration.acquireReadyBackgroundJobsAdapter()
     // Queue-cap changes are reconciled against the persisted backlog here, at
     // main-process startup — the explicit lifecycle for applying queue
     // configuration changes. The store serializes the adoption/release UPDATEs
@@ -241,20 +260,24 @@ export default class BackgroundJobsMain {
   async _stop() {
     this._stopped = true
 
-    await shutdownLifecycle({
-      onStopped: this.onStopped,
-      shutdown: async () => {
-        this._closeWorkers()
-        this._clearTimers()
-        this._disconnectBeaconHandlers()
-        await this.scheduler?.stop()
-        try {
-          await this._drainWorkerHandoffAdoptions()
-        } finally {
-          await this._stopBeaconAndServer()
+    try {
+      await shutdownLifecycle({
+        onStopped: this.onStopped,
+        shutdown: async () => {
+          this._closeWorkers()
+          this._clearTimers()
+          this._disconnectBeaconHandlers()
+          await this.scheduler?.stop()
+          try {
+            await this._drainWorkerHandoffAdoptions()
+          } finally {
+            await this._stopBeaconAndServer()
+          }
         }
-      }
-    })
+      })
+    } finally {
+      this.adapter = undefined
+    }
   }
 
   /**

--- a/src/background-jobs/perform-job.js
+++ b/src/background-jobs/perform-job.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+/**
+ * Performs a job class inside its declared database-connection scope.
+ * @param {object} args - Performance options.
+ * @param {import("../configuration.js").default} args.configuration - Active configuration.
+ * @param {typeof import("./platform-job.js").default} args.JobClass - Job class.
+ * @param {Array<ReturnType<typeof JSON.parse>>} args.jobArgs - Job arguments.
+ * @param {string} args.name - Connection-scope label.
+ * @returns {Promise<void>} - Resolves after performance.
+ */
+export default async function performBackgroundJob({configuration, JobClass, jobArgs, name}) {
+  const jobInstance = new JobClass()
+  /**
+   * Narrows the generic subclass's runtime method to serialized job arguments.
+   * @type {(...args: Array<ReturnType<typeof JSON.parse>>) => Promise<void>}
+   */
+  const perform = jobInstance.perform
+
+  await configuration.withConnections({databaseIdentifiers: JobClass.databaseIdentifiers, name}, async () => {
+    await perform.apply(jobInstance, jobArgs)
+  })
+}

--- a/src/background-jobs/platform-job.js
+++ b/src/background-jobs/platform-job.js
@@ -1,0 +1,156 @@
+// @ts-check
+
+import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
+import {cancelScheduledBackgroundJob, enqueueBackgroundJob, replaceScheduledBackgroundJob} from "./runtime.js"
+
+/**
+ * Base class for background jobs.
+ *
+ * `TArgs` is the tuple of arguments the subclass's `perform` accepts, so a job that
+ * needs arguments declares them as required and typed — for example
+ * `class RunBuildJob extends VelociousJob<[string]>` with `async perform(buildId)`.
+ * The default empty tuple keeps argument-less jobs (`extends VelociousJob`,
+ * `async perform()`) working unchanged.
+ * @template {Array<ReturnType<typeof JSON.parse>>} [TArgs=[]]
+ */
+export default class VelociousJob {
+  /**
+   * Database identifiers checked out while this job performs. Set an explicit
+   * list to avoid holding unrelated configured database connections, or `[]`
+   * when the job establishes any connections it needs itself. Left undefined,
+   * jobs retain the existing behavior of checking out every active database.
+   * @type {string[] | undefined}
+   */
+  static databaseIdentifiers = undefined
+
+  /**
+   * Queue this job class runs on. Subclasses set e.g. `static queue = "builds"`
+   * to route onto a queue with its own cluster-wide concurrency cap (configured
+   * via `backgroundJobs.queues`). The `{queue}` enqueue option overrides it.
+   * Left undefined, jobs run on the `"default"` queue.
+   * @type {string | undefined}
+   */
+  static queue = undefined
+
+  /**
+   * Optional process title shown for the runner while this job executes.
+   * Velocious sets `process.title` to this for the duration of the job — so
+   * `ps`/`top`/`htop` identify what a runner is doing — and restores the
+   * runner's base title when the job finishes. Left undefined, the runner falls
+   * back to `velocious job-runner: <JobName>`. Set e.g.
+   * `static processTitle = "velocious media transcoder"` to give a job a
+   * custom, human-readable title.
+   * @type {string | undefined}
+   */
+  static processTitle = undefined
+
+  /**
+   * Stops this performance and reschedules the same logical job row. This is
+   * normal control flow: it does not count as a failure or consume a retry.
+   * @param {number} delayMs - Non-negative safe-integer delay in milliseconds.
+   * @returns {never} - This method never returns.
+   */
+  rescheduleIn(delayMs) {
+    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+      throw new TypeError("background job reschedule delayMs must be a non-negative safe integer")
+    }
+
+    throw new BackgroundJobRescheduleSignal(delayMs)
+  }
+
+  /**
+   * Runs job name.
+   * @returns {string} - Job name.
+   */
+  static jobName() {
+    return this.name
+  }
+
+  /**
+   * Folds this job class's static `queue` into the enqueue options unless the
+   * caller already specified one.
+   * @param {import("./types.js").BackgroundJobOptions | undefined} options - Job options.
+   * @returns {import("./types.js").BackgroundJobOptions} - Options including the resolved queue.
+   */
+  static _withQueue(options) {
+    const merged = options ? {...options} : {}
+
+    if (merged.queue === undefined && typeof this.queue === "string" && this.queue.length > 0) {
+      merged.queue = this.queue
+    }
+
+    return merged
+  }
+
+  /**
+   * Runs perform later.
+   * @param {...ReturnType<typeof JSON.parse>} args - Job args.
+   * @returns {Promise<string>} - Job id.
+   */
+  static async performLater(...args) {
+    const {jobArgs, jobOptions} = this._splitArgsAndOptions(args)
+    return await enqueueBackgroundJob({JobClass: this, jobArgs, jobOptions})
+  }
+
+  /**
+   * Runs perform later with options.
+   * @param {object} args - Options.
+   * @param {Array<ReturnType<typeof JSON.parse>>} args.args - Job args.
+   * @param {import("./types.js").BackgroundJobOptions} [args.options] - Job options.
+   * @returns {Promise<string>} - Job id.
+   */
+  static async performLaterWithOptions({args, options}) {
+    return await enqueueBackgroundJob({JobClass: this, jobArgs: args, jobOptions: options})
+  }
+
+  /**
+   * Atomically replaces this job class's queued owner for a stable schedule key.
+   * @param {object} args - Options.
+   * @param {string} args.scheduleKey - Stable logical schedule key.
+   * @param {Array<ReturnType<typeof JSON.parse>>} args.args - Job args.
+   * @param {import("./types.js").BackgroundJobOptions} [args.options] - Job options.
+   * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+   */
+  static async replaceScheduled({scheduleKey, args, options}) {
+    return await replaceScheduledBackgroundJob({JobClass: this, scheduleKey, jobArgs: args, jobOptions: options})
+  }
+
+  /**
+   * Cancels or detaches the current owner of a stable schedule key.
+   * @param {string} scheduleKey - Stable logical schedule key.
+   * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+   */
+  static async cancelScheduled(scheduleKey) {
+    return await cancelScheduledBackgroundJob(scheduleKey)
+  }
+
+  /**
+   * Runs split args and options.
+   * @param {Array<ReturnType<typeof JSON.parse>>} args - Job args.
+   * @returns {{jobArgs: Array<ReturnType<typeof JSON.parse>>, jobOptions: import("./types.js").BackgroundJobOptions}} - Split args and options.
+   */
+  static _splitArgsAndOptions(args) {
+    if (args.length === 0) {
+      return {jobArgs: [], jobOptions: {}}
+    }
+
+    const lastArg = args[args.length - 1]
+    const isOptionsArg = lastArg && typeof lastArg === "object" && !Array.isArray(lastArg) && "jobOptions" in lastArg
+
+    if (isOptionsArg) {
+      const {jobOptions} = /** @type {{jobOptions: import("./types.js").BackgroundJobOptions}} */ (lastArg)
+      return {jobArgs: args.slice(0, -1), jobOptions: jobOptions || {}}
+    }
+
+    return {jobArgs: args, jobOptions: {}}
+  }
+
+  /**
+   * Override in subclasses.
+   * @param {TArgs} _args - Job args (the tuple this job class was parameterized with).
+   * @returns {Promise<void>} - Resolves when complete.
+   */
+  async perform(..._args) {
+    throw new Error("perform not implemented")
+  }
+}

--- a/src/background-jobs/runtime.js
+++ b/src/background-jobs/runtime.js
@@ -1,0 +1,156 @@
+// @ts-check
+
+import {currentConfiguration} from "../current-configuration.js"
+import performBackgroundJob from "./perform-job.js"
+import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
+
+let inlinePerformanceSequence = 0
+
+/**
+ * Rejects options whose semantics require durable queue state.
+ * @param {import("./types.js").BackgroundJobOptions | undefined} options - Requested options.
+ * @returns {void}
+ */
+function validateInlineOptions(options) {
+  const optionNames = Object.keys(options || {})
+
+  if (optionNames.length > 0) {
+    throw new Error(`Background job option ${optionNames[0]} is not supported in inline mode`)
+  }
+}
+
+/**
+ * Builds an ephemeral inline performance id.
+ * @returns {string} - Performance id.
+ */
+function inlineJobId() {
+  inlinePerformanceSequence++
+  return `inline-${Date.now()}-${inlinePerformanceSequence}`
+}
+
+/**
+ * Enqueues durably in background mode or performs immediately in inline mode.
+ * @param {object} args - Enqueue request.
+ * @param {typeof import("./platform-job.js").default} args.JobClass - Job class.
+ * @param {Array<ReturnType<typeof JSON.parse>>} args.jobArgs - Job arguments.
+ * @param {import("./types.js").BackgroundJobOptions | undefined} args.jobOptions - Job options.
+ * @returns {Promise<string>} - Durable job id or ephemeral inline performance id.
+ */
+export async function enqueueBackgroundJob({JobClass, jobArgs, jobOptions}) {
+  const configuration = currentConfiguration()
+
+  return await enqueueBackgroundJobForConfiguration({configuration, JobClass, jobArgs, jobOptions})
+}
+
+/**
+ * Enqueues using an explicitly resolved configuration.
+ * @param {object} args - Enqueue request.
+ * @param {import("../configuration.js").default} args.configuration - Configuration.
+ * @param {typeof import("./platform-job.js").default} args.JobClass - Job class.
+ * @param {Array<ReturnType<typeof JSON.parse>>} args.jobArgs - Job arguments.
+ * @param {import("./types.js").BackgroundJobOptions | undefined} args.jobOptions - Job options.
+ * @returns {Promise<string>} - Durable job id or ephemeral inline performance id.
+ */
+export async function enqueueBackgroundJobForConfiguration({configuration, JobClass, jobArgs, jobOptions}) {
+
+  if (configuration.getBackgroundJobsConfig().mode === "inline") {
+    validateInlineOptions(jobOptions)
+    configuration.setCurrent()
+    await configuration.initialize({type: "background-jobs-inline"})
+
+    try {
+      await performBackgroundJob({
+        configuration,
+        JobClass,
+        jobArgs,
+        name: `Background job inline mode: ${JobClass.jobName()}`
+      })
+    } catch (error) {
+      if (error instanceof BackgroundJobRescheduleSignal) {
+        throw new Error("rescheduleIn is not supported in inline mode", {cause: error})
+      }
+
+      throw error
+    }
+
+    return inlineJobId()
+  }
+
+  const client = configuration.getEnvironmentHandler().backgroundJobsClient({configuration})
+
+  return await client.enqueue({
+    jobName: JobClass.jobName(),
+    args: jobArgs,
+    options: JobClass._withQueue(jobOptions)
+  })
+}
+
+/**
+ * Replaces a stable durable schedule in background mode.
+ * @param {object} args - Replacement request.
+ * @param {typeof import("./platform-job.js").default} args.JobClass - Job class.
+ * @param {string} args.scheduleKey - Stable schedule key.
+ * @param {Array<ReturnType<typeof JSON.parse>>} args.jobArgs - Job arguments.
+ * @param {import("./types.js").BackgroundJobOptions | undefined} args.jobOptions - Job options.
+ * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+ */
+export async function replaceScheduledBackgroundJob({JobClass, scheduleKey, jobArgs, jobOptions}) {
+  const configuration = currentConfiguration()
+
+  return await replaceScheduledBackgroundJobForConfiguration({configuration, JobClass, scheduleKey, jobArgs, jobOptions})
+}
+
+/**
+ * Replaces a stable schedule using an explicitly resolved configuration.
+ * @param {object} args - Replacement request.
+ * @param {import("../configuration.js").default} args.configuration - Configuration.
+ * @param {typeof import("./platform-job.js").default} args.JobClass - Job class.
+ * @param {string} args.scheduleKey - Stable schedule key.
+ * @param {Array<ReturnType<typeof JSON.parse>>} args.jobArgs - Job arguments.
+ * @param {import("./types.js").BackgroundJobOptions | undefined} args.jobOptions - Job options.
+ * @returns {Promise<import("./types.js").BackgroundJobReplacementResult>} - Replacement result.
+ */
+export async function replaceScheduledBackgroundJobForConfiguration({configuration, JobClass, scheduleKey, jobArgs, jobOptions}) {
+
+  if (configuration.getBackgroundJobsConfig().mode === "inline") {
+    throw new Error("replaceScheduled is not supported in inline mode")
+  }
+
+  const client = configuration.getEnvironmentHandler().backgroundJobsClient({configuration})
+
+  return await client.replaceScheduled({
+    scheduleKey,
+    jobName: JobClass.jobName(),
+    args: jobArgs,
+    options: JobClass._withQueue(jobOptions)
+  })
+}
+
+/**
+ * Cancels a stable durable schedule in background mode.
+ * @param {string} scheduleKey - Stable schedule key.
+ * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+ */
+export async function cancelScheduledBackgroundJob(scheduleKey) {
+  const configuration = currentConfiguration()
+
+  return await cancelScheduledBackgroundJobForConfiguration({configuration, scheduleKey})
+}
+
+/**
+ * Cancels a stable schedule using an explicitly resolved configuration.
+ * @param {object} args - Cancellation request.
+ * @param {import("../configuration.js").default} args.configuration - Configuration.
+ * @param {string} args.scheduleKey - Stable logical schedule key.
+ * @returns {Promise<import("./types.js").BackgroundJobCancellationResult>} - Cancellation result.
+ */
+export async function cancelScheduledBackgroundJobForConfiguration({configuration, scheduleKey}) {
+
+  if (configuration.getBackgroundJobsConfig().mode === "inline") {
+    throw new Error("cancelScheduled is not supported in inline mode")
+  }
+
+  const client = configuration.getEnvironmentHandler().backgroundJobsClient({configuration})
+
+  return await client.cancelScheduled({scheduleKey})
+}

--- a/src/background-jobs/sql-adapter.js
+++ b/src/background-jobs/sql-adapter.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+import BackgroundJobsStore from "./store.js"
+
+/** Built-in SQL adapter preserving the existing durable store implementation. */
+export default class SqlBackgroundJobsAdapter extends BackgroundJobsStore {
+  /**
+   * Ensures the built-in SQL schema during migration.
+   * @param {{dbs: Record<string, import("../database/drivers/base.js").default>}} args - Migrated databases.
+   * @returns {Promise<void>} - Resolves when the SQL schema is present.
+   */
+  async ensureFrameworkSchema({dbs}) {
+    const databaseIdentifier = this.getDatabaseIdentifier() || "default"
+    const frameworkDb = dbs[databaseIdentifier]
+
+    if (!frameworkDb) return
+
+    await this.ensureSchema(frameworkDb)
+  }
+}

--- a/src/background-jobs/store.js
+++ b/src/background-jobs/store.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import {createHash, randomUUID} from "crypto"
+import BackgroundJobsAdapter from "./adapter.js"
 import Logger from "../logger.js"
 import TableData from "../database/table-data/index.js"
 import VelociousError from "../velocious-error.js"
@@ -100,7 +101,7 @@ const schemaApplyChains = new Map()
 /** @type {Map<string, Promise<void>>} */
 const transactionMutationChains = new Map()
 
-export default class BackgroundJobsStore {
+export default class BackgroundJobsStore extends BackgroundJobsAdapter {
   /**
    * Runs constructor.
    * @param {object} args - Options.
@@ -108,6 +109,7 @@ export default class BackgroundJobsStore {
    * @param {string} [args.databaseIdentifier] - Database identifier.
    */
   constructor({configuration, databaseIdentifier}) {
+    super()
     this.configuration = configuration
     this.databaseIdentifier = databaseIdentifier
     this.logger = new Logger(this)

--- a/src/background-jobs/types.js
+++ b/src/background-jobs/types.js
@@ -4,6 +4,16 @@
  * @typedef {"inline" | "forked" | "pooled" | "spawned"} BackgroundJobExecutionMode
  */
 /**
+ * @typedef {object} BackgroundJobsHealth
+ * @property {boolean} ready - Whether the adapter can accept and process work.
+ */
+/**
+ * @typedef {object} BackgroundJobsProducer
+ * @property {(args: {jobName: string, args: Array<ReturnType<typeof JSON.parse>>, options?: BackgroundJobOptions}) => Promise<string>} enqueue - Enqueues a job.
+ * @property {(args: {scheduleKey: string, jobName: string, args: Array<ReturnType<typeof JSON.parse>>, options?: BackgroundJobOptions}) => Promise<BackgroundJobReplacementResult>} replaceScheduled - Replaces a stable schedule.
+ * @property {(args: {scheduleKey: string}) => Promise<BackgroundJobCancellationResult>} cancelScheduled - Cancels a stable schedule.
+ */
+/**
  * @typedef {object} BackgroundJobHandoff
  * @property {string} handoffId - Unique handoff lease id.
  * @property {number} handedOffAtMs - Time handed to a worker in ms.

--- a/src/background-jobs/web/controller.js
+++ b/src/background-jobs/web/controller.js
@@ -99,11 +99,14 @@ export default class VelociousBackgroundJobsWebController extends Controller {
    */
   async health() {
     await this._respond(async () => {
+      const health = await this.getConfiguration().backgroundJobsHealth()
+
       await this.render({json: {
         capabilities: {backgroundJobCountDeltas: 1},
-        ok: true,
+        ok: health.ready,
+        ready: health.ready,
         service: "velocious-background-jobs"
-      }})
+      }, status: health.ready ? 200 : 503})
     })
   }
 

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -10,6 +10,7 @@ import {randomUUID} from "crypto"
 import {fileURLToPath} from "node:url"
 import shutdownLifecycle from "../utils/shutdown-lifecycle.js"
 import BackgroundJobRescheduleSignal from "./reschedule-signal.js"
+import performBackgroundJob from "./perform-job.js"
 
 /**
  * Per-forked-child timeout bookkeeping.
@@ -958,14 +959,11 @@ export default class BackgroundJobsWorker {
     const registry = new BackgroundJobRegistry({configuration})
     await registry.load()
     const JobClass = registry.getJobByName(payload.jobName)
-    const jobInstance = new JobClass()
-    /**
-     * Perform.
-     * @type {(...args: Array<ReturnType<typeof JSON.parse>>) => Promise<void>} */
-    const perform = jobInstance.perform
-
-    await configuration.withConnections({databaseIdentifiers: JobClass.databaseIdentifiers, name: `Background job worker inline: ${payload.jobName}`}, async () => {
-      await perform.apply(jobInstance, payload.args || [])
+    await performBackgroundJob({
+      configuration,
+      JobClass,
+      jobArgs: payload.args || [],
+      name: `Background job worker inline: ${payload.jobName}`
     })
   }
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -156,8 +156,13 @@
  *   `background_jobs` table (see `pollIntervalMs`).
  */
 
+/** @typedef {"background" | "inline"} BackgroundJobsMode */
+/** @typedef {(args: {configuration: import("./configuration.js").default}) => import("./background-jobs/adapter.js").default} BackgroundJobsAdapterFactory */
+
 /**
  * @typedef {object} BackgroundJobsConfiguration
+ * @property {import("./background-jobs/adapter.js").default | BackgroundJobsAdapterFactory} [adapter] - Adapter instance or synchronous factory. A factory creates one adapter per configuration lifecycle; the framework closes adapters it resolves.
+ * @property {BackgroundJobsMode} [mode] - `"background"` uses the configured adapter/transport and durable queue semantics; `"inline"` performs immediately without durable queue state. Defaults to `"background"`.
  * @property {string} [host] - Hostname for the background jobs main process.
  * @property {number} [port] - Port for the background jobs main process.
  * @property {string} [databaseIdentifier] - Database identifier used to store background jobs.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -11,11 +11,20 @@
  * @property {string[]} [databaseIdentifiers] - Database identifiers to include in the connection scope.
  * @property {string} [name] - Human-readable name for the checked-out database connections.
  */
+/**
+ * One adapter instance and its serialized ready/close lifecycle.
+ * @typedef {object} BackgroundJobsAdapterGeneration
+ * @property {import("./background-jobs/adapter.js").default} adapter - Adapter owned by this generation.
+ * @property {boolean} closing - Whether close has claimed this generation.
+ * @property {Promise<void> | undefined} readyPromise - Shared readiness attempt.
+ * @property {Promise<void> | undefined} closePromise - Shared close operation.
+ */
 
 import {digg} from "diggerize"
 import gettextConfig from "gettext-universal/build/src/config.js"
 import translate from "gettext-universal/build/src/translate.js"
 import Ability from "./authorization/ability.js"
+import BackgroundJobsAdapter from "./background-jobs/adapter.js"
 import DatabaseOperation from "./database/operation.js"
 import {initializeAuditedModelRelationships} from "./database/record/auditing.js"
 import EventEmitter from "./utils/event-emitter.js"
@@ -204,6 +213,9 @@ export default class VelociousConfiguration {
    * @type {Promise<void> | null} */
   _closeDatabaseConnectionsPromise = null
 
+  /** @type {BackgroundJobsAdapterGeneration | undefined} */
+  _backgroundJobsAdapterGeneration = undefined
+
   /**
    * Dedicated advisory-lock connections currently holding a lock. These are spawned
    * outside the pools' tracked sets (so a hold-timeout lock survives pool checkouts),
@@ -268,7 +280,7 @@ export default class VelociousConfiguration {
     this.debug = debug
     this._debugEndpoint = this._normalizeDebugEndpoint(debugEndpoint)
     this._apiManifest = this._normalizeApiManifest(apiManifest)
-    this._environment = environment || process.env.VELOCIOUS_ENV || process.env.NODE_ENV || "development"
+    this._environment = environment || globalThis.process?.env.VELOCIOUS_ENV || globalThis.process?.env.NODE_ENV || "development"
     this._environmentHandler = environmentHandler
     this._enforceTenantDatabaseScopes = enforceTenantDatabaseScopes
     this._exposeInternalErrorsToClients = exposeInternalErrorsToClients
@@ -1441,22 +1453,23 @@ export default class VelociousConfiguration {
 
   /**
    * Runs get background jobs config.
-   * @returns {Required<import("./configuration-types.js").BackgroundJobsConfiguration> & {retention: import("./configuration-types.js").ResolvedBackgroundJobsRetentionConfiguration}} - Background jobs configuration.
+   * @returns {Omit<Required<import("./configuration-types.js").BackgroundJobsConfiguration>, "adapter" | "retention"> & {retention: import("./configuration-types.js").ResolvedBackgroundJobsRetentionConfiguration}} - Background jobs configuration.
    */
   getBackgroundJobsConfig() {
-    const envHost = process.env.VELOCIOUS_BACKGROUND_JOBS_HOST
-    const envPortRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_PORT
-    const envDatabaseIdentifier = process.env.VELOCIOUS_BACKGROUND_JOBS_DATABASE_IDENTIFIER
-    const envMaxConcurrentForkedRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_FORKED_JOBS
-    const envMaxConcurrentRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS
-    const envPooledRunnerCountRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_COUNT
-    const envPooledRunnerConcurrencyRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_CONCURRENCY
-    const envPooledRunnerMaxJobsRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_MAX_JOBS
-    const envPooledRunnerMaxRssBytesRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_MAX_RSS_BYTES
-    const envPooledRunnerMaxLifetimeMsRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_MAX_LIFETIME_MS
-    const envDispatchStrategy = process.env.VELOCIOUS_BACKGROUND_JOBS_DISPATCH_STRATEGY
-    const envPollIntervalRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_POLL_INTERVAL_MS
-    const envJobTimeoutRaw = process.env.VELOCIOUS_BACKGROUND_JOBS_JOB_TIMEOUT_MS
+    const processEnvironment = globalThis.process?.env
+    const envHost = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_HOST
+    const envPortRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_PORT
+    const envDatabaseIdentifier = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_DATABASE_IDENTIFIER
+    const envMaxConcurrentForkedRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_FORKED_JOBS
+    const envMaxConcurrentRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_MAX_CONCURRENT_INLINE_JOBS
+    const envPooledRunnerCountRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_COUNT
+    const envPooledRunnerConcurrencyRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_CONCURRENCY
+    const envPooledRunnerMaxJobsRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_MAX_JOBS
+    const envPooledRunnerMaxRssBytesRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_MAX_RSS_BYTES
+    const envPooledRunnerMaxLifetimeMsRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_POOLED_RUNNER_MAX_LIFETIME_MS
+    const envDispatchStrategy = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_DISPATCH_STRATEGY
+    const envPollIntervalRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_POLL_INTERVAL_MS
+    const envJobTimeoutRaw = processEnvironment?.VELOCIOUS_BACKGROUND_JOBS_JOB_TIMEOUT_MS
     const envPort = envPortRaw ? Number(envPortRaw) : undefined
     const envMaxConcurrentForked = envMaxConcurrentForkedRaw ? Number(envMaxConcurrentForkedRaw) : undefined
     const envMaxConcurrent = envMaxConcurrentRaw ? Number(envMaxConcurrentRaw) : undefined
@@ -1468,6 +1481,11 @@ export default class VelociousConfiguration {
     const envPollInterval = envPollIntervalRaw ? Number(envPollIntervalRaw) : undefined
     const envJobTimeout = envJobTimeoutRaw ? Number(envJobTimeoutRaw) : undefined
     const configured = this._backgroundJobs || {}
+    const mode = configured.mode === undefined ? "background" : configured.mode
+
+    if (mode !== "background" && mode !== "inline") {
+      throw new TypeError(`backgroundJobs.mode must be "background" or "inline", got: ${String(mode)}`)
+    }
     const host = configured.host || envHost || "127.0.0.1"
     const port = typeof configured.port === "number"
       ? configured.port
@@ -1522,7 +1540,146 @@ export default class VelociousConfiguration {
         : 60 * 60 * 1000
     }
 
-    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, pooledRunnerCount, pooledRunnerConcurrency, pooledRunnerMaxJobs, pooledRunnerMaxRssBytes, pooledRunnerMaxLifetimeMs, dispatchStrategy, pollIntervalMs, queues, jobTimeoutMs, retention}
+    return {host, port, databaseIdentifier, maxConcurrentForkedJobs, maxConcurrentInlineJobs, mode, pooledRunnerCount, pooledRunnerConcurrency, pooledRunnerMaxJobs, pooledRunnerMaxRssBytes, pooledRunnerMaxLifetimeMs, dispatchStrategy, pollIntervalMs, queues, jobTimeoutMs, retention}
+  }
+
+  /**
+   * Resolves and memoizes one background-jobs adapter for this configuration lifecycle.
+   * @returns {BackgroundJobsAdapter} - Active adapter.
+   */
+  getBackgroundJobsAdapter() {
+    if (this._backgroundJobsAdapterGeneration) return this._backgroundJobsAdapterGeneration.adapter
+
+    const configuredAdapter = this._backgroundJobs?.adapter
+    const adapter = typeof configuredAdapter === "function"
+      ? configuredAdapter({configuration: this})
+      : (configuredAdapter || this.getEnvironmentHandler().createBackgroundJobsAdapter({configuration: this}))
+
+    if (!(adapter instanceof BackgroundJobsAdapter)) {
+      throw new TypeError("backgroundJobs.adapter must be a BackgroundJobsAdapter instance or a synchronous factory returning one")
+    }
+
+    this._backgroundJobsAdapterGeneration = {
+      adapter,
+      closing: false,
+      closePromise: undefined,
+      readyPromise: undefined
+    }
+    return adapter
+  }
+
+  /**
+   * Atomically acquires the exact ready adapter for the active lifecycle.
+   * A close that claims the generation while readiness is pending wins: this
+   * operation waits for that close, creates the next generation, readies it,
+   * and returns only that live instance.
+   * @returns {Promise<BackgroundJobsAdapter>} - Exact ready adapter generation.
+   */
+  async acquireReadyBackgroundJobsAdapter() {
+    while (true) {
+      const databaseClosePromise = this._closeDatabaseConnectionsPromise
+
+      if (databaseClosePromise) {
+        await databaseClosePromise
+        continue
+      }
+
+      this.getBackgroundJobsAdapter()
+      const generation = this._backgroundJobsAdapterGeneration
+
+      if (!generation) throw new Error("Background jobs adapter generation was not created")
+
+      if (generation.closing) {
+        if (generation.closePromise) await generation.closePromise
+        continue
+      }
+
+      const readyPromise = generation.readyPromise || Promise.resolve().then(async () => {
+        await generation.adapter.ensureReady()
+      })
+
+      generation.readyPromise = readyPromise
+
+      try {
+        await readyPromise
+      } catch (error) {
+        if (generation.readyPromise === readyPromise) generation.readyPromise = undefined
+        throw error
+      }
+
+      if (generation.closing) {
+        if (generation.closePromise) await generation.closePromise
+        continue
+      }
+
+      if (this._backgroundJobsAdapterGeneration !== generation) continue
+
+      return generation.adapter
+    }
+  }
+
+  /**
+   * Readies the active adapter once per lifecycle. A failed attempt remains retryable.
+   * @returns {Promise<void>} - Resolves when ready.
+   */
+  async ensureBackgroundJobsAdapterReady() {
+    await this.acquireReadyBackgroundJobsAdapter()
+  }
+
+  /**
+   * Returns health without resolving persistence in non-durable inline mode.
+   * @returns {Promise<import("./background-jobs/types.js").BackgroundJobsHealth>} - Current health.
+   */
+  async backgroundJobsHealth() {
+    if (this.getBackgroundJobsConfig().mode === "inline") return {ready: true}
+
+    const adapter = await this.acquireReadyBackgroundJobsAdapter()
+
+    return await adapter.health()
+  }
+
+  /**
+   * Closes the resolved adapter once and clears lifecycle caches.
+   * @returns {Promise<void>} - Resolves after close.
+   */
+  async closeBackgroundJobsAdapter() {
+    const generation = this._backgroundJobsAdapterGeneration
+
+    if (!generation) return
+    if (generation.closePromise) return await generation.closePromise
+
+    generation.closing = true
+    const closePromise = (async () => {
+      /** @type {Error[]} */
+      const closeErrors = []
+
+      if (generation.readyPromise) {
+        try {
+          await generation.readyPromise
+        } catch (error) {
+          closeErrors.push(error instanceof Error ? error : new Error(String(error)))
+        }
+      }
+
+      try {
+        await generation.adapter.close()
+      } catch (error) {
+        closeErrors.push(error instanceof Error ? error : new Error(String(error)))
+      }
+
+      if (closeErrors.length === 1) throw closeErrors[0]
+      if (closeErrors.length > 1) throw new AggregateError(closeErrors, "Failed to ready and close the background-jobs adapter")
+    })()
+
+    generation.closePromise = closePromise
+
+    try {
+      await closePromise
+    } finally {
+      if (this._backgroundJobsAdapterGeneration === generation) {
+        this._backgroundJobsAdapterGeneration = undefined
+      }
+    }
   }
 
   /**
@@ -1531,6 +1688,10 @@ export default class VelociousConfiguration {
    * @returns {void}
    */
   setBackgroundJobsConfig(backgroundJobs) {
+    if (this._backgroundJobsAdapterGeneration && backgroundJobs.adapter !== undefined) {
+      throw new Error("Cannot replace backgroundJobs.adapter during an active adapter lifecycle; close it first")
+    }
+
     this._backgroundJobs = Object.assign({}, this._backgroundJobs, backgroundJobs)
   }
 
@@ -2099,8 +2260,8 @@ export default class VelociousConfiguration {
     }
 
     const initializeModelsPromise = (async () => {
-      const shouldSkipDummyModelInitialization = process.env.VELOCIOUS_SKIP_DUMMY_MODEL_INITIALIZATION === "1"
-        && process.env.VELOCIOUS_BROWSER_TESTS === "true"
+      const shouldSkipDummyModelInitialization = globalThis.process?.env.VELOCIOUS_SKIP_DUMMY_MODEL_INITIALIZATION === "1"
+        && globalThis.process?.env.VELOCIOUS_BROWSER_TESTS === "true"
         && this.getEnvironment() === "test"
 
       if (!shouldSkipDummyModelInitialization) {
@@ -3425,34 +3586,50 @@ export default class VelociousConfiguration {
     const constructors = new Set()
 
     this._closeDatabaseConnectionsPromise = (async () => {
+      /** @type {Error[]} */
+      const closeErrors = []
+
       try {
-        // Close dedicated advisory-lock connections first: they are spawned outside the
-        // pools' tracked sets, so `pool.closeAll()` would not reach them and a lock held
-        // by a runner torn down mid-pass would leak until the DB server's `wait_timeout`.
-        // Still close the pools even if this throws, so a stuck lock connection does not
-        // leave the rest of the connections open.
-        await this._closeAdvisoryLockConnections()
-      } finally {
-        for (const pool of Object.values(this.databasePools)) {
-          if (!pool) continue
-
-          await pool.closeAll()
-
-          const PoolClass = /** @type {typeof import("./database/pool/base.js").default} */ (pool.constructor)
-          constructors.add(PoolClass)
-        }
-
-        for (const PoolClass of constructors) {
-          PoolClass.clearGlobalConnections(this)
-        }
-
-        this._frontendTenantSqliteLifecycle.reset()
-
-        // Allow full re-initialization after connections are closed.
-        this._modelInitializationGeneration += 1
-        this._modelsInitialized = false
-        this._isInitialized = false
+        await this.closeBackgroundJobsAdapter()
+      } catch (error) {
+        closeErrors.push(error instanceof Error ? error : new Error(String(error)))
       }
+
+      try {
+        try {
+          // Close dedicated advisory-lock connections first: they are spawned outside the
+          // pools' tracked sets, so `pool.closeAll()` would not reach them and a lock held
+          // by a runner torn down mid-pass would leak until the DB server's `wait_timeout`.
+          // Still close the pools if this throws, so a stuck lock connection does not
+          // leave the rest of the connections open.
+          await this._closeAdvisoryLockConnections()
+        } finally {
+          for (const pool of Object.values(this.databasePools)) {
+            if (!pool) continue
+
+            await pool.closeAll()
+
+            const PoolClass = /** @type {typeof import("./database/pool/base.js").default} */ (pool.constructor)
+            constructors.add(PoolClass)
+          }
+
+          for (const PoolClass of constructors) {
+            PoolClass.clearGlobalConnections(this)
+          }
+
+          this._frontendTenantSqliteLifecycle.reset()
+
+          // Allow full re-initialization after connections are closed.
+          this._modelInitializationGeneration += 1
+          this._modelsInitialized = false
+          this._isInitialized = false
+        }
+      } catch (error) {
+        closeErrors.push(error instanceof Error ? error : new Error(String(error)))
+      }
+
+      if (closeErrors.length === 1) throw closeErrors[0]
+      if (closeErrors.length > 1) throw new AggregateError(closeErrors, "Failed to close background-jobs and database resources")
     })()
 
     try {

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import BackgroundJobsAdapterClient from "../background-jobs/adapter-client.js"
 import {validateTimeZone} from "../time-zone.js"
 
 /**
@@ -573,6 +574,25 @@ export default class VelociousEnvironmentHandlerBase {
    */
   async ensureFrameworkSchema(args) { // eslint-disable-line no-unused-vars
     return
+  }
+
+  /**
+   * Creates the environment's default persistence adapter.
+   * @abstract
+   * @param {{configuration: import("../configuration.js").default}} _args - Adapter options.
+   * @returns {import("../background-jobs/adapter.js").default} - Default adapter.
+   */
+  createBackgroundJobsAdapter(_args) {
+    throw new Error("This environment requires an explicit backgroundJobs.adapter")
+  }
+
+  /**
+   * Creates the platform-neutral producer path for an explicit adapter.
+   * @param {{configuration: import("../configuration.js").default}} args - Client options.
+   * @returns {import("../background-jobs/types.js").BackgroundJobsProducer} - Adapter-backed producer.
+   */
+  backgroundJobsClient(args) {
+    return new BackgroundJobsAdapterClient(args)
   }
 
   /**

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -2,6 +2,8 @@
 
 import "../database/annotations-async-hooks.js"
 import Base from "./base.js"
+import BackgroundJobsClient from "../background-jobs/client.js"
+import SqlBackgroundJobsAdapter from "../background-jobs/sql-adapter.js"
 import CliCommandsDestroyMigration from "./node/cli/commands/destroy/migration.js"
 import CliCommandsInit from "./node/cli/commands/init.js"
 import CliCommandsGenerateBaseModels from "./node/cli/commands/generate/base-models.js"
@@ -65,6 +67,25 @@ function pathWithinAllowedPrefixes(filePath, allowedPathPrefixes) {
 }
 
 export default class VelociousEnvironmentHandlerNode extends Base{
+  /**
+   * Creates the built-in SQL persistence adapter.
+   * @param {{configuration: import("../configuration.js").default}} args - Adapter options.
+   * @returns {SqlBackgroundJobsAdapter} - SQL adapter.
+   */
+  createBackgroundJobsAdapter({configuration}) {
+    return new SqlBackgroundJobsAdapter({configuration})
+  }
+
+  /**
+   * Preserves the Node TCP producer and main-process wake-up path. The main
+   * owns the configured persistence adapter; Node producers never bypass it.
+   * @param {{configuration: import("../configuration.js").default}} args - Client options.
+   * @returns {import("../background-jobs/types.js").BackgroundJobsProducer} - Producer client.
+   */
+  backgroundJobsClient({configuration}) {
+    return new BackgroundJobsClient({configuration})
+  }
+
   /**
    * Gives concurrent shared-transaction child jobs independent proxy sessions.
    * A configured single-connection pool shares mutable transaction state between
@@ -1100,26 +1121,12 @@ export default class VelociousEnvironmentHandlerNode extends Base{
    * @returns {Promise<void>} - Resolves when complete.
    */
   async ensureFrameworkSchema({dbs}) {
-    const {default: BackgroundJobsStore} = await import("../background-jobs/store.js")
-    const store = new BackgroundJobsStore({configuration: this.getConfiguration()})
-    const databaseIdentifier = store.getDatabaseIdentifier() ?? "default"
-    const frameworkDb = dbs[databaseIdentifier]
+    // Migration passes its already checked-out DB into the adapter hook. Do not
+    // run runtime readiness here: SQL readiness would open a nested checkout and
+    // can deadlock a single-connection migration pool.
+    const adapter = this.getConfiguration().getBackgroundJobsAdapter()
 
-    // Only ensure the framework schema when the background-jobs database is actually
-    // part of this migrate operation. When it isn't among the migrated set — e.g.
-    // `db:tenants:migrate <tenant>`, which migrates only tenant databases — the
-    // framework store lives elsewhere (typically the default DB) and was already
-    // ensured by the plain `db:migrate` that precedes it. Reaching into it here would
-    // open a fresh connection to that shared database once per tenant worker for
-    // schema work that is already applied. So skip when the framework DB isn't in
-    // this set; the runtime store still creates it lazily if a plain migrate never
-    // ran. Queue-cap reconciliation never runs on this path at all — it belongs to
-    // main-process startup (`BackgroundJobsStore#reconcileQueueConcurrency`).
-    if (!frameworkDb) return
-
-    // Reuse the connection db:migrate already holds for this database; opening a
-    // nested checkout would deadlock a database whose pool is capped at one connection.
-    await store.ensureSchema(frameworkDb)
+    await adapter.ensureFrameworkSchema({dbs})
   }
 
   /**

--- a/src/jobs/prune-terminal-background-jobs.js
+++ b/src/jobs/prune-terminal-background-jobs.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import BackgroundJobsStore from "../background-jobs/store.js"
 import Configuration from "../configuration.js"
 import VelociousJob from "../background-jobs/job.js"
 
@@ -59,9 +58,9 @@ export default class PruneTerminalBackgroundJobsJob extends VelociousJob {
   async perform() {
     const configuration = Configuration.current()
     const config = configuration.getBackgroundJobsConfig()
-    const store = new BackgroundJobsStore({configuration, databaseIdentifier: config.databaseIdentifier})
+    const adapter = await configuration.acquireReadyBackgroundJobsAdapter()
 
-    await store.pruneTerminalJobs({
+    await adapter.pruneTerminalJobs({
       completedTtlMs: config.retention.completedTtlMs,
       failedTtlMs: config.retention.failedTtlMs,
       batchSize: config.retention.batchSize


### PR DESCRIPTION
## Summary

- add a documented background-jobs adapter lifecycle and built-in SQL adapter
- add explicit platform-safe inline/background job runtime while preserving Node TCP wake and lazy configuration behavior
- preserve durable queue semantics and add lifecycle, restart, browser import, SQL fencing, and health regressions

## Validation

- 57 focused and neighboring assertions passed during implementation
- independent blocker regressions: 11 assertions passed
- terminal current-candidate review: approved, 15 focused assertions passed
- `npm run lint`
- `npm run build`
- Expo web/Android/iOS exports passed; local Selenium execution unavailable because the container lacks browser runtime libraries

## Task

https://tasks.diestoeckels.de/tasks/d25b078e-bb88-5a6c-9a78-dc3117696178
