### PR TITLE
Stop background jobs after queue test failures

### DIFF
--- a/spec/background-jobs/helper-lifecycle-spec.js
+++ b/spec/background-jobs/helper-lifecycle-spec.js
@@ -1,0 +1,57 @@
+// @ts-check
+
+import {describe, expect, it} from "../../src/testing/test.js"
+import {withBackgroundJobs} from "../helpers/background-jobs-helper.js"
+
+describe("Background jobs test helper lifecycle", {tags: ["dummy"], databaseCleaning: {truncate: true}}, () => {
+  it("stops the worker and main before propagating an owning test failure", async () => {
+    const ownerError = new Error("planned owning test failure")
+    let releaseWorkerStop
+    const workerStopBarrier = new Promise((resolve) => { releaseWorkerStop = resolve })
+    let reportWorkerStopStarted
+    const workerStopStarted = new Promise((resolve) => { reportWorkerStopStarted = resolve })
+    let releaseMainStop
+    const mainStopBarrier = new Promise((resolve) => { releaseMainStop = resolve })
+    let reportMainStopStarted
+    const mainStopStarted = new Promise((resolve) => { reportMainStopStarted = resolve })
+    const order = []
+    let ownerSettled = false
+    const owner = withBackgroundJobs(async () => {
+      order.push("callback")
+      throw ownerError
+    }, {
+      start: async () => ({
+        main: {
+          stop: async () => {
+            order.push("main-stop-start")
+            reportMainStopStarted()
+            await mainStopBarrier
+            order.push("main-stop-end")
+          }
+        },
+        store: {},
+        worker: {
+          stop: async () => {
+            order.push("worker-stop-start")
+            reportWorkerStopStarted()
+            await workerStopBarrier
+            order.push("worker-stop-end")
+          }
+        }
+      })
+    }).then(() => undefined, (error) => error).finally(() => { ownerSettled = true })
+
+    await workerStopStarted
+    expect(ownerSettled).toEqual(false)
+    expect(order).toEqual(["callback", "worker-stop-start"])
+    releaseWorkerStop()
+
+    await mainStopStarted
+    expect(ownerSettled).toEqual(false)
+    expect(order).toEqual(["callback", "worker-stop-start", "worker-stop-end", "main-stop-start"])
+    releaseMainStop()
+
+    expect(await owner).toBe(ownerError)
+    expect(order).toEqual(["callback", "worker-stop-start", "worker-stop-end", "main-stop-start", "main-stop-end"])
+  })
+})

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -3,7 +3,7 @@
 import fs from "fs/promises"
 import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
-import {outputPathFor, startBackgroundJobs, waitForOutputJson} from "../helpers/background-jobs-helper.js"
+import {outputPathFor, startBackgroundJobs, waitForOutputJson, withBackgroundJobs} from "../helpers/background-jobs-helper.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import AppendJob from "../dummy/src/jobs/append-job.js"
 import DelayedJob from "../dummy/src/jobs/delayed-job.js"
