### PR TITLE
Add strict timing manifest shard aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ Files absent from the manifest and zero-duration entries use the existing
 deterministic heuristic; stale entries are ignored. When `--timing-manifest` is
 explicitly supplied, its file must be readable and contain a plain JSON object
 with canonical relative paths and finite non-negative durations. Invalid input
-fails the command. A compact measured/heuristic/stale summary reports coverage.
+fails the command even without sharding flags. A compact
+measured/heuristic/stale summary reports coverage.
 The heuristic weights files by spec directory (`system/` = 20,
 `frontend-models/` = 10, `controller/` = 3, default = 1) with a 2x multiplier
 for `.browser-spec.js` files. The heaviest files are assigned first to the group

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 * Gap-less positional lists with automatic reordering via `actsAsList`, including models with numeric, string, or UUID primary keys (see [docs/acts-as-list.md](docs/acts-as-list.md))
 * Rails-style nested-attribute writes on frontend-model `save()` (see [docs/nested-attributes.md](docs/nested-attributes.md))
 * Async-aware test-data factories with inherited traits, graph-first native association autosave, metadata-aware override precedence, callbacks, sequences, linting, and a process-global reload-retention budget that bounds cache-busted re-import memory (see [docs/factories.md](docs/factories.md))
-* Opt-in Benchmark-style test profiling with privacy-safe rich JSON and directly reusable duration-aware shard manifests (see [docs/test-profiling.md](docs/test-profiling.md))
+* Opt-in Benchmark-style test profiling with privacy-safe rich JSON, directly reusable duration-aware shard manifests, and strict generic shard-profile aggregation (see [docs/test-profiling.md](docs/test-profiling.md))
 * Per-row association counts via `.withCount(...)`, including cohort-safe intersected filters, safe batching of structurally identical aggregates, and automatic IN-list chunking for large parent sets, on frontend and backend queries (see [docs/with-count.md](docs/with-count.md))
 * Consumer-defined per-row SQL aggregates/computations via `.queryData(...)`, with compatible projections sharing a roundtrip while preserving declared alias-overwrite order and automatic IN-list chunking for large parent sets, on frontend and backend queries (see [docs/query-data.md](docs/query-data.md))
 * Per-record ability checks via `.abilities(...)` on frontend queries + `record.can(action)` (see [docs/abilities.md](docs/abilities.md))
@@ -239,6 +239,10 @@ npx velocious test --profile-json tmp/test-profile.json \
   --timing-manifest-output tmp/test-timings.json
 npx velocious test --groups=4 --group-number=1 \
   --timing-manifest tmp/test-timings.json
+
+# After every shard wrote rich JSON, merge the complete set for the next run
+npx velocious test:timing-manifest:merge --output tmp/test-timings.json \
+  tmp/profile-1.json tmp/profile-2.json tmp/profile-3.json tmp/profile-4.json
 ```
 
 See [test profiling](docs/test-profiling.md) for lifecycle accounting, custom
@@ -327,12 +331,16 @@ separators:
 }
 ```
 
-Files absent from the manifest, unknown files, invalid duration values, and
-unreadable or malformed JSON all fall back to the existing deterministic
-heuristic. The heuristic weights files by spec directory (`system/` = 20, `frontend-models/` = 10,
-`controller/` = 3, default = 1) with a 2x multiplier for `.browser-spec.js`
-files. The heaviest files are assigned first to the group with the least
-accumulated weight, producing balanced wall-clock times across groups.
+Files absent from the manifest and zero-duration entries use the existing
+deterministic heuristic; stale entries are ignored. When `--timing-manifest` is
+explicitly supplied, its file must be readable and contain a plain JSON object
+with canonical relative paths and finite non-negative durations. Invalid input
+fails the command. A compact measured/heuristic/stale summary reports coverage.
+The heuristic weights files by spec directory (`system/` = 20,
+`frontend-models/` = 10, `controller/` = 3, default = 1) with a 2x multiplier
+for `.browser-spec.js` files. The heaviest files are assigned first to the group
+with the least accumulated weight, producing balanced wall-clock times across
+groups.
 
 The algorithm is deterministic: the same file list always produces the same
 group assignments.

--- a/changelog.d/20260817120000-timing-manifest-merge.md
+++ b/changelog.d/20260817120000-timing-manifest-merge.md
@@ -1,3 +1,4 @@
 Add strict generic timing-manifest aggregation from complete rich test-profile
 shards, canonical path and explicit manifest validation, profile selection
-identity metadata, and compact timing-history coverage reporting.
+identity metadata including configured tag exclusions, locale-independent
+manifest ordering, and compact timing-history coverage reporting.

--- a/changelog.d/20260817120000-timing-manifest-merge.md
+++ b/changelog.d/20260817120000-timing-manifest-merge.md
@@ -1,0 +1,3 @@
+Add strict generic timing-manifest aggregation from complete rich test-profile
+shards, canonical path and explicit manifest validation, profile selection
+identity metadata, and compact timing-history coverage reporting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, and legacy-byte migration.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/tenant-selected-database-generation.md`: Explicit, immutable tenant database selection for base-model and structure generation.
-- `docs/test-profiling.md`: Opt-in test profiling, rich JSON/privacy guarantees, custom activity spans, and timing-manifest generation.
+- `docs/test-profiling.md`: Opt-in test profiling, rich JSON/privacy guarantees, custom activity spans, timing-manifest generation, and strict shard aggregation.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.
 - `docs/translations.md`: Translated record attributes, `currentTranslation`, and translated frontend-model sorting.
 - `docs/routing-hooks-and-autoroutes.md`: Route hook support and frontend-model autoroute behavior.

--- a/docs/test-profiling.md
+++ b/docs/test-profiling.md
@@ -71,7 +71,9 @@ path-base semantics, and `testFileSetHash`: a deterministic SHA-256 identity of
 the sorted canonical pre-shard file universe. The path base is
 `configuration-directory` normally and `test-directory` when
 `VELOCIOUS_TEST_DIR` is set. These additive fields let aggregation prove that
-separately produced profiles describe one complete selection.
+separately produced profiles describe one complete selection. Tag-filter counts
+reflect the effective selection after combining CLI filters with exclusions from
+`configureTests`, so either source makes a profile ineligible for strict merge.
 
 Nested hooks have distinct invocation spans with declaration scope/index and
 execution order. Every retry remains present with its complete cost. Async work
@@ -133,7 +135,8 @@ and `.` segments. Case is preserved. Empty, absolute, drive-qualified, escaping
 `..`, and normalized-collision paths are invalid. With no
 `VELOCIOUS_TEST_DIR`, the base is the configured application directory; with the
 variable set, its test directory is the base. Producer, merger, and consumer
-must use the same semantics.
+must use the same semantics. Canonical output and file-set hashing use
+locale-independent JavaScript code-unit ordering.
 
 ## Merging parallel profiles
 

--- a/docs/test-profiling.md
+++ b/docs/test-profiling.md
@@ -26,6 +26,11 @@ npx velocious test \
   --groups=4 \
   --group-number=1 \
   --timing-manifest=tmp/test-timings.json
+
+# Merge complete rich shard profiles before the next run
+npx velocious test:timing-manifest:merge \
+  --output tmp/test-timings.json \
+  tmp/profile-1.json tmp/profile-2.json tmp/profile-3.json tmp/profile-4.json
 ```
 
 `--timing-manifest-output` also implies `--profile`. Velocious validates missing
@@ -59,6 +64,14 @@ attempt, hook/test/custom spans, database and transaction aggregates, pool
 lifecycle aggregates, an unattributed late-event count, and the embedded timing
 manifest. Durations are finite, non-negative milliseconds rounded to three
 decimal places.
+
+Selection metadata records `discoveredFileCount` before sharding, `fileCount`
+after sharding, whether line filters were present, the shard number/count, the
+path-base semantics, and `testFileSetHash`: a deterministic SHA-256 identity of
+the sorted canonical pre-shard file universe. The path base is
+`configuration-directory` normally and `test-directory` when
+`VELOCIOUS_TEST_DIR` is set. These additive fields let aggregation prove that
+separately produced profiles describe one complete selection.
 
 Nested hooks have distinct invocation spans with declaration scope/index and
 execution order. Every retry remains present with its complete cost. Async work
@@ -104,7 +117,7 @@ span and otherwise behaves as a pass-through.
 ## Timing-manifest ownership
 
 The plain timing manifest is a sorted, two-space JSON object with a trailing
-newline. Each key is a project-relative entry test file and each value is its
+newline. Each key is an entry test file relative to the profiling path base and each value is its
 measured total milliseconds. Its weight includes that entry's import, file-owned
 `beforeAll`/`afterAll`, and every attempt of its tests. Complete attempt time
 includes inherited `beforeEach`/`afterEach` work and retry cost. Shard-global
