### PR TITLE
Add test profiling and timing manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 * Gap-less positional lists with automatic reordering via `actsAsList`, including models with numeric, string, or UUID primary keys (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))
 * Async-aware test-data factories with inherited traits, graph-first native association autosave, metadata-aware override precedence, callbacks, sequences, linting, and a process-global reload-retention budget that bounds cache-busted re-import memory (see [docs/factories.md](docs/factories.md))
+* Opt-in Benchmark-style test profiling with privacy-safe rich JSON and directly reusable duration-aware shard manifests (see [docs/test-profiling.md](docs/test-profiling.md))
 * Per-row association counts via `.withCount(...)`, including cohort-safe intersected filters, safe batching of structurally identical aggregates, and automatic IN-list chunking for large parent sets, on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)`, with compatible projections sharing a roundtrip while preserving declared alias-overwrite order and automatic IN-list chunking for large parent sets, on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
@@ -226,6 +227,22 @@ Slowest 10 tests:
 ```
 
 The report is skipped for single-test runs. See [docs/testing-guidelines.md](docs/testing-guidelines.md).
+
+Add `--profile` for a compact Benchmark-style phase and pool summary. Use
+`--profile-json <path>` for versioned, privacy-safe detail or
+`--timing-manifest-output <path>` to generate a sorted per-file duration map for
+the existing `--timing-manifest` shard input; either output flag implies
+profiling.
+
+```bash
+npx velocious test --profile-json tmp/test-profile.json \
+  --timing-manifest-output tmp/test-timings.json
+npx velocious test --groups=4 --group-number=1 \
+  --timing-manifest tmp/test-timings.json
+```
+
+See [test profiling](docs/test-profiling.md) for lifecycle accounting, custom
+activity spans, schema, and privacy guarantees.
 
 Prefer waiting for a real signal or condition over sleeping a fixed duration. `waitForEvent(emitter, eventName, {timeoutMs, filter})` resolves the instant a matching event fires (a background job finishing, a model update, a websocket message) and rejects on timeout; for polling an arbitrary condition, use awaitery's `waitFor`.
 
