### PR TITLE
Expose frontend-model errors by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,22 +775,20 @@ Use `await FrontendModelBase.waitForIdle()` when a test harness or app lifecycle
 
 Frontend-model HTTP requests always use `credentials: "include"` so shared custom commands can set session cookies without app-level transport overrides.
 
-Unexpected frontend-model endpoint failures return their original message by default with `errorType: "internal_error"` and a server-generated `correlationId` shared with the matching framework-error report. Set `secureFrontendModelErrors: true` to return only explicitly safe messages and otherwise `errorMessage: "Request failed."`. Expected application failures can use `VelociousError.safe(message, {errorType, details, code})`; generated frontend-model callers preserve the server's safe error fields. See [docs/frontend-models.md](docs/frontend-models.md#error-payloads).
+Unexpected frontend-model endpoint failures return their original message and full stack trace by default in every environment, including production. Responses use `errorType: "internal_error"`, a server-generated `correlationId` shared with the matching framework-error report, and the established `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` fields. Expected application failures can use `VelociousError.safe(message, {errorType, details, code})`; generated frontend-model callers preserve the server's safe error fields without adding irrelevant debug fields. See [docs/frontend-models.md](docs/frontend-models.md#error-payloads).
 Invalid client query descriptors, such as unknown `select`, `where`, `search`, `joins`, `preload`, `group`, `sort`, `pluck`, or Ransack attributes, return the specific frontend-model query error message with `velocious.code: "frontend-model-query-error"` and are not emitted as framework errors.
 Invalid frontend-model write attributes and attachment names, including attributes rejected by `permittedParams()`, return the specific safe error message with `velocious.code: "frontend-model-attribute-error"` and are not emitted as framework errors.
-In `development` and `test`, Velocious also includes `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` fields so browser/system-test failures are easier to diagnose without exposing those details in production.
-Other non-production environments, such as `staging`, keep the same client-safe default unless you explicitly opt in with `exposeInternalErrorsToClients: true`:
+To mask unexpected internal details, explicitly opt out for the application configuration:
 
 ```js
 const configuration = new Configuration({
-  environment: "staging",
-  exposeInternalErrorsToClients: true
+  exposeInternalErrorsToClients: false
 })
 ```
 
-This opt-in is ignored in `production`; production frontend-model responses never include internal exception details.
+With this opt-out, built-in commands, custom commands, and sync replay failures return `errorMessage: "Request failed."` and omit the debug message and stack fields in every environment. `secureFrontendModelErrors: true` remains a deprecated compatibility alias when `exposeInternalErrorsToClients` is omitted; an explicit `exposeInternalErrorsToClients` value always wins.
 
-Backends can append client-safe metadata to frontend-model error responses with `configuration.addClientErrorPayloadReporter(...)`. Reporters receive the caught `error`, the current `request`, a safe `requestDetails` snapshot, and a small `context` object, and should only return fields that are safe for clients to see. Frontend-model endpoint failures include `context.frontendModelEndpoint`, `action`, `commandType`, `model`, `requestId`, and `expectedError`. This is useful for attaching an error-reporting URL while keeping the normal production error message generic:
+Backends can append client-safe metadata to frontend-model error responses with `configuration.addClientErrorPayloadReporter(...)`. Reporters receive the caught `error`, the current `request`, a safe `requestDetails` snapshot, and a small `context` object, and should only return fields that are safe for clients to see. Frontend-model endpoint failures include `context.frontendModelEndpoint`, `action`, `commandType`, `model`, `requestId`, and `expectedError`. When exposure is disabled, Velocious strips the established debug fields even if a reporter supplies them. This is useful for attaching an error-reporting URL while keeping an opted-out error message generic:
 
 ```js
 configuration.addClientErrorPayloadReporter(async ({error, requestDetails, context}) => {
@@ -1919,7 +1917,7 @@ configuration.getErrorEvents().on("all-error", ({error, errorType}) => {
 })
 ```
 