@@ -114,3 +127,40 @@ When an entry imports a helper that registers tests or hooks, those registration
 belong deterministically to the importing entry file. This keeps helper source
 paths out of the manifest and makes the generated file directly consumable by
 [`--timing-manifest`](testing-guidelines.md#duration-aware-parallel-sharding).
+
+Canonical paths use `/`, omit leading `./`, and collapse redundant separators
+and `.` segments. Case is preserved. Empty, absolute, drive-qualified, escaping
+`..`, and normalized-collision paths are invalid. With no
+`VELOCIOUS_TEST_DIR`, the base is the configured application directory; with the
+variable set, its test directory is the base. Producer, merger, and consumer
+must use the same semantics.
+
+## Merging parallel profiles
+
+Each shard must write a distinct rich profile. After all shards pass, merge them
+into the plain manifest used by the next run:
+
+```bash
+npx velocious test:timing-manifest:merge --output tmp/test-timings.json \
+  tmp/profile-1.json tmp/profile-2.json tmp/profile-3.json tmp/profile-4.json
+```
+
+Inputs are rich `velocious.test-profile` JSON only; plain timing maps are not
+accepted as merge inputs. The command requires compatible schema versions,
+`passed` status, no focused or filtered selection, the same positive group
+count, exactly one profile for every group `1..groups`, and identical path base,
+pre-shard discovered count, and file-set hash. It rejects invalid paths,
+normalized collisions, duplicate files, mismatched per-shard counts, and a
+merged key set that is not the complete pre-shard universe. Failed, focused,
+interrupted, no-test, and error profiles therefore cannot update timing history.
+Profiles may come from different times when these suite and selection invariants
+still match; there is intentionally no run ID.
+
+All inputs are read and validated before output starts. Success atomically
+replaces `--output` with the existing plain `{path: duration}` format (sorted,
+two-space JSON, trailing newline), so existing splitter consumers remain
+compatible. Failure leaves an existing output untouched.
+
+The filesystem-free validation and aggregation primitives are also available as
+the public deep import `velocious/build/src/testing/timing-manifest.js`. They are
+not added to the package root export.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -125,7 +125,7 @@ reusable file weights, enable the opt-in [test profiler](test-profiling.md).
 ## Duration-aware parallel sharding
 Pass `--timing-manifest=<path>` together with `--groups` and `--group-number` to
 weight discovered test files by recorded wall-clock duration. The JSON object maps
-normalized project-relative test paths to positive finite numbers:
+normalized relative test paths to finite non-negative numbers:
 
 ```json
 {
@@ -135,13 +135,21 @@ normalized project-relative test paths to positive finite numbers:
 ```
 
 Forward slashes are the portable manifest format; leading `./` and backslashes are
-normalized when reading keys. A valid duration takes precedence over the static
-directory/browser heuristic for that file. Missing paths, unknown paths, non-number,
-non-positive, or non-finite durations fall back per file. Missing, unreadable, or
-malformed JSON manifests also leave the existing deterministic heuristic intact.
-Generate a compatible sorted manifest from a representative run with
-`--timing-manifest-output <path>`; see [test profiling](test-profiling.md#timing-manifest-ownership)
-for file ownership and retry/hook accounting.
+normalized when reading keys; redundant separators and `.` segments are
+collapsed. Empty, absolute, drive-qualified, escaping `..`, colliding normalized
+paths, and invalid durations are rejected. An explicitly supplied manifest must
+be readable, valid JSON, and a plain object; corruption fails the command instead
+of silently disabling timing. Positive durations take precedence over the static
+directory/browser heuristic. Zero durations and missing/new paths use the
+heuristic, while stale keys are ignored. An empty object is valid. Velocious prints
+one compact measured/heuristic/stale coverage line when consuming timing history.
+
+Generate a compatible sorted manifest from one representative unsharded run with
+`--timing-manifest-output <path>`. For parallel profiling, write one rich
+`--profile-json` document per shard and merge the complete set with
+`velocious test:timing-manifest:merge`; see
+[test profiling](test-profiling.md#merging-parallel-profiles) for the strict
+completeness contract and path semantics.
 
 ## Avoiding fixed sleeps
 Never `await wait(<fixed ms>)` to let something async settle — it is both slow and

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -139,10 +139,11 @@ normalized when reading keys; redundant separators and `.` segments are
 collapsed. Empty, absolute, drive-qualified, escaping `..`, colliding normalized
 paths, and invalid durations are rejected. An explicitly supplied manifest must
 be readable, valid JSON, and a plain object; corruption fails the command instead
-of silently disabling timing. Positive durations take precedence over the static
-directory/browser heuristic. Zero durations and missing/new paths use the
-heuristic, while stale keys are ignored. An empty object is valid. Velocious prints
-one compact measured/heuristic/stale coverage line when consuming timing history.
+of silently disabling timing, including when no sharding flags are present.
+Positive durations take precedence over the static directory/browser heuristic.
+Zero durations and missing/new paths use the heuristic, while stale keys are
+ignored. An empty object is valid. Velocious prints one compact
+measured/heuristic/stale coverage line when consuming timing history.
 
 Generate a compatible sorted manifest from one representative unsharded run with
 `--timing-manifest-output <path>`. For parallel profiling, write one rich

--- a/spec/cli/commands/test-profile-integration-spec.js
+++ b/spec/cli/commands/test-profile-integration-spec.js
@@ -6,6 +6,7 @@ import path from "node:path"
 import { promisify } from "node:util"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "../../../src/testing/test.js"
+import { timingManifestFileSetHash } from "../../../src/testing/timing-manifest.js"
 
 const execFileAsync = promisify(execFile)
 const repositoryDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
@@ -131,6 +132,10 @@ describe("test profile CLI integration", () => {
       expect(profile.status).toBe("passed")
       expect(profile.counts).toEqual({attempts: 1, discovered: 1, executed: 1, failed: 0, passed: 1})
       expect(profile.selection.fileCount).toBe(1)
+      expect(profile.selection.discoveredFileCount).toBe(1)
+      expect(profile.selection.hasLineFilters).toBe(false)
+      expect(profile.selection.pathBase).toBe("configuration-directory")
+      expect(profile.selection.testFileSetHash).toBe(timingManifestFileSetHash([testPath]))
       expect(profile.phases.discovery.count).toBe(1)
       expect(profile.phases.imports.count).toBe(1)
       expect(Object.keys(manifest)).toEqual([testPath])

--- a/spec/cli/commands/test-timing-manifest-merge-integration-spec.js
+++ b/spec/cli/commands/test-timing-manifest-merge-integration-spec.js
@@ -1,0 +1,146 @@
+// @ts-check
+
+import { execFile } from "node:child_process"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { promisify } from "node:util"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import { timingManifestFileSetHash } from "../../../src/testing/timing-manifest.js"
+
+const execFileAsync = promisify(execFile)
+const repositoryDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
+const dummyDirectory = path.join(repositoryDirectory, "spec", "dummy")
+const cliPath = path.join(repositoryDirectory, "bin", "velocious.js")
+
+/**
+ * Runs one isolated dummy-app CLI child sequentially.
+ * @param {string[]} args - Complete CLI command arguments.
+ * @param {{testDirectory?: string}} [options] - Child environment options.
+ * @returns {Promise<{code: number, stderr: string, stdout: string}>} - Child result.
+ */
+async function runCli(args, {testDirectory} = {}) {
+  const environment = {...process.env, MSSQL_SA_PASSWORD: "test-password", VELOCIOUS_DISABLE_MSSQL: "1"}
+
+  if (testDirectory) {
+    environment.VELOCIOUS_TEST_DIR = testDirectory
+  } else {
+    delete environment.VELOCIOUS_TEST_DIR
+  }
+
+  try {
+    const {stderr, stdout} = await execFileAsync(process.execPath, [cliPath, ...args], {
+      cwd: dummyDirectory,
+      env: environment
+    })
+
+    return {code: 0, stderr, stdout}
+  } catch (error) {
+    const childError = /** @type {Error & {code?: number, stderr?: string, stdout?: string}} */ (error)
+
+    return {
+      code: typeof childError.code === "number" ? childError.code : 1,
+      stderr: childError.stderr || "",
+      stdout: childError.stdout || ""
+    }
+  }
+}
+
+describe("test timing manifest merge CLI integration", () => {
+  it("profiles two shards, safely merges them, and consumes the complete manifest on the next cycle", async () => {
+    const temporaryRoot = path.join(dummyDirectory, "tmp")
+
+    await fs.mkdir(temporaryRoot, {recursive: true})
+    const directory = await fs.mkdtemp(path.join(temporaryRoot, "velocious-timing-cycle-"))
+    const profile1Path = path.join(directory, "profile-1.json")
+    const profile2Path = path.join(directory, "profile-2.json")
+    const manifestPath = path.join(directory, "timings.json")
+
+    try {
+      const testPaths = []
+
+      for (const fileName of ["a.fixture.js", "b.fixture.js"]) {
+        const filePath = path.join(directory, fileName)
+
+        await fs.writeFile(filePath, `
+          import { describe, it } from "velocious/build/src/testing/test.js"
+          describe("timing cycle ${fileName}", () => { it("passes", async () => {}) })
+        `, "utf8")
+        testPaths.push(path.relative(dummyDirectory, filePath).replaceAll(path.sep, "/"))
+      }
+
+      const firstShard = await runCli([
+        "test", "--groups=2", "--group-number=1", `--profile-json=${profile1Path}`, ...testPaths
+      ])
+      const secondShard = await runCli([
+        "test", "--groups=2", "--group-number=2", `--profile-json=${profile2Path}`, ...testPaths
+      ])
+
+      expect(firstShard.code).toBe(0)
+      expect(secondShard.code).toBe(0)
+
+      await fs.writeFile(manifestPath, "existing output\n", "utf8")
+      const incompleteMerge = await runCli([
+        "test:timing-manifest:merge", "--output", manifestPath, profile1Path
+      ])
+
+      expect(incompleteMerge.code).toBe(1)
+      expect(incompleteMerge.stderr).toMatch(/missing shard/i)
+      expect(await fs.readFile(manifestPath, "utf8")).toBe("existing output\n")
+
+      const merge = await runCli([
+        "test:timing-manifest:merge", `--output=${manifestPath}`, profile2Path, profile1Path
+      ])
+      const manifestContent = await fs.readFile(manifestPath, "utf8")
+      const manifest = JSON.parse(manifestContent)
+
+      expect(merge.code).toBe(0)
+      expect(merge.stdout).toMatch(/Merged 2 test profile shards/)
+      expect(Object.keys(manifest)).toEqual([...testPaths].sort())
+      expect(manifestContent.endsWith("\n")).toBe(true)
+      expect(manifestContent.startsWith("{\n  \"")).toBe(true)
+
+      for (const groupNumber of [1, 2]) {
+        const nextCycle = await runCli([
+          "test",
+          "--groups=2",
+          `--group-number=${groupNumber}`,
+          `--timing-manifest=${manifestPath}`,
+          ...testPaths
+        ])
+
+        expect(nextCycle.code).toBe(0)
+        expect(nextCycle.stdout).toMatch(/Timing manifest coverage: measured=2 heuristic=0 stale=0/)
+      }
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("uses VELOCIOUS_TEST_DIR as the explicit profiling path base", async () => {
+    const temporaryRoot = path.join(dummyDirectory, "tmp")
+
+    await fs.mkdir(temporaryRoot, {recursive: true})
+    const directory = await fs.mkdtemp(path.join(temporaryRoot, "velocious-timing-test-base-"))
+    const testPath = path.join(directory, "base.fixture.js")
+    const profilePath = path.join(directory, "profile.json")
+
+    try {
+      await fs.writeFile(testPath, `
+        import { describe, it } from "velocious/build/src/testing/test.js"
+        describe("test directory timing base", () => { it("passes", async () => {}) })
+      `, "utf8")
+      const result = await runCli(["test", `--profile-json=${profilePath}`, testPath], {testDirectory: directory})
+      const profile = JSON.parse(await fs.readFile(profilePath, "utf8"))
+
+      expect(result.code).toBe(0)
+      expect(profile.selection.pathBase).toBe("test-directory")
+      expect(profile.selection.discoveredFileCount).toBe(1)
+      expect(profile.selection.fileCount).toBe(1)
+      expect(profile.selection.testFileSetHash).toBe(timingManifestFileSetHash(["base.fixture.js"]))
+      expect(Object.keys(profile.timingManifest)).toEqual(["base.fixture.js"])
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+})

--- a/spec/cli/commands/test-timing-manifest-merge-integration-spec.js
+++ b/spec/cli/commands/test-timing-manifest-merge-integration-spec.js
@@ -143,4 +143,67 @@ describe("test timing manifest merge CLI integration", () => {
       await fs.rm(directory, {force: true, recursive: true})
     }
   })
+
+  it("records configured tag exclusions so strict aggregation rejects the filtered profile", async () => {
+    const temporaryRoot = path.join(dummyDirectory, "tmp")
+
+    await fs.mkdir(temporaryRoot, {recursive: true})
+    const directory = await fs.mkdtemp(path.join(temporaryRoot, "velocious-timing-config-tags-"))
+    const testPath = path.join(directory, "configured-exclusion.fixture.js")
+    const profilePath = path.join(directory, "profile.json")
+    const manifestPath = path.join(directory, "timings.json")
+
+    try {
+      await fs.writeFile(testPath, `
+        import { configureTests, describe, it } from "velocious/build/src/testing/test.js"
+        configureTests({excludeTags: ["timing-excluded"]})
+        describe("configured exclusion timing profile", () => {
+          it("is excluded", {tags: ["timing-excluded"]}, async () => {})
+          it("still runs an unfiltered test", async () => {})
+        })
+      `, "utf8")
+      const profileResult = await runCli([
+        "test", "--groups=1", "--group-number=1", `--profile-json=${profilePath}`, testPath
+      ])
+      const profile = JSON.parse(await fs.readFile(profilePath, "utf8"))
+      const mergeResult = await runCli([
+        "test:timing-manifest:merge", `--output=${manifestPath}`, profilePath
+      ])
+
+      expect(profileResult.code).toBe(0)
+      expect(profile.selection.excludeTagCount).toBe(1)
+      expect(mergeResult.code).toBe(1)
+      expect(mergeResult.stderr).toMatch(/filtered test profile/i)
+      await expect(() => fs.access(manifestPath)).toThrow()
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
+
+  it("validates an explicit timing manifest even without sharding", async () => {
+    const temporaryRoot = path.join(dummyDirectory, "tmp")
+
+    await fs.mkdir(temporaryRoot, {recursive: true})
+    const directory = await fs.mkdtemp(path.join(temporaryRoot, "velocious-timing-unsharded-input-"))
+    const testPath = path.join(directory, "pass.fixture.js")
+    const malformedPath = path.join(directory, "malformed.json")
+    const missingPath = path.join(directory, "missing.json")
+
+    try {
+      await fs.writeFile(testPath, `
+        import { describe, it } from "velocious/build/src/testing/test.js"
+        describe("unsharded timing input", () => { it("passes", async () => {}) })
+      `, "utf8")
+      await fs.writeFile(malformedPath, "not json", "utf8")
+      const missingResult = await runCli(["test", `--timing-manifest=${missingPath}`, testPath])
+      const malformedResult = await runCli(["test", `--timing-manifest=${malformedPath}`, testPath])
+
+      expect(missingResult.code).toBe(1)
+      expect(missingResult.stderr).toMatch(/read timing manifest/i)
+      expect(malformedResult.code).toBe(1)
+      expect(malformedResult.stderr).toMatch(/parse timing manifest/i)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
+  })
 })

--- a/spec/cli/commands/test-timing-manifest-spec.js
+++ b/spec/cli/commands/test-timing-manifest-spec.js
@@ -1,24 +1,39 @@
 // @ts-check
 
+import fs from "node:fs/promises"
+import os from "node:os"
 import path from "node:path"
-import {fileURLToPath} from "node:url"
-import {describe, expect, it} from "../../../src/testing/test.js"
-import {loadTimingManifest} from "../../../src/environment-handlers/node/cli/commands/test.js"
+import { describe, expect, it } from "../../../src/testing/test.js"
+import { loadTimingManifest } from "../../../src/environment-handlers/node/cli/commands/test.js"
 
-const repositoryDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
+describe("test timing manifest loading", () => {
+  it("loads and validates a canonical plain timing map", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-timing-loader-"))
+    const manifestPath = path.join(directory, "timings.json")
 
-describe("test timing manifest loading", {databaseCleaning: {transaction: true}}, () => {
-  it("loads valid JSON", async () => {
-    const manifest = await loadTimingManifest(path.join(repositoryDirectory, "package.json"))
-
-    expect(manifest.name).toBe("velocious")
+    try {
+      await fs.writeFile(manifestPath, JSON.stringify({"./spec//task-spec.js": 0}), "utf8")
+      expect(await loadTimingManifest(manifestPath)).toEqual({"spec/task-spec.js": 0})
+      expect(await loadTimingManifest(undefined)).toBe(undefined)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
   })
 
-  it("returns undefined for malformed JSON", async () => {
-    expect(await loadTimingManifest(path.join(repositoryDirectory, "AGENTS.md"))).toBe(undefined)
-  })
+  it("fails for explicitly supplied missing malformed and invalid manifests", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "velocious-timing-loader-errors-"))
+    const malformedPath = path.join(directory, "malformed.json")
+    const invalidPath = path.join(directory, "invalid.json")
 
-  it("returns undefined for an unreadable path", async () => {
-    expect(await loadTimingManifest(path.join(repositoryDirectory, "missing-test-timing-manifest.json"))).toBe(undefined)
+    try {
+      await fs.writeFile(malformedPath, "not json", "utf8")
+      await fs.writeFile(invalidPath, JSON.stringify({"spec/task-spec.js": "12"}), "utf8")
+
+      await expect(() => loadTimingManifest(path.join(directory, "missing.json"))).toThrow(/read timing manifest/)
+      await expect(() => loadTimingManifest(malformedPath)).toThrow(/parse timing manifest/)
+      await expect(() => loadTimingManifest(invalidPath)).toThrow(/duration/)
+    } finally {
+      await fs.rm(directory, {force: true, recursive: true})
+    }
   })
 })

--- a/spec/helpers/mysql-deadlock-diagnostics-test-helper.js
+++ b/spec/helpers/mysql-deadlock-diagnostics-test-helper.js
@@ -120,6 +120,7 @@ ${"ignored status line\n".repeat(500)}`
 export class NonPromiseDiagnosticMysqlDriver extends DiagnosticMysqlDriver {
   /** @returns {Promise<Record<string, ReturnType<typeof JSON.parse>>>} - Deliberately malformed diagnostic result. */
   // Base-driver hook invoked through the detached diagnostics contract.
+  // fallow-ignore-next-line unused-class-member
   _deadlockDiagnosticContext() {
     // @ts-expect-error Simulates a runtime subclass that violates the documented Promise contract.
     return {statusCapture: "malformed-non-promise"}

--- a/spec/testing/test-suite-splitter-spec.js
+++ b/spec/testing/test-suite-splitter-spec.js
@@ -258,6 +258,30 @@ describe("TestSuiteSplitter", {databaseCleaning: {transaction: true}}, () => {
     ])
   })
 
+  it("reports compact measured heuristic and stale timing coverage", () => {
+    const splitter = new TestSuiteSplitter({
+      groups: 1,
+      groupNumber: 1,
+      testFiles: [
+        "/project/spec/models/measured-spec.js",
+        "/project/spec/system/zero-spec.js",
+        "/project/spec/controller/missing-spec.js"
+      ],
+      baseDirectory: "/project",
+      timingManifest: {
+        "spec/models/measured-spec.js": 12,
+        "spec/system/zero-spec.js": 0,
+        "spec/stale/removed-spec.js": 99
+      }
+    })
+
+    expect(splitter.getTimingManifestCoverage()).toEqual({
+      heuristicFiles: 2,
+      measuredFiles: 1,
+      staleEntries: 1
+    })
+  })
+
   it("falls back per file for malformed unknown and unusable timing entries", () => {
     const testFiles = [
       "/project/spec/system/zero-spec.js",

--- a/spec/testing/test-suite-splitter-spec.js
+++ b/spec/testing/test-suite-splitter-spec.js
@@ -221,6 +221,21 @@ describe("TestSuiteSplitter", {databaseCleaning: {transaction: true}}, () => {
     expect(byPath["/project/spec/utils/string-spec.js"]).toBe(1)
   })
 
+  it("shards an external absolute test file with deterministic heuristic weight", () => {
+    const externalTestFile = "/external/spec/system/login.browser-spec.js"
+    const splitter = new TestSuiteSplitter({
+      groups: 1,
+      groupNumber: 1,
+      testFiles: [externalTestFile],
+      baseDirectory: "/project"
+    })
+
+    expect(splitter.computeWeightedFiles()).toEqual([
+      {filePath: externalTestFile, weight: 2}
+    ])
+    expect(splitter.getGroupFiles()).toEqual([externalTestFile])
+  })
+
   it("uses normalized relative timing manifest durations as primary weights", () => {
     const splitter = new TestSuiteSplitter({
       groups: 1,

--- a/spec/testing/timing-manifest-merge-spec.js
+++ b/spec/testing/timing-manifest-merge-spec.js
@@ -1,0 +1,109 @@
+// @ts-check
+
+import { describe, expect, it } from "../../src/testing/test.js"
+import {
+  mergeTestProfileTimingManifests,
+  timingManifestFileSetHash
+} from "../../src/testing/timing-manifest.js"
+
+const allFiles = ["spec/a-spec.js", "spec/b-spec.js"]
+const suiteHash = timingManifestFileSetHash(allFiles)
+
+/**
+ * @param {object} args - Profile overrides.
+ * @param {number} args.groupNumber - One-indexed shard number.
+ * @param {Record<string, number>} args.timingManifest - Shard timing map.
+ * @param {number} [args.groups] - Total shard count.
+ * @param {string} [args.pathBase] - Profile path base.
+ * @param {string} [args.status] - Profile status.
+ * @param {boolean} [args.focused] - Focused selection state.
+ * @param {number} [args.includeTagCount] - Include-tag count.
+ * @param {boolean} [args.hasLineFilters] - Line-filter state.
+ * @param {string} [args.testFileSetHash] - Complete suite hash.
+ * @param {number} [args.discoveredFileCount] - Pre-shard file count.
+ * @returns {ReturnType<typeof JSON.parse>} - Rich profile fixture.
+ */
+function profile({
+  groupNumber,
+  timingManifest,
+  groups = 2,
+  pathBase = "configuration-directory",
+  status = "passed",
+  focused = false,
+  includeTagCount = 0,
+  hasLineFilters = false,
+  testFileSetHash = suiteHash,
+  discoveredFileCount = 2
+}) {
+  return {
+    schema: "velocious.test-profile",
+    schemaVersion: 1,
+    status,
+    selection: {
+      discoveredFileCount,
+      excludeTagCount: 0,
+      fileCount: Object.keys(timingManifest).length,
+      focused,
+      hasExampleFilters: false,
+      hasLineFilters,
+      includeTagCount,
+      pathBase,
+      shard: {groups, groupNumber},
+      testFileSetHash
+    },
+    timingManifest
+  }
+}
+
+describe("timing manifest profile aggregation", () => {
+  it("merges a complete compatible shard set into one sorted plain manifest", () => {
+    const merged = mergeTestProfileTimingManifests([
+      {profile: profile({groupNumber: 2, timingManifest: {"spec/b-spec.js": 20}}), source: "shard-2.json"},
+      {profile: profile({groupNumber: 1, timingManifest: {"./spec/a-spec.js": 10}}), source: "shard-1.json"}
+    ])
+
+    expect(merged).toEqual({"spec/a-spec.js": 10, "spec/b-spec.js": 20})
+  })
+
+  it("rejects non-passing focused and filtered profiles", async () => {
+    const invalidProfiles = [
+      profile({groupNumber: 1, timingManifest: {"spec/a-spec.js": 10}, status: "failed"}),
+      profile({groupNumber: 1, timingManifest: {"spec/a-spec.js": 10}, focused: true}),
+      profile({groupNumber: 1, timingManifest: {"spec/a-spec.js": 10}, includeTagCount: 1}),
+      profile({groupNumber: 1, timingManifest: {"spec/a-spec.js": 10}, hasLineFilters: true})
+    ]
+
+    for (const invalidProfile of invalidProfiles) {
+      await expect(() => mergeTestProfileTimingManifests([
+        {profile: invalidProfile, source: "shard-1.json"},
+        {profile: profile({groupNumber: 2, timingManifest: {"spec/b-spec.js": 20}}), source: "shard-2.json"}
+      ])).toThrow(/passed|focused|filtered/)
+    }
+  })
+
+  it("rejects incomplete duplicate and incompatible shard sets", async () => {
+    const shard1 = profile({groupNumber: 1, timingManifest: {"spec/a-spec.js": 10}})
+
+    await expect(() => mergeTestProfileTimingManifests([{profile: shard1, source: "shard-1.json"}])).toThrow(/missing shard/i)
+    await expect(() => mergeTestProfileTimingManifests([
+      {profile: shard1, source: "shard-1.json"},
+      {profile: profile({groupNumber: 1, timingManifest: {"spec/b-spec.js": 20}}), source: "duplicate-shard.json"}
+    ])).toThrow(/duplicate shard/i)
+    await expect(() => mergeTestProfileTimingManifests([
+      {profile: shard1, source: "shard-1.json"},
+      {profile: profile({groupNumber: 2, timingManifest: {"spec/b-spec.js": 20}, pathBase: "test-directory"}), source: "shard-2.json"}
+    ])).toThrow(/path base/)
+    await expect(() => mergeTestProfileTimingManifests([
+      {profile: shard1, source: "shard-1.json"},
+      {profile: profile({groupNumber: 2, timingManifest: {"spec/b-spec.js": 20}, testFileSetHash: timingManifestFileSetHash(["spec/a-spec.js", "spec/c-spec.js"])}), source: "shard-2.json"}
+    ])).toThrow(/file set/)
+    await expect(() => mergeTestProfileTimingManifests([
+      {profile: shard1, source: "shard-1.json"},
+      {profile: profile({groupNumber: 2, timingManifest: {"spec/a-spec.js": 20}}), source: "shard-2.json"}
+    ])).toThrow(/duplicate timing path/i)
+    await expect(() => mergeTestProfileTimingManifests([
+      {profile: shard1, source: "shard-1.json"},
+      {profile: profile({groupNumber: 2, timingManifest: {"spec/c-spec.js": 20}}), source: "shard-2.json"}
+    ])).toThrow(/complete file universe/i)
+  })
+})

--- a/spec/testing/timing-manifest-validation-spec.js
+++ b/spec/testing/timing-manifest-validation-spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { describe, expect, it } from "../../src/testing/test.js"
+import sha256Hex from "../../src/utils/sha256-hex.js"
 import {
   canonicalTimingManifestPath,
   timingManifestFileSetHash,
@@ -44,5 +45,16 @@ describe("timing manifest validation", () => {
 
     expect(firstHash).toBe(secondHash)
     expect(firstHash).toMatch(/^sha256:[a-f0-9]{64}$/)
+  })
+
+  it("orders non-ASCII paths by locale-independent code units for output and identity", () => {
+    const filePaths = ["spec/é-spec.js", "spec/z-spec.js"]
+    const expectedIdentity = `velocious.test-file-set.v1\0spec/z-spec.js\0spec/é-spec.js`
+
+    expect(Object.keys(validateTimingManifest({
+      "spec/é-spec.js": 2,
+      "spec/z-spec.js": 1
+    }))).toEqual(["spec/z-spec.js", "spec/é-spec.js"])
+    expect(timingManifestFileSetHash(filePaths)).toBe(`sha256:${sha256Hex(expectedIdentity)}`)
   })
 })

--- a/spec/testing/timing-manifest-validation-spec.js
+++ b/spec/testing/timing-manifest-validation-spec.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+import { describe, expect, it } from "../../src/testing/test.js"
+import {
+  canonicalTimingManifestPath,
+  timingManifestFileSetHash,
+  validateTimingManifest
+} from "../../src/testing/timing-manifest.js"
+
+describe("timing manifest validation", () => {
+  it("canonicalizes portable relative paths and preserves sorted non-negative durations", () => {
+    expect(validateTimingManifest({})).toEqual({})
+    expect(validateTimingManifest({
+      "spec\\models\\task-spec.js": 0,
+      "./spec//controllers/./tasks-spec.js": 12.345
+    }, {source: "timings.json"})).toEqual({
+      "spec/controllers/tasks-spec.js": 12.345,
+      "spec/models/task-spec.js": 0
+    })
+  })
+
+  it("rejects invalid roots paths durations and normalized collisions", async () => {
+    for (const invalidRoot of [null, [], "timings"]) {
+      await expect(() => validateTimingManifest(invalidRoot, {source: "timings.json"})).toThrow(/plain JSON object/)
+    }
+
+    for (const invalidPath of ["", "/spec/task-spec.js", "C:spec/task-spec.js", "C:\\spec\\task-spec.js", "../spec/task-spec.js", "spec/../../task-spec.js"]) {
+      await expect(() => canonicalTimingManifestPath(invalidPath)).toThrow(/relative path/)
+    }
+
+    for (const invalidDuration of [-1, "12", null, Infinity]) {
+      await expect(() => validateTimingManifest({"spec/task-spec.js": invalidDuration}, {source: "timings.json"})).toThrow(/duration/)
+    }
+
+    await expect(() => validateTimingManifest({
+      "./spec/task-spec.js": 1,
+      "spec\\task-spec.js": 2
+    }, {source: "timings.json"})).toThrow(/collision/)
+  })
+
+  it("hashes a canonical file universe independently of input path order and spelling", () => {
+    const firstHash = timingManifestFileSetHash(["spec\\b-spec.js", "./spec/a-spec.js"])
+    const secondHash = timingManifestFileSetHash(["spec/a-spec.js", "spec/b-spec.js"])
+
+    expect(firstHash).toBe(secondHash)
+    expect(firstHash).toMatch(/^sha256:[a-f0-9]{64}$/)
+  })
+})

--- a/src/cli/commands/test/timing-manifest/merge.js
+++ b/src/cli/commands/test/timing-manifest/merge.js
@@ -1,0 +1,14 @@
+// @ts-check
+
+import BaseCommand from "../../../base-command.js"
+
+/** CLI command for merging complete rich test-profile shards into timing history. */
+export default class TestTimingManifestMerge extends BaseCommand {
+  /**
+   * Runs execute.
+   * @returns {Promise<ReturnType<typeof JSON.parse>>} - Resolves with the merged manifest.
+   */
+  async execute() {
+    return await this.getConfiguration().getEnvironmentHandler().cliCommandsTestTimingManifestMerge(this)
+  }
+}

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -407,6 +407,15 @@ export default class VelociousEnvironmentHandlerBase {
   }
 
   /**
+   * Runs cli commands test timing manifest merge.
+   * @param {import("../cli/base-command.js").default} _command - Command.
+   * @returns {Promise<ReturnType<typeof JSON.parse>>} - Resolves with the command result.
+   */
+  async cliCommandsTestTimingManifestMerge(_command) {
+    throw new Error("cliCommandsTestTimingManifestMerge not implemented")
+  }
+
+  /**
    * Runs cli commands background jobs main.
    * @param {import("../cli/base-command.js").default} _command - Command.
    * @returns {Promise<ReturnType<typeof JSON.parse>>} - Resolves with the command result.

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -14,6 +14,7 @@ import CliCommandsLintRelationships from "./node/cli/commands/lint/relationships
 import CliCommandsRoutes from "./node/cli/commands/routes.js"
 import CliCommandsServer from "./node/cli/commands/server.js"
 import CliCommandsTest from "./node/cli/commands/test.js"
+import CliCommandsTestTimingManifestMerge from "./node/cli/commands/test/timing-manifest/merge.js"
 import CliCommandsBackgroundJobsMain from "./node/cli/commands/background-jobs-main.js"
 import CliCommandsBackgroundJobsWorker from "./node/cli/commands/background-jobs-worker.js"
 import CliCommandsBackgroundJobsRunner from "./node/cli/commands/background-jobs-runner.js"
@@ -828,6 +829,15 @@ export default class VelociousEnvironmentHandlerNode extends Base{
    */
   async cliCommandsTest(command) {
     return await this.forwardCommand(command, CliCommandsTest)
+  }
+
+  /**
+   * Runs cli commands test timing manifest merge.
+   * @param {import("../cli/base-command.js").default} command - Command.
+   * @returns {Promise<ReturnType<typeof JSON.parse>>} - Resolves with the command result.
+   */
+  async cliCommandsTestTimingManifestMerge(command) {
+    return await this.forwardCommand(command, CliCommandsTestTimingManifestMerge)
   }
 
   /**

--- a/src/environment-handlers/node/cli/commands/test.js
+++ b/src/environment-handlers/node/cli/commands/test.js
@@ -10,6 +10,11 @@ import { formatTestProfileSummary, writeTestProfileOutputs } from "../../../../t
 import TestRunner from "../../../../testing/test-runner.js"
 import TestSuiteSplitter from "../../../../testing/test-suite-splitter.js"
 import { normalizeExamplePatterns, parseFilters } from "../../../../testing/test-filter-parser.js"
+import {
+  canonicalTimingManifestPath,
+  timingManifestFileSetHash,
+  validateTimingManifest
+} from "../../../../testing/timing-manifest.js"
 import { prepareSourcePeerPackage } from "../../source-peer-package.js"
 
 export default class VelociousCliCommandsTest extends BaseCommand {
@@ -96,6 +101,20 @@ export default class VelociousCliCommandsTest extends BaseCommand {
     try {
       const discoverTestFiles = async () => {
         let discoveredTestFiles = await testFilesFinder.findTestFiles()
+        const lineFilters = testFilesFinder.getLineFiltersByFile()
+
+        if (profiler) {
+          const discoveredFilePaths = discoveredTestFiles.map((filePath) => {
+            return canonicalTimingManifestPath(path.relative(directory, filePath))
+          })
+
+          profiler.setSelection({
+            discoveredFileCount: discoveredTestFiles.length,
+            hasLineFilters: Object.keys(lineFilters).length > 0,
+            pathBase: process.env.VELOCIOUS_TEST_DIR ? "test-directory" : "configuration-directory",
+            testFileSetHash: timingManifestFileSetHash(discoveredFilePaths)
+          })
+        }
 
         if (groups !== undefined || groupNumber !== undefined) {
           if (groups === undefined || groupNumber === undefined) {
@@ -110,6 +129,15 @@ export default class VelociousCliCommandsTest extends BaseCommand {
             baseDirectory: directory,
             timingManifest
           })
+
+          if (profileOptions.timingManifestPath) {
+            const coverage = splitter.getTimingManifestCoverage()
+
+            console.log(picocolors.cyan(
+              `Timing manifest coverage: measured=${coverage.measuredFiles} ` +
+              `heuristic=${coverage.heuristicFiles} stale=${coverage.staleEntries}`
+            ))
+          }
 
           discoveredTestFiles = splitter.getGroupFiles()
           console.log(picocolors.cyan(`Running group ${groupNumber} of ${groups} (${discoveredTestFiles.length} files)`))
@@ -277,20 +305,30 @@ export function resolveTestProfileOptions({cwd, profile, profileJsonPath, timing
 }
 
 /**
- * Loads an optional JSON timing manifest. Unreadable or malformed input intentionally falls back to heuristics.
+ * Loads and validates an explicitly supplied plain JSON timing manifest.
  * @param {string | undefined} timingManifestPath - Timing manifest path.
- * @returns {Promise<ReturnType<typeof JSON.parse> | undefined>} - Parsed manifest when readable and valid JSON.
+ * @returns {Promise<Record<string, number> | undefined>} - Canonical manifest, or undefined when not requested.
  */
 export async function loadTimingManifest(timingManifestPath) {
   if (!timingManifestPath) return undefined
 
-  try {
-    return JSON.parse(await fs.readFile(timingManifestPath, "utf8"))
-  } catch (error) {
-    if (error instanceof Error) return undefined
+  let content
 
-    throw error
+  try {
+    content = await fs.readFile(timingManifestPath, "utf8")
+  } catch (error) {
+    throw new Error(`Failed to read timing manifest: ${timingManifestPath}`, {cause: error})
   }
+
+  let parsed
+
+  try {
+    parsed = JSON.parse(content)
+  } catch (error) {
+    throw new Error(`Failed to parse timing manifest: ${timingManifestPath}`, {cause: error})
+  }
+
+  return validateTimingManifest(parsed, {source: `Timing manifest ${timingManifestPath}`})
 }
 
 /**

--- a/src/environment-handlers/node/cli/commands/test.js
+++ b/src/environment-handlers/node/cli/commands/test.js
@@ -100,6 +100,7 @@ export default class VelociousCliCommandsTest extends BaseCommand {
 
     try {
       const discoverTestFiles = async () => {
+        const timingManifest = await loadTimingManifest(profileOptions.timingManifestPath)
         let discoveredTestFiles = await testFilesFinder.findTestFiles()
         const lineFilters = testFilesFinder.getLineFiltersByFile()
 
@@ -121,7 +122,6 @@ export default class VelociousCliCommandsTest extends BaseCommand {
             throw new Error("Both --groups and --group-number must be provided together")
           }
 
-          const timingManifest = await loadTimingManifest(profileOptions.timingManifestPath)
           const splitter = new TestSuiteSplitter({
             groups,
             groupNumber,
@@ -186,6 +186,9 @@ export default class VelociousCliCommandsTest extends BaseCommand {
       process.once("SIGTERM", () => { void handleSignal("SIGTERM") })
 
       await testRunner.prepare()
+      const effectiveExcludeTagCount = testRunner.getExcludeTagSet().size
+
+      profiler?.setSelection({excludeTagCount: effectiveExcludeTagCount})
 
       if (testRunner.getTestsCount() === 0) {
         await finalizeProfile("no-tests")
@@ -198,7 +201,7 @@ export default class VelociousCliCommandsTest extends BaseCommand {
       const lineFilters = testRunner.getLineFilters()
       const hasLineFilters = Object.keys(lineFilters).length > 0
       const hasExampleFilters = examplePatterns.length > 0
-      const hasTagFilters = includeTags.length > 0 || excludeTags.length > 0
+      const hasTagFilters = includeTags.length > 0 || effectiveExcludeTagCount > 0
 
       if ((hasTagFilters || hasLineFilters || hasExampleFilters) && executedTests === 0) {
         console.error(picocolors.red("\nNo tests matched the provided filters"))

--- a/src/environment-handlers/node/cli/commands/test/timing-manifest/merge.js
+++ b/src/environment-handlers/node/cli/commands/test/timing-manifest/merge.js
@@ -1,0 +1,108 @@
+// @ts-check
+
+import BaseCommand from "../../../../../../cli/base-command.js"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { writeTimingManifest } from "../../../../../../testing/test-profile-output.js"
+import { mergeTestProfileTimingManifests } from "../../../../../../testing/timing-manifest.js"
+
+/**
+ * @typedef {object} TimingManifestMergeArguments
+ * @property {string[]} inputPaths - Rich profile input paths.
+ * @property {string} outputPath - Plain timing manifest output path.
+ */
+
+/** Node implementation for timing-manifest aggregation. */
+export default class TestTimingManifestMerge extends BaseCommand {
+  /**
+   * Runs execute.
+   * @returns {Promise<Record<string, number>>} - Complete merged timing manifest.
+   */
+  async execute() {
+    const {inputPaths, outputPath} = parseTimingManifestMergeArguments(this.processArgs || [], process.cwd())
+    const inputs = []
+
+    for (const inputPath of inputPaths) {
+      let content
+
+      try {
+        content = await fs.readFile(inputPath, "utf8")
+      } catch (error) {
+        throw new Error(`Failed to read test profile: ${inputPath}`, {cause: error})
+      }
+
+      let profile
+
+      try {
+        profile = JSON.parse(content)
+      } catch (error) {
+        throw new Error(`Failed to parse test profile: ${inputPath}`, {cause: error})
+      }
+
+      inputs.push({profile, source: inputPath})
+    }
+
+    const timingManifest = mergeTestProfileTimingManifests(inputs)
+
+    await writeTimingManifest({outputPath, timingManifest})
+    console.log(`Merged ${inputPaths.length} test profile shards into ${outputPath} (${Object.keys(timingManifest).length} files)`)
+
+    return timingManifest
+  }
+}
+
+/**
+ * Recognizes one output option spelling.
+ * @param {string} argument - Current argument.
+ * @param {string | undefined} nextArgument - Following argument.
+ * @returns {{matched: boolean, skipNext: boolean, value: string | undefined}} - Parsed output option.
+ */
+function timingManifestOutputArgument(argument, nextArgument) {
+  if (argument === "--output") {
+    return {matched: true, skipNext: true, value: nextArgument}
+  }
+
+  if (argument.startsWith("--output=")) {
+    return {matched: true, skipNext: false, value: argument.slice("--output=".length)}
+  }
+
+  return {matched: false, skipNext: false, value: undefined}
+}
+
+/**
+ * Parses strict merge arguments and resolves their paths.
+ * @param {string[]} processArgs - Raw CLI arguments, including command name.
+ * @param {string} cwd - Command working directory.
+ * @returns {TimingManifestMergeArguments} - Validated resolved paths.
+ */
+export function parseTimingManifestMergeArguments(processArgs, cwd) {
+  const commandName = processArgs[0] || "test:timing-manifest:merge"
+  const inputPaths = []
+  let outputPath
+
+  for (let index = 1; index < processArgs.length; index++) {
+    const argument = processArgs[index]
+    const outputArgument = timingManifestOutputArgument(argument, processArgs[index + 1])
+
+    if (outputArgument.matched) {
+      if (!outputArgument.value || outputArgument.value.startsWith("-")) throw new Error("Missing value for --output")
+      if (outputPath) throw new Error("--output may only be provided once")
+      outputPath = path.resolve(cwd, outputArgument.value)
+      if (outputArgument.skipNext) index++
+      continue
+    }
+
+    if (argument.startsWith("-")) throw new Error(`Unknown argument for ${commandName}: ${argument}`)
+    inputPaths.push(path.resolve(cwd, argument))
+  }
+
+  if (!outputPath) throw new Error("--output is required")
+  if (inputPaths.length === 0) throw new Error("At least one rich test profile input is required")
+
+  const uniqueInputPaths = new Set(inputPaths)
+
+  if (uniqueInputPaths.size !== inputPaths.length) throw new Error("Each rich test profile input must be provided once")
+  if (uniqueInputPaths.has(outputPath)) throw new Error("Timing manifest output must not overwrite an input profile")
+
+  return {inputPaths, outputPath}
+}

--- a/src/testing/test-profile-output.js
+++ b/src/testing/test-profile-output.js
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 import { roundProfileDuration } from "./test-profiler.js"
+import { validateTimingManifest } from "./timing-manifest.js"
 
 const FORBIDDEN_PROFILE_FIELDS = new Set([
   "bind",
@@ -156,18 +157,32 @@ async function atomicWrite(outputPath, content) {
 export function timingManifestFromProfile(profile) {
   /** @type {Record<string, number>} */
   const manifest = {}
+  const validatedManifest = validateTimingManifest(profile.timingManifest || {}, {source: "Test profile timing manifest"})
 
-  for (const filePath of Object.keys(profile.timingManifest || {}).sort()) {
-    const durationMs = profile.timingManifest[filePath]
-
-    if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0) {
-      throw new Error(`Invalid timing manifest duration for ${filePath}`)
-    }
-
+  for (const [filePath, durationMs] of Object.entries(validatedManifest)) {
     manifest[filePath] = roundProfileDuration(durationMs)
   }
 
   return manifest
+}
+
+/**
+ * Atomically writes a canonical splitter-compatible timing manifest.
+ * @param {object} args - Output arguments.
+ * @param {string} args.outputPath - Final output path.
+ * @param {Record<string, number>} args.timingManifest - Validated or candidate timing manifest.
+ * @returns {Promise<void>} - Resolves after atomic replacement.
+ */
+export async function writeTimingManifest({outputPath, timingManifest}) {
+  const normalized = validateTimingManifest(timingManifest)
+  /** @type {Record<string, number>} */
+  const rounded = {}
+
+  for (const [filePath, durationMs] of Object.entries(normalized)) {
+    rounded[filePath] = roundProfileDuration(durationMs)
+  }
+
+  await atomicWrite(outputPath, `${JSON.stringify(rounded, null, 2)}\n`)
 }
 
 /**
@@ -189,7 +204,7 @@ export async function writeTestProfileOutputs({profile, profileJsonPath, timingM
   }
 
   if (timingManifestOutputPath) {
-    await atomicWrite(timingManifestOutputPath, `${JSON.stringify(timingManifest, null, 2)}\n`)
+    await writeTimingManifest({outputPath: timingManifestOutputPath, timingManifest})
   }
 }
 

--- a/src/testing/test-profiler.js
+++ b/src/testing/test-profiler.js
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto"
 import path from "node:path"
 import { registerTestProfileContextReader } from "./test-profile-context.js"
 import { validateTestActivityName } from "./test-profile-activity.js"
+import { compareTimingManifestPaths } from "./timing-manifest.js"
 
 /** @typedef {"passed" | "failed" | "interrupted" | "timed-out"} TestProfileAttemptStatus */
 /** @typedef {{user: number, system: number}} ProcessCpuUsage */
@@ -625,7 +626,7 @@ export default class TestProfiler {
         attemptsMs: roundProfileDuration(file.attemptsMs),
         totalMs: roundProfileDuration(file.totalMs)
       }))
-      .sort((fileA, fileB) => fileA.path.localeCompare(fileB.path))
+      .sort((fileA, fileB) => compareTimingManifestPaths(fileA.path, fileB.path))
     const timingManifest = Object.fromEntries(files.map((file) => [file.path, file.totalMs]))
     const attempts = this._tests.reduce((sum, test) => sum + test.attempts.length, 0)
 

--- a/src/testing/test-suite-splitter.js
+++ b/src/testing/test-suite-splitter.js
@@ -2,7 +2,7 @@
 
 import path from "path"
 import restArgsError from "../utils/rest-args-error.js"
-import { canonicalTimingManifestPath } from "./timing-manifest.js"
+import { canonicalTimingManifestPath, compareTimingManifestPaths } from "./timing-manifest.js"
 
 /**
  * SplitterFileEntry type.
@@ -225,7 +225,7 @@ export default class TestSuiteSplitter {
         return b.weight - a.weight
       }
 
-      return a.filePath.localeCompare(b.filePath)
+      return compareTimingManifestPaths(a.filePath, b.filePath)
     })
   }
 

--- a/src/testing/test-suite-splitter.js
+++ b/src/testing/test-suite-splitter.js
@@ -102,7 +102,7 @@ export default class TestSuiteSplitter {
       return duration
     }
 
-    const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
+    const relativePath = this.heuristicRelativePath(filePath)
     let weight = DEFAULT_WEIGHT
 
     // Extract the type directory from the relative path.
@@ -161,6 +161,31 @@ export default class TestSuiteSplitter {
   }
 
   /**
+   * Returns the permissive relative path used only for heuristic classification.
+   * @param {string} filePath - Absolute test file path.
+   * @returns {string} - Portable relative path which may escape the profiling base.
+   */
+  heuristicRelativePath(filePath) {
+    return path.relative(this._baseDirectory, filePath)
+      .replaceAll("\\", "/")
+      .replace(/^\.\//, "")
+  }
+
+  /**
+   * Returns a canonical manifest key when the file is representable under the profiling base.
+   * @param {string} filePath - Absolute test file path.
+   * @returns {string | undefined} - Canonical relative path, or undefined for an external file.
+   */
+  manifestRelativePath(filePath) {
+    const relativePath = path.relative(this._baseDirectory, filePath)
+
+    if (!relativePath || path.isAbsolute(relativePath)) return
+    if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`)) return
+
+    return this.normalizeRelativePath(relativePath)
+  }
+
+  /**
    * Returns the first manifest entry matching a discovered test file.
    * @param {string} filePath - Absolute test file path.
    * @returns {number | undefined} - Recorded duration, including zero.
@@ -179,7 +204,10 @@ export default class TestSuiteSplitter {
    * @returns {string[]} - Canonical keys in matching priority order.
    */
   timingManifestPaths(filePath) {
-    const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
+    const relativePath = this.manifestRelativePath(filePath)
+
+    if (!relativePath) return []
+
     const projectRelativePath = this.normalizeRelativePath(path.join(path.basename(this._baseDirectory), relativePath))
 
     return relativePath === projectRelativePath ? [relativePath] : [relativePath, projectRelativePath]

--- a/src/testing/test-suite-splitter.js
+++ b/src/testing/test-suite-splitter.js
@@ -2,6 +2,7 @@
 
 import path from "path"
 import restArgsError from "../utils/rest-args-error.js"
+import { canonicalTimingManifestPath } from "./timing-manifest.js"
 
 /**
  * SplitterFileEntry type.
@@ -95,14 +96,13 @@ export default class TestSuiteSplitter {
    * @returns {number} - Weight value.
    */
   computeWeight(filePath) {
-    const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
-    const projectRelativePath = this.normalizeRelativePath(path.join(path.basename(this._baseDirectory), relativePath))
-    const duration = this._timingManifest[relativePath] ?? this._timingManifest[projectRelativePath]
+    const duration = this.timingManifestDuration(filePath)
 
-    if (duration !== undefined) {
+    if (duration !== undefined && duration > 0) {
       return duration
     }
 
+    const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
     let weight = DEFAULT_WEIGHT
 
     // Extract the type directory from the relative path.
@@ -139,8 +139,12 @@ export default class TestSuiteSplitter {
     }
 
     for (const [filePath, duration] of Object.entries(timingManifest)) {
-      if (typeof duration === "number" && Number.isFinite(duration) && duration > 0) {
+      if (typeof duration !== "number" || !Number.isFinite(duration) || duration < 0) continue
+
+      try {
         normalized[this.normalizeRelativePath(filePath)] = duration
+      } catch (error) {
+        if (!(error instanceof Error)) throw error
       }
     }
 
@@ -153,9 +157,61 @@ export default class TestSuiteSplitter {
    * @returns {string} - Normalized relative test path.
    */
   normalizeRelativePath(filePath) {
-    return filePath
-      .replaceAll("\\", "/")
-      .replace(/^\.\//, "")
+    return canonicalTimingManifestPath(filePath)
+  }
+
+  /**
+   * Returns the first manifest entry matching a discovered test file.
+   * @param {string} filePath - Absolute test file path.
+   * @returns {number | undefined} - Recorded duration, including zero.
+   */
+  timingManifestDuration(filePath) {
+    for (const manifestPath of this.timingManifestPaths(filePath)) {
+      if (Object.hasOwn(this._timingManifest, manifestPath)) return this._timingManifest[manifestPath]
+    }
+
+    return undefined
+  }
+
+  /**
+   * Returns compatible manifest keys for one discovered file.
+   * @param {string} filePath - Absolute test file path.
+   * @returns {string[]} - Canonical keys in matching priority order.
+   */
+  timingManifestPaths(filePath) {
+    const relativePath = this.normalizeRelativePath(path.relative(this._baseDirectory, filePath))
+    const projectRelativePath = this.normalizeRelativePath(path.join(path.basename(this._baseDirectory), relativePath))
+
+    return relativePath === projectRelativePath ? [relativePath] : [relativePath, projectRelativePath]
+  }
+
+  /**
+   * Summarizes timing-history coverage for the complete discovered suite.
+   * @returns {{heuristicFiles: number, measuredFiles: number, staleEntries: number}} - Compact coverage counts.
+   */
+  getTimingManifestCoverage() {
+    const matchedManifestPaths = new Set()
+    let measuredFiles = 0
+
+    for (const filePath of this._testFiles) {
+      let matchedDuration
+
+      for (const manifestPath of this.timingManifestPaths(filePath)) {
+        if (!Object.hasOwn(this._timingManifest, manifestPath)) continue
+
+        matchedManifestPaths.add(manifestPath)
+        matchedDuration = this._timingManifest[manifestPath]
+        break
+      }
+
+      if (matchedDuration !== undefined && matchedDuration > 0) measuredFiles++
+    }
+
+    return {
+      heuristicFiles: this._testFiles.length - measuredFiles,
+      measuredFiles,
+      staleEntries: Object.keys(this._timingManifest).length - matchedManifestPaths.size
+    }
   }
 
   /**

--- a/src/testing/timing-manifest.js
+++ b/src/testing/timing-manifest.js
@@ -64,6 +64,18 @@ export function canonicalTimingManifestPath(filePath) {
 }
 
 /**
+ * Compares timing-manifest paths by JavaScript code units without locale rules.
+ * @param {string} filePathA - First path.
+ * @param {string} filePathB - Second path.
+ * @returns {number} - Negative, zero, or positive ordering result.
+ */
+export function compareTimingManifestPaths(filePathA, filePathB) {
+  if (filePathA === filePathB) return 0
+
+  return filePathA < filePathB ? -1 : 1
+}
+
+/**
  * Validates and sorts a plain timing manifest.
  * @param {ReturnType<typeof JSON.parse>} timingManifest - Parsed timing manifest.
  * @param {{source?: string}} [options] - Validation context.
@@ -94,7 +106,7 @@ export function validateTimingManifest(timingManifest, {source = "timing manifes
 
   return Object.fromEntries(
     [...entries.entries()]
-      .sort(([filePathA], [filePathB]) => filePathA.localeCompare(filePathB))
+      .sort(([filePathA], [filePathB]) => compareTimingManifestPaths(filePathA, filePathB))
       .map(([filePath, entry]) => [filePath, entry.duration])
   )
 }

--- a/src/testing/timing-manifest.js
+++ b/src/testing/timing-manifest.js
@@ -1,0 +1,334 @@
+// @ts-check
+
+import sha256Hex from "../utils/sha256-hex.js"
+
+/** @typedef {Record<string, number>} TimingManifest */
+
+/**
+ * ValidatedProfileShard type.
+ * @typedef {object} ValidatedProfileShard
+ * @property {number} discoveredFileCount - Complete pre-shard file count.
+ * @property {number} fileCount - Selected post-shard file count.
+ * @property {number} groupNumber - One-indexed shard number.
+ * @property {number} groups - Complete shard count.
+ * @property {string} pathBase - Profiling path-base semantics.
+ * @property {string} testFileSetHash - Complete canonical file-set identity.
+ * @property {TimingManifest} timingManifest - Canonical shard timing map.
+ */
+
+/**
+ * TestProfileTimingManifestInput type.
+ * @typedef {object} TestProfileTimingManifestInput
+ * @property {ReturnType<typeof JSON.parse>} profile - Parsed rich test profile.
+ * @property {string} source - Human-readable input source for validation errors.
+ */
+
+/**
+ * Canonicalizes a timing-manifest path relative to its profiling base.
+ * @param {string} filePath - Candidate relative path.
+ * @returns {string} - Portable canonical path.
+ */
+export function canonicalTimingManifestPath(filePath) {
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    throw new Error("Timing manifest keys must be non-empty relative paths")
+  }
+
+  const portablePath = filePath.replaceAll("\\", "/")
+
+  if (portablePath.startsWith("/") || /^[A-Za-z]:/.test(portablePath)) {
+    throw new Error(`Timing manifest key must be a relative path: ${filePath}`)
+  }
+
+  const segments = []
+
+  for (const segment of portablePath.split("/")) {
+    if (!segment || segment === ".") continue
+
+    if (segment === "..") {
+      if (segments.length === 0) {
+        throw new Error(`Timing manifest key must be a non-escaping relative path: ${filePath}`)
+      }
+
+      segments.pop()
+      continue
+    }
+
+    segments.push(segment)
+  }
+
+  if (segments.length === 0) {
+    throw new Error(`Timing manifest key must be a non-empty relative path: ${filePath}`)
+  }
+
+  return segments.join("/")
+}
+
+/**
+ * Validates and sorts a plain timing manifest.
+ * @param {ReturnType<typeof JSON.parse>} timingManifest - Parsed timing manifest.
+ * @param {{source?: string}} [options] - Validation context.
+ * @returns {TimingManifest} - Canonical sorted timing manifest.
+ */
+export function validateTimingManifest(timingManifest, {source = "timing manifest"} = {}) {
+  if (!timingManifest || typeof timingManifest !== "object" || Array.isArray(timingManifest)) {
+    throw new Error(`${source} must be a plain JSON object mapping relative paths to durations`)
+  }
+
+  /** @type {Map<string, {duration: number, originalPath: string}>} */
+  const entries = new Map()
+
+  for (const [originalPath, duration] of Object.entries(timingManifest)) {
+    if (typeof duration !== "number" || !Number.isFinite(duration) || duration < 0) {
+      throw new Error(`${source} has an invalid duration for ${originalPath}`)
+    }
+
+    const canonicalPath = canonicalTimingManifestPath(originalPath)
+    const existing = entries.get(canonicalPath)
+
+    if (existing) {
+      throw new Error(`${source} has a normalized path collision between ${existing.originalPath} and ${originalPath}`)
+    }
+
+    entries.set(canonicalPath, {duration, originalPath})
+  }
+
+  return Object.fromEntries(
+    [...entries.entries()]
+      .sort(([filePathA], [filePathB]) => filePathA.localeCompare(filePathB))
+      .map(([filePath, entry]) => [filePath, entry.duration])
+  )
+}
+
+/**
+ * Returns an opaque deterministic identity for a complete canonical test-file set.
+ * @param {string[]} filePaths - Paths relative to one profiling base.
+ * @returns {string} - SHA-256 file-set identity.
+ */
+export function timingManifestFileSetHash(filePaths) {
+  const pathManifest = Object.fromEntries(filePaths.map((filePath) => [filePath, 0]))
+  const canonicalPaths = Object.keys(validateTimingManifest(pathManifest, {source: "test file set"}))
+  const identity = `velocious.test-file-set.v1\0${canonicalPaths.join("\0")}`
+
+  return `sha256:${sha256Hex(identity)}`
+}
+
+/**
+ * Validates that a parsed JSON value is a non-array object.
+ * @param {ReturnType<typeof JSON.parse>} value - Candidate object.
+ * @param {string} message - Validation error message.
+ * @returns {void}
+ */
+function assertJsonObject(value, message) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(message)
+}
+
+/**
+ * Requires unfiltered, non-focused profile selection metadata.
+ * @param {ReturnType<typeof JSON.parse>} selection - Rich profile selection.
+ * @param {string} source - Input source.
+ * @returns {void}
+ */
+function assertCompleteSelection(selection, source) {
+  if (selection.focused !== false) throw new Error(`${source} must not be a focused test profile`)
+
+  const selectionFilters = [
+    [selection.includeTagCount, 0],
+    [selection.excludeTagCount, 0],
+    [selection.hasExampleFilters, false],
+    [selection.hasLineFilters, false]
+  ]
+
+  if (selectionFilters.some(([value, expected]) => value !== expected)) {
+    throw new Error(`${source} must not be a filtered test profile`)
+  }
+}
+
+/**
+ * Validates shard numbering metadata.
+ * @param {ReturnType<typeof JSON.parse>} shard - Candidate shard selection.
+ * @param {string} source - Input source.
+ * @returns {{groupNumber: number, groups: number}} - Validated shard numbers.
+ */
+function validatedShardNumbers(shard, source) {
+  assertJsonObject(shard, `${source} is missing shard metadata`)
+
+  if (!Number.isInteger(shard.groups) || shard.groups < 1) {
+    throw new Error(`${source} has an invalid shard group count`)
+  }
+
+  if (!Number.isInteger(shard.groupNumber) || shard.groupNumber < 1 || shard.groupNumber > shard.groups) {
+    throw new Error(`${source} has an invalid shard number`)
+  }
+
+  return {groupNumber: shard.groupNumber, groups: shard.groups}
+}
+
+/**
+ * Validates a non-negative integer selection count.
+ * @param {ReturnType<typeof JSON.parse>} value - Candidate count.
+ * @param {string} message - Validation error message.
+ * @returns {number} - Validated count.
+ */
+function validatedSelectionCount(value, message) {
+  if (!Number.isInteger(value) || value < 0) throw new Error(message)
+
+  return value
+}
+
+/**
+ * Validates the selection identity used across shard profiles.
+ * @param {ReturnType<typeof JSON.parse>} selection - Rich profile selection.
+ * @param {string} source - Input source.
+ * @returns {{pathBase: string, testFileSetHash: string}} - Validated identity.
+ */
+function validatedSelectionIdentity(selection, source) {
+  if (!["configuration-directory", "test-directory"].includes(selection.pathBase)) {
+    throw new Error(`${source} has an invalid timing manifest path base`)
+  }
+
+  if (typeof selection.testFileSetHash !== "string" || !/^sha256:[a-f0-9]{64}$/.test(selection.testFileSetHash)) {
+    throw new Error(`${source} has an invalid test file set identity`)
+  }
+
+  return {pathBase: selection.pathBase, testFileSetHash: selection.testFileSetHash}
+}
+
+/**
+ * Validates one rich profile and returns its aggregation contract.
+ * @param {TestProfileTimingManifestInput} input - Profile input.
+ * @returns {ValidatedProfileShard} - Validated shard contract.
+ */
+function validatedProfileShard(input) {
+  const {profile, source} = input
+
+  assertJsonObject(profile, `${source} must be a rich Velocious test profile`)
+
+  if (profile.schema !== "velocious.test-profile" || profile.schemaVersion !== 1) {
+    throw new Error(`${source} has an incompatible Velocious test profile schema`)
+  }
+
+  if (profile.status !== "passed") throw new Error(`${source} must have passed status for timing aggregation`)
+
+  const selection = profile.selection
+
+  assertJsonObject(selection, `${source} is missing test profile selection metadata`)
+  assertCompleteSelection(selection, source)
+  const {groupNumber, groups} = validatedShardNumbers(selection.shard, source)
+  const discoveredFileCount = validatedSelectionCount(
+    selection.discoveredFileCount,
+    `${source} has an invalid pre-shard discovered file count`
+  )
+  const fileCount = validatedSelectionCount(
+    selection.fileCount,
+    `${source} has an invalid post-shard file count`
+  )
+  const {pathBase, testFileSetHash} = validatedSelectionIdentity(selection, source)
+
+  const timingManifest = validateTimingManifest(profile.timingManifest, {source: `${source} timing manifest`})
+
+  if (Object.keys(timingManifest).length !== fileCount) {
+    throw new Error(`${source} timing manifest does not match its post-shard file count`)
+  }
+
+  return {
+    discoveredFileCount,
+    fileCount,
+    groupNumber,
+    groups,
+    pathBase,
+    testFileSetHash,
+    timingManifest
+  }
+}
+
+/**
+ * Requires one shard to describe the same complete selection as the first.
+ * @param {ValidatedProfileShard} shard - Candidate shard.
+ * @param {ValidatedProfileShard} expected - First shard contract.
+ * @param {string} source - Candidate source.
+ * @returns {void}
+ */
+function assertCompatibleShard(shard, expected, source) {
+  if (shard.groups !== expected.groups) throw new Error(`${source} has a different shard group count`)
+  if (shard.pathBase !== expected.pathBase) throw new Error(`${source} has a different timing manifest path base`)
+  if (shard.discoveredFileCount !== expected.discoveredFileCount) throw new Error(`${source} has a different discovered file count`)
+  if (shard.testFileSetHash !== expected.testFileSetHash) throw new Error(`${source} has a different test file set identity`)
+}
+
+/**
+ * Adds one validated shard timing map without allowing duplicate canonical keys.
+ * @param {object} args - Merge state.
+ * @param {Map<string, {duration: number, source: string}>} args.mergedEntries - Destination timing entries.
+ * @param {ValidatedProfileShard} args.shard - Candidate shard.
+ * @param {string} args.source - Candidate source.
+ * @returns {void}
+ */
+function mergeShardTimingManifest({mergedEntries, shard, source}) {
+  for (const [filePath, duration] of Object.entries(shard.timingManifest)) {
+    const existingEntry = mergedEntries.get(filePath)
+
+    if (existingEntry) {
+      throw new Error(`Duplicate timing path ${filePath} in ${existingEntry.source} and ${source}`)
+    }
+
+    mergedEntries.set(filePath, {duration, source})
+  }
+}
+
+/**
+ * Merges a complete compatible set of rich Velocious shard profiles.
+ * @param {TestProfileTimingManifestInput[]} inputs - Parsed profile documents and sources.
+ * @returns {TimingManifest} - Complete sorted plain timing manifest.
+ */
+export function mergeTestProfileTimingManifests(inputs) {
+  if (inputs.length === 0) throw new Error("At least one rich test profile is required")
+
+  const shards = inputs.map((input) => validatedProfileShard(input))
+  const expected = shards[0]
+  /** @type {Map<number, string>} */
+  const shardSources = new Map()
+  /** @type {Map<string, {duration: number, source: string}>} */
+  const mergedEntries = new Map()
+  let selectedFileCount = 0
+
+  for (let index = 0; index < shards.length; index++) {
+    const shard = shards[index]
+    const source = inputs[index].source
+
+    assertCompatibleShard(shard, expected, source)
+
+    const existingShardSource = shardSources.get(shard.groupNumber)
+
+    if (existingShardSource) {
+      throw new Error(`Duplicate shard ${shard.groupNumber} in ${existingShardSource} and ${source}`)
+    }
+
+    shardSources.set(shard.groupNumber, source)
+    selectedFileCount += shard.fileCount
+    mergeShardTimingManifest({mergedEntries, shard, source})
+  }
+
+  const missingShardNumbers = []
+
+  for (let groupNumber = 1; groupNumber <= expected.groups; groupNumber++) {
+    if (!shardSources.has(groupNumber)) missingShardNumbers.push(groupNumber)
+  }
+
+  if (missingShardNumbers.length > 0) {
+    throw new Error(`Missing shard profiles: ${missingShardNumbers.join(", ")}`)
+  }
+
+  if (selectedFileCount !== expected.discoveredFileCount || mergedEntries.size !== expected.discoveredFileCount) {
+    throw new Error("Merged timing manifest does not cover the complete file universe")
+  }
+
+  const merged = Object.fromEntries(
+    [...mergedEntries].map(([filePath, entry]) => [filePath, entry.duration])
+  )
+
+  if (timingManifestFileSetHash(Object.keys(merged)) !== expected.testFileSetHash) {
+    throw new Error("Merged timing manifest does not match the complete file universe")
+  }
+
+  return validateTimingManifest(merged, {source: "merged timing manifest"})
+}


### PR DESCRIPTION
## Summary

- add `velocious test:timing-manifest:merge` for strict aggregation of complete rich shard profiles into the existing plain timing manifest
- add canonical path validation, deterministic suite identity metadata, strict explicit manifest loading, and measured/heuristic/stale coverage reporting
- preserve existing plain manifest consumption while documenting shard aggregation and path-base semantics
- restore the reviewed Fallow annotation for an intentionally dynamically invoked MySQL diagnostic test hook

## Validation

- 39 focused tests across seven spec files, run sequentially
- real two-shard profile → merge → next-cycle consumption integration
- `VELOCIOUS_TEST_DIR` path-base integration
- `npm run build`
- exact copied-config gate: `npm run lint`, `npm run typecheck`, `npm run fallow`
- independent current-head review: PASS

## Compatibility

Existing valid plain timing manifests remain directly consumable. The intentional behavior change is that an explicitly supplied missing, unreadable, malformed, or invalid `--timing-manifest` now fails instead of silently disabling timing history. Missing/new file keys still use deterministic heuristics and stale keys remain ignored.