@@ -1769,7 +1786,12 @@ database: {
 
 `pool.max` caps live async-tracked connections for that pool and defaults to `10` when omitted. When the cap is reached, new checkouts wait until a matching checked-in connection can be handed over or capacity is freed. Set `pool.max` to `null` only when a process is deliberately allowed to open an unbounded number of database connections. The built-in debug endpoint reports each in-use connection's `checkedOutForMs`, each idle connection's `idleForMs`, and queued `pendingCheckouts[].waitingForMs` so production diagnostics can distinguish long-held checkouts from pool-capacity waits.
 
-Debug snapshots also expose cumulative checkout-wait and idle-reaper disposal telemetry. The [MySQL idle-reaping benchmark and methodology](docs/mysql-pool-idle-reaping-research.md) compare the 5-second default with 60 seconds and disabled reaping under a fixed cap; absent representative measured evidence, retain the 5-second default.
+Debug snapshots also expose cumulative connection-creation, checkout-wait and
+timeout, idle-reap, and peak-live-connection telemetry. Opt-in test profiles can
+attribute safe aggregate deltas to their current spans. The [MySQL idle-reaping
+benchmark and methodology](docs/mysql-pool-idle-reaping-research.md) compare the
+5-second default with 60 seconds and disabled reaping under a fixed cap; absent
+representative measured evidence, retain the 5-second default.
 
 # Websockets
 

--- a/changelog.d/20260816175427-test-profiling.md
+++ b/changelog.d/20260816175427-test-profiling.md
@@ -1,0 +1,3 @@
+Add opt-in Benchmark-style test profiling with async-safe lifecycle attribution,
+privacy-safe versioned JSON, database and pool aggregates, custom activity spans,
+and directly reusable duration-aware shard manifests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, and legacy-byte migration.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/tenant-selected-database-generation.md`: Explicit, immutable tenant database selection for base-model and structure generation.
+- `docs/test-profiling.md`: Opt-in test profiling, rich JSON/privacy guarantees, custom activity spans, and timing-manifest generation.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/translations.md`: Translated record attributes, `currentTranslation`, and translated frontend-model sorting.
 - `docs/routing-hooks-and-autoroutes.md`: Route hook support and frontend-model autoroute behavior.

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -36,7 +36,15 @@ Framework persistence stores that already own one database identifier, such as t
 
 When every allowed connection is checked out, additional checkouts wait for a compatible connection to be checked in or for capacity to be freed. Waiting checkouts time out after `10000` ms by default. Configure `database.<environment>.<identifier>.pool.checkoutTimeoutMillis` to change that wait, or set it to `null` to wait indefinitely.
 
-Pool debug snapshots include cumulative low-cardinality telemetry for completed checkout queue waits (`checkoutWaitCount`, `checkoutWaitTotalMs`, and `checkoutWaitMaxMs`) and idle-reaper disposals (`idleReapDisposalCount`). These counters contain no checkout or tenant labels. See [MySQL outer-pool idle reaping research](mysql-pool-idle-reaping-research.md) for the reproducible 5-second/60-second/disabled comparison and safe interpretation for tenant-heavy processes.
+Pool debug snapshots include cumulative low-cardinality telemetry for connection
+creation count/failures/total/max, completed checkout queue waits, checkout
+timeouts, idle-reap count/failures/total/max/disposals, and peak live
+connections. These counters contain no checkout or tenant labels. When opt-in
+[test profiling](test-profiling.md) is active, safe aggregate deltas are also
+attributed to the current profile span. See [MySQL outer-pool idle reaping
+research](mysql-pool-idle-reaping-research.md) for the reproducible
+5-second/60-second/disabled comparison and safe interpretation for tenant-heavy
+processes.
 
 MySQL/MariaDB callers can cancel queued and in-flight statements with an `AbortSignal`, including ORM model queries and cross-tenant aggregates. See [Database Query Cancellation](database-query-cancellation.md) for the API and driver-specific behavior.
 

--- a/docs/test-profiling.md
+++ b/docs/test-profiling.md
@@ -1,0 +1,116 @@
+# Test profiling
+
+Velocious test profiling is opt-in. A normal `npx velocious test` run does not
+create a collector or write profile files.
+
+## CLI flags
+
+Profiling flags must appear before the `--` argument separator. Paths may use a
+separate argument or `=` syntax, and relative paths resolve from the command's
+current working directory.
+
+```bash
+# Compact Benchmark-style console summary only
+npx velocious test --profile spec/models/task-spec.js
+
+# Console summary plus rich JSON; this flag implies --profile
+npx velocious test --profile-json tmp/test-profile.json spec/models/task-spec.js
+
+# Generate weights for the existing duration-aware shard splitter
+npx velocious test \
+  --profile-json=tmp/test-profile.json \
+  --timing-manifest-output=tmp/test-timings.json
+
+# Consume the generated map unchanged on a later run
+npx velocious test \
+  --groups=4 \
+  --group-number=1 \
+  --timing-manifest=tmp/test-timings.json
+```
+
+`--timing-manifest-output` also implies `--profile`. Velocious validates missing
+values, duplicate output destinations, and an output that aliases the
+`--timing-manifest` input before test discovery. Requested files are written via
+a same-directory temporary file and atomic rename. A write failure fails the
+command. Profiles are finalized when possible for passing, failing, focused,
+no-test, import-error, and handled interruption outcomes.
+
+## Console and rich JSON
+
+The console output is deliberately compact: a fixed-width table reports count,
+wall-clock milliseconds, and process CPU milliseconds for discovery, imports,
+testing configuration/global setup, hooks, test bodies, bounded custom
+activities, runner overhead, and total time. A low-cardinality pool summary and
+requested output paths follow the table. It never prints individual queries or
+every test.
+
+Rich output is identified by:
+
+```json
+{
+  "schema": "velocious.test-profile",
+  "schemaVersion": 1
+}
+```
+
+Schema version 1 includes the run status, aggregate selection and shard data,
+counts, phase aggregates, file weights, opaque scopes and tests, every retry
+attempt, hook/test/custom spans, database and transaction aggregates, pool
+lifecycle aggregates, an unattributed late-event count, and the embedded timing
+manifest. Durations are finite, non-negative milliseconds rounded to three
+decimal places.
+
+Nested hooks have distinct invocation spans with declaration scope/index and
+execution order. Every retry remains present with its complete cost. Async work
+that outlives its attempt retains that attempt's closed async context; it cannot
+be attributed to the next test and instead increments
+`unattributedLateEventCount` when it emits profiled activity.
+
+Database metrics count successful and failed physical query attempts and
+physical start/commit/rollback actions. Query fingerprints contain only a hash
+and a fixed-allowlist operation plus aggregate count/failed/total/max values;
+unrecognized leading tokens are reported as `UNKNOWN`, and at most 50 distinct
+fingerprints are retained. Pool metrics contain logical pool identifiers and
+aggregate connection-creation, checkout-wait/timeout, idle-reap, and peak-live
+connection values.
+
+## Privacy boundary
+
+The profile contains project-relative source paths, logical pool identifiers,
+aggregate numeric values, and hashes. Test and scope descriptions become opaque
+hashes.
+
+Velocious does not serialize SQL, bind values, credentials, database names,
+hosts, usernames, tenant values, checkout names, connection reuse keys, error
+messages or stacks. Application data must not be placed in custom activity
+labels. Labels are restricted to lowercase identifiers of at most 64 characters
+using letters, digits, `.`, `_`, `:`, or `-`, and the profile retains at most 20
+distinct labels before aggregating new labels as `other`.
+
+## Application-defined setup and cleanup spans
+
+Use `Configuration#profileTestActivity(name, callback)` around app-owned work
+whose cost is otherwise hidden inside a broader hook or test body:
+
+```js
+await configuration.profileTestActivity("search-index.reset", async () => {
+  await resetSearchIndex()
+})
+```
+
+The callback always runs. Outside an active opt-in profile, the method adds no
+span and otherwise behaves as a pass-through.
+
+## Timing-manifest ownership
+
+The plain timing manifest is a sorted, two-space JSON object with a trailing
+newline. Each key is a project-relative entry test file and each value is its
+measured total milliseconds. Its weight includes that entry's import, file-owned
+`beforeAll`/`afterAll`, and every attempt of its tests. Complete attempt time
+includes inherited `beforeEach`/`afterEach` work and retry cost. Shard-global
+fixed setup is excluded.
+
+When an entry imports a helper that registers tests or hooks, those registrations
+belong deterministically to the importing entry file. This keeps helper source
+paths out of the manifest and makes the generated file directly consumable by
+[`--timing-manifest`](testing-guidelines.md#duration-aware-parallel-sharding).

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -117,6 +117,11 @@ run. Each line shows the duration, full description and `file:line`.
 `TestRunner#getSlowestTests(limit = 10)` exposes the same data programmatically
 (slowest first; `limit` of `0` returns every recorded test).
 
+For a phase breakdown, retry/hook attribution, database and pool aggregates, or
+reusable file weights, enable the opt-in [test profiler](test-profiling.md).
+`--profile` prints only the compact summary, while `--profile-json <path>` and
+`--timing-manifest-output <path>` also write atomic outputs and imply profiling.
+
 ## Duration-aware parallel sharding
 Pass `--timing-manifest=<path>` together with `--groups` and `--group-number` to
 weight discovered test files by recorded wall-clock duration. The JSON object maps
@@ -134,6 +139,9 @@ normalized when reading keys. A valid duration takes precedence over the static
 directory/browser heuristic for that file. Missing paths, unknown paths, non-number,
 non-positive, or non-finite durations fall back per file. Missing, unreadable, or
 malformed JSON manifests also leave the existing deterministic heuristic intact.
+Generate a compatible sorted manifest from a representative run with
+`--timing-manifest-output <path>`; see [test profiling](test-profiling.md#timing-manifest-ownership)
+for file ownership and retry/hook accounting.
 
 ## Avoiding fixed sleeps
 Never `await wait(<fixed ms>)` to let something async settle — it is both slow and

--- a/spec/cli/commands/test-profile-integration-spec.js
+++ b/spec/cli/commands/test-profile-integration-spec.js
@@ -1,0 +1,310 @@
+// @ts-check
+
+import { execFile, spawn } from "node:child_process"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { promisify } from "node:util"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "../../../src/testing/test.js"
+
+const execFileAsync = promisify(execFile)
+const repositoryDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
+const dummyDirectory = path.join(repositoryDirectory, "spec", "dummy")
+const cliPath = path.join(repositoryDirectory, "bin", "velocious.js")
+
+/**
+ * Creates an ignored dummy-app temporary directory for CLI fixture files and outputs.
+ * @param {string} prefix - Directory prefix.
+ * @returns {Promise<string>} - Absolute temporary directory.
+ */
+async function makeTestDirectory(prefix) {
+  const temporaryRoot = path.join(dummyDirectory, "tmp")
+
+  await fs.mkdir(temporaryRoot, {recursive: true})
+  return await fs.mkdtemp(path.join(temporaryRoot, prefix))
+}
+
+/**
+ * Writes a temporary test entry and returns its dummy-project-relative path.
+ * @param {string} directory - Temporary directory.
+ * @param {string} fileName - Fixture filename.
+ * @param {string} source - Fixture source.
+ * @returns {Promise<string>} - Portable project-relative path.
+ */
+async function writeTestFixture(directory, fileName, source) {
+  const filePath = path.join(directory, fileName)
+
+  await fs.writeFile(filePath, source, "utf8")
+  return path.relative(dummyDirectory, filePath).replaceAll(path.sep, "/")
+}
+
+/**
+ * @param {string[]} args - Test command arguments after `test`.
+ * @returns {Promise<{code: number, stderr: string, stdout: string}>} - Child result.
+ */
+async function runTestCommand(args) {
+  const environment = {...process.env, MSSQL_SA_PASSWORD: "test-password", VELOCIOUS_DISABLE_MSSQL: "1"}
+
+  delete environment.VELOCIOUS_TEST_DIR
+
+  try {
+    const {stderr, stdout} = await execFileAsync(process.execPath, [cliPath, "test", ...args], {
+      cwd: dummyDirectory,
+      env: environment
+    })
+
+    return {code: 0, stderr, stdout}
+  } catch (error) {
+    const childError = /** @type {Error & {code?: number, stderr?: string, stdout?: string}} */ (error)
+
+    return {
+      code: typeof childError.code === "number" ? childError.code : 1,
+      stderr: childError.stderr || "",
+      stdout: childError.stdout || ""
+    }
+  }
+}
+
+/**
+ * Starts a test command and interrupts it once its test body reports readiness.
+ * @param {string[]} args - Test command arguments after `test`.
+ * @param {string} readyOutput - Output proving the test lifecycle is active.
+ * @returns {Promise<{code: number, stderr: string, stdout: string}>} - Interrupted child result.
+ */
+async function runInterruptedTestCommand(args, readyOutput) {
+  const environment = {...process.env, MSSQL_SA_PASSWORD: "test-password", VELOCIOUS_DISABLE_MSSQL: "1"}
+
+  delete environment.VELOCIOUS_TEST_DIR
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, "test", ...args], {
+      cwd: dummyDirectory,
+      env: environment
+    })
+    let signalSent = false
+    let stderr = ""
+    let stdout = ""
+
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString() })
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString()
+
+      if (!signalSent && stdout.includes(readyOutput)) {
+        signalSent = true
+        child.kill("SIGINT")
+      }
+    })
+    child.once("error", reject)
+    child.once("close", (code) => {
+      if (!signalSent) {
+        reject(new Error(`Test command exited before emitting ${JSON.stringify(readyOutput)}`))
+        return
+      }
+
+      resolve({code: code ?? 1, stderr, stdout})
+    })
+  })
+}
+
+describe("test profile CLI integration", () => {
+  it("writes pass profile and manifest outputs and prints the compact summary", async () => {
+    const directory = await makeTestDirectory("velocious-profile-cli-pass-")
+    const profilePath = path.join(directory, "profile.json")
+    const manifestPath = path.join(directory, "timings.json")
+
+    try {
+      const testPath = await writeTestFixture(directory, "pass.fixture.js", `
+        import { describe, it } from "velocious/build/src/testing/test.js"
+        describe("profile CLI pass fixture", () => { it("passes", async () => {}) })
+      `)
+      const result = await runTestCommand([
+        "--profile-json",
+        profilePath,
+        `--timing-manifest-output=${manifestPath}`,
+        testPath
+      ])
+      const profile = JSON.parse(await fs.readFile(profilePath, "utf8"))
+      const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"))
+
+      expect(result.code).toBe(0)
+      expect(result.stdout.includes("Test profile")).toBe(true)
+      expect(profile.status).toBe("passed")
+      expect(profile.counts).toEqual({attempts: 1, discovered: 1, executed: 1, failed: 0, passed: 1})
+      expect(profile.selection.fileCount).toBe(1)
+      expect(profile.phases.discovery.count).toBe(1)
+      expect(profile.phases.imports.count).toBe(1)
+      expect(Object.keys(manifest)).toEqual([testPath])
+      expect(profile.timingManifest).toEqual(manifest)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("assigns imported helper declarations and inherited hook costs to the entry file", async () => {
+    const directory = await makeTestDirectory("velocious-profile-cli-owner-")
+    const profilePath = path.join(directory, "profile.json")
+    const manifestPath = path.join(directory, "timings.json")
+
+    try {
+      await writeTestFixture(directory, "helper-definitions.js", `
+        import { beforeEach, describe, it } from "velocious/build/src/testing/test.js"
+        describe("profile helper-owned declarations", () => {
+          beforeEach(async () => {})
+          it("belongs to its importing entry file", async () => {})
+        })
+      `)
+      const entryPath = await writeTestFixture(directory, "helper-owned.fixture.js", `
+        import "./helper-definitions.js"
+      `)
+      const result = await runTestCommand([
+        `--profile-json=${profilePath}`,
+        `--timing-manifest-output=${manifestPath}`,
+        entryPath
+      ])
+      const profile = JSON.parse(await fs.readFile(profilePath, "utf8"))
+      const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"))
+      const beforeEachSpan = profile.tests[0].attempts[0].spans.find((span) => span.phase === "beforeEach")
+
+      expect(result.code).toBe(0)
+      expect(Object.keys(manifest)).toEqual([entryPath])
+      expect(profile.files.map((file) => file.path)).toEqual([entryPath])
+      expect(profile.tests[0].attempts.length).toBe(1)
+      expect(beforeEachSpan.file).toBe(entryPath)
+      expect(profile.timingManifest).toEqual(manifest)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("finalizes failure and focused profiles before their non-zero exits", async () => {
+    const directory = await makeTestDirectory("velocious-profile-cli-outcomes-")
+
+    try {
+      const failurePath = path.join(directory, "failure.json")
+      const focusedPath = path.join(directory, "focused.json")
+      const failureTestPath = await writeTestFixture(directory, "fail.fixture.js", `
+        import { describe, it } from "velocious/build/src/testing/test.js"
+        describe("profile CLI failure fixture", () => {
+          it("fails", async () => { throw new Error("fixture failure must not enter profile JSON") })
+        })
+      `)
+      const focusedTestPath = await writeTestFixture(directory, "focused.fixture.js", `
+        import { describe, fit } from "velocious/build/src/testing/test.js"
+        describe("profile CLI focused fixture", () => { fit("is focused", async () => {}) })
+      `)
+      const failure = await runTestCommand([`--profile-json=${failurePath}`, failureTestPath])
+      const focused = await runTestCommand([`--profile-json=${focusedPath}`, focusedTestPath])
+      const failureProfile = JSON.parse(await fs.readFile(failurePath, "utf8"))
+      const focusedProfile = JSON.parse(await fs.readFile(focusedPath, "utf8"))
+
+      expect(failure.code).toBe(1)
+      expect(focused.code).toBe(1)
+      expect(failureProfile.status).toBe("failed")
+      expect(failureProfile.counts.failed).toBe(1)
+      expect(focusedProfile.status).toBe("focused")
+      expect(focusedProfile.selection.focused).toBe(true)
+      expect(JSON.stringify(failureProfile).includes("fixture failure")).toBe(false)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("counts tests once when successful bodies have failing cleanup and retries", async () => {
+    const directory = await makeTestDirectory("velocious-profile-cli-cleanup-counts-")
+    const failureProfilePath = path.join(directory, "failure-profile.json")
+    const retryProfilePath = path.join(directory, "retry-profile.json")
+
+    try {
+      const failureTestPath = await writeTestFixture(directory, "cleanup-failure.fixture.js", `
+        import { afterEach, describe, it } from "velocious/build/src/testing/test.js"
+        describe("profile cleanup failure", () => {
+          afterEach(async () => { throw new Error("expected cleanup failure") })
+          it("has a successful body", async () => {})
+        })
+      `)
+      const retryTestPath = await writeTestFixture(directory, "cleanup-retry.fixture.js", `
+        import { afterEach, describe, it } from "velocious/build/src/testing/test.js"
+        describe("profile cleanup retry", () => {
+          let cleanupCount = 0
+          afterEach(async () => {
+            cleanupCount++
+            if (cleanupCount === 1) throw new Error("expected retry cleanup failure")
+          })
+          it("retries a successful body", {retry: 1}, async () => {})
+        })
+      `)
+      const failureResult = await runTestCommand([`--profile-json=${failureProfilePath}`, failureTestPath])
+      const retryResult = await runTestCommand([`--profile-json=${retryProfilePath}`, retryTestPath])
+      const failureProfile = JSON.parse(await fs.readFile(failureProfilePath, "utf8"))
+      const retryProfile = JSON.parse(await fs.readFile(retryProfilePath, "utf8"))
+
+      expect(failureResult.code).toBe(1)
+      expect(retryResult.code).toBe(0)
+      expect(failureProfile.counts).toEqual({attempts: 1, discovered: 1, executed: 1, failed: 1, passed: 0})
+      expect(retryProfile.counts).toEqual({attempts: 2, discovered: 1, executed: 1, failed: 0, passed: 1})
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("finalizes no-tests and import-error profiles when output remains possible", async () => {
+    const directory = await makeTestDirectory("velocious-profile-cli-errors-")
+
+    try {
+      const noTestsPath = path.join(directory, "no-tests.json")
+      const importErrorPath = path.join(directory, "import-error.json")
+      const noTestsTestPath = await writeTestFixture(directory, "empty.fixture.js", "export {}\n")
+      const importErrorTestPath = await writeTestFixture(
+        directory,
+        "import-error.fixture.js",
+        'throw new Error("fixture import error must not enter profile JSON")\n'
+      )
+      const noTests = await runTestCommand([`--profile-json=${noTestsPath}`, noTestsTestPath])
+      const importError = await runTestCommand([`--profile-json=${importErrorPath}`, importErrorTestPath])
+      const noTestsProfile = JSON.parse(await fs.readFile(noTestsPath, "utf8"))
+      const importErrorProfile = JSON.parse(await fs.readFile(importErrorPath, "utf8"))
+
+      expect(noTests.code).toBe(1)
+      expect(importError.code).toBe(1)
+      expect(noTestsProfile.status).toBe("no-tests")
+      expect(noTestsProfile.counts.executed).toBe(0)
+      expect(importErrorProfile.status).toBe("error")
+      expect(JSON.stringify(importErrorProfile).includes("fixture import error")).toBe(false)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("closes the active attempt and spans at the signal interruption boundary", async () => {
+    const directory = await makeTestDirectory("velocious-profile-cli-interrupt-")
+    const profilePath = path.join(directory, "interrupted.json")
+    const readyOutput = "VELOCIOUS_PROFILE_INTERRUPT_READY"
+
+    try {
+      const testPath = await writeTestFixture(directory, "interrupted.fixture.js", `
+        import { configureTests, describe, it } from "velocious/build/src/testing/test.js"
+        configureTests({consoleOutput: "live"})
+        describe("profile CLI interruption fixture", () => {
+          it("is interrupted", async () => {
+            console.log("${readyOutput}")
+            await new Promise(() => {})
+          })
+        })
+      `)
+      const result = await runInterruptedTestCommand([`--profile-json=${profilePath}`, testPath], readyOutput)
+      const profile = JSON.parse(await fs.readFile(profilePath, "utf8"))
+      const attempt = profile.tests[0].attempts[0]
+      const file = profile.files.find((profileFile) => profileFile.path === testPath)
+
+      expect(result.code).toBe(130)
+      expect(profile.status).toBe("interrupted")
+      expect(attempt.status).toBe("interrupted")
+      expect(attempt.durationMs).toBeGreaterThan(0)
+      expect(attempt.spans.every((span) => span.durationMs > 0)).toBe(true)
+      expect(file.attemptsMs).toBe(attempt.durationMs)
+      expect(profile.timingManifest[testPath]).toBe(file.totalMs)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+})

--- a/spec/cli/commands/test-profile-options-spec.js
+++ b/spec/cli/commands/test-profile-options-spec.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+import path from "node:path"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import { resolveTestProfileOptions } from "../../../src/environment-handlers/node/cli/commands/test.js"
+
+describe("test profile CLI options", () => {
+  it("resolves relative output paths from the command cwd", () => {
+    const cwd = path.join(path.sep, "workspace", "application")
+    const options = resolveTestProfileOptions({
+      cwd,
+      profile: false,
+      profileJsonPath: "tmp/profile.json",
+      timingManifestOutputPath: "tmp/timings.json"
+    })
+
+    expect(options.profile).toBe(true)
+    expect(options.profileJsonPath).toBe(path.join(cwd, "tmp/profile.json"))
+    expect(options.timingManifestOutputPath).toBe(path.join(cwd, "tmp/timings.json"))
+  })
+
+  it("rejects output collisions", async () => {
+    await expect(() => resolveTestProfileOptions({
+      cwd: "/workspace",
+      profile: true,
+      profileJsonPath: "tmp/result.json",
+      timingManifestOutputPath: "./tmp/result.json"
+    })).toThrow(/profiling output paths must be different/)
+  })
+
+  it("rejects an output that aliases the timing manifest input", async () => {
+    await expect(() => resolveTestProfileOptions({
+      cwd: "/workspace",
+      profile: true,
+      profileJsonPath: "tmp/timings.json",
+      timingManifestPath: "./tmp/timings.json"
+    })).toThrow(/must not overwrite --timing-manifest input/)
+  })
+})

--- a/spec/database/drivers/test-profiler-database-metrics-spec.js
+++ b/spec/database/drivers/test-profiler-database-metrics-spec.js
@@ -1,0 +1,139 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import DatabaseDriverBase from "../../../src/database/drivers/base.js"
+import EnvironmentHandlerNode from "../../../src/environment-handlers/node.js"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import TestProfiler from "../../../src/testing/test-profiler.js"
+
+class ProfileMetricsDriver extends DatabaseDriverBase {
+  /** @returns {string} - Driver type. */
+  getType() { return "profile-test" }
+
+  /** @returns {string} - Primary key type. */
+  primaryKeyType() { return "bigint" }
+
+  /**
+   * @param {string} sql - SQL string.
+   * @returns {Promise<import("../../../src/database/drivers/base.js").QueryResultType>} - Query result.
+   */
+  async _queryActual(sql) {
+    if (sql.includes("FAIL_PROFILE_QUERY")) throw new Error("secret database failure text")
+
+    return []
+  }
+
+  /** @returns {Promise<number>} - Simulated affected rows. */
+  async _affectedRowsActual() { return 1 }
+}
+
+describe("test profiler database metrics", () => {
+  it("allowlists serialized SQL operations without exposing arbitrary leading tokens", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const filePath = `${process.cwd()}/spec/database/profile-operation-example-spec.js`
+    const attempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["database profile operations"],
+      testData: {args: {}, filePath, line: 8, ownerFilePath: filePath, function: async () => {}},
+      testDescription: "records safe operations"
+    })
+    const driver = new ProfileMetricsDriver({}, configuration)
+
+    await profiler.runAttempt(attempt, async () => {
+      await driver.query("SensitiveTenantValue malformed profile query")
+      await driver.query("SELECT 1")
+      await driver.query("INSERT INTO profile_values(id) VALUES (1)")
+      await driver.query("WITH profile_value AS (SELECT 1) SELECT * FROM profile_value")
+    })
+    profiler.finishAttempt(attempt, "passed")
+
+    const profile = profiler.finish({
+      counts: {discovered: 1, executed: 1, failed: 0, passed: 1},
+      focused: false,
+      status: "passed"
+    })
+    const serialized = JSON.stringify(profile)
+    const operations = profile.database.fingerprints.map((fingerprint) => fingerprint.operation)
+
+    expect(operations).toEqual(["INSERT", "SELECT", "UNKNOWN", "WITH"])
+    expect(serialized.includes("SENSITIVETENANTVALUE")).toBe(false)
+    expect(serialized.includes("SensitiveTenantValue")).toBe(false)
+  })
+
+  it("records physical query attempts and transaction actions without retaining sensitive values", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const filePath = `${process.cwd()}/spec/database/profile-example-spec.js`
+    const attempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["database profile"],
+      testData: {args: {}, filePath, line: 12, ownerFilePath: filePath, function: async () => {}},
+      testDescription: "does database work"
+    })
+    const driver = new ProfileMetricsDriver({}, configuration)
+
+    await profiler.runAttempt(attempt, async () => {
+      await profiler.runSpan({phase: "test body"}, async () => {
+        await driver.query("SELECT * FROM accounts WHERE token = 'super-secret-tenant'")
+        await driver.affectedRows("DELETE FROM accounts WHERE token = 'super-secret-tenant'")
+
+        try {
+          await driver.query("UPDATE accounts SET token = 'super-secret-tenant' /* FAIL_PROFILE_QUERY */", {retry: false})
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error)
+        }
+
+        await driver.transaction(async () => {})
+
+        try {
+          await driver.transaction(async () => { throw new Error("secret callback failure") })
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error)
+        }
+
+        for (let index = 0; index < 55; index++) {
+          await driver.query(`SELECT profile_column_${index} FROM profile_table_${index}`)
+        }
+      })
+    })
+    profiler.finishAttempt(attempt, "passed")
+
+    const profile = profiler.finish({
+      counts: {discovered: 1, executed: 1, failed: 0, passed: 1},
+      focused: false,
+      status: "passed"
+    })
+    const serialized = JSON.stringify(profile)
+
+    expect(profile.database.queryCount).toBe(62)
+    expect(profile.database.failedQueryCount).toBe(1)
+    expect(profile.database.fingerprints.length).toBe(50)
+    expect(profile.database.transactions.start.count).toBe(2)
+    expect(profile.database.transactions.commit.count).toBe(1)
+    expect(profile.database.transactions.rollback.count).toBe(1)
+    expect(profile.database.totalMs).toBeGreaterThanOrEqual(0)
+    expect(profile.database.maxMs).toBeGreaterThanOrEqual(0)
+    expect(serialized.includes("super-secret-tenant")).toBe(false)
+    expect(serialized.includes("secret database failure text")).toBe(false)
+    expect(profile.tests[0].attempts[0].spans[0].database.queryCount).toBe(62)
+  })
+})

--- a/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
+++ b/spec/database/pool/async-tracked-multi-connection-idle-reaper-spec.js
@@ -101,12 +101,22 @@ describe("database - pool - async tracked multi connection idle reaper", () => {
       await pool.reapIdleConnections()
 
       expect(checkedInConnection.connection).toEqual(undefined)
-      expect(pool.getDebugSnapshot().telemetry).toEqual({
-        checkoutWaitCount: 0,
-        checkoutWaitMaxMs: 0,
-        checkoutWaitTotalMs: 0,
-        idleReapDisposalCount: 1
-      })
+      const telemetry = pool.getDebugSnapshot().telemetry
+
+      expect(telemetry?.connectionCreationCount).toEqual(1)
+      expect(telemetry?.connectionCreationFailureCount).toEqual(0)
+      expect(telemetry?.connectionCreationMaxMs).toBeGreaterThanOrEqual(0)
+      expect(telemetry?.connectionCreationTotalMs).toBeGreaterThanOrEqual(0)
+      expect(telemetry?.checkoutTimeoutCount).toEqual(0)
+      expect(telemetry?.checkoutWaitCount).toEqual(0)
+      expect(telemetry?.checkoutWaitMaxMs).toEqual(0)
+      expect(telemetry?.checkoutWaitTotalMs).toEqual(0)
+      expect(telemetry?.idleReapCount).toEqual(1)
+      expect(telemetry?.idleReapDisposalCount).toEqual(1)
+      expect(telemetry?.idleReapFailureCount).toEqual(0)
+      expect(telemetry?.idleReapMaxMs).toBeGreaterThanOrEqual(0)
+      expect(telemetry?.idleReapTotalMs).toBeGreaterThanOrEqual(0)
+      expect(telemetry?.peakLiveConnections).toEqual(1)
     } finally {
       await cleanup()
     }

--- a/spec/database/pool/test-profiler-pool-metrics-spec.js
+++ b/spec/database/pool/test-profiler-pool-metrics-spec.js
@@ -1,0 +1,343 @@
+// @ts-check
+
+import Configuration from "../../../src/configuration.js"
+import DatabaseDriverBase from "../../../src/database/drivers/base.js"
+import AsyncTrackedMultiConnection from "../../../src/database/pool/async-tracked-multi-connection.js"
+import EnvironmentHandlerNode from "../../../src/environment-handlers/node.js"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import TestProfiler from "../../../src/testing/test-profiler.js"
+
+class ProfilePoolDriver extends DatabaseDriverBase {
+  connected = false
+  closed = false
+
+  async connect() { this.connected = true }
+  async close() { this.closed = true }
+  /** @returns {string} - Driver type. */
+  getType() { return "profile-pool" }
+  /** @returns {string} - Primary key type. */
+  primaryKeyType() { return "bigint" }
+}
+
+class FailingProfilePoolDriver extends ProfilePoolDriver {
+  async connect() { throw new Error("secret connection failure") }
+}
+
+class ContextCapturingProfilePoolDriver extends ProfilePoolDriver {
+  /** @type {import("../../../src/testing/test-profiler.js").TestProfileAsyncContext | undefined} */
+  activationProfileContext = undefined
+
+  async setConnectionCheckoutName(name) {
+    this.activationProfileContext = this.configuration.getEnvironmentHandler().getCurrentTestProfileContext()
+    await super.setConnectionCheckoutName(name)
+  }
+}
+
+class FailingCloseProfilePoolDriver extends ProfilePoolDriver {
+  async close() { throw new Error("secret close failure") }
+}
+
+class DeterministicProfilePool extends AsyncTrackedMultiConnection {
+  /** @type {number[]} */
+  clockValues = []
+
+  /** @param {number[]} values - Clock reads. */
+  setClockValues(values) { this.clockValues = [...values] }
+
+  /** @returns {number} - Deterministic time. */
+  nowMs() {
+    const value = this.clockValues.shift()
+
+    if (value === undefined) throw new Error("Expected a deterministic pool clock value")
+
+    return value
+  }
+
+  /**
+   * @returns {{expiredConnections: import("../../../src/database/drivers/base.js").default[], keptConnections: import("../../../src/database/drivers/base.js").default[]}} - Deterministic expiry.
+   */
+  classifyIdleConnectionsForReaping() {
+    return {expiredConnections: [...this.connections], keptConnections: []}
+  }
+}
+
+function buildConfiguration() {
+  return new Configuration({
+    database: {
+      test: {
+        default: {
+          driver: ProfilePoolDriver,
+          pool: {idleTimeoutMillis: 1},
+          type: "profile-pool"
+        }
+      }
+    },
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+}
+
+describe("test profiler pool metrics", () => {
+  it("records lifecycle telemetry and attributes aggregate deltas to the active span", async () => {
+    const configuration = buildConfiguration()
+    const pool = new DeterministicProfilePool({configuration, identifier: "default"})
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const filePath = `${process.cwd()}/spec/database/profile-pool-example-spec.js`
+    const attempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["pool profile"],
+      testData: {args: {}, filePath, line: 18, ownerFilePath: filePath, function: async () => {}},
+      testDescription: "uses a pool"
+    })
+    /** @type {ProfilePoolDriver | undefined} */
+    let createdConnection
+
+    await profiler.runAttempt(attempt, async () => {
+      await profiler.runSpan({phase: "test body"}, async () => {
+        pool.setClockValues([10, 14])
+        createdConnection = /** @type {ProfilePoolDriver} */ (await pool.spawnConnectionWithConfiguration({driver: ProfilePoolDriver}))
+
+        pool.setClockValues([20, 27])
+        await expect(() => pool.spawnConnectionWithConfiguration({driver: FailingProfilePoolDriver})).toThrow(/secret connection failure/)
+
+        let checkoutError
+        const pendingCheckout = {
+          databaseConfig: configuration.getDatabaseConfiguration().default,
+          enqueuedAt: 30,
+          options: {name: "tenant-sensitive-checkout"},
+          reject: (error) => { checkoutError = error },
+          resolve: () => {},
+          reuseKey: "secret-reuse-key",
+          timeoutAt: 35,
+          timeoutMillis: 5,
+          timeoutTimer: undefined,
+          testProfileContext: configuration.getEnvironmentHandler().getCurrentTestProfileContext()
+        }
+
+        pool.pendingCheckouts.push(pendingCheckout)
+        pool.setClockValues([35])
+        pool.timeoutPendingCheckout(pendingCheckout)
+        expect(checkoutError).toBeInstanceOf(Error)
+
+        pool.connections = [createdConnection]
+        pool.setClockValues([40, 40, 46])
+        await pool.reapIdleConnections()
+      })
+    })
+    profiler.finishAttempt(attempt, "passed")
+
+    const telemetry = pool.getDebugSnapshot().telemetry
+    const profile = profiler.finish({
+      counts: {discovered: 1, executed: 1, failed: 0, passed: 1},
+      focused: false,
+      status: "passed"
+    })
+    const poolProfile = profile.pools[0]
+
+    expect(telemetry.connectionCreationCount).toBe(2)
+    expect(telemetry.connectionCreationFailureCount).toBe(1)
+    expect(telemetry.connectionCreationTotalMs).toBe(11)
+    expect(telemetry.connectionCreationMaxMs).toBe(7)
+    expect(telemetry.checkoutTimeoutCount).toBe(1)
+    expect(telemetry.idleReapCount).toBe(1)
+    expect(telemetry.idleReapFailureCount).toBe(0)
+    expect(telemetry.idleReapTotalMs).toBe(6)
+    expect(telemetry.idleReapMaxMs).toBe(6)
+    expect(telemetry.idleReapDisposalCount).toBe(1)
+    expect(telemetry.peakLiveConnections).toBe(1)
+    expect(poolProfile.identifier).toBe("default")
+    expect(poolProfile.connectionCreation.count).toBe(2)
+    expect(poolProfile.checkoutWait.count).toBe(1)
+    expect(poolProfile.checkoutTimeoutCount).toBe(1)
+    expect(poolProfile.idleReap.count).toBe(1)
+    expect(poolProfile.idleReap.disposalCount).toBe(1)
+    expect(profile.tests[0].attempts[0].spans[0].pools[0].identifier).toBe("default")
+    expect(JSON.stringify(profile).includes("tenant-sensitive-checkout")).toBe(false)
+    expect(JSON.stringify(profile).includes("secret-reuse-key")).toBe(false)
+  })
+
+  it("does not schedule or measure idle reaping when idleTimeoutMillis is null", async () => {
+    const configuration = buildConfiguration()
+    configuration.getDatabaseConfiguration().default.pool = {idleTimeoutMillis: null}
+    const pool = new DeterministicProfilePool({configuration, identifier: "default"})
+    const connection = new ProfilePoolDriver({}, configuration)
+
+    pool.connections = [connection]
+
+    expect(pool.idleTimeoutMillis()).toBe(null)
+    expect(pool.hasIdleConnectionsToReap()).toBe(false)
+    pool.scheduleIdleConnectionReaper()
+    await pool.reapIdleConnections()
+
+    expect(pool.idleConnectionReaperTimer).toBe(undefined)
+    expect(pool.connections).toEqual([connection])
+    expect(connection.closed).toBe(false)
+    expect(pool.getDebugSnapshot().telemetry.idleReapCount).toBe(0)
+  })
+
+  it("records failed idle reap attempts with the deterministic pool clock", async () => {
+    const configuration = buildConfiguration()
+    const pool = new DeterministicProfilePool({configuration, identifier: "default"})
+    const connection = new FailingCloseProfilePoolDriver({}, configuration)
+
+    pool.connections = [connection]
+    pool.setClockValues([50, 50, 58])
+
+    await expect(() => pool.reapIdleConnections()).toThrow(/secret close failure/)
+
+    expect(pool.getDebugSnapshot().telemetry.idleReapCount).toBe(1)
+    expect(pool.getDebugSnapshot().telemetry.idleReapFailureCount).toBe(1)
+    expect(pool.getDebugSnapshot().telemetry.idleReapDisposalCount).toBe(0)
+    expect(pool.getDebugSnapshot().telemetry.idleReapTotalMs).toBe(8)
+    expect(pool.getDebugSnapshot().telemetry.idleReapMaxMs).toBe(8)
+  })
+
+  it("keeps queued checkout metrics on the context captured at enqueue", async () => {
+    const configuration = buildConfiguration()
+    const pool = new DeterministicProfilePool({configuration, identifier: "default"})
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const firstFilePath = `${process.cwd()}/spec/database/profile-pool-first-spec.js`
+    const secondFilePath = `${process.cwd()}/spec/database/profile-pool-second-spec.js`
+    const firstAttempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["pool profile"],
+      testData: {args: {}, filePath: firstFilePath, line: 20, ownerFilePath: firstFilePath, function: async () => {}},
+      testDescription: "queues the checkout"
+    })
+    const secondAttempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["pool profile"],
+      testData: {args: {}, filePath: secondFilePath, line: 30, ownerFilePath: secondFilePath, function: async () => {}},
+      testDescription: "drains the checkout"
+    })
+    /** @type {import("../../../src/testing/test-profiler.js").TestProfileAsyncContext | undefined} */
+    let capturedContext
+    let markFirstSpanStarted
+    let releaseFirstSpan
+    const firstSpanStarted = new Promise((resolve) => { markFirstSpanStarted = resolve })
+    const firstSpanGate = new Promise((resolve) => { releaseFirstSpan = resolve })
+    const runningFirstSpan = profiler.runAttempt(firstAttempt, async () => {
+      await profiler.runSpan({phase: "test body"}, async () => {
+        capturedContext = configuration.getEnvironmentHandler().getCurrentTestProfileContext()
+        markFirstSpanStarted()
+        await firstSpanGate
+      })
+    })
+
+    await firstSpanStarted
+
+    if (!capturedContext) throw new Error("Expected the checkout profile context")
+
+    /** @type {ContextCapturingProfilePoolDriver | undefined} */
+    let resolvedConnection
+    let failedCreationError
+    let noContextTimeoutError
+    let profiledTimeoutError
+
+    await profiler.runAttempt(secondAttempt, async () => {
+      await profiler.runSpan({phase: "test body"}, async () => {
+        const noContextCheckout = {
+          databaseConfig: configuration.getDatabaseConfiguration().default,
+          enqueuedAt: 5,
+          options: {},
+          reject: (error) => { noContextTimeoutError = error },
+          resolve: () => {},
+          reuseKey: "no-profile-context",
+          timeoutAt: 10,
+          timeoutMillis: 5,
+          timeoutTimer: undefined,
+          testProfileContext: undefined
+        }
+
+        pool.pendingCheckouts.push(noContextCheckout)
+        pool.setClockValues([10])
+        pool.timeoutPendingCheckout(noContextCheckout)
+
+        const profiledTimeoutCheckout = {
+          databaseConfig: configuration.getDatabaseConfiguration().default,
+          enqueuedAt: 15,
+          options: {},
+          reject: (error) => { profiledTimeoutError = error },
+          resolve: () => {},
+          reuseKey: "profiled-timeout",
+          timeoutAt: 20,
+          timeoutMillis: 5,
+          timeoutTimer: undefined,
+          testProfileContext: capturedContext
+        }
+
+        pool.pendingCheckouts.push(profiledTimeoutCheckout)
+        pool.setClockValues([20])
+        pool.timeoutPendingCheckout(profiledTimeoutCheckout)
+
+        const successfulCheckout = {
+          databaseConfig: {driver: ContextCapturingProfilePoolDriver},
+          enqueuedAt: 25,
+          options: {},
+          reject: () => {},
+          resolve: (connection) => { resolvedConnection = /** @type {ContextCapturingProfilePoolDriver} */ (connection) },
+          reuseKey: "profiled-success",
+          timeoutAt: null,
+          timeoutMillis: null,
+          timeoutTimer: undefined,
+          testProfileContext: capturedContext
+        }
+
+        pool.pendingCheckouts.push(successfulCheckout)
+        pool.setClockValues([30])
+        pool.removePendingCheckoutAt(0)
+        pool.setClockValues([40, 46])
+        await pool.spawnAndResolvePendingCheckout(successfulCheckout)
+
+        const failedCheckout = {
+          databaseConfig: {driver: FailingProfilePoolDriver},
+          enqueuedAt: 45,
+          options: {},
+          reject: (error) => { failedCreationError = error },
+          resolve: () => {},
+          reuseKey: "profiled-failure",
+          timeoutAt: null,
+          timeoutMillis: null,
+          timeoutTimer: undefined,
+          testProfileContext: capturedContext
+        }
+
+        pool.pendingCheckouts.push(failedCheckout)
+        pool.setClockValues([50])
+        pool.removePendingCheckoutAt(0)
+        pool.setClockValues([60, 68])
+        await pool.spawnAndResolvePendingCheckout(failedCheckout)
+      })
+    })
+    profiler.finishAttempt(secondAttempt, "passed")
+    releaseFirstSpan()
+    await runningFirstSpan
+    profiler.finishAttempt(firstAttempt, "passed")
+
+    const profile = profiler.finish({
+      counts: {discovered: 2, executed: 2, failed: 0, passed: 2},
+      focused: false,
+      status: "passed"
+    })
+    const firstSpan = profile.tests[0].attempts[0].spans[0]
+    const secondSpan = profile.tests[1].attempts[0].spans[0]
+
+    expect(noContextTimeoutError).toBeInstanceOf(Error)
+    expect(profiledTimeoutError).toBeInstanceOf(Error)
+    expect(failedCreationError).toBeInstanceOf(Error)
+    expect(resolvedConnection).toBeInstanceOf(ContextCapturingProfilePoolDriver)
+    expect(resolvedConnection.activationProfileContext).toBe(capturedContext)
+    expect(firstSpan.pools[0].checkoutWait.count).toBe(3)
+    expect(firstSpan.pools[0].checkoutTimeoutCount).toBe(1)
+    expect(firstSpan.pools[0].connectionCreation.count).toBe(2)
+    expect(firstSpan.pools[0].connectionCreation.failedCount).toBe(1)
+    expect(secondSpan.pools).toBe(undefined)
+
+    await pool.closeAll()
+  })
+})

--- a/spec/helpers/mysql-deadlock-diagnostics-test-helper.js
+++ b/spec/helpers/mysql-deadlock-diagnostics-test-helper.js
@@ -120,7 +120,6 @@ ${"ignored status line\n".repeat(500)}`
 export class NonPromiseDiagnosticMysqlDriver extends DiagnosticMysqlDriver {
   /** @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Deliberately malformed diagnostic result. */
   // Base-driver hook invoked through the detached diagnostics contract.
-  // fallow-ignore-next-line unused-class-member
   _deadlockDiagnosticContext() {
     // @ts-expect-error Simulates a runtime subclass that violates the documented Promise contract.
     return {statusCapture: "malformed-non-promise"}

--- a/spec/testing/test-filter-parser-spec.js
+++ b/spec/testing/test-filter-parser-spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-import {parseFilters} from "../../src/testing/test-filter-parser.js"
-import {describe, expect, it} from "../../src/testing/test.js"
+import { parseFilters } from "../../src/testing/test-filter-parser.js"
+import { describe, expect, it } from "../../src/testing/test.js"
 
 describe("parseFilters", {databaseCleaning: {transaction: true}}, () => {
   describe("group splitting flags", () => {
@@ -52,6 +52,39 @@ describe("parseFilters", {databaseCleaning: {transaction: true}}, () => {
       expect(result.groupNumber).toBe(1)
       expect(result.includeTags).toEqual(["fast"])
       expect(result.excludeTags).toEqual(["slow"])
+    })
+  })
+
+  describe("profiling flags", () => {
+    it("parses profile outputs with separate and equals values", () => {
+      const result = parseFilters([
+        "test",
+        "--profile",
+        "--profile-json",
+        "tmp/profile.json",
+        "--timing-manifest-output=tmp/timings.json",
+        "spec/testing/"
+      ])
+
+      expect(result.profile).toBe(true)
+      expect(result.profileJsonPath).toBe("tmp/profile.json")
+      expect(result.timingManifestOutputPath).toBe("tmp/timings.json")
+      expect(result.filteredProcessArgs).toEqual(["test", "spec/testing/"])
+    })
+
+    it("leaves profiling flags after -- untouched", () => {
+      const result = parseFilters(["test", "--", "--profile", "--profile-json=tmp/profile.json"])
+
+      expect(result.profile).toBe(false)
+      expect(result.profileJsonPath).toBe(undefined)
+      expect(result.filteredProcessArgs).toEqual(["test", "--", "--profile", "--profile-json=tmp/profile.json"])
+    })
+
+    it("rejects missing manifest and profiling output values", async () => {
+      await expect(() => parseFilters(["test", "--timing-manifest"])).toThrow(/--timing-manifest requires a path/)
+      await expect(() => parseFilters(["test", "--profile-json"])).toThrow(/--profile-json requires a path/)
+      await expect(() => parseFilters(["test", "--profile-json="])).toThrow(/--profile-json requires a path/)
+      await expect(() => parseFilters(["test", "--timing-manifest-output", "--profile"])).toThrow(/--timing-manifest-output requires a path/)
     })
   })
 })

--- a/spec/testing/test-profile-output-spec.js
+++ b/spec/testing/test-profile-output-spec.js
@@ -1,0 +1,125 @@
+// @ts-check
+
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import { describe, expect, it } from "../../src/testing/test.js"
+import TestProfiler from "../../src/testing/test-profiler.js"
+import { formatTestProfileSummary, writeTestProfileOutputs } from "../../src/testing/test-profile-output.js"
+import TestSuiteSplitter from "../../src/testing/test-suite-splitter.js"
+
+function buildProfile() {
+  const configuration = new Configuration({
+    database: {test: {}},
+    directory: process.cwd(),
+    environment: "test",
+    environmentHandler: new EnvironmentHandlerNode(),
+    initializeModels: async () => {},
+    locale: "en",
+    localeFallbacks: {en: ["en"]},
+    locales: ["en"]
+  })
+  const profiler = new TestProfiler({
+    configuration,
+    projectDirectory: process.cwd(),
+    selection: {fileCount: 2, hasExampleFilters: false, includeTagCount: 0, excludeTagCount: 0, shard: {groups: 2, groupNumber: 1}}
+  })
+
+  profiler.addFileDuration("spec/z-profile-spec.js", "imports", 9.87654)
+  profiler.addFileDuration("spec/a-profile-spec.js", "imports", 4.32109)
+
+  return profiler.finish({
+    counts: {discovered: 2, executed: 2, failed: 0, passed: 2},
+    focused: false,
+    status: "passed"
+  })
+}
+
+describe("test profile output", () => {
+  it("atomically writes deterministic rich JSON and a splitter-compatible sorted manifest", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-profile-output-"))
+    const profileJsonPath = path.join(directory, "nested", "profile.json")
+    const timingManifestOutputPath = path.join(directory, "nested", "timings.json")
+
+    try {
+      const profile = buildProfile()
+
+      await writeTestProfileOutputs({profile, profileJsonPath, timingManifestOutputPath})
+
+      const profileContent = await fs.readFile(profileJsonPath, "utf8")
+      const manifestContent = await fs.readFile(timingManifestOutputPath, "utf8")
+      const writtenProfile = JSON.parse(profileContent)
+      const manifest = JSON.parse(manifestContent)
+
+      expect(profileContent.endsWith("\n")).toBe(true)
+      expect(manifestContent).toBe('{' + '\n  "spec/a-profile-spec.js": 4.321,' + '\n  "spec/z-profile-spec.js": 9.877' + '\n}\n')
+      expect(writtenProfile.schema).toBe("velocious.test-profile")
+      expect(writtenProfile.schemaVersion).toBe(1)
+      expect(writtenProfile.selection.shard).toEqual({groups: 2, groupNumber: 1})
+      expect(writtenProfile.timingManifest).toEqual(manifest)
+
+      const splitter = new TestSuiteSplitter({
+        baseDirectory: process.cwd(),
+        groupNumber: 1,
+        groups: 2,
+        testFiles: [
+          path.join(process.cwd(), "spec/z-profile-spec.js"),
+          path.join(process.cwd(), "spec/a-profile-spec.js")
+        ],
+        timingManifest: manifest
+      })
+
+      expect(splitter.computeWeightedFiles().map((entry) => entry.weight)).toEqual([9.877, 4.321])
+      expect((await fs.readdir(path.join(directory, "nested"))).sort()).toEqual(["profile.json", "timings.json"])
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("rejects forbidden sensitive fields before writing and propagates write failures", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-profile-privacy-"))
+    const profileJsonPath = path.join(directory, "profile.json")
+    const blockedParent = path.join(directory, "blocked")
+
+    try {
+      const unsafeProfile = {...buildProfile(), sql: "SELECT secret_value FROM credentials"}
+
+      await expect(() => writeTestProfileOutputs({profile: unsafeProfile, profileJsonPath})).toThrow(/forbidden profile field/i)
+      await expect(() => fs.access(profileJsonPath)).toThrow()
+      await fs.writeFile(blockedParent, "not a directory", "utf8")
+      await expect(() => writeTestProfileOutputs({
+        profile: buildProfile(),
+        profileJsonPath: path.join(blockedParent, "profile.json")
+      })).toThrow()
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("formats a compact fixed-width phase table, pool summary, and output paths", () => {
+    const profile = buildProfile()
+    profile.pools = [{
+      identifier: "default",
+      connectionCreation: {count: 2, failedCount: 0, totalMs: 3, maxMs: 2},
+      checkoutWait: {count: 1, totalMs: 4, maxMs: 4},
+      checkoutTimeoutCount: 0,
+      idleReap: {count: 1, failedCount: 0, totalMs: 2, maxMs: 2, disposalCount: 1},
+      peakLiveConnections: 2
+    }]
+
+    const summary = formatTestProfileSummary(profile, {
+      profileJsonPath: "/workspace/tmp/profile.json",
+      timingManifestOutputPath: "/workspace/tmp/timings.json"
+    })
+    const lines = summary.split("\n")
+
+    expect(lines[0]).toBe("Test profile")
+    expect(lines[1]).toBe("Phase                          Count      Real ms       CPU ms")
+    expect(lines.some((line) => line.includes("runner overhead"))).toBe(true)
+    expect(lines.some((line) => line.includes("Pool default"))).toBe(true)
+    expect(lines.some((line) => line.includes("Rich JSON: /workspace/tmp/profile.json"))).toBe(true)
+    expect(lines.some((line) => line.includes("Timing manifest: /workspace/tmp/timings.json"))).toBe(true)
+  })
+})

--- a/spec/testing/test-profiler-lifecycle-spec.js
+++ b/spec/testing/test-profiler-lifecycle-spec.js
@@ -1,0 +1,205 @@
+// @ts-check
+
+import Configuration from "../../src/configuration.js"
+import EnvironmentHandlerNode from "../../src/environment-handlers/node.js"
+import { describe, expect, it } from "../../src/testing/test.js"
+import TestProfiler from "../../src/testing/test-profiler.js"
+import TestRunner from "../../src/testing/test-runner.js"
+
+describe("test profiler lifecycle", () => {
+  it("records nested hook invocations, retry attempts, custom activity, and detached late work", async () => {
+    const environmentHandler = new EnvironmentHandlerNode()
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler,
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const filePath = `${process.cwd()}/spec/example-profile-spec.js`
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const testRunner = new TestRunner({configuration, profiler, testFiles: [filePath]})
+    let attemptCount = 0
+    let resolveLateActivity
+    /** @type {Promise<void> | undefined} */
+    let lateActivity
+    const lateGate = new Promise((resolve) => { resolveLateActivity = resolve })
+    const parentBeforeEach = {callback: async () => {}, declarationIndex: 0, ownerFilePath: filePath}
+    const childBeforeEach = {callback: async () => {}, declarationIndex: 0, ownerFilePath: filePath}
+    const childAfterEach = {callback: async () => {}, declarationIndex: 0, ownerFilePath: filePath}
+    const tests = {
+      args: {},
+      afterAlls: [],
+      afterEaches: [],
+      beforeAlls: [],
+      beforeEaches: [parentBeforeEach],
+      filePath,
+      ownerFilePath: filePath,
+      subs: {
+        child: {
+          args: {},
+          afterAlls: [],
+          afterEaches: [childAfterEach],
+          beforeAlls: [],
+          beforeEaches: [childBeforeEach],
+          filePath,
+          ownerFilePath: filePath,
+          subs: {},
+          tests: {
+            "retries once": {
+              args: {retry: 1},
+              filePath,
+              line: 42,
+              ownerFilePath: filePath,
+              function: async () => {
+                attemptCount++
+
+                await configuration.profileTestActivity("cache-warmup", async () => {})
+
+                if (attemptCount === 1) throw new Error("expected first-attempt failure")
+
+                lateActivity = lateGate.then(async () => {
+                  await configuration.profileTestActivity("detached-cleanup", async () => {})
+                })
+              }
+            }
+          }
+        }
+      },
+      tests: {}
+    }
+
+    await testRunner.runTests({afterEaches: [], beforeEaches: [], tests, descriptions: [], indentLevel: 0})
+    resolveLateActivity()
+    await lateActivity
+
+    const profile = profiler.finish({
+      counts: {discovered: 1, executed: 1, failed: 0, passed: 1},
+      focused: false,
+      status: "passed"
+    })
+    const profiledTest = profile.tests[0]
+
+    expect(profile.unattributedLateEventCount).toBe(1)
+    expect(profile.counts.attempts).toBe(2)
+    expect(profiledTest.attempts.map((attempt) => attempt.status)).toEqual(["failed", "passed"])
+    expect(profiledTest.attempts.every((attempt) => {
+      return attempt.spans.map((span) => span.phase).join(",") === "beforeEach,beforeEach,test body,custom,afterEach"
+    })).toBe(true)
+
+    const secondAttemptHookSpans = profiledTest.attempts[1].spans.filter((span) => span.phase === "beforeEach")
+
+    expect(secondAttemptHookSpans.map((span) => span.declarationIndex)).toEqual([0, 0])
+    expect(secondAttemptHookSpans[0].declarationScopeId).not.toBe(secondAttemptHookSpans[1].declarationScopeId)
+    expect(profiledTest.attempts[1].spans.map((span) => span.executionOrder)).toEqual([6, 7, 8, 9, 10])
+    expect(profiledTest.attempts[1].spans.some((span) => span.activity === "detached-cleanup")).toBe(false)
+  })
+
+  it("validates activity names but remains a no-op when profiling is inactive", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    let callbackRan = false
+
+    await configuration.profileTestActivity("cache-cleanup", async () => { callbackRan = true })
+
+    expect(callbackRan).toBe(true)
+    await expect(() => configuration.profileTestActivity("tenant=user@example.com", async () => {})).toThrow(/activity name/)
+  })
+
+  it("bounds distinct custom activity labels", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const filePath = `${process.cwd()}/spec/custom-activity-profile-spec.js`
+    const attempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["custom activities"],
+      testData: {args: {}, filePath, line: 12, ownerFilePath: filePath, function: async () => {}},
+      testDescription: "caps labels"
+    })
+
+    await profiler.runAttempt(attempt, async () => {
+      for (let index = 0; index < 22; index++) {
+        await configuration.profileTestActivity(`activity-${index}`, async () => {})
+      }
+    })
+    profiler.finishAttempt(attempt, "passed")
+
+    const profile = profiler.finish({
+      counts: {discovered: 1, executed: 1, failed: 0, passed: 1},
+      focused: false,
+      status: "passed"
+    })
+    const activities = profile.tests[0].attempts[0].spans.map((span) => span.activity)
+
+    expect(new Set(activities).size).toBe(21)
+    expect(activities.slice(20)).toEqual(["other", "other"])
+  })
+
+  it("closes nested span attribution as soon as an attempt times out", async () => {
+    const configuration = new Configuration({
+      database: {test: {}},
+      directory: process.cwd(),
+      environment: "test",
+      environmentHandler: new EnvironmentHandlerNode(),
+      initializeModels: async () => {},
+      locale: "en",
+      localeFallbacks: {en: ["en"]},
+      locales: ["en"]
+    })
+    const profiler = new TestProfiler({configuration, projectDirectory: process.cwd()})
+    const filePath = `${process.cwd()}/spec/timed-out-profile-spec.js`
+    const attempt = profiler.startAttempt({
+      attemptNumber: 1,
+      descriptions: ["timed out activity"],
+      testData: {args: {}, filePath, line: 12, ownerFilePath: filePath, function: async () => {}},
+      testDescription: "stops attribution"
+    })
+    let releaseSpan
+    let markSpanStarted
+    const spanStarted = new Promise((resolve) => { markSpanStarted = resolve })
+    const spanGate = new Promise((resolve) => { releaseSpan = resolve })
+    const runningSpan = profiler.runAttempt(attempt, async () => {
+      await profiler.runSpan({phase: "test body"}, async () => {
+        markSpanStarted()
+        await spanGate
+        await configuration.profileTestActivity("late-timeout-work", async () => {})
+      })
+    })
+
+    await spanStarted
+    profiler.finishAttempt(attempt, "timed-out")
+    releaseSpan()
+    await runningSpan
+
+    const profile = profiler.finish({
+      counts: {discovered: 1, executed: 1, failed: 1, passed: 0},
+      focused: false,
+      status: "failed"
+    })
+    const profiledAttempt = profile.tests[0].attempts[0]
+
+    expect(profiledAttempt.status).toBe("timed-out")
+    expect(profiledAttempt.spans.some((span) => span.activity === "late-timeout-work")).toBe(false)
+    expect(profile.unattributedLateEventCount).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -35,6 +35,7 @@ import {frontendModelApiManifest, frontendModelResourceClassFromDefinition, fron
 import {currentOfflineGrantSigningKey, normalizeOfflineGrantSigningKey} from "./sync/offline-grant.js"
 import PluginRoutes from "./routes/plugin-routes.js"
 import restArgsError from "./utils/rest-args-error.js"
+import { validateTestActivityName } from "./testing/test-profile-activity.js"
 import {validateTimeZone} from "./time-zone.js"
 import {withTrackedStack} from "./utils/with-tracked-stack.js"
 import VelociousPackage from "./packages/velocious-package.js"
@@ -3148,6 +3149,24 @@ export default class VelociousConfiguration {
    */
   async runWithRequestTiming(requestTiming, callback) {
     return await this.getEnvironmentHandler().runWithRequestTiming(requestTiming, callback)
+  }
+
+  /**
+   * Profiles an application-defined test activity when an opt-in test profile
+   * context is active. The callback always runs, including outside profiling.
+   * @template T
+   * @param {string} name - Low-cardinality activity identifier.
+   * @param {() => (T | Promise<T>)} callback - Activity callback.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async profileTestActivity(name, callback) {
+    const validatedName = validateTestActivityName(name)
+
+    const context = this.getEnvironmentHandler().getCurrentTestProfileContext()
+
+    if (!context) return await callback()
+
+    return await context.profiler.profileActivity(context, validatedName, callback)
   }
 
   /**

--- a/src/database/drivers/base.js
+++ b/src/database/drivers/base.js
@@ -92,6 +92,14 @@
  */
 
 /**
+ * TestProfileQueryAttempt type.
+ * @typedef {object} TestProfileQueryAttempt
+ * @property {import("../../testing/test-profiler.js").TestProfileAsyncContext} context - Captured async attribution.
+ * @property {{sqlFingerprint: string, sqlOperation: string}} diagnostic - Redacted statement diagnostic.
+ * @property {number} startedAtMs - Physical attempt start time.
+ */
+
+/**
  * ActiveQueryDebugSnapshot type.
  * @typedef {object} ActiveQueryDebugSnapshot
  * @property {string[]} annotations - Database annotations active when the query started.
@@ -164,6 +172,7 @@ import TableForeignKey from "../table-data/table-foreign-key.js"
 import wait from "awaitery/build/wait.js"
 import { optionalPositiveInteger } from "typanic"
 import { coordinateSharedTransactionConnection } from "../../testing/shared-transaction-connection-coordinator.js"
+import { currentTestProfileContext } from "../../testing/test-profile-context.js"
 import sha256Hex from "../../utils/sha256-hex.js"
 
 /** Maximum characters inspected when building the debug SQL preview. */
@@ -1740,7 +1749,9 @@ export default class VelociousDatabaseDriversBase {
           return
         }
 
-        await this._startTransactionAction(options)
+        await this._runProfiledTransactionAction("start", async () => {
+          await this._startTransactionAction(options)
+        })
         this._transactionsCount++
 
         if (this._transactionsCount === 1) {
@@ -1772,7 +1783,9 @@ export default class VelociousDatabaseDriversBase {
    */
   async commitTransaction(options = {}) {
     await this._transactionsActionsMutex.sync(async () => {
-      await this._commitTransactionAction(options)
+      await this._runProfiledTransactionAction("commit", async () => {
+        await this._commitTransactionAction(options)
+      })
       this._transactionsCount--
       this._resolveCompletedTransaction()
     })
@@ -1795,6 +1808,68 @@ export default class VelociousDatabaseDriversBase {
    */
   async _commitTransactionAction(options = {}) {
     await this.query("COMMIT", options)
+  }
+
+  /**
+   * Times a physical transaction action only when test profiling is active.
+   * @template T
+   * @param {"start" | "commit" | "rollback"} action - Transaction action.
+   * @param {() => Promise<T>} callback - Physical action callback.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async _runProfiledTransactionAction(action, callback) {
+    const profileContext = currentTestProfileContext(this.configuration)
+
+    if (!profileContext) return await callback()
+
+    const startedAtMs = nowMs()
+    let failed = true
+
+    try {
+      const result = await callback()
+
+      failed = false
+      return result
+    } finally {
+      profileContext.profiler.recordDatabaseTransaction(profileContext, {
+        action,
+        durationMs: nowMs() - startedAtMs,
+        failed
+      })
+    }
+  }
+
+  /**
+   * Starts an optional physical-query profile attempt without retaining SQL.
+   * @param {string} sql - Original SQL used only to derive its redacted diagnostic.
+   * @returns {TestProfileQueryAttempt | undefined} - Active profile handle.
+   */
+  _startProfiledQueryAttempt(sql) {
+    const context = currentTestProfileContext(this.configuration)
+
+    if (!context) return undefined
+
+    return {
+      context,
+      diagnostic: sqlDiagnostic(sql),
+      startedAtMs: nowMs()
+    }
+  }
+
+  /**
+   * Completes an optional physical-query profile attempt.
+   * @param {TestProfileQueryAttempt | undefined} attempt - Profile handle.
+   * @param {boolean} failed - Whether the physical driver call failed.
+   * @returns {void}
+   */
+  _finishProfiledQueryAttempt(attempt, failed) {
+    if (!attempt) return
+
+    attempt.context.profiler.recordDatabaseQuery(attempt.context, {
+      durationMs: nowMs() - attempt.startedAtMs,
+      failed,
+      ...attempt.diagnostic
+    })
   }
 
   /**
@@ -1916,7 +1991,17 @@ export default class VelociousDatabaseDriversBase {
       await this.beforeQuery(sql, options)
 
       try {
-        return await this._affectedRowsActual(sql)
+        const profileAttempt = this._startProfiledQueryAttempt(sql)
+        let failed = true
+
+        try {
+          const affectedRows = await this._affectedRowsActual(sql)
+
+          failed = false
+          return affectedRows
+        } finally {
+          this._finishProfiledQueryAttempt(profileAttempt, failed)
+        }
       } finally {
         await this.afterQuery(sql, options)
       }
@@ -1945,7 +2030,7 @@ export default class VelociousDatabaseDriversBase {
     let result
 
     try {
-      const runQueryActualWithHooks = async () => await this._queryActualWithHooks(querySql, options)
+      const runQueryActualWithHooks = async () => await this._queryActualWithHooks(querySql, options, originalSql)
 
       if (requestTiming && tries === 1) {
         result = await requestTiming.measureDbQuery(runQueryActualWithHooks)
@@ -1980,14 +2065,25 @@ export default class VelociousDatabaseDriversBase {
    * Runs query actual with before/after hooks.
    * @param {string} sql - SQL string.
    * @param {QueryOptions} options - Query options.
+   * @param {string} originalSql - SQL before process-list comments.
    * @returns {Promise<QueryResultType>} - Resolves with the query.
    */
-  async _queryActualWithHooks(sql, options) {
+  async _queryActualWithHooks(sql, options, originalSql) {
     return await coordinateSharedTransactionConnection(this, async () => {
       await this.beforeQuery(sql, options)
 
       try {
-        return await this._queryActual(sql, options)
+        const profileAttempt = this._startProfiledQueryAttempt(originalSql)
+        let failed = true
+
+        try {
+          const result = await this._queryActual(sql, options)
+
+          failed = false
+          return result
+        } finally {
+          this._finishProfiledQueryAttempt(profileAttempt, failed)
+        }
       } finally {
         await this.afterQuery(sql, options)
       }
@@ -2403,7 +2499,9 @@ export default class VelociousDatabaseDriversBase {
   async rollbackTransaction(options = {}) {
     await this._transactionsActionsMutex.sync(async () => {
       try {
-        await this._rollbackTransactionAction(options)
+        await this._runProfiledTransactionAction("rollback", async () => {
+          await this._rollbackTransactionAction(options)
+        })
       } finally {
         this._transactionsCount--
         this._resolveCompletedTransaction()

--- a/src/database/drivers/mysql/index.js
+++ b/src/database/drivers/mysql/index.js
@@ -518,7 +518,15 @@ export default class VelociousDatabaseDriversMysql extends Base{
     if (!this.pool) await this.connect()
     if (!this.pool) throw new Error("MySQL pool failed to initialize")
 
-    yield* streamQuery(this.pool, sql)
+    const profileAttempt = this._startProfiledQueryAttempt(sql)
+    let failed = true
+
+    try {
+      yield* streamQuery(this.pool, sql)
+      failed = false
+    } finally {
+      this._finishProfiledQueryAttempt(profileAttempt, failed)
+    }
   }
 
   /**
@@ -558,13 +566,20 @@ export default class VelociousDatabaseDriversMysql extends Base{
     if (!this.pool) throw new Error("MySQL pool failed to initialize")
 
     const pool = this.pool
+    const profileAttempt = this._startProfiledQueryAttempt(structureSql)
+    let failed = true
 
-    await new Promise((resolve, reject) => {
-      pool.query(structureSql, (error) => {
-        if (error) reject(error)
-        else resolve(undefined)
+    try {
+      await new Promise((resolve, reject) => {
+        pool.query(structureSql, (error) => {
+          if (error) reject(error)
+          else resolve(undefined)
+        })
       })
-    })
+      failed = false
+    } finally {
+      this._finishProfiledQueryAttempt(profileAttempt, failed)
+    }
 
     return true
   }

--- a/src/database/pool/async-tracked-multi-connection.js
+++ b/src/database/pool/async-tracked-multi-connection.js
@@ -1,7 +1,8 @@
 // @ts-check
 
-import {AsyncLocalStorage} from "async_hooks"
-import BasePool, {POOL_CONFIGURATION_KEY} from "./base.js"
+import { AsyncLocalStorage } from "async_hooks"
+import BasePool, { POOL_CONFIGURATION_KEY } from "./base.js"
+import { currentTestProfileContext } from "../../testing/test-profile-context.js"
 
 /**
  * PendingCheckout type.
@@ -15,6 +16,7 @@ import BasePool, {POOL_CONFIGURATION_KEY} from "./base.js"
  * @property {number | null} timeoutAt - Timestamp when the checkout will time out, or null when disabled.
  * @property {number | null} timeoutMillis - Milliseconds to wait before rejecting, or null when disabled.
  * @property {ReturnType<typeof setTimeout> | undefined} timeoutTimer - Timer that rejects the pending checkout.
+ * @property {import("../../testing/test-profiler.js").TestProfileAsyncContext | undefined} [testProfileContext] - Async-safe profile attribution captured at enqueue.
  */
 export const CLOSED_CONNECTION = Symbol("velociousClosedConnection")
 const IDLE_CONNECTION_CHECKED_IN_AT = Symbol("velociousIdleConnectionCheckedInAt")
@@ -115,10 +117,20 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
 
   /** Cumulative low-cardinality pool telemetry. */
   telemetry = {
+    connectionCreationCount: 0,
+    connectionCreationFailureCount: 0,
+    connectionCreationMaxMs: 0,
+    connectionCreationTotalMs: 0,
+    checkoutTimeoutCount: 0,
     checkoutWaitCount: 0,
     checkoutWaitMaxMs: 0,
     checkoutWaitTotalMs: 0,
-    idleReapDisposalCount: 0
+    idleReapCount: 0,
+    idleReapDisposalCount: 0,
+    idleReapFailureCount: 0,
+    idleReapMaxMs: 0,
+    idleReapTotalMs: 0,
+    peakLiveConnections: 0
   }
 
   idSeq = 0
@@ -137,6 +149,58 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
      */
     const withoutCurrentConnectionContext = (callback) => this.asyncLocalStorage.run(SUPPRESSED_CONNECTION_CONTEXT, callback)
     this._withoutCurrentConnectionContext = withoutCurrentConnectionContext
+  }
+
+  /**
+   * Returns the pool telemetry clock.
+   * @returns {number} - Current time in milliseconds.
+   */
+  nowMs() { return Date.now() }
+
+  /**
+   * Records a pool metric in the active async-safe test profile context.
+   * @param {import("../../testing/test-profiler.js").TestProfileAsyncContext | undefined} context - Captured profile context.
+   * @param {"connectionCreation" | "checkoutWait" | "checkoutTimeout" | "idleReap" | "idleReapDisposal" | "peakLiveConnections"} metric - Metric name.
+   * @param {{durationMs?: number, failed?: boolean, value?: number}} [values] - Aggregate values.
+   * @returns {void}
+   */
+  recordTestProfilePoolMetric(context, metric, values = {}) {
+    if (!context) return
+
+    context.profiler.recordPoolMetric(context, this.identifier, metric, values)
+  }
+
+  /**
+   * Spawns and times a physical connection without retaining its configuration.
+   * @param {import("../../configuration-types.js").DatabaseConfigurationType} config - Resolved database configuration.
+   * @returns {Promise<import("../drivers/base.js").default>} - Connected driver.
+   */
+  async spawnConnectionWithConfiguration(config) {
+    const startedAt = this.nowMs()
+    const profileContext = currentTestProfileContext(this.configuration)
+    let failed = true
+
+    try {
+      const connection = await super.spawnConnectionWithConfiguration(config)
+
+      failed = false
+      const liveConnectionCount = this.liveConnectionCount() - this.connectionsBeingSpawned + 1
+
+      if (liveConnectionCount > this.telemetry.peakLiveConnections) {
+        this.telemetry.peakLiveConnections = liveConnectionCount
+        this.recordTestProfilePoolMetric(profileContext, "peakLiveConnections", {value: liveConnectionCount})
+      }
+
+      return connection
+    } finally {
+      const durationMs = Math.max(0, this.nowMs() - startedAt)
+
+      this.telemetry.connectionCreationCount++
+      if (failed) this.telemetry.connectionCreationFailureCount++
+      this.telemetry.connectionCreationTotalMs += durationMs
+      this.telemetry.connectionCreationMaxMs = Math.max(this.telemetry.connectionCreationMaxMs, durationMs)
+      this.recordTestProfilePoolMetric(profileContext, "connectionCreation", {durationMs, failed})
+    }
   }
 
   /**
@@ -258,7 +322,11 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
       // The post-reap configuration is fresh for the current caller, and its reuse key is
       // derived from this exact captured object so the connection cannot open one tenant while
       // being stamped for another. The queued path retains the same captured pair.
-      connection = await this.spawnConnectionForCheckout(databaseConfig, reuseKey)
+      connection = await this.spawnConnectionForCheckout(
+        databaseConfig,
+        reuseKey,
+        currentTestProfileContext(this.configuration)
+      )
 
       return await this.activateConnection(connection, options)
     }
@@ -291,7 +359,11 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (connection) return await this.activateConnection(connection, options)
 
     if (this.canSpawnConnection(databaseConfig)) {
-      connection = await this.spawnConnectionForCheckout(databaseConfig, reuseKey)
+      connection = await this.spawnConnectionForCheckout(
+        databaseConfig,
+        reuseKey,
+        currentTestProfileContext(this.configuration)
+      )
 
       return await this.activateConnection(connection, options)
     }
@@ -436,13 +508,17 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * Runs spawn connection for checkout.
    * @param {import("../../configuration-types.js").DatabaseConfigurationType} databaseConfig - Resolved database config for the checkout.
    * @param {string} reuseKey - Database configuration reuse key for the checkout.
+   * @param {import("../../testing/test-profiler.js").TestProfileAsyncContext | undefined} profileContext - Profile context captured when checkout began.
    * @returns {Promise<import("../drivers/base.js").default>} - Spawned connection.
    */
-  async spawnConnectionForCheckout(databaseConfig, reuseKey) {
+  async spawnConnectionForCheckout(databaseConfig, reuseKey, profileContext) {
     this.connectionsBeingSpawned++
 
     try {
-      const connection = await this.spawnConnectionWithConfiguration(databaseConfig)
+      const environmentHandler = this.configuration.getEnvironmentHandler()
+      const connection = await environmentHandler.runWithTestProfileContext(profileContext, async () => {
+        return await this.spawnConnectionWithConfiguration(databaseConfig)
+      })
 
       this.stampConnectionForConfigurationReuseKey(connection, reuseKey)
 
@@ -473,7 +549,8 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
         reuseKey,
         timeoutAt: timeoutMillis === null ? null : enqueuedAt + timeoutMillis,
         timeoutMillis,
-        timeoutTimer: undefined
+        timeoutTimer: undefined,
+        testProfileContext: currentTestProfileContext(this.configuration)
       }
 
       checkout.timeoutTimer = this.startPendingCheckoutTimeout(checkout)
@@ -573,11 +650,12 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {void}
    */
   recordCheckoutWait(checkout) {
-    const waitedForMs = Math.max(0, Date.now() - checkout.enqueuedAt)
+    const waitedForMs = Math.max(0, this.nowMs() - checkout.enqueuedAt)
 
     this.telemetry.checkoutWaitCount++
     this.telemetry.checkoutWaitTotalMs += waitedForMs
     this.telemetry.checkoutWaitMaxMs = Math.max(this.telemetry.checkoutWaitMaxMs, waitedForMs)
+    this.recordTestProfilePoolMetric(checkout.testProfileContext, "checkoutWait", {durationMs: waitedForMs})
   }
 
   /**
@@ -606,6 +684,8 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     if (index === -1) return
 
     this.removePendingCheckoutAt(index)
+    this.telemetry.checkoutTimeoutCount++
+    this.recordTestProfilePoolMetric(checkout.testProfileContext, "checkoutTimeout")
     checkout.reject(this.pendingCheckoutTimeoutError(checkout))
   }
 
@@ -739,16 +819,24 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {Promise<void>} - Resolves when the checkout has been handled.
    */
   async spawnAndResolvePendingCheckout(checkout) {
-    let connection
+    const environmentHandler = this.configuration.getEnvironmentHandler()
 
-    try {
-      connection = await this.spawnConnectionForCheckout(checkout.databaseConfig, checkout.reuseKey)
-    } catch (error) {
-      checkout.reject(error instanceof Error ? error : new Error("Failed to spawn database connection.", {cause: error}))
-      return
-    }
+    return await environmentHandler.runWithTestProfileContext(checkout.testProfileContext, async () => {
+      let connection
 
-    await this.resolvePendingCheckout(checkout, connection)
+      try {
+        connection = await this.spawnConnectionForCheckout(
+          checkout.databaseConfig,
+          checkout.reuseKey,
+          checkout.testProfileContext
+        )
+      } catch (error) {
+        checkout.reject(error instanceof Error ? error : new Error("Failed to spawn database connection.", {cause: error}))
+        return
+      }
+
+      await this.resolvePendingCheckout(checkout, connection)
+    })
   }
 
   /**
@@ -758,11 +846,15 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
    * @returns {Promise<void>} - Resolves when the checkout has been handled.
    */
   async resolvePendingCheckout(checkout, connection) {
-    try {
-      checkout.resolve(await this.activateConnection(connection, checkout.options))
-    } catch (error) {
-      checkout.reject(error instanceof Error ? error : new Error("Failed to activate database connection.", {cause: error}))
-    }
+    const environmentHandler = this.configuration.getEnvironmentHandler()
+
+    return await environmentHandler.runWithTestProfileContext(checkout.testProfileContext, async () => {
+      try {
+        checkout.resolve(await this.activateConnection(connection, checkout.options))
+      } catch (error) {
+        checkout.reject(error instanceof Error ? error : new Error("Failed to activate database connection.", {cause: error}))
+      }
+    })
   }
 
   /**
@@ -1308,24 +1400,40 @@ export default class VelociousDatabasePoolAsyncTrackedMultiConnection extends Ba
     const idleTimeoutMillis = this.idleTimeoutMillis()
 
     if (idleTimeoutMillis === null) return
+    const startedAt = this.nowMs()
+    const profileContext = currentTestProfileContext(this.configuration)
+    let failed = true
 
-    const {expiredConnections, keptConnections} = this.classifyIdleConnectionsForReaping({idleTimeoutMillis, now: Date.now()})
+    try {
+      const {expiredConnections, keptConnections} = this.classifyIdleConnectionsForReaping({idleTimeoutMillis, now: this.nowMs()})
 
-    this.connections = keptConnections
-    await this.closeExpiredIdleConnections(expiredConnections)
-    await this.awaitInflightConnectionCloses()
-    if (this.connections.length > 0) this.scheduleIdleConnectionReaper()
+      this.connections = keptConnections
+      await this.closeExpiredIdleConnections(expiredConnections, profileContext)
+      await this.awaitInflightConnectionCloses()
+      if (this.connections.length > 0) this.scheduleIdleConnectionReaper()
+      failed = false
+    } finally {
+      const durationMs = Math.max(0, this.nowMs() - startedAt)
+
+      this.telemetry.idleReapCount++
+      if (failed) this.telemetry.idleReapFailureCount++
+      this.telemetry.idleReapTotalMs += durationMs
+      this.telemetry.idleReapMaxMs = Math.max(this.telemetry.idleReapMaxMs, durationMs)
+      this.recordTestProfilePoolMetric(profileContext, "idleReap", {durationMs, failed})
+    }
   }
 
   /**
    * Runs close expired idle connections.
    * @param {import("../drivers/base.js").default[]} expiredConnections - Connections to close.
+   * @param {import("../../testing/test-profiler.js").TestProfileAsyncContext | undefined} [profileContext] - Reaper profile context.
    * @returns {Promise<void>} - Resolves when closed.
    */
-  async closeExpiredIdleConnections(expiredConnections) {
+  async closeExpiredIdleConnections(expiredConnections, profileContext) {
     for (const connection of expiredConnections) {
       await this.closeConnection(connection)
       this.telemetry.idleReapDisposalCount++
+      this.recordTestProfilePoolMetric(profileContext, "idleReapDisposal")
     }
   }
 

--- a/src/database/pool/base.js
+++ b/src/database/pool/base.js
@@ -45,7 +45,7 @@ import sha256Hex from "../../utils/sha256-hex.js"
  * @property {Array<DatabasePoolPendingCheckoutDebugSnapshot>} [pendingCheckouts] - Waiting checkout snapshots.
  * @property {number} pendingCheckoutCount - Number of queued checkout requests.
  * @property {string} poolClass - Pool class name.
- * @property {{checkoutWaitCount: number, checkoutWaitMaxMs: number, checkoutWaitTotalMs: number, idleReapDisposalCount: number}} [telemetry] - Cumulative pool lifecycle telemetry.
+ * @property {{connectionCreationCount: number, connectionCreationFailureCount: number, connectionCreationMaxMs: number, connectionCreationTotalMs: number, checkoutTimeoutCount: number, checkoutWaitCount: number, checkoutWaitMaxMs: number, checkoutWaitTotalMs: number, idleReapCount: number, idleReapDisposalCount: number, idleReapFailureCount: number, idleReapMaxMs: number, idleReapTotalMs: number, peakLiveConnections: number}} [telemetry] - Cumulative pool lifecycle telemetry.
  */
 export const POOL_CONFIGURATION_KEY = Symbol("velociousPoolConfigurationKey")
 

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -55,6 +55,22 @@ export default class VelociousEnvironmentHandlerBase {
   runWithSharedTransactionCoordinatorOwner(_connection, _owner, callback) { return callback() }
 
   /**
+   * Runs work with test-profile attribution. Runtimes without async-context
+   * storage execute the callback without installing ambient attribution.
+   * @template T
+   * @param {import("../testing/test-profiler.js").TestProfileAsyncContext | undefined} _context - Captured profile context, or an explicit absence of attribution.
+   * @param {() => T} callback - Profiled work.
+   * @returns {T} - Callback result.
+   */
+  runWithTestProfileContext(_context, callback) { return callback() }
+
+  /**
+   * Gets the current test-profile attribution context.
+   * @returns {import("../testing/test-profiler.js").TestProfileAsyncContext | undefined} - Active context.
+   */
+  getCurrentTestProfileContext() { return undefined }
+
+  /**
    * Mutable ambient tenant used by runtimes without async-context storage.
    * @type {ReturnType<typeof JSON.parse> | undefined}
    */

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -43,7 +43,7 @@ import { createSharedTransactionProxyDriver, sharedTransactionBrokerConfig } fro
 
 /**
  * Defines this typedef.
- * @typedef {{ability?: import("../authorization/ability.js").default, offsetMinutes: number, requestTiming?: import("../http-server/client/request-timing.js").default, tenant?: ReturnType<typeof JSON.parse>, timeZone?: string}} TimezoneStore */
+ * @typedef {{ability?: import("../authorization/ability.js").default, offsetMinutes: number, requestTiming?: import("../http-server/client/request-timing.js").default, tenant?: ReturnType<typeof JSON.parse>, testProfileContext?: import("../testing/test-profiler.js").TestProfileAsyncContext, timeZone?: string}} TimezoneStore */
 
 /**
  * Runs path within allowed prefixes.
@@ -145,6 +145,36 @@ export default class VelociousEnvironmentHandlerNode extends Base{
 
     owners.set(connection, owner)
     return this._sharedTransactionCoordinatorAsyncLocalStorage.run(owners, callback)
+  }
+
+  /**
+   * Runs work with async-safe test profile attribution.
+   * @template T
+   * @param {import("../testing/test-profiler.js").TestProfileAsyncContext | undefined} context - Captured profile context, or an explicit absence of attribution.
+   * @param {() => T} callback - Profiled work.
+   * @returns {T} - Callback result.
+   */
+  runWithTestProfileContext(context, callback) {
+    if (!this._timezoneAsyncLocalStorage) return callback()
+
+    const existingStore = this._timezoneAsyncLocalStorage.getStore()
+
+    return this._timezoneAsyncLocalStorage.run({
+      ability: existingStore?.ability,
+      offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
+      requestTiming: existingStore?.requestTiming,
+      tenant: existingStore?.tenant,
+      testProfileContext: context,
+      timeZone: existingStore?.timeZone ?? this.getTimeZone(this.getConfiguration())
+    }, callback)
+  }
+
+  /**
+   * Gets the current async-safe test profile attribution context.
+   * @returns {import("../testing/test-profiler.js").TestProfileAsyncContext | undefined} - Current context.
+   */
+  getCurrentTestProfileContext() {
+    return this._timezoneAsyncLocalStorage?.getStore()?.testProfileContext
   }
 
   /**
@@ -378,6 +408,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       offsetMinutes,
       requestTiming: existingStore?.requestTiming,
       tenant: existingStore?.tenant,
+      testProfileContext: existingStore?.testProfileContext,
       timeZone: existingStore?.timeZone ?? this.getTimeZone(this.getConfiguration())
     }, callback)
   }
@@ -400,6 +431,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
       requestTiming: existingStore?.requestTiming,
       tenant: existingStore?.tenant,
+      testProfileContext: existingStore?.testProfileContext,
       timeZone: validateTimeZone(timeZone, "timeZone")
     }, callback)
   }
@@ -424,6 +456,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         offsetMinutes,
         requestTiming: existingStore?.requestTiming,
         tenant: existingStore?.tenant,
+        testProfileContext: existingStore?.testProfileContext,
         timeZone: existingStore?.timeZone ?? this.getTimeZone(this.getConfiguration())
       })
     }
@@ -453,6 +486,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
         requestTiming: existingStore?.requestTiming,
         tenant: existingStore?.tenant,
+        testProfileContext: existingStore?.testProfileContext,
         timeZone: normalizedTimeZone
       })
     }
@@ -510,6 +544,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
       requestTiming: existingStore?.requestTiming,
       tenant: existingStore?.tenant,
+      testProfileContext: existingStore?.testProfileContext,
       timeZone: existingStore?.timeZone ?? this.getTimeZone(this.getConfiguration())
     }, callback)
   }
@@ -535,6 +570,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         offsetMinutes: this.getTimezoneOffsetMinutes(this.getConfiguration()),
         requestTiming: undefined,
         tenant: undefined,
+        testProfileContext: undefined,
         timeZone: this.getTimeZone(this.getConfiguration())
       })
     }
@@ -570,6 +606,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
       requestTiming,
       tenant: existingStore?.tenant,
+      testProfileContext: existingStore?.testProfileContext,
       timeZone: existingStore?.timeZone ?? this.getTimeZone(this.getConfiguration())
     }, callback)
   }
@@ -604,6 +641,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
       offsetMinutes: existingStore?.offsetMinutes ?? this.getTimezoneOffsetMinutes(this.getConfiguration()),
       requestTiming: existingStore?.requestTiming,
       tenant,
+      testProfileContext: existingStore?.testProfileContext,
       timeZone: existingStore?.timeZone ?? this.getTimeZone(this.getConfiguration())
     }, callback)
   }
@@ -629,6 +667,7 @@ export default class VelociousEnvironmentHandlerNode extends Base{
         offsetMinutes: this.getTimezoneOffsetMinutes(this.getConfiguration()),
         requestTiming: undefined,
         tenant,
+        testProfileContext: undefined,
         timeZone: this.getTimeZone(this.getConfiguration())
       })
     }

--- a/src/environment-handlers/node/cli/commands/test.js
+++ b/src/environment-handlers/node/cli/commands/test.js
@@ -2,12 +2,15 @@
 
 import BaseCommand from "../../../../cli/base-command.js"
 import fs from "fs/promises"
+import path from "node:path"
 import picocolors from "picocolors"
 import TestFilesFinder from "../../../../testing/test-files-finder.js"
+import TestProfiler from "../../../../testing/test-profiler.js"
+import { formatTestProfileSummary, writeTestProfileOutputs } from "../../../../testing/test-profile-output.js"
 import TestRunner from "../../../../testing/test-runner.js"
 import TestSuiteSplitter from "../../../../testing/test-suite-splitter.js"
-import {normalizeExamplePatterns, parseFilters} from "../../../../testing/test-filter-parser.js"
-import {prepareSourcePeerPackage} from "../../source-peer-package.js"
+import { normalizeExamplePatterns, parseFilters } from "../../../../testing/test-filter-parser.js"
+import { prepareSourcePeerPackage } from "../../source-peer-package.js"
 
 export default class VelociousCliCommandsTest extends BaseCommand {
   async execute() {
@@ -27,116 +30,249 @@ export default class VelociousCliCommandsTest extends BaseCommand {
       directories.push(`${this.directory()}/spec`)
     }
 
-    const {includeTags, excludeTags, examplePatterns, filteredProcessArgs, groups, groupNumber, timingManifestPath} = parseFilters(this.processArgs || [])
-    const testFilesFinder = new TestFilesFinder({directory, directories, processArgs: filteredProcessArgs})
-    let testFiles = await testFilesFinder.findTestFiles()
-
-    if (groups !== undefined || groupNumber !== undefined) {
-      if (groups === undefined || groupNumber === undefined) {
-        throw new Error("Both --groups and --group-number must be provided together")
-      }
-
-      const timingManifest = await loadTimingManifest(timingManifestPath)
-      const splitter = new TestSuiteSplitter({groups, groupNumber, testFiles, baseDirectory: directory, timingManifest})
-
-      testFiles = splitter.getGroupFiles()
-      console.log(picocolors.cyan(`Running group ${groupNumber} of ${groups} (${testFiles.length} files)`))
-    }
-
-    const testRunner = new TestRunner({
-      configuration: this.getConfiguration(),
-      excludeTags,
+    const {
       includeTags,
-      testFiles,
-      lineFilters: testFilesFinder.getLineFiltersByFile(),
-      examplePatterns: normalizeExamplePatterns(examplePatterns)
+      excludeTags,
+      examplePatterns,
+      filteredProcessArgs,
+      groups,
+      groupNumber,
+      profile,
+      profileJsonPath,
+      timingManifestPath,
+      timingManifestOutputPath
+    } = parseFilters(this.processArgs || [])
+    const profileOptions = resolveTestProfileOptions({
+      cwd: process.cwd(),
+      profile,
+      profileJsonPath,
+      timingManifestPath,
+      timingManifestOutputPath
     })
-    let signalHandled = false
+    const selection = {
+      excludeTagCount: excludeTags.length,
+      hasExampleFilters: examplePatterns.length > 0,
+      includeTagCount: includeTags.length,
+      shard: groups !== undefined && groupNumber !== undefined ? {groups, groupNumber} : undefined
+    }
+    const profiler = profileOptions.profile
+      ? new TestProfiler({configuration: this.getConfiguration(), projectDirectory: directory, selection})
+      : undefined
+    const testFilesFinder = new TestFilesFinder({directory, directories, processArgs: filteredProcessArgs})
+    /** @type {TestRunner | undefined} */
+    let testRunner
+    let profileFinalized = false
 
-    const handleSignal = async (/** @type {string} */ signal) => {
-      if (signalHandled) return
-      signalHandled = true
-      console.error(`\nReceived ${signal}, running afterAll hooks before exit...`)
+    /**
+     * Finalizes requested outputs once for every command outcome.
+     * @param {string} status - Run status.
+     * @returns {Promise<void>} - Resolves after requested outputs are written.
+     */
+    const finalizeProfile = async (status) => {
+      if (!profiler || profileFinalized) return
 
-      try {
-        await testRunner.runAfterAllsForActiveScopes()
-      } catch (error) {
-        console.error("Failed while running afterAll hooks:", error)
-      } finally {
-        process.exit(130)
+      profileFinalized = true
+      const failed = testRunner?.getFailedTests() ?? 0
+      const passed = testRunner?.getSuccessfulTests() ?? 0
+      const profileDocument = profiler.finish({
+        counts: {
+          discovered: testRunner?.getTestsCount() ?? 0,
+          executed: testRunner?.getExecutedTestsCount() ?? 0,
+          failed,
+          passed
+        },
+        focused: Boolean(testRunner?.anyTestsFocussed),
+        status
+      })
+
+      await writeTestProfileOutputs({
+        profile: profileDocument,
+        profileJsonPath: profileOptions.profileJsonPath,
+        timingManifestOutputPath: profileOptions.timingManifestOutputPath
+      })
+      console.log(`\n${formatTestProfileSummary(profileDocument, profileOptions)}`)
+    }
+
+    try {
+      const discoverTestFiles = async () => {
+        let discoveredTestFiles = await testFilesFinder.findTestFiles()
+
+        if (groups !== undefined || groupNumber !== undefined) {
+          if (groups === undefined || groupNumber === undefined) {
+            throw new Error("Both --groups and --group-number must be provided together")
+          }
+
+          const timingManifest = await loadTimingManifest(profileOptions.timingManifestPath)
+          const splitter = new TestSuiteSplitter({
+            groups,
+            groupNumber,
+            testFiles: discoveredTestFiles,
+            baseDirectory: directory,
+            timingManifest
+          })
+
+          discoveredTestFiles = splitter.getGroupFiles()
+          console.log(picocolors.cyan(`Running group ${groupNumber} of ${groups} (${discoveredTestFiles.length} files)`))
+        }
+
+        return discoveredTestFiles
       }
-    }
+      const testFiles = profiler
+        ? await profiler.measurePhase("discovery", discoverTestFiles)
+        : await discoverTestFiles()
 
-    process.once("SIGINT", () => { void handleSignal("SIGINT") })
-    process.once("SIGTERM", () => { void handleSignal("SIGTERM") })
+      profiler?.setSelection({fileCount: testFiles.length})
+      testRunner = new TestRunner({
+        configuration: this.getConfiguration(),
+        excludeTags,
+        includeTags,
+        testFiles,
+        lineFilters: testFilesFinder.getLineFiltersByFile(),
+        examplePatterns: normalizeExamplePatterns(examplePatterns),
+        profiler
+      })
+      const activeTestRunner = testRunner
+      let signalHandled = false
 
-    await testRunner.prepare()
+      const handleSignal = async (/** @type {string} */ signal) => {
+        if (signalHandled) return
+        signalHandled = true
+        profiler?.interrupt()
+        console.error(`\nReceived ${signal}, running afterAll hooks before exit...`)
 
-    if (testRunner.getTestsCount() === 0) {
-      throw new Error(`${testRunner.getTestsCount()} tests was found in ${testFiles.length} file(s)`)
-    }
-
-    await testRunner.run()
-
-    const executedTests = testRunner.getExecutedTestsCount()
-
-    const lineFilters = testRunner.getLineFilters()
-    const hasLineFilters = Object.keys(lineFilters).length > 0
-    const hasExampleFilters = examplePatterns.length > 0
-    const hasTagFilters = includeTags.length > 0 || excludeTags.length > 0
-
-    if ((hasTagFilters || hasLineFilters || hasExampleFilters) && executedTests === 0) {
-      console.error(picocolors.red("\nNo tests matched the provided filters"))
-      process.exit(1)
-    }
-
-    // Report the slowest tests so suite hotspots are visible every run. Defaults to
-    // the top 10; tune with VELOCIOUS_SLOW_TEST_COUNT (0 disables). Skipped for
-    // single-test runs where it would just be noise.
-    const slowTestCount = resolveSlowTestCount(process.env.VELOCIOUS_SLOW_TEST_COUNT)
-
-    if (slowTestCount > 0 && executedTests > 1) {
-      const slowestTests = testRunner.getSlowestTests(slowTestCount)
-
-      if (slowestTests.length > 0) {
-        console.log(picocolors.cyan(`\nSlowest ${slowestTests.length} tests:`))
-
-        for (const slowTest of slowestTests) {
-          const location = slowTest.filePath && slowTest.line ? ` (${slowTest.filePath}:${slowTest.line})` : ""
-
-          console.log(picocolors.cyan(`  ${String(slowTest.durationMs).padStart(6)}ms  ${slowTest.fullDescription}${location}`))
+        try {
+          await activeTestRunner.runAfterAllsForActiveScopes()
+        } catch (error) {
+          console.error("Failed while running afterAll hooks:", error)
+        } finally {
+          try {
+            await finalizeProfile("interrupted")
+          } catch (error) {
+            console.error("Failed while writing interrupted test profile:", error)
+          }
+          process.exit(130)
         }
       }
-    }
 
-    if (testRunner.isFailed()) {
-      await testRunner.persistFailedTestConsoleOutputsToAssets()
-      const failedTests = testRunner.getFailedTestDetails()
+      process.once("SIGINT", () => { void handleSignal("SIGINT") })
+      process.once("SIGTERM", () => { void handleSignal("SIGTERM") })
 
-      if (failedTests.length > 0) {
-      console.error(picocolors.red("\nFailed tests:"))
+      await testRunner.prepare()
 
-        for (const failed of failedTests) {
-          const location = failed.filePath && failed.line
-            ? ` (${failed.filePath}:${failed.line})`
-            : ""
-          console.error(picocolors.red(`- ${failed.fullDescription}${location}`))
+      if (testRunner.getTestsCount() === 0) {
+        await finalizeProfile("no-tests")
+        throw new Error(`${testRunner.getTestsCount()} tests was found in ${testFiles.length} file(s)`)
+      }
 
-          if (failed.consoleLogPath) {
-            console.error(picocolors.red(`  Console log: ${failed.consoleLogPath}`))
+      await testRunner.run()
+
+      const executedTests = testRunner.getExecutedTestsCount()
+      const lineFilters = testRunner.getLineFilters()
+      const hasLineFilters = Object.keys(lineFilters).length > 0
+      const hasExampleFilters = examplePatterns.length > 0
+      const hasTagFilters = includeTags.length > 0 || excludeTags.length > 0
+
+      if ((hasTagFilters || hasLineFilters || hasExampleFilters) && executedTests === 0) {
+        console.error(picocolors.red("\nNo tests matched the provided filters"))
+        await finalizeProfile("no-tests")
+        process.exit(1)
+      }
+
+      // Report the slowest tests so suite hotspots are visible every run. Defaults to
+      // the top 10; tune with VELOCIOUS_SLOW_TEST_COUNT (0 disables). Skipped for
+      // single-test runs where it would just be noise.
+      const slowTestCount = resolveSlowTestCount(process.env.VELOCIOUS_SLOW_TEST_COUNT)
+
+      if (slowTestCount > 0 && executedTests > 1) {
+        const slowestTests = testRunner.getSlowestTests(slowTestCount)
+
+        if (slowestTests.length > 0) {
+          console.log(picocolors.cyan(`\nSlowest ${slowestTests.length} tests:`))
+
+          for (const slowTest of slowestTests) {
+            const location = slowTest.filePath && slowTest.line ? ` (${slowTest.filePath}:${slowTest.line})` : ""
+
+            console.log(picocolors.cyan(`  ${String(slowTest.durationMs).padStart(6)}ms  ${slowTest.fullDescription}${location}`))
           }
         }
       }
 
-      console.error(picocolors.red(`\nTest run failed with ${testRunner.getFailedTests()} failed tests and ${testRunner.getSuccessfulTests()} successfull`))
-      process.exit(1)
-    } else if (testRunner.areAnyTestsFocussed()) {
-      console.error(picocolors.red(`\nFocussed run with ${testRunner.getFailedTests()} failed tests and ${testRunner.getSuccessfulTests()} successfull`))
-      process.exit(1)
-    } else {
-      console.log(picocolors.green(`\nTest run succeeded with ${testRunner.getSuccessfulTests()} successful tests`))
-      process.exit(0)
+      if (testRunner.isFailed()) {
+        await testRunner.persistFailedTestConsoleOutputsToAssets()
+        const failedTests = testRunner.getFailedTestDetails()
+
+        if (failedTests.length > 0) {
+          console.error(picocolors.red("\nFailed tests:"))
+
+          for (const failed of failedTests) {
+            const location = failed.filePath && failed.line
+              ? ` (${failed.filePath}:${failed.line})`
+              : ""
+            console.error(picocolors.red(`- ${failed.fullDescription}${location}`))
+
+            if (failed.consoleLogPath) {
+              console.error(picocolors.red(`  Console log: ${failed.consoleLogPath}`))
+            }
+          }
+        }
+
+        console.error(picocolors.red(`\nTest run failed with ${testRunner.getFailedTests()} failed tests and ${testRunner.getSuccessfulTests()} successfull`))
+        await finalizeProfile("failed")
+        process.exit(1)
+      } else if (testRunner.areAnyTestsFocussed()) {
+        console.error(picocolors.red(`\nFocussed run with ${testRunner.getFailedTests()} failed tests and ${testRunner.getSuccessfulTests()} successfull`))
+        await finalizeProfile("focused")
+        process.exit(1)
+      } else {
+        console.log(picocolors.green(`\nTest run succeeded with ${testRunner.getSuccessfulTests()} successful tests`))
+        await finalizeProfile("passed")
+        process.exit(0)
+      }
+    } catch (error) {
+      try {
+        await finalizeProfile("error")
+      } catch (profileError) {
+        throw new AggregateError([error, profileError], "Test command and profile finalization both failed", {cause: profileError})
+      }
+
+      throw error
     }
+  }
+}
+
+/**
+ * Resolves and validates profiling paths before test discovery starts.
+ * @param {object} args - Raw profiling options.
+ * @param {string} args.cwd - Command working directory.
+ * @param {boolean} args.profile - Whether console profiling was requested.
+ * @param {string} [args.profileJsonPath] - Rich profile output path.
+ * @param {string} [args.timingManifestPath] - Timing manifest input path.
+ * @param {string} [args.timingManifestOutputPath] - Timing manifest output path.
+ * @returns {{profile: boolean, profileJsonPath: string | undefined, timingManifestPath: string | undefined, timingManifestOutputPath: string | undefined}} - Resolved profiling options.
+ */
+export function resolveTestProfileOptions({cwd, profile, profileJsonPath, timingManifestPath, timingManifestOutputPath}) {
+  const resolvedProfileJsonPath = profileJsonPath ? path.resolve(cwd, profileJsonPath) : undefined
+  const resolvedTimingManifestPath = timingManifestPath ? path.resolve(cwd, timingManifestPath) : undefined
+  const resolvedTimingManifestOutputPath = timingManifestOutputPath
+    ? path.resolve(cwd, timingManifestOutputPath)
+    : undefined
+
+  if (resolvedProfileJsonPath && resolvedTimingManifestOutputPath && resolvedProfileJsonPath === resolvedTimingManifestOutputPath) {
+    throw new Error("Test profiling output paths must be different")
+  }
+
+  if (resolvedTimingManifestPath && (
+    resolvedProfileJsonPath === resolvedTimingManifestPath ||
+    resolvedTimingManifestOutputPath === resolvedTimingManifestPath
+  )) {
+    throw new Error("Test profiling outputs must not overwrite --timing-manifest input")
+  }
+
+  return {
+    profile: profile || Boolean(resolvedProfileJsonPath || resolvedTimingManifestOutputPath),
+    profileJsonPath: resolvedProfileJsonPath,
+    timingManifestPath: resolvedTimingManifestPath,
+    timingManifestOutputPath: resolvedTimingManifestOutputPath
   }
 }
 

--- a/src/testing/test-filter-parser.js
+++ b/src/testing/test-filter-parser.js
@@ -7,7 +7,10 @@
  * @property {string[]} filteredProcessArgs - Remaining process args with filter flags removed.
  * @property {number | undefined} groups - Total number of groups for test splitting.
  * @property {number | undefined} groupNumber - Which group to run (1-indexed).
+ * @property {boolean} profile - Whether test profiling is enabled.
+ * @property {string | undefined} profileJsonPath - Rich profile output path.
  * @property {string | undefined} timingManifestPath - JSON timing manifest path.
+ * @property {string | undefined} timingManifestOutputPath - Timing manifest output path.
  */
 // @ts-check
 
@@ -17,6 +20,8 @@ const EXAMPLE_FLAGS = new Set(["--example", "--name", "-e"])
 const GROUPS_FLAGS = new Set(["--groups"])
 const GROUP_NUMBER_FLAGS = new Set(["--group-number"])
 const TIMING_MANIFEST_FLAGS = new Set(["--timing-manifest"])
+const PROFILE_JSON_FLAGS = new Set(["--profile-json"])
+const TIMING_MANIFEST_OUTPUT_FLAGS = new Set(["--timing-manifest-output"])
 
 /**
  * Runs split tags.
@@ -81,8 +86,13 @@ export function parseFilters(processArgs) {
    * Defines groupNumber.
    * @type {number | undefined} */
   let groupNumber
+  let profile = false
+  /** @type {string | undefined} */
+  let profileJsonPath
   /** @type {string | undefined} */
   let timingManifestPath
+  /** @type {string | undefined} */
+  let timingManifestOutputPath
 
   let inRestArgs = false
 
@@ -189,15 +199,54 @@ export function parseFilters(processArgs) {
       if (TIMING_MANIFEST_FLAGS.has(arg)) {
         const nextValue = processArgs[i + 1]
 
-        if (nextValue && !nextValue.startsWith("-")) {
-          timingManifestPath = nextValue
-          i++
-        }
+        if (!nextValue || nextValue.startsWith("-")) throw new Error("--timing-manifest requires a path")
+        timingManifestPath = nextValue
+        i++
         continue
       }
 
       if (arg.startsWith("--timing-manifest=")) {
         timingManifestPath = arg.slice("--timing-manifest=".length)
+        if (!timingManifestPath) throw new Error("--timing-manifest requires a path")
+        continue
+      }
+
+      if (arg === "--profile") {
+        profile = true
+        continue
+      }
+
+      if (PROFILE_JSON_FLAGS.has(arg)) {
+        const nextValue = processArgs[i + 1]
+
+        if (!nextValue || nextValue.startsWith("-")) throw new Error("--profile-json requires a path")
+        profileJsonPath = nextValue
+        profile = true
+        i++
+        continue
+      }
+
+      if (arg.startsWith("--profile-json=")) {
+        profileJsonPath = arg.slice("--profile-json=".length)
+        if (!profileJsonPath) throw new Error("--profile-json requires a path")
+        profile = true
+        continue
+      }
+
+      if (TIMING_MANIFEST_OUTPUT_FLAGS.has(arg)) {
+        const nextValue = processArgs[i + 1]
+
+        if (!nextValue || nextValue.startsWith("-")) throw new Error("--timing-manifest-output requires a path")
+        timingManifestOutputPath = nextValue
+        profile = true
+        i++
+        continue
+      }
+
+      if (arg.startsWith("--timing-manifest-output=")) {
+        timingManifestOutputPath = arg.slice("--timing-manifest-output=".length)
+        if (!timingManifestOutputPath) throw new Error("--timing-manifest-output requires a path")
+        profile = true
         continue
       }
     }
@@ -212,6 +261,9 @@ export function parseFilters(processArgs) {
     filteredProcessArgs,
     groups,
     groupNumber,
-    timingManifestPath
+    profile,
+    profileJsonPath,
+    timingManifestPath,
+    timingManifestOutputPath
   }
 }

--- a/src/testing/test-profile-activity.js
+++ b/src/testing/test-profile-activity.js
@@ -1,0 +1,14 @@
+// @ts-check
+
+/**
+ * Validates a low-cardinality activity label suitable for profile output.
+ * @param {string} name - Activity name.
+ * @returns {string} - Validated name.
+ */
+export function validateTestActivityName(name) {
+  if (typeof name !== "string" || !/^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$/.test(name) || name.length > 64) {
+    throw new Error("Test profile activity name must be a lowercase identifier of at most 64 characters")
+  }
+
+  return name
+}

--- a/src/testing/test-profile-context.js
+++ b/src/testing/test-profile-context.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/** @type {WeakMap<import("../configuration.js").default, () => import("./test-profiler.js").TestProfileAsyncContext | undefined>} */
+const profileContextReaders = new WeakMap()
+
+/**
+ * Enables profile-context lookup for one configuration only when a collector exists.
+ * @param {import("../configuration.js").default} configuration - Configuration identity.
+ * @param {() => import("./test-profiler.js").TestProfileAsyncContext | undefined} reader - Async-context reader.
+ * @returns {void}
+ */
+export function registerTestProfileContextReader(configuration, reader) {
+  profileContextReaders.set(configuration, reader)
+}
+
+/**
+ * Gets an active profile context without requiring configuration doubles to
+ * implement profiling APIs and without reading async context in normal runs.
+ * @param {import("../configuration.js").default} configuration - Configuration identity.
+ * @returns {import("./test-profiler.js").TestProfileAsyncContext | undefined} - Active context.
+ */
+export function currentTestProfileContext(configuration) {
+  const reader = profileContextReaders.get(configuration)
+
+  if (!reader) return undefined
+
+  return reader()
+}

--- a/src/testing/test-profile-output.js
+++ b/src/testing/test-profile-output.js
@@ -1,0 +1,240 @@
+// @ts-check
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { roundProfileDuration } from "./test-profiler.js"
+
+const FORBIDDEN_PROFILE_FIELDS = new Set([
+  "bind",
+  "binds",
+  "checkoutname",
+  "credential",
+  "credentials",
+  "databasename",
+  "error",
+  "host",
+  "password",
+  "reusekey",
+  "sql",
+  "stack",
+  "tenant",
+  "username"
+])
+const PHASE_ORDER = [
+  "discovery",
+  "imports",
+  "testing config/global setup",
+  "beforeAll",
+  "beforeEach",
+  "test body",
+  "afterEach",
+  "afterAll",
+  "custom",
+  "runner overhead",
+  "total"
+]
+let atomicWriteSequence = 0
+
+/**
+ * Recursively rejects fields that are forbidden from rich profile output.
+ * @param {ReturnType<typeof JSON.parse>} value - Profile value.
+ * @param {string} [pathName] - Diagnostic field path.
+ * @returns {void}
+ */
+function assertProfilePrivacy(value, pathName = "profile") {
+  if (!value || typeof value !== "object") return
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      assertProfilePrivacy(value[index], `${pathName}[${index}]`)
+    }
+    return
+  }
+
+  for (const [key, childValue] of Object.entries(value)) {
+    if (FORBIDDEN_PROFILE_FIELDS.has(key.toLowerCase())) {
+      throw new Error(`Forbidden profile field: ${pathName}.${key}`)
+    }
+
+    assertProfilePrivacy(childValue, `${pathName}.${key}`)
+  }
+}
+
+/**
+ * Recursively rounds duration fields and rejects invalid duration values.
+ * @param {ReturnType<typeof JSON.parse>} value - Profile value.
+ * @param {string | undefined} [parentKey] - Parent field name.
+ * @returns {void}
+ */
+function normalizeDurations(value, parentKey) {
+  if (!value || typeof value !== "object") return
+
+  if (Array.isArray(value)) {
+    for (const childValue of value) normalizeDurations(childValue, parentKey)
+    return
+  }
+
+  for (const [key, childValue] of Object.entries(value)) {
+    const durationField = key.endsWith("Ms") || parentKey === "cpuMs"
+
+    if (durationField && typeof childValue === "number") {
+      if (typeof childValue !== "number" || !Number.isFinite(childValue) || childValue < 0) {
+        throw new Error(`Invalid test profile duration field: ${key}`)
+      }
+
+      value[key] = roundProfileDuration(childValue)
+      continue
+    }
+
+    if (key.endsWith("Ms") && key !== "cpuMs") {
+      throw new Error(`Invalid test profile duration field: ${key}`)
+    }
+
+    normalizeDurations(childValue, key)
+  }
+}
+
+/**
+ * Returns a normalized JSON-safe rich profile.
+ * @param {ReturnType<typeof JSON.parse>} profile - Rich profile document.
+ * @returns {ReturnType<typeof JSON.parse>} - Normalized document.
+ */
+function normalizedProfile(profile) {
+  if (profile?.schema !== "velocious.test-profile" || profile?.schemaVersion !== 1) {
+    throw new Error("Invalid Velocious test profile schema")
+  }
+
+  assertProfilePrivacy(profile)
+  const normalized = JSON.parse(JSON.stringify(profile))
+
+  normalizeDurations(normalized)
+  return normalized
+}
+
+/**
+ * Writes text through a same-directory temporary file and atomic rename.
+ * @param {string} outputPath - Final output path.
+ * @param {string} content - Complete output content.
+ * @returns {Promise<void>} - Resolves after rename.
+ */
+async function atomicWrite(outputPath, content) {
+  const directory = path.dirname(outputPath)
+  const sequence = ++atomicWriteSequence
+  const temporaryPath = path.join(directory, `.${path.basename(outputPath)}.${process.pid}.${sequence}.tmp`)
+  let temporaryFileCreated = false
+
+  await fs.mkdir(directory, {recursive: true})
+
+  try {
+    await fs.writeFile(temporaryPath, content, {encoding: "utf8", flag: "wx"})
+    temporaryFileCreated = true
+    await fs.rename(temporaryPath, outputPath)
+  } catch (error) {
+    if (temporaryFileCreated) {
+      try {
+        await fs.unlink(temporaryPath)
+      } catch (cleanupError) {
+        if (!(cleanupError instanceof Error) || !("code" in cleanupError) || cleanupError.code !== "ENOENT") {
+          throw new AggregateError(
+            [error, cleanupError],
+            `Failed to write and clean up test profile output: ${outputPath}`,
+            {cause: cleanupError}
+          )
+        }
+      }
+    }
+
+    throw error
+  }
+}
+
+/**
+ * Creates a sorted plain timing manifest.
+ * @param {ReturnType<typeof JSON.parse>} profile - Rich profile document.
+ * @returns {Record<string, number>} - Sorted file-duration map.
+ */
+export function timingManifestFromProfile(profile) {
+  /** @type {Record<string, number>} */
+  const manifest = {}
+
+  for (const filePath of Object.keys(profile.timingManifest || {}).sort()) {
+    const durationMs = profile.timingManifest[filePath]
+
+    if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0) {
+      throw new Error(`Invalid timing manifest duration for ${filePath}`)
+    }
+
+    manifest[filePath] = roundProfileDuration(durationMs)
+  }
+
+  return manifest
+}
+
+/**
+ * Atomically writes requested test profile outputs.
+ * @param {object} args - Output options.
+ * @param {ReturnType<typeof JSON.parse>} args.profile - Rich profile document.
+ * @param {string} [args.profileJsonPath] - Rich JSON path.
+ * @param {string} [args.timingManifestOutputPath] - Plain timing manifest path.
+ * @returns {Promise<void>} - Resolves after all requested writes.
+ */
+export async function writeTestProfileOutputs({profile, profileJsonPath, timingManifestOutputPath}) {
+  const normalized = normalizedProfile(profile)
+  const timingManifest = timingManifestFromProfile(normalized)
+
+  normalized.timingManifest = timingManifest
+
+  if (profileJsonPath) {
+    await atomicWrite(profileJsonPath, `${JSON.stringify(normalized, null, 2)}\n`)
+  }
+
+  if (timingManifestOutputPath) {
+    await atomicWrite(timingManifestOutputPath, `${JSON.stringify(timingManifest, null, 2)}\n`)
+  }
+}
+
+/**
+ * Formats a compact Benchmark-style console summary.
+ * @param {ReturnType<typeof JSON.parse>} profile - Rich profile document.
+ * @param {{profileJsonPath?: string, timingManifestOutputPath?: string}} [outputs] - Written output paths.
+ * @returns {string} - Console summary.
+ */
+export function formatTestProfileSummary(profile, outputs = {}) {
+  const lines = [
+    "Test profile",
+    "Phase".padEnd(31) + "Count".padStart(5) + "Real ms".padStart(13) + "CPU ms".padStart(13)
+  ]
+
+  for (const phase of PHASE_ORDER) {
+    const aggregate = profile.phases?.[phase]
+
+    if (!aggregate) continue
+
+    lines.push(
+      phase.padEnd(31) +
+      String(aggregate.count).padStart(5) +
+      aggregate.totalMs.toFixed(3).padStart(13) +
+      aggregate.cpuMs.total.toFixed(3).padStart(13)
+    )
+  }
+
+  if (profile.pools?.length > 0) {
+    lines.push("Pools")
+
+    for (const pool of profile.pools) {
+      lines.push(
+        `Pool ${pool.identifier}: created=${pool.connectionCreation.count}` +
+        ` failed=${pool.connectionCreation.failedCount}` +
+        ` wait=${pool.checkoutWait.count}/${pool.checkoutWait.totalMs.toFixed(3)}ms` +
+        ` timeouts=${pool.checkoutTimeoutCount}` +
+        ` reaped=${pool.idleReap.disposalCount}` +
+        ` peak=${pool.peakLiveConnections}`
+      )
+    }
+  }
+
+  if (outputs.profileJsonPath) lines.push(`Rich JSON: ${outputs.profileJsonPath}`)
+  if (outputs.timingManifestOutputPath) lines.push(`Timing manifest: ${outputs.timingManifestOutputPath}`)
+
+  return lines.join("\n")
+}

--- a/src/testing/test-profiler.js
+++ b/src/testing/test-profiler.js
@@ -1,0 +1,917 @@
+// @ts-check
+
+import { createHash } from "node:crypto"
+import path from "node:path"
+import { registerTestProfileContextReader } from "./test-profile-context.js"
+import { validateTestActivityName } from "./test-profile-activity.js"
+
+/** @typedef {"passed" | "failed" | "interrupted" | "timed-out"} TestProfileAttemptStatus */
+/** @typedef {{user: number, system: number}} ProcessCpuUsage */
+/** @typedef {{queryCount: number, failedQueryCount: number, totalMs: number, maxMs: number}} ProfileDatabaseAggregate */
+/** @typedef {{count: number, failedCount: number, totalMs: number, maxMs: number}} ProfileActionAggregate */
+/** @typedef {{identifier: string, connectionCreation: ProfileActionAggregate, checkoutWait: {count: number, totalMs: number, maxMs: number}, checkoutTimeoutCount: number, idleReap: ProfileActionAggregate & {disposalCount: number}, peakLiveConnections: number}} ProfilePoolAggregate */
+
+/**
+ * @typedef {object} TestProfileAsyncContext
+ * @property {TestProfiler} profiler - Owning profiler.
+ * @property {TestProfileAttemptRecord | undefined} attempt - Active test attempt.
+ * @property {boolean} active - Whether attribution is still open.
+ * @property {Set<TestProfileAsyncContext> | undefined} [attemptContexts] - Contexts sharing one attempt lifetime.
+ * @property {string | undefined} filePath - Project-relative owning test file.
+ * @property {TestProfileSpan | undefined} [span] - Innermost active profile span.
+ * @property {number} [spanStartedAt] - Span monotonic start time.
+ * @property {ProcessCpuUsage} [spanCpuStartedAt] - Span CPU start time.
+ */
+
+/**
+ * @typedef {object} TestProfileSpan
+ * @property {string} phase - Profile phase.
+ * @property {number} executionOrder - Monotonic span start order.
+ * @property {number} durationMs - Real duration.
+ * @property {{user: number, system: number, total: number}} cpuMs - Process CPU duration.
+ * @property {string} [activity] - Validated custom activity name.
+ * @property {number} [declarationIndex] - Hook index within its declaration scope.
+ * @property {string} [declarationScopeId] - Opaque declaration scope identifier.
+ * @property {string} [file] - Project-relative source path.
+ * @property {ProfileDatabaseAggregate} [database] - Span database aggregate.
+ * @property {ProfilePoolAggregate[]} [pools] - Span pool aggregates.
+ */
+
+/**
+ * @typedef {object} TestProfileAttemptRecord
+ * @property {number} number - One-indexed attempt number.
+ * @property {TestProfileAttemptStatus | "running"} status - Attempt result.
+ * @property {number} durationMs - Real duration.
+ * @property {{user: number, system: number, total: number}} cpuMs - Process CPU duration.
+ * @property {TestProfileSpan[]} spans - Attempt-owned spans.
+ */
+
+/**
+ * @typedef {object} TestProfileAttemptHandle
+ * @property {TestProfileAsyncContext} context - Async attribution context.
+ * @property {TestProfileAttemptRecord} attempt - Output attempt record.
+ * @property {number} startedAt - Real start time.
+ * @property {ProcessCpuUsage} cpuStartedAt - CPU start time.
+ */
+
+/**
+ * @typedef {object} InternalPhaseAggregate
+ * @property {number} count - Invocation count.
+ * @property {number} totalMs - Total real duration.
+ * @property {number} maxMs - Maximum real duration.
+ * @property {number} cpuUserMs - Total user CPU time.
+ * @property {number} cpuSystemMs - Total system CPU time.
+ */
+
+/**
+ * @typedef {object} InternalFileAggregate
+ * @property {string} path - Project-relative path.
+ * @property {number} importMs - Import duration.
+ * @property {number} hooksMs - Hook duration.
+ * @property {number} testsMs - Test body duration.
+ * @property {number} attemptsMs - Complete test-attempt duration.
+ * @property {number} totalMs - Total file weight duration.
+ */
+
+/**
+ * @typedef {object} InternalTestRecord
+ * @property {string} id - Opaque stable test identifier.
+ * @property {string} file - Project-relative source path.
+ * @property {number | undefined} line - Declaration line.
+ * @property {TestProfileAttemptRecord[]} attempts - Attempt records.
+ */
+
+const BUILT_IN_PHASES = [
+  "discovery",
+  "imports",
+  "testing config/global setup",
+  "beforeAll",
+  "beforeEach",
+  "test body",
+  "afterEach",
+  "afterAll"
+]
+const MAX_CUSTOM_ACTIVITY_NAMES = 20
+const SAFE_SQL_OPERATIONS = new Set([
+  "ALTER",
+  "ANALYZE",
+  "BEGIN",
+  "CALL",
+  "COMMIT",
+  "COPY",
+  "CREATE",
+  "DELETE",
+  "DESCRIBE",
+  "DROP",
+  "EXEC",
+  "EXECUTE",
+  "EXPLAIN",
+  "GRANT",
+  "INSERT",
+  "MERGE",
+  "PRAGMA",
+  "RELEASE",
+  "REPLACE",
+  "REVOKE",
+  "ROLLBACK",
+  "SAVEPOINT",
+  "SELECT",
+  "SET",
+  "SHOW",
+  "TRUNCATE",
+  "UPDATE",
+  "VACUUM",
+  "VALUES",
+  "WITH"
+])
+
+/**
+ * Rounds and bounds duration values for public output.
+ * @param {number} durationMs - Raw duration.
+ * @returns {number} - Safe duration.
+ */
+export function roundProfileDuration(durationMs) {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return 0
+
+  return Math.round(durationMs * 1000) / 1000
+}
+
+/**
+ * Collects opt-in test-run timing without retaining application payloads.
+ */
+export default class TestProfiler {
+  /**
+   * Creates an opt-in test profile collector.
+   * @param {object} args - Profiler options.
+   * @param {import("../configuration.js").default} args.configuration - Test configuration.
+   * @param {string} args.projectDirectory - Project root used for portable paths.
+   * @param {Record<string, ReturnType<typeof JSON.parse>>} [args.selection] - Sanitized selection metadata.
+   */
+  constructor({configuration, projectDirectory, selection = {}}) {
+    this._configuration = configuration
+    this._projectDirectory = path.resolve(projectDirectory)
+    this._selection = selection
+    this._startedAt = this.now()
+    this._cpuStartedAt = process.cpuUsage()
+    this._executionOrder = 0
+    this._unattributedLateEventCount = 0
+    /** @type {Map<string, InternalPhaseAggregate>} */
+    this._phases = new Map()
+    /** @type {Map<string, InternalFileAggregate>} */
+    this._files = new Map()
+    /** @type {InternalTestRecord[]} */
+    this._tests = []
+    /** @type {Map<string, InternalTestRecord>} */
+    this._testsById = new Map()
+    /** @type {Set<TestProfileAttemptHandle>} */
+    this._activeAttempts = new Set()
+    /** @type {Set<TestProfileAsyncContext>} */
+    this._activeSpanContexts = new Set()
+    /** @type {TestProfileSpan[]} */
+    this._spans = []
+    /** @type {Array<{id: string, parentId: string | undefined, file: string, line: number | undefined}>} */
+    this._scopes = []
+    /** @type {WeakMap<import("./test-runner.js").TestsArgument, string>} */
+    this._scopeIds = new WeakMap()
+    /** @type {Set<string>} */
+    this._customActivityNames = new Set()
+    this._database = this.emptyDatabaseAggregate()
+    /** @type {Map<string, {hash: string, operation: string, count: number, failedCount: number, totalMs: number, maxMs: number}>} */
+    this._queryFingerprints = new Map()
+    this._transactions = {
+      start: this.phaseAggregateShape(),
+      commit: this.phaseAggregateShape(),
+      rollback: this.phaseAggregateShape()
+    }
+    /** @type {Map<string, ProfilePoolAggregate>} */
+    this._pools = new Map()
+    this._finishedProfile = undefined
+
+    registerTestProfileContextReader(configuration, () => {
+      return configuration.getEnvironmentHandler().getCurrentTestProfileContext()
+    })
+
+    for (const phase of BUILT_IN_PHASES) this.phaseAggregate(phase)
+  }
+
+  /**
+   * Returns the profiler's monotonic clock.
+   * @returns {number} - Monotonic milliseconds.
+   */
+  now() {
+    return globalThis.performance.now()
+  }
+
+  /**
+   * Converts a source path to a project-relative path or an opaque hash.
+   * @param {string | undefined} filePath - Source path.
+   * @returns {string} - Safe source identifier.
+   */
+  safeSourcePath(filePath) {
+    if (!filePath) return "sha256:unknown"
+
+    const absolutePath = path.resolve(filePath)
+    const relativePath = path.relative(this._projectDirectory, absolutePath)
+
+    if (relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+      return relativePath.replaceAll(path.sep, "/")
+    }
+
+    if (!relativePath) return path.basename(absolutePath)
+
+    return this.hash(`external-source:${absolutePath}`)
+  }
+
+  /**
+   * Returns a bounded opaque SHA-256 identifier.
+   * @param {string} value - Value to hash.
+   * @returns {string} - Opaque hash.
+   */
+  hash(value) {
+    return `sha256:${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
+  }
+
+  /**
+   * Adds aggregate-only selection metadata as discovery progresses.
+   * @param {Record<string, ReturnType<typeof JSON.parse>>} selection - Safe selection metadata.
+   * @returns {void}
+   */
+  setSelection(selection) {
+    Object.assign(this._selection, selection)
+  }
+
+  /**
+   * Registers and returns a deterministic scope identifier.
+   * @param {import("./test-runner.js").TestsArgument} scope - Scope object.
+   * @param {object} args - Scope metadata.
+   * @param {string[]} args.descriptions - Scope description path.
+   * @param {string | undefined} args.filePath - Scope source path.
+   * @param {number | undefined} [args.line] - Scope source line.
+   * @param {string | undefined} [args.parentId] - Parent scope identifier.
+   * @returns {string} - Opaque scope identifier.
+   */
+  scopeId(scope, {descriptions, filePath, line, parentId}) {
+    const existing = this._scopeIds.get(scope)
+    if (existing) return existing
+
+    const safeFilePath = this.safeSourcePath(filePath)
+    const id = this.hash(`scope:${safeFilePath}:${line ?? 0}:${descriptions.join("\u0000")}`)
+
+    this._scopeIds.set(scope, id)
+    this._scopes.push({id, parentId, file: safeFilePath, line})
+    return id
+  }
+
+  /**
+   * Starts an attempt and its async attribution context.
+   * @param {object} args - Attempt metadata.
+   * @param {string[]} args.descriptions - Parent descriptions.
+   * @param {number} args.attemptNumber - Attempt number.
+   * @param {import("./test-runner.js").TestData} args.testData - Test declaration.
+   * @param {string} args.testDescription - Test description.
+   * @returns {TestProfileAttemptHandle} - Active attempt handle.
+   */
+  startAttempt({descriptions, attemptNumber, testData, testDescription}) {
+    const file = this.safeSourcePath(testData.ownerFilePath ?? testData.filePath)
+    const id = this.hash(`test:${file}:${testData.line ?? 0}:${[...descriptions, testDescription].join("\u0000")}`)
+    let testRecord = this._testsById.get(id)
+
+    if (!testRecord) {
+      testRecord = {id, file, line: testData.line, attempts: []}
+      this._testsById.set(id, testRecord)
+      this._tests.push(testRecord)
+    }
+
+    /** @type {TestProfileAttemptRecord} */
+    const attempt = {
+      number: attemptNumber,
+      status: "running",
+      durationMs: 0,
+      cpuMs: {user: 0, system: 0, total: 0},
+      spans: []
+    }
+    /** @type {Set<TestProfileAsyncContext>} */
+    const attemptContexts = new Set()
+    const context = {profiler: this, attempt, active: true, attemptContexts, filePath: file, span: undefined}
+
+    attemptContexts.add(context)
+
+    const handle = {context, attempt, startedAt: this.now(), cpuStartedAt: process.cpuUsage()}
+
+    testRecord.attempts.push(attempt)
+    this._activeAttempts.add(handle)
+
+    return handle
+  }
+
+  /**
+   * Runs work inside an attempt's async context.
+   * @template T
+   * @param {TestProfileAttemptHandle} handle - Attempt handle.
+   * @param {() => Promise<T>} callback - Attempt lifecycle.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async runAttempt(handle, callback) {
+    return await this._configuration
+      .getEnvironmentHandler()
+      .runWithTestProfileContext(handle.context, callback)
+  }
+
+  /**
+   * Completes an attempt and prevents descendant late work from retaining attribution.
+   * @param {TestProfileAttemptHandle} handle - Attempt handle.
+   * @param {TestProfileAttemptStatus} status - Attempt result.
+   * @returns {void}
+   */
+  finishAttempt(handle, status) {
+    if (handle.attempt.status !== "running") return
+
+    for (const context of handle.context.attemptContexts || []) {
+      if (context.span) this.finishSpanContext(context)
+      context.active = false
+    }
+
+    handle.attempt.status = status
+    handle.attempt.durationMs = roundProfileDuration(this.now() - handle.startedAt)
+    handle.attempt.cpuMs = this.cpuDuration(handle.cpuStartedAt)
+    this.addFileAttemptDuration(handle.context.filePath, handle.attempt.durationMs)
+    this._activeAttempts.delete(handle)
+  }
+
+  /**
+   * Closes every active attempt and nested span at the current interruption boundary.
+   * @returns {void}
+   */
+  interrupt() {
+    for (const handle of [...this._activeAttempts]) {
+      this.finishAttempt(handle, "interrupted")
+    }
+
+    for (const context of [...this._activeSpanContexts]) {
+      this.finishSpanContext(context)
+    }
+  }
+
+  /**
+   * Runs a runner-owned phase span.
+   * @template T
+   * @param {object} args - Span metadata.
+   * @param {string} args.phase - Phase name.
+   * @param {string} [args.activity] - Custom activity label.
+   * @param {number} [args.declarationIndex] - Hook declaration index.
+   * @param {string} [args.declarationScopeId] - Hook declaration scope.
+   * @param {string} [args.filePath] - Source or owning test file.
+   * @param {() => (T | Promise<T>)} callback - Timed work.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async runSpan({phase, activity, declarationIndex, declarationScopeId, filePath}, callback) {
+    const currentContext = this._configuration.getEnvironmentHandler().getCurrentTestProfileContext()
+
+    if (currentContext && !this.contextIsActive(currentContext)) {
+      this._unattributedLateEventCount++
+      return await callback()
+    }
+
+    const safeFilePath = currentContext?.filePath ?? (filePath ? this.safeSourcePath(filePath) : undefined)
+    const startedAt = this.now()
+    const cpuStartedAt = process.cpuUsage()
+    /** @type {TestProfileSpan} */
+    const span = {
+      phase,
+      executionOrder: ++this._executionOrder,
+      durationMs: 0,
+      cpuMs: {user: 0, system: 0, total: 0}
+    }
+
+    if (activity) span.activity = activity
+    if (declarationIndex !== undefined) span.declarationIndex = declarationIndex
+    if (declarationScopeId) span.declarationScopeId = declarationScopeId
+    if (safeFilePath) span.file = safeFilePath
+
+    if (currentContext?.attempt) {
+      currentContext.attempt.spans.push(span)
+    } else {
+      this._spans.push(span)
+    }
+
+    const spanContext = {
+      profiler: this,
+      attempt: currentContext?.attempt,
+      active: true,
+      attemptContexts: currentContext?.attemptContexts,
+      filePath: safeFilePath,
+      span,
+      spanStartedAt: startedAt,
+      spanCpuStartedAt: cpuStartedAt
+    }
+
+    spanContext.attemptContexts?.add(spanContext)
+    this._activeSpanContexts.add(spanContext)
+
+    try {
+      return await this._configuration
+        .getEnvironmentHandler()
+        .runWithTestProfileContext(spanContext, callback)
+    } finally {
+      if (spanContext.active) {
+        this.finishSpanContext(spanContext)
+      } else if (spanContext.attempt) {
+        this._unattributedLateEventCount++
+      }
+    }
+  }
+
+  /**
+   * Finalizes an open span, including partial work closed by a timeout.
+   * @param {TestProfileAsyncContext} context - Span context.
+   * @returns {void}
+   */
+  finishSpanContext(context) {
+    if (!context.active || !context.span || context.spanStartedAt === undefined || !context.spanCpuStartedAt) return
+
+    context.active = false
+    context.span.durationMs = roundProfileDuration(this.now() - context.spanStartedAt)
+    context.span.cpuMs = this.cpuDuration(context.spanCpuStartedAt)
+    this.addPhaseDuration(context.span.phase, context.span.durationMs, context.span.cpuMs)
+    this.addFileDuration(context.filePath, context.span.phase, context.span.durationMs, Boolean(context.attempt))
+    this._activeSpanContexts.delete(context)
+  }
+
+  /**
+   * Checks both a nested span boundary and its owning attempt boundary.
+   * @param {TestProfileAsyncContext} context - Candidate profile context.
+   * @returns {boolean} - Whether events may still be attributed.
+   */
+  contextIsActive(context) {
+    return context.active && (!context.attempt || context.attempt.status === "running")
+  }
+
+  /**
+   * Runs a validated application-defined activity.
+   * @template T
+   * @param {TestProfileAsyncContext} context - Captured async context.
+   * @param {string} name - Validated activity name.
+   * @param {() => (T | Promise<T>)} callback - Activity callback.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async profileActivity(context, name, callback) {
+    if (!this.contextIsActive(context)) {
+      this._unattributedLateEventCount++
+      return await callback()
+    }
+
+    const validatedName = validateTestActivityName(name)
+    let outputName = validatedName
+
+    if (!this._customActivityNames.has(validatedName)) {
+      if (this._customActivityNames.size >= MAX_CUSTOM_ACTIVITY_NAMES) {
+        outputName = "other"
+      } else {
+        this._customActivityNames.add(validatedName)
+      }
+    }
+
+    return await this.runSpan({phase: "custom", activity: outputName}, callback)
+  }
+
+  /**
+   * Measures a command-level phase outside an attempt.
+   * @template T
+   * @param {string} phase - Phase name.
+   * @param {() => (T | Promise<T>)} callback - Timed work.
+   * @param {{filePath?: string}} [metadata] - Optional source ownership.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async measurePhase(phase, callback, metadata = {}) {
+    return await this.runSpan({phase, filePath: metadata.filePath}, callback)
+  }
+
+  /**
+   * Records one successful or failed physical database query attempt.
+   * @param {TestProfileAsyncContext} context - Context captured when the query began.
+   * @param {{durationMs: number, failed: boolean, sqlFingerprint: string, sqlOperation: string}} args - Query aggregate values.
+   * @returns {void}
+   */
+  recordDatabaseQuery(context, {durationMs, failed, sqlFingerprint, sqlOperation}) {
+    if (!this.contextIsActive(context)) {
+      this._unattributedLateEventCount++
+      return
+    }
+
+    const safeDurationMs = roundProfileDuration(durationMs)
+
+    this.addDatabaseQueryAggregate(this._database, {durationMs: safeDurationMs, failed})
+    if (context.span) {
+      context.span.database ||= this.emptyDatabaseAggregate()
+      this.addDatabaseQueryAggregate(context.span.database, {durationMs: safeDurationMs, failed})
+    }
+
+    const safeOperation = SAFE_SQL_OPERATIONS.has(sqlOperation) ? sqlOperation : "UNKNOWN"
+    const fingerprintKey = `${safeOperation}:${sqlFingerprint}`
+    let fingerprint = this._queryFingerprints.get(fingerprintKey)
+
+    if (!fingerprint && this._queryFingerprints.size < 50) {
+      fingerprint = {
+        hash: sqlFingerprint,
+        operation: safeOperation,
+        count: 0,
+        failedCount: 0,
+        totalMs: 0,
+        maxMs: 0
+      }
+      this._queryFingerprints.set(fingerprintKey, fingerprint)
+    }
+
+    if (fingerprint) {
+      fingerprint.count++
+      if (failed) fingerprint.failedCount++
+      fingerprint.totalMs += safeDurationMs
+      fingerprint.maxMs = Math.max(fingerprint.maxMs, safeDurationMs)
+    }
+  }
+
+  /**
+   * Records a physical transaction action.
+   * @param {TestProfileAsyncContext} context - Context captured when the action began.
+   * @param {{action: "start" | "commit" | "rollback", durationMs: number, failed: boolean}} args - Transaction aggregate values.
+   * @returns {void}
+   */
+  recordDatabaseTransaction(context, {action, durationMs, failed}) {
+    if (!this.contextIsActive(context)) {
+      this._unattributedLateEventCount++
+      return
+    }
+
+    const aggregate = this._transactions[action]
+    const safeDurationMs = roundProfileDuration(durationMs)
+
+    aggregate.count++
+    if (failed) aggregate.failedCount++
+    aggregate.totalMs += safeDurationMs
+    aggregate.maxMs = Math.max(aggregate.maxMs, safeDurationMs)
+  }
+
+  /**
+   * Records one low-cardinality pool lifecycle delta.
+   * @param {TestProfileAsyncContext} context - Context captured when the operation began.
+   * @param {string} identifier - Logical pool identifier.
+   * @param {"connectionCreation" | "checkoutWait" | "checkoutTimeout" | "idleReap" | "idleReapDisposal" | "peakLiveConnections"} metric - Metric name.
+   * @param {{durationMs?: number, failed?: boolean, value?: number}} [values] - Aggregate values.
+   * @returns {void}
+   */
+  recordPoolMetric(context, identifier, metric, values = {}) {
+    if (!this.contextIsActive(context)) {
+      this._unattributedLateEventCount++
+      return
+    }
+
+    const aggregate = this.poolAggregate(this._pools, identifier)
+
+    this.addPoolMetric(aggregate, metric, values)
+
+    if (context.span) {
+      context.span.pools ||= []
+      const spanPools = new Map(context.span.pools.map((pool) => [pool.identifier, pool]))
+      const spanAggregate = this.poolAggregate(spanPools, identifier)
+
+      if (!context.span.pools.includes(spanAggregate)) context.span.pools.push(spanAggregate)
+      this.addPoolMetric(spanAggregate, metric, values)
+    }
+  }
+
+  /**
+   * Builds the final privacy-safe profile document.
+   * @param {object} args - Run result.
+   * @param {{discovered: number, executed: number, failed: number, passed: number}} args.counts - Run counts.
+   * @param {boolean} args.focused - Whether focused tests were selected.
+   * @param {string} args.status - Run status.
+   * @returns {ReturnType<typeof JSON.parse>} - Rich profile document.
+   */
+  finish({counts, focused, status}) {
+    if (this._finishedProfile) return this._finishedProfile
+
+    const totalDurationMs = roundProfileDuration(this.now() - this._startedAt)
+    const totalCpuMs = this.cpuDuration(this._cpuStartedAt)
+    const exclusivePhaseNames = BUILT_IN_PHASES
+    const measuredDurationMs = exclusivePhaseNames.reduce((sum, phase) => sum + this.phaseAggregate(phase).totalMs, 0)
+    const measuredCpuUserMs = exclusivePhaseNames.reduce((sum, phase) => sum + this.phaseAggregate(phase).cpuUserMs, 0)
+    const measuredCpuSystemMs = exclusivePhaseNames.reduce((sum, phase) => sum + this.phaseAggregate(phase).cpuSystemMs, 0)
+
+    this._phases.set("runner overhead", {
+      count: 1,
+      totalMs: Math.max(0, totalDurationMs - measuredDurationMs),
+      maxMs: Math.max(0, totalDurationMs - measuredDurationMs),
+      cpuUserMs: Math.max(0, totalCpuMs.user - measuredCpuUserMs),
+      cpuSystemMs: Math.max(0, totalCpuMs.system - measuredCpuSystemMs)
+    })
+    this._phases.set("total", {
+      count: 1,
+      totalMs: totalDurationMs,
+      maxMs: totalDurationMs,
+      cpuUserMs: totalCpuMs.user,
+      cpuSystemMs: totalCpuMs.system
+    })
+
+    const phases = Object.fromEntries([...this._phases.entries()].map(([phase, aggregate]) => [
+      phase,
+      this.publicAggregate(aggregate)
+    ]))
+    const files = [...this._files.values()]
+      .map((file) => ({
+        path: file.path,
+        importMs: roundProfileDuration(file.importMs),
+        hooksMs: roundProfileDuration(file.hooksMs),
+        testsMs: roundProfileDuration(file.testsMs),
+        attemptsMs: roundProfileDuration(file.attemptsMs),
+        totalMs: roundProfileDuration(file.totalMs)
+      }))
+      .sort((fileA, fileB) => fileA.path.localeCompare(fileB.path))
+    const timingManifest = Object.fromEntries(files.map((file) => [file.path, file.totalMs]))
+    const attempts = this._tests.reduce((sum, test) => sum + test.attempts.length, 0)
+
+    this._finishedProfile = {
+      schema: "velocious.test-profile",
+      schemaVersion: 1,
+      status,
+      selection: {...this._selection, focused},
+      counts: {...counts, attempts},
+      durationMs: totalDurationMs,
+      cpuMs: totalCpuMs,
+      phases,
+      files,
+      scopes: [...this._scopes].sort((scopeA, scopeB) => scopeA.id.localeCompare(scopeB.id)),
+      tests: this._tests.map((test) => ({
+        id: test.id,
+        file: test.file,
+        line: test.line,
+        durationMs: roundProfileDuration(test.attempts.reduce((sum, attempt) => sum + attempt.durationMs, 0)),
+        attempts: test.attempts
+      })),
+      spans: this._spans,
+      database: {
+        queryCount: this._database.queryCount,
+        failedQueryCount: this._database.failedQueryCount,
+        totalMs: roundProfileDuration(this._database.totalMs),
+        maxMs: roundProfileDuration(this._database.maxMs),
+        fingerprints: [...this._queryFingerprints.values()]
+          .map((fingerprint) => ({
+            ...fingerprint,
+            totalMs: roundProfileDuration(fingerprint.totalMs),
+            maxMs: roundProfileDuration(fingerprint.maxMs)
+          }))
+          .sort((fingerprintA, fingerprintB) => {
+            return fingerprintA.operation.localeCompare(fingerprintB.operation) || fingerprintA.hash.localeCompare(fingerprintB.hash)
+          }),
+        transactions: {
+          start: this.publicActionAggregate(this._transactions.start),
+          commit: this.publicActionAggregate(this._transactions.commit),
+          rollback: this.publicActionAggregate(this._transactions.rollback)
+        }
+      },
+      pools: [...this._pools.values()]
+        .map((pool) => this.publicPoolAggregate(pool))
+        .sort((poolA, poolB) => poolA.identifier.localeCompare(poolB.identifier)),
+      unattributedLateEventCount: this._unattributedLateEventCount,
+      timingManifest
+    }
+
+    return this._finishedProfile
+  }
+
+  /**
+   * Returns an internal phase aggregate.
+   * @param {string} phase - Phase name.
+   * @returns {InternalPhaseAggregate} - Aggregate.
+   */
+  phaseAggregate(phase) {
+    let aggregate = this._phases.get(phase)
+
+    if (!aggregate) {
+      aggregate = {count: 0, totalMs: 0, maxMs: 0, cpuUserMs: 0, cpuSystemMs: 0}
+      this._phases.set(phase, aggregate)
+    }
+
+    return aggregate
+  }
+
+  /**
+   * Adds a completed span to its aggregate phase.
+   * @param {string} phase - Phase name.
+   * @param {number} durationMs - Real duration.
+   * @param {{user: number, system: number, total: number}} cpuMs - CPU duration.
+   * @returns {void}
+   */
+  addPhaseDuration(phase, durationMs, cpuMs) {
+    const aggregate = this.phaseAggregate(phase)
+
+    aggregate.count++
+    aggregate.totalMs += durationMs
+    aggregate.maxMs = Math.max(aggregate.maxMs, durationMs)
+    aggregate.cpuUserMs += cpuMs.user
+    aggregate.cpuSystemMs += cpuMs.system
+  }
+
+  /**
+   * Adds an exclusive file-owned phase to timing-manifest weight.
+   * @param {string | undefined} filePath - Safe project-relative path.
+   * @param {string} phase - Phase name.
+   * @param {number} durationMs - Real duration.
+   * @param {boolean} [insideAttempt] - Whether the phase is already covered by complete attempt time.
+   * @returns {void}
+   */
+  addFileDuration(filePath, phase, durationMs, insideAttempt = false) {
+    if (!filePath) return
+    if (!["imports", "beforeAll", "beforeEach", "test body", "afterEach", "afterAll"].includes(phase)) return
+
+    let file = this._files.get(filePath)
+
+    if (!file) {
+      file = {path: filePath, importMs: 0, hooksMs: 0, testsMs: 0, attemptsMs: 0, totalMs: 0}
+      this._files.set(filePath, file)
+    }
+
+    if (phase === "imports") file.importMs += durationMs
+    if (phase === "test body") file.testsMs += durationMs
+    if (["beforeAll", "beforeEach", "afterEach", "afterAll"].includes(phase)) file.hooksMs += durationMs
+    if (!insideAttempt) file.totalMs += durationMs
+  }
+
+  /**
+   * Adds the complete cost of an attempt to its owning file weight.
+   * @param {string | undefined} filePath - Safe project-relative path.
+   * @param {number} durationMs - Attempt duration.
+   * @returns {void}
+   */
+  addFileAttemptDuration(filePath, durationMs) {
+    if (!filePath) return
+
+    let file = this._files.get(filePath)
+
+    if (!file) {
+      file = {path: filePath, importMs: 0, hooksMs: 0, testsMs: 0, attemptsMs: 0, totalMs: 0}
+      this._files.set(filePath, file)
+    }
+
+    file.attemptsMs += durationMs
+    file.totalMs += durationMs
+  }
+
+  /**
+   * Calculates process CPU time since a start sample.
+   * @param {ProcessCpuUsage} start - CPU start sample.
+   * @returns {{user: number, system: number, total: number}} - Millisecond CPU duration.
+   */
+  cpuDuration(start) {
+    const cpu = process.cpuUsage(start)
+    const user = roundProfileDuration(cpu.user / 1000)
+    const system = roundProfileDuration(cpu.system / 1000)
+
+    return {user, system, total: roundProfileDuration(user + system)}
+  }
+
+  /**
+   * Converts an internal aggregate to public rounded values.
+   * @param {InternalPhaseAggregate} [aggregate] - Internal aggregate.
+   * @returns {{count: number, totalMs: number, maxMs: number, cpuMs: {user: number, system: number, total: number}}} - Public aggregate.
+   */
+  publicAggregate(aggregate = {count: 0, totalMs: 0, maxMs: 0, cpuUserMs: 0, cpuSystemMs: 0}) {
+    const user = roundProfileDuration(aggregate.cpuUserMs)
+    const system = roundProfileDuration(aggregate.cpuSystemMs)
+
+    return {
+      count: aggregate.count,
+      totalMs: roundProfileDuration(aggregate.totalMs),
+      maxMs: roundProfileDuration(aggregate.maxMs),
+      cpuMs: {user, system, total: roundProfileDuration(user + system)}
+    }
+  }
+
+  /**
+   * Returns an empty query aggregate.
+   * @returns {ProfileDatabaseAggregate} - Empty aggregate.
+   */
+  emptyDatabaseAggregate() {
+    return {queryCount: 0, failedQueryCount: 0, totalMs: 0, maxMs: 0}
+  }
+
+  /**
+   * Adds a query attempt to a database aggregate.
+   * @param {ProfileDatabaseAggregate} aggregate - Aggregate to update.
+   * @param {{durationMs: number, failed: boolean}} args - Attempt values.
+   * @returns {void}
+   */
+  addDatabaseQueryAggregate(aggregate, {durationMs, failed}) {
+    aggregate.queryCount++
+    if (failed) aggregate.failedQueryCount++
+    aggregate.totalMs += durationMs
+    aggregate.maxMs = Math.max(aggregate.maxMs, durationMs)
+  }
+
+  /**
+   * Returns an empty action aggregate.
+   * @returns {ProfileActionAggregate} - Empty aggregate.
+   */
+  phaseAggregateShape() {
+    return {count: 0, failedCount: 0, totalMs: 0, maxMs: 0}
+  }
+
+  /**
+   * Rounds a transaction or pool action aggregate.
+   * @param {ProfileActionAggregate} aggregate - Internal aggregate.
+   * @returns {ProfileActionAggregate} - Public aggregate.
+   */
+  publicActionAggregate(aggregate) {
+    return {
+      count: aggregate.count,
+      failedCount: aggregate.failedCount,
+      totalMs: roundProfileDuration(aggregate.totalMs),
+      maxMs: roundProfileDuration(aggregate.maxMs)
+    }
+  }
+
+  /**
+   * Returns an empty pool aggregate.
+   * @param {string} [identifier] - Logical pool identifier.
+   * @returns {ProfilePoolAggregate} - Empty aggregate.
+   */
+  emptyPoolAggregate(identifier = "") {
+    return {
+      identifier,
+      connectionCreation: this.phaseAggregateShape(),
+      checkoutWait: {count: 0, totalMs: 0, maxMs: 0},
+      checkoutTimeoutCount: 0,
+      idleReap: {...this.phaseAggregateShape(), disposalCount: 0},
+      peakLiveConnections: 0
+    }
+  }
+
+  /**
+   * Gets or creates a pool aggregate in a map.
+   * @param {Map<string, ProfilePoolAggregate>} pools - Pool map.
+   * @param {string} identifier - Logical pool identifier.
+   * @returns {ProfilePoolAggregate} - Pool aggregate.
+   */
+  poolAggregate(pools, identifier) {
+    let aggregate = pools.get(identifier)
+
+    if (!aggregate) {
+      aggregate = this.emptyPoolAggregate(identifier)
+      pools.set(identifier, aggregate)
+    }
+
+    return aggregate
+  }
+
+  /**
+   * Applies one pool metric delta.
+   * @param {ProfilePoolAggregate} aggregate - Pool aggregate.
+   * @param {"connectionCreation" | "checkoutWait" | "checkoutTimeout" | "idleReap" | "idleReapDisposal" | "peakLiveConnections"} metric - Metric name.
+   * @param {{durationMs?: number, failed?: boolean, value?: number}} values - Metric values.
+   * @returns {void}
+   */
+  addPoolMetric(aggregate, metric, values) {
+    const durationMs = roundProfileDuration(values.durationMs ?? 0)
+
+    if (metric === "connectionCreation" || metric === "idleReap") {
+      const actionAggregate = metric === "connectionCreation" ? aggregate.connectionCreation : aggregate.idleReap
+
+      actionAggregate.count++
+      if (values.failed) actionAggregate.failedCount++
+      actionAggregate.totalMs += durationMs
+      actionAggregate.maxMs = Math.max(actionAggregate.maxMs, durationMs)
+    } else if (metric === "checkoutWait") {
+      aggregate.checkoutWait.count++
+      aggregate.checkoutWait.totalMs += durationMs
+      aggregate.checkoutWait.maxMs = Math.max(aggregate.checkoutWait.maxMs, durationMs)
+    } else if (metric === "checkoutTimeout") {
+      aggregate.checkoutTimeoutCount++
+    } else if (metric === "idleReapDisposal") {
+      aggregate.idleReap.disposalCount++
+    } else if (metric === "peakLiveConnections") {
+      aggregate.peakLiveConnections = Math.max(aggregate.peakLiveConnections, values.value ?? 0)
+    }
+  }
+
+  /**
+   * Rounds a pool aggregate for output.
+   * @param {ProfilePoolAggregate} aggregate - Internal aggregate.
+   * @returns {ProfilePoolAggregate} - Public aggregate.
+   */
+  publicPoolAggregate(aggregate) {
+    return {
+      identifier: aggregate.identifier,
+      connectionCreation: this.publicActionAggregate(aggregate.connectionCreation),
+      checkoutWait: {
+        count: aggregate.checkoutWait.count,
+        totalMs: roundProfileDuration(aggregate.checkoutWait.totalMs),
+        maxMs: roundProfileDuration(aggregate.checkoutWait.maxMs)
+      },
+      checkoutTimeoutCount: aggregate.checkoutTimeoutCount,
+      idleReap: {
+        ...this.publicActionAggregate(aggregate.idleReap),
+        disposalCount: aggregate.idleReap.disposalCount
+      },
+      peakLiveConnections: aggregate.peakLiveConnections
+    }
+  }
+}

--- a/src/testing/test-runner.js
+++ b/src/testing/test-runner.js
@@ -46,6 +46,7 @@ import { SHARED_TRANSACTION_BROKER_ENV } from "./shared-transaction-proxy-driver
  * @property {TestArgs} args - Arguments passed to the test.
  * @property {string} [filePath] - Source file path.
  * @property {number} [line] - Source line number.
+ * @property {string} [ownerFilePath] - Deterministic importing test file.
  * @property {(arg: TestArgs) => (void|Promise<void>)} function - Test callback to execute.
  */
 /**
@@ -63,6 +64,7 @@ import { SHARED_TRANSACTION_BROKER_ENV } from "./shared-transaction-proxy-driver
  * @typedef {object} ActiveAfterAllScopeEntry
  * @property {TestsArgument} tests - Scope test tree.
  * @property {boolean} afterAllsRun - Whether cleanup hooks have run.
+ * @property {string} [profileScopeId] - Opaque profile scope identifier.
  */
 /**
  * Defines this typedef.
@@ -72,6 +74,9 @@ import { SHARED_TRANSACTION_BROKER_ENV } from "./shared-transaction-proxy-driver
  * AfterBeforeEachCallbackObjectType type.
  * @typedef {object} AfterBeforeEachCallbackObjectType
  * @property {AfterBeforeEachCallbackType} callback - Hook callback to execute.
+ * @property {number} [declarationIndex] - Hook index within its declaration scope.
+ * @property {string} [declarationScopeId] - Opaque profile scope identifier.
+ * @property {string} [ownerFilePath] - Deterministic importing test file.
  */
 /**
  * Defines this typedef.
@@ -81,6 +86,9 @@ import { SHARED_TRANSACTION_BROKER_ENV } from "./shared-transaction-proxy-driver
  * BeforeAfterAllCallbackObjectType type.
  * @typedef {object} BeforeAfterAllCallbackObjectType
  * @property {BeforeAfterAllCallbackType} callback - Hook callback to execute.
+ * @property {number} [declarationIndex] - Hook index within its declaration scope.
+ * @property {string} [declarationScopeId] - Opaque profile scope identifier.
+ * @property {string} [ownerFilePath] - Deterministic importing test file.
  */
 /**
  * TestsArgument type.
@@ -93,6 +101,7 @@ import { SHARED_TRANSACTION_BROKER_ENV } from "./shared-transaction-proxy-driver
  * @property {AfterBeforeEachCallbackObjectType[]} beforeEaches - Before-each hooks for this scope.
  * @property {string} [filePath] - Source file path.
  * @property {number} [line] - Source line number.
+ * @property {string} [ownerFilePath] - Deterministic importing test file.
  * @property {Record<string, TestData>} tests - A unique identifier for the node.
  * @property {Record<string, TestsArgument>} subs - Optional child nodes. Each item is another `Node`, allowing recursion.
  */
@@ -206,8 +215,9 @@ export default class TestRunner {
    * @param {Array<string>} args.testFiles - Test files.
    * @param {Record<string, number[]>} [args.lineFilters] - Line filters by file.
    * @param {RegExp[]} [args.examplePatterns] - Example patterns.
+   * @param {import("./test-profiler.js").default} [args.profiler] - Opt-in profiler.
    */
-  constructor({configuration, excludeTags, includeTags, testFiles, lineFilters, examplePatterns, ...restArgs}) {
+  constructor({configuration, excludeTags, includeTags, testFiles, lineFilters, examplePatterns, profiler, ...restArgs}) {
     restArgsError(restArgs)
 
     if (!configuration) throw new Error("configuration is required")
@@ -220,6 +230,7 @@ export default class TestRunner {
     this._testFiles = testFiles
     this._lineFilters = lineFilters || {}
     this._examplePatterns = examplePatterns || []
+    this._profiler = profiler
 
     this._failedTests = 0
     this._successfulTests = 0
@@ -255,6 +266,41 @@ export default class TestRunner {
    * @returns {RegExp[]} - Example patterns.
    */
   getExamplePatterns() { return this._examplePatterns }
+
+  /**
+   * Runs a profiler span only when profiling was explicitly enabled.
+   * @template T
+   * @param {object} metadata - Span metadata.
+   * @param {string} metadata.phase - Phase name.
+   * @param {number} [metadata.declarationIndex] - Hook declaration index.
+   * @param {string} [metadata.declarationScopeId] - Hook declaration scope.
+   * @param {string} [metadata.filePath] - Source ownership.
+   * @param {() => (T | Promise<T>)} callback - Timed callback.
+   * @returns {Promise<T>} - Callback result.
+   */
+  async runProfileSpan(metadata, callback) {
+    if (!this._profiler) return await callback()
+
+    return await this._profiler.runSpan(metadata, callback)
+  }
+
+  /**
+   * Adds declaration metadata to hooks only for an active profile.
+   * @template {AfterBeforeEachCallbackObjectType | BeforeAfterAllCallbackObjectType} T
+   * @param {T[]} hooks - Hooks declared in one scope.
+   * @param {string | undefined} declarationScopeId - Profile scope identifier.
+   * @param {string | undefined} ownerFilePath - Scope owner file.
+   * @returns {T[]} - Profile-aware hook entries.
+   */
+  profileHookEntries(hooks, declarationScopeId, ownerFilePath) {
+    if (!this._profiler) return hooks
+
+    return hooks.map((hook, declarationIndex) => Object.assign({}, hook, {
+      declarationIndex: hook.declarationIndex ?? declarationIndex,
+      declarationScopeId: hook.declarationScopeId ?? declarationScopeId,
+      ownerFilePath: hook.ownerFilePath ?? ownerFilePath
+    }))
+  }
 
   /**
    * Runs normalize tags.
@@ -652,7 +698,64 @@ export default class TestRunner {
    * @returns {Promise<void>} - Resolves when complete.
    */
   async importTestFiles() {
-    await this.getConfiguration().getEnvironmentHandler().importTestFiles(this.getTestFiles())
+    const environmentHandler = this.getConfiguration().getEnvironmentHandler()
+
+    if (!this._profiler) {
+      await environmentHandler.importTestFiles(this.getTestFiles())
+      return
+    }
+
+    for (const testFile of this.getTestFiles()) {
+      const existingRegistrations = this.testRegistrationObjects(tests)
+
+      await this._profiler.measurePhase("imports", async () => {
+        await environmentHandler.importTestFiles([testFile])
+      }, {filePath: testFile})
+      this.assignTestRegistrationOwnership(tests, existingRegistrations, testFile)
+    }
+  }
+
+  /**
+   * Collects registered scope, hook, and test objects by identity.
+   * @param {TestsArgument} scope - Test scope.
+   * @param {Set<object>} [registrations] - Accumulated identities.
+   * @returns {Set<object>} - Registration identities.
+   */
+  testRegistrationObjects(scope, registrations = new Set()) {
+    registrations.add(scope)
+
+    for (const hook of [...scope.beforeAlls, ...scope.beforeEaches, ...scope.afterEaches, ...scope.afterAlls]) {
+      registrations.add(hook)
+    }
+
+    for (const testData of Object.values(scope.tests)) registrations.add(testData)
+    for (const childScope of Object.values(scope.subs)) this.testRegistrationObjects(childScope, registrations)
+
+    return registrations
+  }
+
+  /**
+   * Assigns deterministic ownership to registrations added by one entry file,
+   * including declarations originating in a helper imported by that entry file.
+   * @param {TestsArgument} scope - Test scope.
+   * @param {Set<object>} previousRegistrations - Identities present before import.
+   * @param {string} ownerFilePath - Importing entry file.
+   * @returns {void}
+   */
+  assignTestRegistrationOwnership(scope, previousRegistrations, ownerFilePath) {
+    if (!previousRegistrations.has(scope)) scope.ownerFilePath ??= ownerFilePath
+
+    for (const hook of [...scope.beforeAlls, ...scope.beforeEaches, ...scope.afterEaches, ...scope.afterAlls]) {
+      if (!previousRegistrations.has(hook)) hook.ownerFilePath ??= ownerFilePath
+    }
+
+    for (const testData of Object.values(scope.tests)) {
+      if (!previousRegistrations.has(testData)) testData.ownerFilePath ??= ownerFilePath
+    }
+
+    for (const childScope of Object.values(scope.subs)) {
+      this.assignTestRegistrationOwnership(childScope, previousRegistrations, ownerFilePath)
+    }
   }
 
   /**
@@ -748,11 +851,7 @@ export default class TestRunner {
    * @returns {number} - The executed tests count.
    */
   getExecutedTestsCount() {
-    if (this._successfulTests === undefined || this._failedTests === undefined) {
-      throw new Error("Tests hasn't been run yet")
-    }
-
-    return this._successfulTests + this._failedTests
+    return this._testDurations.length
   }
 
   /**
@@ -784,7 +883,9 @@ export default class TestRunner {
     const testingConfigPath = this.getConfiguration().getTesting()
 
     if (testingConfigPath) {
-      await this.getConfiguration().getEnvironmentHandler().importTestingConfigPath()
+      await this.runProfileSpan({phase: "testing config/global setup"}, async () => {
+        await this.getConfiguration().getEnvironmentHandler().importTestingConfigPath()
+      })
     }
   }
 
@@ -957,24 +1058,43 @@ export default class TestRunner {
    * @param {string[]} args.descriptions - Descriptions.
    * @param {number} args.indentLevel - Indent level.
    * @param {boolean} [args.lineMatchedInScope] - Whether line matched in scope.
+   * @param {string} [args.parentProfileScopeId] - Parent profile scope.
    * @returns {Promise<void>} - Resolves when complete.
    */
-  async runTests({afterEaches, beforeEaches, tests, descriptions, indentLevel, lineMatchedInScope = false}) {
+  async runTests({afterEaches, beforeEaches, tests, descriptions, indentLevel, lineMatchedInScope = false, parentProfileScopeId}) {
     const leftPadding = " ".repeat(indentLevel * 2)
-    const newAfterEaches = [...afterEaches, ...tests.afterEaches]
-    const newBeforeEaches = [...beforeEaches, ...tests.beforeEaches]
+    const scopeOwnerFilePath = tests.ownerFilePath ?? tests.filePath
+    const profileScopeId = this._profiler?.scopeId(tests, {
+      descriptions,
+      filePath: scopeOwnerFilePath,
+      line: tests.line,
+      parentId: parentProfileScopeId
+    })
+    const ownAfterEaches = this.profileHookEntries(tests.afterEaches, profileScopeId, scopeOwnerFilePath)
+    const ownBeforeEaches = this.profileHookEntries(tests.beforeEaches, profileScopeId, scopeOwnerFilePath)
+    const newAfterEaches = [...afterEaches, ...ownAfterEaches]
+    const newBeforeEaches = [...beforeEaches, ...ownBeforeEaches]
     const scopeLineMatch = lineMatchedInScope || this.matchesLineFilter(tests)
     const shouldRunAnyTests = this.hasRunnableTests(tests, descriptions, scopeLineMatch)
 
     if (!shouldRunAnyTests) return
 
     /** @type {ActiveAfterAllScopeEntry} */
-    const scopeEntry = {tests, afterAllsRun: false}
+    const scopeEntry = {tests, afterAllsRun: false, profileScopeId}
     this._activeAfterAllScopes.push(scopeEntry)
 
     try {
-      for (const beforeAllData of tests.beforeAlls || []) {
-        await beforeAllData.callback({configuration: this.getConfiguration()})
+      const beforeAlls = this.profileHookEntries(tests.beforeAlls || [], profileScopeId, scopeOwnerFilePath)
+
+      for (const beforeAllData of beforeAlls) {
+        await this.runProfileSpan({
+          phase: "beforeAll",
+          declarationIndex: beforeAllData.declarationIndex,
+          declarationScopeId: beforeAllData.declarationScopeId,
+          filePath: beforeAllData.ownerFilePath
+        }, async () => {
+          await beforeAllData.callback({configuration: this.getConfiguration()})
+        })
       }
 
       for (const testDescription in tests.tests) {
@@ -1035,23 +1155,23 @@ export default class TestRunner {
           let testSharedConnectionRegistrations = []
           /** @type {{broker: SharedTransactionBroker, previousEnvironment: string | undefined} | undefined} */
           let sharedTransactionBrokerRegistration
-          /**
-           * Shared mutable flag so the catch block can suppress the
-           * `_successfulTests` increment inside the still-detached lifecycle:
-           * when the lifecycle eventually resolves after a timeout rejection,
-           * the success increment must not count a test that was already
-           * recorded as failed.
-           * @type {{timedOut: boolean}} */
-          const timeoutState = {timedOut: false}
           const stopConsoleCapture = this.startConsoleCapture({
             passthrough: testConfig.consoleOutput === "live"
           })
+          const profiler = this._profiler
+          const profileAttempt = profiler?.startAttempt({
+            descriptions,
+            attemptNumber,
+            testData,
+            testDescription
+          })
+          let attemptTimedOut = false
 
           try {
             // Run the whole per-test lifecycle (dummy/server startup, connection
             // acquisition, beforeEach hooks, the test body and afterEach hooks) as
             // one promise so the timeout below can cover all of it.
-            testLifecycle = this.runWithDummyIfNeeded(testArgs, async () => {
+            const lifecycleCallback = async () => await this.runWithDummyIfNeeded(testArgs, async () => {
               // Pin one connection per test so beforeEach, the test body and afterEach
               // all run on the SAME connection. This is required for transaction-based
               // database cleaning (beforeEach starts a transaction, afterEach rolls it
@@ -1069,7 +1189,14 @@ export default class TestRunner {
                   try {
                     clearDeliveries()
                     for (const beforeEachData of newBeforeEaches) {
-                      await beforeEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                      await this.runProfileSpan({
+                        phase: "beforeEach",
+                        declarationIndex: beforeEachData.declarationIndex,
+                        declarationScopeId: beforeEachData.declarationScopeId,
+                        filePath: beforeEachData.ownerFilePath
+                      }, async () => {
+                        await beforeEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                      })
                     }
 
                     sharedTransactionBrokerRegistration = await this.startSharedTransactionBroker()
@@ -1085,16 +1212,22 @@ export default class TestRunner {
                       filePath: testData.filePath ?? "<unknown>",
                       line: testData.line ?? 0
                     }
-                    await testData.function(testArgs)
-                    if (!timeoutState.timedOut) {
-                      this._successfulTests++
-                    }
+                    await this.runProfileSpan({phase: "test body", filePath: testData.ownerFilePath ?? testData.filePath}, async () => {
+                      await testData.function(testArgs)
+                    })
                   } finally {
                     try {
                       await this.stopSharedTransactionBroker(sharedTransactionBrokerRegistration)
                     } finally {
                       for (const afterEachData of newAfterEaches) {
-                        await afterEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                        await this.runProfileSpan({
+                          phase: "afterEach",
+                          declarationIndex: afterEachData.declarationIndex,
+                          declarationScopeId: afterEachData.declarationScopeId,
+                          filePath: afterEachData.ownerFilePath
+                        }, async () => {
+                          await afterEachData.callback({configuration: this.getConfiguration(), testArgs, testData})
+                        })
                       }
                     }
                   }
@@ -1103,6 +1236,9 @@ export default class TestRunner {
                 }
               })
             })
+            testLifecycle = profileAttempt && profiler
+              ? profiler.runAttempt(profileAttempt, lifecycleCallback)
+              : lifecycleCallback()
 
             // Time out the ENTIRE lifecycle, not just the test body. A hang in any
             // phase — a connection checkout that never resolves, a beforeEach/afterEach
@@ -1114,6 +1250,11 @@ export default class TestRunner {
             } else {
               await testLifecycle
             }
+
+            // A test is successful only after its complete lifecycle settles.
+            // Cleanup failures and timed-out detached work must not overlap the
+            // final successful and failed counters used for executed-test totals.
+            this._successfulTests++
           } catch (error) {
             caughtError = error
             lastError = error
@@ -1129,9 +1270,10 @@ export default class TestRunner {
             // still can't stall the whole run: if it will not settle within the
             // grace, we proceed exactly as before (no worse than today).
             const timedOut = Boolean(/** @type {TestTimeoutError} */ (error)?.velociousTestTimeout)
+            attemptTimedOut = timedOut
 
             if (timedOut && testLifecycle) {
-              timeoutState.timedOut = true
+              if (profileAttempt && profiler) profiler.finishAttempt(profileAttempt, "timed-out")
               await awaitSettledOrGrace(testLifecycle, timeoutMs ?? 60000)
 
               // If the abandoned lifecycle never settled within the grace, its
@@ -1159,6 +1301,12 @@ export default class TestRunner {
             }
           } finally {
             const consoleOutput = stopConsoleCapture()
+
+            if (profileAttempt && profiler) {
+              profiler.finishAttempt(profileAttempt, caughtError === undefined
+                ? "passed"
+                : (attemptTimedOut ? "timed-out" : "failed"))
+            }
 
             if (consoleOutput) {
               attemptConsoleOutputs.push({attemptNumber, output: consoleOutput})
@@ -1284,7 +1432,8 @@ export default class TestRunner {
             tests: subTest,
             descriptions: newDecriptions,
             indentLevel: indentLevel + 1,
-            lineMatchedInScope: childScopeLineMatch
+            lineMatchedInScope: childScopeLineMatch,
+            parentProfileScopeId: profileScopeId
           })
         }
       }
@@ -1308,8 +1457,22 @@ export default class TestRunner {
 
     scopeEntry.afterAllsRun = true
 
-    for (const afterAllData of scopeEntry.tests.afterAlls || []) {
-      await afterAllData.callback({configuration: this.getConfiguration()})
+    const scopeOwnerFilePath = scopeEntry.tests.ownerFilePath ?? scopeEntry.tests.filePath
+    const afterAlls = this.profileHookEntries(
+      scopeEntry.tests.afterAlls || [],
+      scopeEntry.profileScopeId,
+      scopeOwnerFilePath
+    )
+
+    for (const afterAllData of afterAlls) {
+      await this.runProfileSpan({
+        phase: "afterAll",
+        declarationIndex: afterAllData.declarationIndex,
+        declarationScopeId: afterAllData.declarationScopeId,
+        filePath: afterAllData.ownerFilePath
+      }, async () => {
+        await afterAllData.callback({configuration: this.getConfiguration()})
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

- add opt-in `--profile`, `--profile-json`, and `--timing-manifest-output` test-runner options
- capture lifecycle, database, transaction, pool, import, and custom-activity timings without SQL or parameter values
- emit atomic versioned JSON profiles, compact console summaries, and splitter-compatible timing manifests
- support `idleTimeoutMillis: null` as an explicit no-reaping test-pool setting
- document the profiler, privacy contract, and timing-manifest feedback loop

## Validation

- focused profiler/parser/CLI/database/pool/runner compatibility specs run sequentially
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- `git diff --check`

No full suite or shard was run locally; the multi-database/browser matrix is delegated to CI.