### PR TITLE
Fix recurring schedule drain coupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2501,6 +2501,13 @@ Supported schedule syntax:
 - `every: ["1h", {firstIn: "30s"}]`
 - `every: ["1 day", {firstIn: "5 minutes"}]`
 
+Each recurring tick completes after its enqueue is durably stored and workers
+are notified. Dispatch runs through the coalesced background-job drain without
+holding the schedule's in-flight enqueue marker, so a slow dispatcher cannot
+suppress later ticks. Use `deduplicateWhileQueued` together with a durable
+`concurrencyKey` / `maxConcurrency` limit when a recurring logical job must have
+at most one queued or running execution.
+
 Or a 5-field POSIX crontab expression via `cron`:
 
 ```js

--- a/changelog.d/20260817000000-scheduled-recurrence-drain-boundary.md
+++ b/changelog.d/20260817000000-scheduled-recurrence-drain-boundary.md
@@ -1,0 +1,1 @@
+Fixed recurring background-job schedules suppressing later timer occurrences while an unrelated dispatcher drain remains active. Scheduled enqueue completion now follows durable persistence and worker notification, while dispatch continues through the existing coalesced drain lifecycle.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -204,6 +204,12 @@ The cap-fallthrough guarantee is a property of the **queue-derived** cap. A job 
 
 `deduplicateWhileQueued: true` coalesces an enqueue by job identity: job name, serialized arguments, and queue. It returns the earliest identical queued job only when that job is scheduled no later than the new enqueue. This preserves one queued copy for repeated immediate or recurring triggers, but a failed job whose retry is backed off into the future cannot block fresh immediate work.
 
+Recurring schedule ticks finish their enqueue lifecycle once the job is durably
+stored and workers have been notified. Dispatch is requested separately through
+the main process's coalesced drain. A slow dispatcher drain therefore cannot
+suppress future timer ticks; queued deduplication and durable concurrency limits
+continue to enforce the configured logical-job overlap policy.
+
 ## Durable idempotent enqueue
 
 Pass a producer-owned stable `idempotencyKey` when replaying one logical enqueue must return the original job rather than create another one:

--- a/spec/background-jobs/scheduled-enqueue-drain-boundary-spec.js
+++ b/spec/background-jobs/scheduled-enqueue-drain-boundary-spec.js
@@ -53,4 +53,26 @@ describe("Background jobs - scheduled enqueue drain boundary", {databaseCleaning
       await main.stop()
     }
   })
+
+  it("still waits for the requested drain during shutdown", async () => {
+    dummyConfiguration.setScheduledBackgroundJobsConfig(undefined)
+    const {main} = await startBackgroundJobsMain()
+    let releaseDrain
+    const heldDrain = new Promise((resolve) => { releaseDrain = resolve })
+
+    main._drainPromise = heldDrain
+
+    const stopPromise = main.stop()
+    let stopped = false
+
+    void stopPromise.then(() => { stopped = true })
+    await Promise.resolve()
+    expect(stopped).toBeFalse()
+
+    if (!releaseDrain) throw new Error("Expected the drain release callback to be assigned")
+
+    releaseDrain()
+    await stopPromise
+    expect(stopped).toBeTrue()
+  })
 })

--- a/spec/background-jobs/scheduled-enqueue-drain-boundary-spec.js
+++ b/spec/background-jobs/scheduled-enqueue-drain-boundary-spec.js
@@ -1,0 +1,56 @@
+// @ts-check
+
+import {startBackgroundJobsMain} from "../helpers/background-jobs-helper.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import TestJob from "../dummy/src/jobs/test-job.js"
+
+describe("Background jobs - scheduled enqueue drain boundary", {databaseCleaning: {truncate: true}}, () => {
+  it("persists later ticks while an unrelated dispatcher drain remains held", async () => {
+    dummyConfiguration.setScheduledBackgroundJobsConfig(undefined)
+    const {main, store} = await startBackgroundJobsMain()
+    let releaseDrain
+    const heldDrain = new Promise((resolve) => { releaseDrain = resolve })
+
+    main._drainPromise = heldDrain
+
+    try {
+      const scheduler = main.scheduler
+
+      if (!scheduler) throw new Error("Expected the background jobs scheduler to be started")
+
+      const jobConfiguration = {
+        args: ["scheduled", "unused-output-path"],
+        class: TestJob,
+        every: "10m",
+        options: {
+          concurrencyKey: "scheduled-single-flight",
+          executionMode: /** @type {const} */ ("pooled"),
+          maxConcurrency: 1
+        }
+      }
+
+      await scheduler.runScheduledJob({jobConfiguration, jobKey: "scheduledTestJob"})
+
+      expect(scheduler.pendingEnqueuesByJobKey.has("scheduledTestJob")).toBeFalse()
+
+      await scheduler.runScheduledJob({jobConfiguration, jobKey: "scheduledTestJob"})
+
+      // The second timer occurrence reaches durable enqueue. Store-level
+      // deduplication preserves the one queued logical-job contract.
+      const jobs = await store.listJobs({jobName: TestJob.jobName(), limit: 10})
+
+      expect(jobs.length).toEqual(1)
+      expect(jobs[0]).toMatchObject({
+        concurrencyKey: "scheduled-single-flight",
+        maxConcurrency: 1,
+        status: "queued"
+      })
+      expect(main._drainPromise).toEqual(heldDrain)
+    } finally {
+      if (releaseDrain) releaseDrain()
+      await heldDrain
+      main._drainPromise = undefined
+      await main.stop()
+    }
+  })
+})

--- a/spec/background-jobs/scheduler-overlap-spec.js
+++ b/spec/background-jobs/scheduler-overlap-spec.js
@@ -3,7 +3,7 @@
 import BackgroundJobsScheduler from "../../src/background-jobs/scheduler.js"
 import TestJob from "../dummy/src/jobs/test-job.js"
 
-describe("Background jobs - scheduler overlapping intervals", {databaseCleaning: {truncate: true}}, () => {
+describe("Background jobs - scheduler overlapping intervals", {databaseCleaning: {transaction: false, truncate: false}}, () => {
   it("keeps one enqueue in flight when another interval tick fires", async () => {
     const originalSetInterval = globalThis.setInterval
     const originalSetTimeout = globalThis.setTimeout
@@ -71,5 +71,25 @@ describe("Background jobs - scheduler overlapping intervals", {databaseCleaning:
       globalThis.clearInterval = originalClearInterval
       globalThis.clearTimeout = originalClearTimeout
     }
+  })
+
+  it("allows the next interval tick after an enqueue failure", async () => {
+    const scheduler = new BackgroundJobsScheduler({
+      configuration: {
+        async getScheduledBackgroundJobsConfig() {
+          return {jobs: {}}
+        }
+      },
+      enqueueJob: async () => {
+        throw new Error("controlled enqueue failure")
+      }
+    })
+    const jobConfiguration = {class: TestJob, every: 1}
+
+    await scheduler.runScheduledJob({jobConfiguration, jobKey: "scheduledTestJob"})
+    expect(scheduler.pendingEnqueuesByJobKey.has("scheduledTestJob")).toBeFalse()
+
+    await scheduler.runScheduledJob({jobConfiguration, jobKey: "scheduledTestJob"})
+    expect(scheduler.pendingEnqueuesByJobKey.has("scheduledTestJob")).toBeFalse()
   })
 })

--- a/spec/database/drivers/mysql/deadlock-diagnostics-retry-spec.js
+++ b/spec/database/drivers/mysql/deadlock-diagnostics-retry-spec.js
@@ -5,7 +5,6 @@ import { describe, expect, it } from "../../../../src/testing/test.js"
 import {
   configuration,
   DiagnosticMysqlDriver,
-  NonPromiseDiagnosticMysqlDriver,
   SECRET_SQL
 } from "../../../helpers/mysql-deadlock-diagnostics-test-helper.js"
 
@@ -116,12 +115,13 @@ describe("Database - drivers - mysql deadlock diagnostic retry behavior", () => 
 
   it("isolates a non-Promise driver diagnostic result without changing the retry result", async () => {
     const appConfiguration = configuration()
-    const driver = new NonPromiseDiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
+    const driver = new DiagnosticMysqlDriver({deadlockBaseWaitMs: 1, deadlockMaxRetries: 2}, appConfiguration)
     const frameworkErrors = []
     const allErrors = []
     const frameworkErrorReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("framework-error", resolve))
     const allErrorReported = new Promise((resolve) => appConfiguration.getErrorEvents().once("all-error", resolve))
 
+    driver.diagnosticReturnsNonPromise = true
     driver.setDesiredSessionTimeZone(null)
     appConfiguration.getErrorEvents().on("framework-error", (payload) => frameworkErrors.push(payload))
     appConfiguration.getErrorEvents().on("all-error", (payload) => allErrors.push(payload))

--- a/spec/helpers/mysql-deadlock-diagnostics-test-helper.js
+++ b/spec/helpers/mysql-deadlock-diagnostics-test-helper.js
@@ -33,6 +33,7 @@ export class DiagnosticMysqlDriver extends MysqlDriver {
   clockMs = 100
   contentionCode = "ER_LOCK_DEADLOCK"
   diagnosticPipelineFailure = false
+  diagnosticReturnsNonPromise = false
   failedAttempts = 1
   /** @type {Error | undefined} */
   lastQueryError
@@ -70,10 +71,14 @@ ${"ignored status line\n".repeat(500)}`
    * @param {import("../../src/database/drivers/base.js").DeadlockRetryDiagnosticSnapshot} snapshot - Immutable retry snapshot.
    * @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Safe diagnostic context.
    */
