### PR TITLE
Emit orphan events before dispatch redrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2285,7 +2285,7 @@ Velocious includes a simple background jobs system inspired by Sidekiq.
 
 Jobs can opt into cross-worker durable concurrency limits by pairing a non-empty `concurrencyKey` with a positive-integer `maxConcurrency` in their background-job options. The first cap registered for a key is stable; conflicting caps are rejected. See [durable concurrency limits](docs/background-jobs.md#durable-concurrency-limits).
 
-Production apps can listen for `background-job-failed` (or its `all-error` mirror) to report accepted failed attempts, including retry and terminal-state metadata, and for `background-job-orphaned` to react to a specific job the main process reclaimed after its worker died mid-run — e.g. enqueue a targeted recovery for the work it left behind, instead of only polling for the aftermath. See [docs/background-jobs.md](docs/background-jobs.md#failure-events).
+Production apps can listen for `background-job-failed` (or its `all-error` mirror) to report accepted failed attempts, including retry and terminal-state metadata, and for `background-job-orphaned` to react to a specific job the main process reclaimed after its worker died mid-run — e.g. enqueue a targeted recovery for the work it left behind, instead of only polling for the aftermath. Orphan handlers run before the sweep waits for reclaimed jobs to be dispatched, so a stalled dispatcher does not delay application recovery. See [docs/background-jobs.md](docs/background-jobs.md#failure-events).
 
 ## Setup
 

--- a/changelog.d/20260817142214-orphan-event-before-redrain.md
+++ b/changelog.d/20260817142214-orphan-event-before-redrain.md
@@ -1,0 +1,1 @@
+Fix `background-job-orphaned` notifications waiting behind the orphan sweep's dispatch drain, which could prevent application recovery handlers from running while the dispatcher was stalled.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -341,7 +341,7 @@ The mirrored `all-error` payload includes the same `error` and `context` plus `e
 
 ### Orphaned jobs
 
-`background-jobs-main` also emits a `background-job-orphaned` error event (mirrored to `all-error` as `errorType: "background-job-orphaned"`) for each job its time-based orphan sweep reclaims — a job whose worker died mid-run and stopped reporting, so it was stuck `handed_off` past the orphan timeout. Unlike `background-job-failed`, which fires on a worker's failure report, this fires from the main process's sweep, so an application can react to the specific job a dead worker left behind — enqueue a targeted recovery for the work it was doing — instead of only polling for the aftermath.
+`background-jobs-main` also emits a `background-job-orphaned` error event (mirrored to `all-error` as `errorType: "background-job-orphaned"`) for each job its time-based orphan sweep reclaims — a job whose worker died mid-run and stopped reporting, so it was stuck `handed_off` past the orphan timeout. Unlike `background-job-failed`, which fires on a worker's failure report, this fires from the main process's sweep, so an application can react to the specific job a dead worker left behind — enqueue a targeted recovery for the work it was doing — instead of only polling for the aftermath. The sweep emits these events before waiting for reclaimed jobs to be dispatched, so a stalled dispatcher does not delay application recovery handlers.
 
 ```js
 configuration.getErrorEvents().on("background-job-orphaned", ({error, context}) => {

--- a/spec/background-jobs/queue-spec.js
+++ b/spec/background-jobs/queue-spec.js
@@ -1,14 +1,62 @@
 // @ts-check
 
 import fs from "fs/promises"
+import {deferred} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import wait from "awaitery/build/wait.js"
+import BackgroundJobsMain from "../../src/background-jobs/main.js"
+import BackgroundJobsStore from "../../src/background-jobs/store.js"
 import {outputPathFor, startBackgroundJobs, waitForOutputJson, withBackgroundJobs} from "../helpers/background-jobs-helper.js"
 import dummyConfiguration from "../dummy/src/config/configuration.js"
 import AppendJob from "../dummy/src/jobs/append-job.js"
 import DelayedJob from "../dummy/src/jobs/delayed-job.js"
 import FailingJob from "../dummy/src/jobs/failing-job.js"
 import SlowTestJob from "../dummy/src/jobs/slow-test-job.js"
+
+class QueuedOrphanStore extends BackgroundJobsStore {
+  /** @returns {Promise<import("../../src/background-jobs/types.js").BackgroundJobRow[]>} - Reclaimed orphan rows. */
+  async markOrphanedJobs() {
+    return [{
+      args: ["stale build"],
+      attempts: 1,
+      completedAtMs: null,
+      concurrencyKey: null,
+      createdAtMs: 1,
+      executionMode: "inline",
+      failedAtMs: null,
+      handedOffAtMs: null,
+      handoffId: null,
+      id: "orphaned-job",
+      jobName: FailingJob.jobName(),
+      lastError: "Worker heartbeat expired",
+      maxConcurrency: null,
+      maxRetries: 2,
+      orphanedAtMs: 2,
+      queue: "default",
+      scheduledAtMs: 2,
+      scheduleKey: null,
+      status: "queued",
+      timeoutMs: null,
+      workerId: null
+    }]
+  }
+}
+
+class MainWithBlockedDrain extends BackgroundJobsMain {
+  /** @param {ConstructorParameters<typeof BackgroundJobsMain>[0]} args - Main options. */
+  constructor(args) {
+    super(args)
+    this.store = new QueuedOrphanStore({configuration: args.configuration})
+    this.drainStarted = deferred()
+    this.drainCanFinish = deferred()
+  }
+
+  /** @returns {Promise<void>} - Resolves when the test releases the drain. */
+  async _drain() {
+    this.drainStarted.resolve(undefined)
+    await this.drainCanFinish.promise
+  }
+}
 
 /**
  * @param {string} outputPath - Output path.
@@ -27,6 +75,24 @@ async function appendInlineAndWait(outputPath) {
 }
 
 describe("Background jobs - queue", {databaseCleaning: {truncate: true}}, () => {
+  it("emits orphan notifications before a blocked redrain finishes", async () => {
+    const main = new MainWithBlockedDrain({configuration: dummyConfiguration, host: "127.0.0.1", port: 0})
+    const errorEvents = dummyConfiguration.getErrorEvents()
+    const orphanEvents = []
+    const onOrphan = (/** @type {ReturnType<typeof JSON.parse>} */ payload) => orphanEvents.push(payload)
+    errorEvents.on("background-job-orphaned", onOrphan)
+    const sweep = main._sweepOrphans()
+
+    try {
+      await main.drainStarted.promise
+      expect(orphanEvents).toMatchObject([{context: {jobId: "orphaned-job", willRetry: true}}])
+    } finally {
+      main.drainCanFinish.resolve(undefined)
+      await sweep
+      errorEvents.off("background-job-orphaned", onOrphan)
+    }
+  })
+
   it("processes inline jobs in order", async () => {
     const {main, worker} = await startBackgroundJobs({workerOptions: {maxConcurrentInlineJobs: 1}})
     const outputPath = await outputPathFor("queue")

--- a/src/background-jobs/main.js
+++ b/src/background-jobs/main.js
@@ -1500,11 +1500,11 @@ export default class BackgroundJobsMain {
         // an application event handler that throws below cannot strand them
         // queued until the next external enqueue/reconnect.
         this._notifyEnqueued()
-        await this._drain()
         // Emit an event per orphaned job so applications can react to a dead
         // worker's specific job (e.g. targeted recovery) instead of only polling
-        // for its aftermath. Isolate each so one throwing handler can't suppress
-        // the events for the rest.
+        // for its aftermath. Emit before awaiting the drain so a blocked
+        // dispatcher cannot delay application recovery. Isolate each so one
+        // throwing handler can't suppress the events for the rest.
         for (const job of orphanedJobs) {
           try {
             this._emitBackgroundJobOrphaned({job})
@@ -1512,6 +1512,7 @@ export default class BackgroundJobsMain {
             this.logger.error(() => ["A background-job-orphaned event handler threw:", error])
           }
         }
+        await this._drain()
       }
     } catch (error) {
       this.logger.error(() => ["Failed to mark orphaned jobs:", error])


### PR DESCRIPTION
## Summary

- emit `background-job-orphaned` events before waiting for the orphan sweep's dispatch drain
- preserve the dispatch wake-up and per-handler error isolation
- document the ordering guarantee and add a changelog fragment

## Testing

- `MSSQL_SA_PASSWORD=unused VELOCIOUS_DISABLE_MSSQL=1 npm test -- spec/background-jobs/queue-spec.js`
- `MSSQL_SA_PASSWORD=unused VELOCIOUS_DISABLE_MSSQL=1 npm run lint`