-Genuinely unexpected frontend-model command failures reach this bus too. The frontend-model controller catches them to return an `internal_error` response with the original message by default (or `Request failed.` when `secureFrontendModelErrors` is enabled) and a correlation ID, then emits them as `framework-error`/`all-error` with the same correlation ID and `context.frontendModelEndpoint === true`. Expected user-flow errors are excluded: validation failures are forwarded with their real message (for example `Name can't be blank`), invalid client query descriptors are returned as frontend-model query errors, and `error.velocious`-annotated / `safeToExpose` errors keep their expected-error status. A raw `errorType` property alone is not considered safe and does not suppress reporting.
+Genuinely unexpected frontend-model command failures reach this bus too. The frontend-model controller catches them to return an `internal_error` response with the original message and stack trace by default (or `Request failed.` without debug fields when `exposeInternalErrorsToClients: false`) and a correlation ID, then emits them as `framework-error`/`all-error` with the same correlation ID and `context.frontendModelEndpoint === true`. Expected user-flow errors are excluded: validation failures are forwarded with their real message (for example `Name can't be blank`), invalid client query descriptors are returned as frontend-model query errors, and `error.velocious`-annotated / `safeToExpose` errors keep their expected-error status without irrelevant debug fields. A raw `errorType` property alone is not considered safe and does not suppress reporting.
 
 Unexpected inbound decoded WebSocket dispatch failures emit one `framework-error` and one matching `all-error`. Established expected client-flow errors remain excluded from both events.
 

--- a/changelog.d/20260814220000-expose-frontend-model-errors-by-default.md
+++ b/changelog.d/20260814220000-expose-frontend-model-errors-by-default.md
@@ -1,0 +1,1 @@
+Frontend-model clients now receive unexpected error messages and stack traces by default in every environment, including production. Set `exposeInternalErrorsToClients: false` to return `"Request failed."` and omit debug fields consistently for built-in commands, custom commands, and sync replay failures.

--- a/docs/frontend-models.md
+++ b/docs/frontend-models.md
@@ -13,11 +13,10 @@ Projects sharing resource policy between backend and local/offline runtimes shou
 ## Error payloads
 
 ### Unexpected errors
-- Unexpected frontend-model endpoint failures return their original message by default with `errorType: "internal_error"` and a server-generated `correlationId`. Set `secureFrontendModelErrors: true` to expose only explicitly safe messages and otherwise return `errorMessage: "Request failed."`.
-- `development` and `test` responses also include `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` for faster browser/system-test diagnosis.
-- Other non-production environments, such as `staging`, can opt into the same debug fields with `exposeInternalErrorsToClients: true` on the app `Configuration`.
-- `production` always keeps the generic response, even if `exposeInternalErrorsToClients` is set.
-- `configuration.addClientErrorPayloadReporter(...)` can append client-safe metadata to the error payload. For frontend-model endpoint failures, the reporter `context` includes `frontendModelEndpoint`, `action`, `commandType`, `model`, `requestId`, and `expectedError`. Reporters also receive `requestDetails` with `httpMethod`, `path`, and a sanitized parsed `body` snapshot when available.
+- Unexpected frontend-model endpoint failures return their original message and full stack trace by default in every environment, including production. The response uses `errorType: "internal_error"`, a server-generated `correlationId`, and the established `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace` fields.
+- Set `exposeInternalErrorsToClients: false` on the app `Configuration` to return `errorMessage: "Request failed."` and omit `debugErrorClass`, `debugErrorMessage`, and `debugBacktrace`. This opt-out applies consistently to built-in commands, custom commands, and sync replay failures.
+- `secureFrontendModelErrors: true` remains supported as a deprecated compatibility alias for the opt-out when `exposeInternalErrorsToClients` is omitted. An explicit `exposeInternalErrorsToClients` value is authoritative.
+- `configuration.addClientErrorPayloadReporter(...)` can append client-safe metadata to the error payload. For frontend-model endpoint failures, the reporter `context` includes `frontendModelEndpoint`, `action`, `commandType`, `model`, `requestId`, and `expectedError`. Reporters also receive `requestDetails` with `httpMethod`, `path`, and a sanitized parsed `body` snapshot when available. The explicit exposure opt-out strips the established debug fields even if a reporter supplies them.
 - Unexpected frontend-model failures are emitted on `configuration.getErrorEvents()` as `framework-error` and `all-error`. These event payloads include the same `correlationId` returned to the client, the raw `request` for compatibility, and the same sanitized `requestDetails` snapshot. Expected user-flow errors, including validation errors, `safeToExpose` errors, and `error.velocious` metadata, are not emitted as framework errors. A raw `error.errorType` property is not a safety marker and does not suppress reporting.
 - `requestDetails.body` redacts common secret keys, truncates large strings and arrays, summarizes uploaded files and buffers without bytes, and compacts oversized frontend-model batches while preserving `requestId`, `model`, `commandType` / `customPath`, and payload shape.
 - Invalid client query descriptors, such as unknown `select`, `where`, `search`, `joins`, `preload`, `group`, `sort`, `pluck`, or Ransack attributes, are frontend-model query errors. They return the specific query error message and `velocious.code: "frontend-model-query-error"` instead of being emitted as framework errors.