-  async _deadlockDiagnosticContext(snapshot) {
+  _deadlockDiagnosticContext(snapshot) {
     if (this.diagnosticPipelineFailure) throw new Error("simulated diagnostic pipeline failure")
+    if (this.diagnosticReturnsNonPromise) {
+      // @ts-expect-error Simulates a runtime driver that violates the documented Promise contract.
+      return {statusCapture: "malformed-non-promise"}
+    }
 
-    return await super._deadlockDiagnosticContext(snapshot)
+    return super._deadlockDiagnosticContext(snapshot)
   }
 
   /** @returns {Promise<import("../../src/database/drivers/base.js").QueryResultType>} - Query result. */
@@ -114,14 +119,5 @@ ${"ignored status line\n".repeat(500)}`
     if (this.parserFailure) throw new Error("simulated deadlock parser failure")
 
     return super._innodbDeadlockSummary(status)
-  }
-}
-
-export class NonPromiseDiagnosticMysqlDriver extends DiagnosticMysqlDriver {
-  /** @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Deliberately malformed diagnostic result. */
-  // Base-driver hook invoked through the detached diagnostics contract.
-  _deadlockDiagnosticContext() {
-    // @ts-expect-error Simulates a runtime subclass that violates the documented Promise contract.
-    return {statusCapture: "malformed-non-promise"}
   }
 }

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -288,6 +288,7 @@ export default class BackgroundJobsMain {
           this._disconnectBeaconHandlers()
           try {
             await this.scheduler?.stop()
+            if (this._drainPromise) await this._drainPromise
           } finally {
             try {
               await this._drainWorkerHandoffAdoptions()

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -222,7 +222,11 @@ export default class BackgroundJobsMain {
             options: jobClass._withQueue(options)
           })
           this._notifyEnqueued()
-          await this._drain()
+          // Persistence is the scheduler enqueue boundary. Dispatch remains
+          // coalesced, but a slow active drain must not make the recurring
+          // scheduler treat this job key as still being enqueued and suppress
+          // later timer occurrences.
+          void this._drain()
         }
       })
       await this.scheduler.start()


### PR DESCRIPTION
## Summary

- end the built-in recurring scheduler's pending-enqueue lifecycle after durable enqueue and worker notification
- request dispatch through the existing coalesced drain without awaiting unrelated drain completion
- preserve queued deduplication and durable concurrency limits for one-logical-job execution
- add controlled-promise coverage for held drains, unresolved enqueues, and enqueue failures

## Incident

TensorBuzz production disk/CPU/memory/liveness schedules skipped interval occurrences while the shared background-job dispatcher drain was slow. This fixes the owning Velocious lifecycle boundary without changing schedule configuration or concurrency semantics.

## Validation

- focused scheduler and real main/store boundary specs: 3 passing
- npm run lint
- npm run typecheck
- npm run fallow