@@ -84,41 +84,39 @@ describe("Background jobs - queue", {databaseCleaning: {truncate: true}}, () => 
   })
 
   it("limits forked runner concurrency without blocking inline job capacity", async () => {
-    const {main, worker} = await startBackgroundJobs({workerOptions: {
+    await withBackgroundJobs(async () => {
+      const firstForkedPath = await outputPathFor("forked-limit-first")
+      const secondForkedPath = await outputPathFor("forked-limit-second")
+      const inlinePath = await outputPathFor("forked-limit-inline")
+
+      await SlowTestJob.performLater("first", firstForkedPath, 1)
+      await SlowTestJob.performLater("second", secondForkedPath, 0.01)
+      const inlineResult = await appendInlineAndWait(inlinePath)
+
+      let secondForkedExists = true
+
+      try {
+        await fs.readFile(secondForkedPath, "utf8")
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+
+        secondForkedExists = false
+      }
+
+      expect(secondForkedExists).toBeFalse()
+
+      const [firstForkedResult, secondForkedResult] = await Promise.all([
+        waitForOutputJson({outputPath: firstForkedPath, timeoutSeconds: 5}),
+        waitForOutputJson({outputPath: secondForkedPath, timeoutSeconds: 5})
+      ])
+
+      expect(inlineResult).toEqual(["inline"])
+      expect(firstForkedResult).toEqual({message: "first"})
+      expect(secondForkedResult).toEqual({message: "second"})
+    }, {workerOptions: {
       maxConcurrentForkedJobs: 1,
       maxConcurrentInlineJobs: 4
     }})
-    const firstForkedPath = await outputPathFor("forked-limit-first")
-    const secondForkedPath = await outputPathFor("forked-limit-second")
-    const inlinePath = await outputPathFor("forked-limit-inline")
-
-    await SlowTestJob.performLater("first", firstForkedPath, 1)
-    await SlowTestJob.performLater("second", secondForkedPath, 0.01)
-    const inlineResult = await appendInlineAndWait(inlinePath)
-
-    let secondForkedExists = true
-
-    try {
-      await fs.readFile(secondForkedPath, "utf8")
-    } catch (error) {
-      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
-
-      secondForkedExists = false
-    }
-
-    expect(secondForkedExists).toBeFalse()
-
-    const [firstForkedResult, secondForkedResult] = await Promise.all([
-      waitForOutputJson({outputPath: firstForkedPath, timeoutSeconds: 5}),
-      waitForOutputJson({outputPath: secondForkedPath, timeoutSeconds: 5})
-    ])
-
-    expect(inlineResult).toEqual(["inline"])
-    expect(firstForkedResult).toEqual({message: "first"})
-    expect(secondForkedResult).toEqual({message: "second"})
-
-    await worker.stop()
-    await main.stop()
   })
 
   it("runs multiple inline jobs in parallel up to maxConcurrentInlineJobs", async () => {

--- a/spec/helpers/background-jobs-helper.js
+++ b/spec/helpers/background-jobs-helper.js
@@ -55,6 +55,62 @@ export async function startBackgroundJobs({workerOptions = {}} = {}) {
 }
 
 /**
+ * Runs a callback with an owned main/worker pair and stops both services before returning or throwing.
+ * @template T
+ * @param {(backgroundJobs: {main: BackgroundJobsMain, store: BackgroundJobsStore, worker: BackgroundJobsWorker}) => Promise<T>} callback - Owned background-jobs callback.
+ * @param {object} [args] - Start options.
+ * @param {(args: {workerOptions?: ConstructorParameters<typeof BackgroundJobsWorker>[0]}) => Promise<{main: BackgroundJobsMain, store: BackgroundJobsStore, worker: BackgroundJobsWorker}>} [args.start] - Service factory override for lifecycle tests.
+ * @param {ConstructorParameters<typeof BackgroundJobsWorker>[0]} [args.workerOptions] - Worker constructor options.
+ * @returns {Promise<T>} - Callback result after both services stop.
+ */
+export async function withBackgroundJobs(callback, args) {
+  const start = args?.start || startBackgroundJobs
+  const backgroundJobs = await start({workerOptions: args?.workerOptions})
+  let callbackFailed = false
+  let callbackError
+  /** @type {T} */
+  let result
+
+  try {
+    result = await callback(backgroundJobs)
+  } catch (error) {
+    callbackFailed = true
+    callbackError = error
+  }
+
+  const cleanupErrors = []
+
+  try {
+    await backgroundJobs.worker.stop()
+  } catch (error) {
+    cleanupErrors.push(error)
+  }
+
+  try {
+    await backgroundJobs.main.stop()
+  } catch (error) {
+    cleanupErrors.push(error)
+  }
+
+  if (callbackFailed && cleanupErrors.length > 0) {
+    throw new AggregateError(
+      [callbackError, ...cleanupErrors],
+      "Background jobs callback and cleanup failed",
+      {cause: callbackError}
+    )
+  }
+
+  if (cleanupErrors.length > 1) {
+    throw new AggregateError(cleanupErrors, "Background jobs cleanup failed", {cause: cleanupErrors[0]})
+  }
+
+  if (cleanupErrors.length === 1) throw cleanupErrors[0]
+  if (callbackFailed) throw callbackError
+
+  return result
+}
+
+/**
  * @param {object} [args] - Options.
  * @param {import("../../src/configuration-types.js").BackgroundJobsConfiguration} [args.backgroundJobsConfig] - Background jobs config override.
  * @param {boolean} [args.waitForWorkerStop] - Wait for the paired worker before closing shared test connections.


### PR DESCRIPTION
## Summary

- add an ownership helper for background-jobs tests that always awaits worker shutdown followed by main shutdown
- preserve callback failures and aggregate simultaneous callback/cleanup failures
- convert the MSSQL-poisoning queue test so an early assertion failure cannot leak scheduler/main work into later database cleanup
- add deterministic barrier-driven lifecycle coverage

## Root cause

Post-merge master CI showed `MS-SQL (3/3)` continuing after `queue-spec.js:86` failed before its trailing manual `worker.stop()` / `main.stop()` calls. The leaked `BackgroundJobsScheduler` and `BackgroundJobsMain` retained MSSQL transaction activity; repeated `_reconcileConcurrency()` updates waited on `LCK_M_U` while later tests attempted foreign-key disable/truncation. This poisoned dozens of subsequent tests until the one-hour build timeout.

## Validation

- helper lifecycle regression — 1 passing
- queue producer spec — 7 passing
- scheduler overlap — 1 passing
- main startup adapter lifecycle — 3 passing
- stable schedule dispatch — 5 passing
- worker/main shutdown — 22 passing
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`

## Review

Terminal independent read-only review: **PASS**, no findings.

## Release chain

Direct blocker for publishing `velocious@1.0.601` after merged PR #1045.