@@ -42,7 +41,7 @@ Projects sharing resource policy between backend and local/offline runtimes shou
 - `errorType` is `"validation_error"` to distinguish validation failures from unexpected internal errors.
 - `validationErrors` is keyed by attribute name; each entry is an array of objects with `type` (validator name), `message` (short description), and `fullMessage` (human-readable error including the attribute label).
 - Unlike unexpected errors, validation errors are safe to expose in all environments (including production) because they only carry user-fixable input errors.
-- Internal details (stack traces, SQL errors) are never leaked through validation error responses.
+- Validation error responses do not gain debug fields; only genuinely unexpected errors use the configured internal-error exposure behavior.
 
 ### Safe application errors
 - Backend code can throw `VelociousError.safe(message, {errorType, details, code})` when the message and optional structured details are explicitly safe for clients.

--- a/spec/controller/frontend-model-actions-spec.js
+++ b/spec/controller/frontend-model-actions-spec.js
@@ -95,7 +95,9 @@ function buildFrontendModelControllerConfiguration(environment, options = {}) {
     directory: dummyDirectory(),
     environment,
     environmentHandler: new EnvironmentHandlerNode(),
-    exposeInternalErrorsToClients: options.exposeInternalErrorsToClients === true,
+    ...(options.exposeInternalErrorsToClients === undefined
+      ? {}
+      : {exposeInternalErrorsToClients: options.exposeInternalErrorsToClients}),
     initializeModels: async () => {},
     locale: "en",
     localeFallbacks: {en: ["en"]},
@@ -172,13 +174,13 @@ async function runFrontendApiWithResponse({configuration, params, requestPayload
 
 /**
  * @param {Record<string, any>} payload - Error payload.
- * @param {RegExp} messagePattern - Expected debug message.
+ * @param {RegExp} messagePattern - Expected exposed message.
  * @returns {void}
  */
-function expectDebugFrontendModelError(payload, messagePattern) {
+function expectExposedFrontendModelError(payload, messagePattern) {
   expect(payload.status).toEqual("error")
   expect(payload.errorType).toEqual("internal_error")
-  expect(payload.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
+  expect(payload.errorMessage).toMatch(messagePattern)
   expect(payload.correlationId).toMatch(/^[0-9a-f-]{36}$/)
   expect(payload.debugErrorClass).toEqual("Error")
   expect(payload.debugErrorMessage).toMatch(messagePattern)
@@ -463,7 +465,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     })
   })
 
-  it("returns generic client-safe errors from shared frontend-model API for unexpected failures", async () => {
+  it("exposes internal errors from shared frontend-model API by default", async () => {
     await Dummy.run(async () => {
       const payload = await postFrontendModel("/frontend-models", {
         requests: [
@@ -478,7 +480,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
 
       expect(payload.status).toEqual("success")
       expect(payload.responses.length).toEqual(1)
-      expectDebugFrontendModelError(payload.responses[0].response, /No frontend model resource configuration/)
+      expectExposedFrontendModelError(payload.responses[0].response, /No frontend model resource configuration/)
     })
   })
 
@@ -600,38 +602,38 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     return payload.responses[0].response
   }
 
-  it("keeps unexpected shared frontend-model failures generic in production", async () => {
+  it("exposes unexpected shared frontend-model failures in production by default", async () => {
     const configuration = buildFrontendModelControllerConfiguration("production")
     const payload = await runFrontendApi({
       configuration,
       params: unknownSharedFrontendModelRequestParams()
     })
 
-    expectGenericFrontendModelError(expectSingleSharedFrontendModelResponse(payload))
+    expectExposedFrontendModelError(expectSingleSharedFrontendModelResponse(payload), /No frontend model resource configuration/)
   })
 
-  it("keeps unexpected shared frontend-model failures generic in staging by default", async () => {
+  it("exposes unexpected shared frontend-model failures in staging by default", async () => {
     const configuration = buildFrontendModelControllerConfiguration("staging")
     const payload = await runFrontendApi({
       configuration,
       params: unknownSharedFrontendModelRequestParams()
     })
 
-    expectGenericFrontendModelError(expectSingleSharedFrontendModelResponse(payload))
+    expectExposedFrontendModelError(expectSingleSharedFrontendModelResponse(payload), /No frontend model resource configuration/)
   })
 
-  it("returns debug details for unexpected shared frontend-model failures when staging opts in", async () => {
+  it("exposes unexpected shared frontend-model failures when staging explicitly enables exposure", async () => {
     const configuration = buildFrontendModelControllerConfiguration("staging", {exposeInternalErrorsToClients: true})
     const payload = await runFrontendApi({
       configuration,
       params: unknownSharedFrontendModelRequestParams()
     })
 
-    expectDebugFrontendModelError(expectSingleSharedFrontendModelResponse(payload), /No frontend model resource configuration/)
+    expectExposedFrontendModelError(expectSingleSharedFrontendModelResponse(payload), /No frontend model resource configuration/)
   })
 
   it("adds registered client error reporter payloads to shared frontend-model failures", async () => {
-    const configuration = buildFrontendModelControllerConfiguration("production")
+    const configuration = buildFrontendModelControllerConfiguration("production", {exposeInternalErrorsToClients: false})
     /** @type {import("../../src/configuration-types.js").ClientErrorPayloadContext[]} */
     const reporterContexts = []
     /** @type {Array<import("../../src/configuration-types.js").ErrorRequestDetails | null>} */
@@ -652,6 +654,9 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
       return {
         bugReportUrl: "https://tensorbuzz.test/bugs/1",
         correlationId: "reporter-correlation-id",
+        debugBacktrace: ["Reporter stack"],
+        debugErrorClass: "ReporterError",
+        debugErrorMessage: "Reporter leaked internal details",
         errorType: "reporter_error"
       }
     })
@@ -683,7 +688,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
   })
 
   it("compacts oversized shared frontend-model request details for client error reporters", async () => {
-    const configuration = buildFrontendModelControllerConfiguration("production")
+    const configuration = buildFrontendModelControllerConfiguration("production", {exposeInternalErrorsToClients: false})
     /** @type {Array<import("../../src/configuration-types.js").ErrorRequestDetails | null>} */
     const reporterRequestDetails = []
     const requestPayload = unknownSharedFrontendModelRequestParams()
@@ -759,7 +764,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     const responseJson = responseText.length > 0 ? JSON.parse(responseText) : {}
     const payload = /** @type {Record<string, import("../../src/frontend-models/query.js").FrontendModelTransportValue>} */ (deserializeFrontendModelTransportValue(responseJson))
 
-    expectGenericFrontendModelError(payload)
+    expectExposedFrontendModelError(payload, /Could not parse nested params key/)
     expect(frameworkErrors.length).toEqual(1)
     expect(frameworkErrors[0].context.frontendModelEndpoint).toEqual(true)
     expect(frameworkErrors[0].error.message).toMatch(/Could not parse nested params key/)
@@ -790,8 +795,12 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     expect(payload.errorMessage).toEqual("Ticket scan failed")
     expect(payload.details).toEqual({maximumLength: 100})
     expect(payload.velocious).toEqual({code: "ticket-scan-path-too-long"})
+    expect(payload.debugErrorClass).toEqual(undefined)
+    expect(payload.debugErrorMessage).toEqual(undefined)
+    expect(payload.debugBacktrace).toEqual(undefined)
     expect(authorizationPayload.errorType).toEqual("authorization_error")
     expect(authorizationPayload.errorMessage).toEqual("Not signed in.")
+    expect(authorizationPayload.debugErrorMessage).toEqual(undefined)
   })
 
   it("returns record-not-found errors with a stable safe type", async () => {
@@ -812,8 +821,8 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
     expect(payload.errorMessage).toEqual("Record not found.")
   })
 
-  it("keeps unexpected shared frontend-model failures generic in production when debug details are enabled", async () => {
-    const configuration = buildFrontendModelControllerConfiguration("production", {exposeInternalErrorsToClients: true})
+  it("keeps unexpected shared frontend-model failures generic in production when exposure is disabled", async () => {
+    const configuration = buildFrontendModelControllerConfiguration("production", {exposeInternalErrorsToClients: false})
     const payload = await runFrontendApi({
       configuration,
       params: unknownSharedFrontendModelRequestParams()
@@ -1661,7 +1670,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
       const reloadedForeignInteraction = await Interaction.find(foreignInteraction.id())
 
       expect(updatePayload.status).toEqual("error")
-      expect(updatePayload.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
+      expect(updatePayload.errorMessage).toMatch(/Cannot update nested interactions/)
       expect(reloadedForeignInteraction.kind()).toEqual("Foreign task interaction")
     })
   })
@@ -1804,7 +1813,7 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
       })
 
       expect(payload.status).toEqual("error")
-      expect(payload.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
+      expect(payload.errorMessage).toEqual("Attachment path input is disabled")
     })
   })
 
@@ -2038,10 +2047,13 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
       expect(payload.validationErrors.name[0].type).toEqual("presence")
       expect(payload.validationErrors.name[0].message).toEqual("can't be blank")
       expect(payload.validationErrors.name[0].fullMessage).toEqual("Name can't be blank")
+      expect(payload.debugErrorClass).toEqual(undefined)
+      expect(payload.debugErrorMessage).toEqual(undefined)
+      expect(payload.debugBacktrace).toEqual(undefined)
     })
   })
 
-  it("masks non-validation internal errors as generic in production frontend-model responses", async () => {
+  it("exposes non-validation internal errors in production frontend-model responses by default", async () => {
     await Dummy.run(async () => {
       const configuration = buildFrontendModelControllerConfiguration("production")
       const params = {
@@ -2057,12 +2069,8 @@ describe("Controller frontend model actions", {databaseCleaning: {transaction: f
       const payload = await runFrontendApi({configuration, params})
       const response = /** @type {Record<string, any>} */ (payload.responses?.[0]?.response || payload)
 
-      expect(response.status).toEqual("error")
-      expect(response.errorMessage).toEqual(FRONTEND_MODEL_CLIENT_SAFE_ERROR_MESSAGE)
-      expect(response.errorType).toEqual("internal_error")
-      expect(response.correlationId).toMatch(/^[0-9a-f-]{36}$/)
+      expectExposedFrontendModelError(response, /No ability in context for Task/)
       expect(response.validationErrors).toBeUndefined()
-      expect(response.debugErrorClass).toBeUndefined()
     })
   })
 

--- a/spec/controller/frontend-model-custom-command-spec.js
+++ b/spec/controller/frontend-model-custom-command-spec.js
@@ -92,7 +92,7 @@ describe("Controller frontend model custom commands", () => {
     expect(response.receivedName).toEqual("John")
   })
 
-  it("masks unexpected custom frontend-model command failures in secure mode", async () => {
+  it("masks unexpected custom frontend-model command failures when exposure is disabled", async () => {
     const configuration = new Configuration({
       database: {test: {}},
       directory: dummyDirectory(),
@@ -102,7 +102,7 @@ describe("Controller frontend model custom commands", () => {
       locale: "en",
       localeFallbacks: {en: ["en"]},
       locales: ["en"],
-      secureFrontendModelErrors: true
+      exposeInternalErrorsToClients: false
     })
 
     configuration.routes((routes) => {
@@ -148,10 +148,9 @@ describe("Controller frontend model custom commands", () => {
     expect(responsePayload.status).toEqual("success")
     expect(responsePayload.responses[0].response.status).toEqual("error")
     expect(responsePayload.responses[0].response.errorMessage).toEqual("Request failed.")
-    expect(responsePayload.responses[0].response.debugErrorClass).toEqual("Error")
-    expect(responsePayload.responses[0].response.debugErrorMessage).toEqual("Custom frontend model command exploded.")
-    expect(Array.isArray(responsePayload.responses[0].response.debugBacktrace)).toEqual(true)
-    expect(responsePayload.responses[0].response.debugBacktrace[0]).toMatch(/Custom frontend model command exploded\./)
+    expect(responsePayload.responses[0].response.debugErrorClass).toEqual(undefined)
+    expect(responsePayload.responses[0].response.debugErrorMessage).toEqual(undefined)
+    expect(responsePayload.responses[0].response.debugBacktrace).toEqual(undefined)
   })
 
   it("returns the message + velocious metadata and suppresses the endpoint-failed log line when error.velocious is set", async () => {
@@ -222,11 +221,13 @@ describe("Controller frontend model custom commands", () => {
       process.stdout.write = originalWrite
     }
 
-    // The message still reaches the client (exposed because
-    // `error.velocious` was set; otherwise the framework returns a
-    // generic safe message).
+    // The message reaches the client as an expected application error because
+    // `error.velocious` was set, without irrelevant internal debug fields.
     expect(responsePayload.responses[0].response.status).toEqual("error")
     expect(responsePayload.responses[0].response.errorMessage).toEqual("Invalid email or password")
+    expect(responsePayload.responses[0].response.debugErrorClass).toEqual(undefined)
+    expect(responsePayload.responses[0].response.debugErrorMessage).toEqual(undefined)
+    expect(responsePayload.responses[0].response.debugBacktrace).toEqual(undefined)
 
     // The velocious metadata bag is forwarded to the client so app
     // code can branch on `error.velocious?.type`.

--- a/spec/controller/frontend-model-sync-replay-spec.js
+++ b/spec/controller/frontend-model-sync-replay-spec.js
@@ -392,7 +392,10 @@ describe("frontend-model sync replay", () => {
 
     expect(payload.results[0].status).toEqual("success")
     expect(payload.results[0].response.status).toEqual("error")
-    expect(payload.results[0].response.errorMessage).toEqual("Request failed.")
+    expect(payload.results[0].response.errorMessage).toEqual("Replay command exploded")
+    expect(payload.results[0].response.debugErrorMessage).toEqual("Replay command exploded")
+    expect(Array.isArray(payload.results[0].response.debugBacktrace)).toEqual(true)
+    expect(payload.results[0].response.debugBacktrace[0]).toMatch(/Replay command exploded/)
     expect(frameworkErrors.length).toEqual(1)
     expect(frameworkErrors[0].error.message).toEqual("Replay command exploded")
     expect(frameworkErrors[0].context.action).toEqual("frontendSyncReplay")
@@ -438,7 +441,10 @@ describe("frontend-model sync replay", () => {
     expect(payload.results[0].response).toEqual({status: "success", replayed: true})
     expect(payload.results[0].serverSequence).toEqual(null)
     expect(payload.results[0].serverChangeFeedStatus).toEqual("error")
-    expect(payload.results[0].serverChangeFeedError.errorMessage).toEqual("Request failed.")
+    expect(payload.results[0].serverChangeFeedError.errorMessage).toEqual("Change feed exploded")
+    expect(payload.results[0].serverChangeFeedError.debugErrorMessage).toEqual("Change feed exploded")
+    expect(Array.isArray(payload.results[0].serverChangeFeedError.debugBacktrace)).toEqual(true)
+    expect(payload.results[0].serverChangeFeedError.debugBacktrace[0]).toMatch(/Change feed exploded/)
     expect(controller.replayedCommands).toEqual([{action: "update", params: {attributes: {scanned: true}, id: "ticket-1", model: "Ticket"}}])
   })
 

--- a/src/configuration-types.js
+++ b/src/configuration-types.js
@@ -697,9 +697,9 @@
  * @property {boolean} [enforceTenantDatabaseScopes] - Require tenant-switched model queries to resolve a tenant database identifier. Defaults to true.
  * @property {string} [environment] - Current environment name.
  * @property {import("./environment-handlers/base.js").default} environmentHandler - Environment handler instance.
- * @property {boolean} [exposeInternalErrorsToClients] - Return unexpected internal error details in client API payloads outside production. Defaults to false.
+ * @property {boolean} [exposeInternalErrorsToClients] - Return unexpected internal error messages and stack traces in frontend-model client payloads in every environment. Defaults to true.
  * @property {{maxOpenHandles?: number}} [frontendTenantSqlite] - Bounded frontend tenant SQLite lifecycle configuration.
- * @property {boolean} [secureFrontendModelErrors] - Return only explicitly safe frontend-model error messages to clients. Defaults to false.
+ * @property {boolean} [secureFrontendModelErrors] - Deprecated compatibility alias for `exposeInternalErrorsToClients: false` when the authoritative option is omitted.
  * @property {HttpServerConfiguration} [httpServer] - Default HTTP server configuration for applications started from this configuration.
  * @property {LoggingConfiguration} [logging] - Logging configuration.
  * @property {BackgroundJobsConfiguration} [backgroundJobs] - Background jobs configuration.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -236,7 +236,7 @@ export default class VelociousConfiguration {
    * Runs constructor.
    * @param {import("./configuration-types.js").ConfigurationArgsType} args - Configuration arguments.
    */
-  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, apiManifest = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients = false, frontendTenantSqlite, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, packages, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, secureFrontendModelErrors = false, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
+  constructor({abilityResolver, abilityResources, attachments, autoload = true, backgroundJobs, backendProjects, beacon, cookieSecret, cors, database, debug = false, debugEndpoint = false, apiManifest = false, directory, enforceTenantDatabaseScopes = true, environment, environmentHandler, exposeInternalErrorsToClients, frontendTenantSqlite, httpServer, initializeModels, initializers, locale, localeFallbacks, locales, logging, mailerBackend, packages, requestTimeoutMs, routeResolverHooks, scheduledBackgroundJobs, secureFrontendModelErrors, structureSql, sync, tenantDatabaseProviders, tenantDatabaseResolver, tenantResolver, testing, timeZone, timezoneOffsetMinutes, trustedProxies, websocketChannelResolver, websocketMessageHandlerResolver, ...restArgs}) {
     restArgsError(restArgs)
 
     this._abilityResolver = abilityResolver
@@ -283,8 +283,9 @@ export default class VelociousConfiguration {
     this._environment = environment || globalThis.process?.env.VELOCIOUS_ENV || globalThis.process?.env.NODE_ENV || "development"
     this._environmentHandler = environmentHandler
     this._enforceTenantDatabaseScopes = enforceTenantDatabaseScopes
-    this._exposeInternalErrorsToClients = exposeInternalErrorsToClients
-    this._secureFrontendModelErrors = secureFrontendModelErrors
+    this._exposeInternalErrorsToClients = exposeInternalErrorsToClients === undefined
+      ? secureFrontendModelErrors !== true
+      : exposeInternalErrorsToClients
     this._directory = directory
     this._initializeModels = initializeModels
     /** @type {VelociousPackage[]} */
@@ -461,9 +462,10 @@ export default class VelociousConfiguration {
 
   /**
    * Returns whether frontend-model errors expose only explicitly safe messages.
-   * @returns {boolean} Whether frontend-model errors expose only explicitly safe messages.
+   * @deprecated Use `getExposeInternalErrorsToClients()`.
+   * @returns {boolean} Whether frontend-model internal error exposure is disabled.
    */
-  getSecureFrontendModelErrors() { return this._secureFrontendModelErrors === true }
+  getSecureFrontendModelErrors() { return !this.getExposeInternalErrorsToClients() }
 
   /**
    * Runs get debug endpoint.

--- a/src/frontend-model-controller.js
+++ b/src/frontend-model-controller.js
@@ -175,7 +175,6 @@ const frontendModelJoinedPathsSymbol = Symbol("frontendModelJoinedPaths")
 const frontendModelGroupedColumnsSymbol = Symbol("frontendModelGroupedColumns")
 const frontendModelWhereNoMatchSymbol = Symbol("frontendModelWhereNoMatch")
 const frontendModelClientSafeErrorMessage = "Request failed."
-const frontendModelDebugErrorEnvironments = new Set(["development", "test"])
 
 /**
  * Builds a client-safe sync replay validation error.
@@ -277,10 +276,10 @@ function frontendModelVelociousMetadataForError(error) {
 /**
  * Runs frontend model client message for error.
  * @param {unknown} error - Caught error.
- * @param {boolean} forwardUnexpectedErrorMessage - Whether unexpected error messages may be exposed.
+ * @param {boolean} exposeInternalErrorsToClients - Whether unexpected error messages may be exposed.
  * @returns {string} - Message safe to return to API clients.
  */
-function frontendModelClientMessageForError(error, forwardUnexpectedErrorMessage) {
+function frontendModelClientMessageForError(error, exposeInternalErrorsToClients) {
   if (error instanceof RecordNotFoundError) {
     return "Record not found."
   }
@@ -301,7 +300,7 @@ function frontendModelClientMessageForError(error, forwardUnexpectedErrorMessage
     return error.message
   }
 
-  if (forwardUnexpectedErrorMessage && error instanceof Error) return error.message
+  if (exposeInternalErrorsToClients && error instanceof Error) return error.message
 
   return frontendModelClientSafeErrorMessage
 }
@@ -310,14 +309,11 @@ function frontendModelClientMessageForError(error, forwardUnexpectedErrorMessage
  * Runs frontend model debug payload for error.
  * @param {object} args - Arguments.
  * @param {import("./configuration.js").default} args.configuration - Current configuration.
- * @param {string} args.environment - Current environment.
  * @param {unknown} args.error - Caught error.
- * @returns {import("./configuration-types.js").ClientErrorPayloadReporterPayload} - Optional debug payload for non-production environments.
+ * @returns {import("./configuration-types.js").ClientErrorPayloadReporterPayload} - Optional internal error details when client exposure is enabled.
  */
-function frontendModelDebugPayloadForError({configuration, environment, error}) {
-  const debugAllowed = frontendModelDebugErrorEnvironments.has(environment) || environment !== "production" && configuration.getExposeInternalErrorsToClients()
-
-  if (!debugAllowed) {
+function frontendModelDebugPayloadForError({configuration, error}) {
+  if (!configuration.getExposeInternalErrorsToClients()) {
     return {}
   }
 
@@ -3259,10 +3255,9 @@ export default class FrontendModelController extends Controller {
    * Runs frontend model client error payload for error.
    * @param {unknown} error - Caught error.
    * @param {FrontendModelEndpointErrorContext | undefined} [endpointErrorContext] - Frontend-model endpoint error context.
-   * @param {{forwardUnexpectedErrorMessage?: boolean}} [options] - Client error rendering options.
    * @returns {Promise<import("./configuration-types.js").ClientErrorPayloadReporterPayload>} - Client payload for the current environment.
    */
-  async frontendModelClientErrorPayloadForError(error, endpointErrorContext, {forwardUnexpectedErrorMessage = false} = {}) {
+  async frontendModelClientErrorPayloadForError(error, endpointErrorContext) {
     const velociousMetadata = frontendModelVelociousMetadataForError(error)
     const normalizedError = error instanceof Error ? error : new Error(String(error))
     /** @type {import("./configuration-types.js").ClientErrorPayloadReporterPayload} */
@@ -3312,15 +3307,20 @@ export default class FrontendModelController extends Controller {
       request: this.getRequest()
     })
 
+    if (!this.getConfiguration().getExposeInternalErrorsToClients()) {
+      delete reporterPayload.debugBacktrace
+      delete reporterPayload.debugErrorClass
+      delete reporterPayload.debugErrorMessage
+    }
+
     return {
       ...reporterPayload,
       ...this.frontendModelErrorPayload(frontendModelClientMessageForError(
         error,
-        forwardUnexpectedErrorMessage && !this.getConfiguration().getSecureFrontendModelErrors()
+        this.getConfiguration().getExposeInternalErrorsToClients()
       )),
       ...frontendModelDebugPayloadForError({
         configuration: this.getConfiguration(),
-        environment: this.getConfiguration().getEnvironment(),
         error
       }),
       ...(velociousMetadata ? {velocious: velociousMetadata} : {}),
@@ -4397,9 +4397,7 @@ export default class FrontendModelController extends Controller {
 
         responses.push({
           requestId,
-          response: await this.frontendModelClientErrorPayloadForError(error, errorContext, {
-            forwardUnexpectedErrorMessage: !isBuiltInCommand
-          })
+          response: await this.frontendModelClientErrorPayloadForError(error, errorContext)
         })
       }
     }
@@ -4623,9 +4621,7 @@ export default class FrontendModelController extends Controller {
       await this.frontendModelLogEndpointError({error, errorContext})
 
       await this.render({
-        json: /** @type {Record<string, ReturnType<typeof JSON.parse>>} */ (serializeFrontendModelTransportValue(await this.frontendModelClientErrorPayloadForError(error, errorContext, {
-          forwardUnexpectedErrorMessage: true
-        }), this.transportSerializationOptions()))
+        json: /** @type {Record<string, ReturnType<typeof JSON.parse>>} */ (serializeFrontendModelTransportValue(await this.frontendModelClientErrorPayloadForError(error, errorContext), this.transportSerializationOptions()))
       })
     }
   }


### PR DESCRIPTION
## Summary

- expose unexpected frontend-model error messages and full stack traces by default in every environment, including production
- make `exposeInternalErrorsToClients: false` the authoritative opt-out across built-in, custom-command, sync-replay, and reporter payload paths
- retain `secureFrontendModelErrors: true` as a deprecated compatibility alias when the authoritative option is omitted
- preserve structured expected errors, correlation IDs, and framework/all-error reporting
- document the changed default and opt-out behavior

## Validation

- `node ../../bin/velocious.js test ../../spec/controller/frontend-model-actions-spec.js` — 78 passing
- `node ../../bin/velocious.js test ../../spec/controller/frontend-model-custom-command-spec.js` — 4 passing
- `node ../../bin/velocious.js test ../../spec/controller/frontend-model-sync-replay-spec.js` — 15 passing
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`

## Review

Independent read-only Codex review: **PASS**, no material or nonblocking findings.

## Task

https://tasks.diestoeckels.de/tasks/ad231b93-3ab5-49fc-ad98-9ce453313288
