### PR TITLE
Fix background-job enqueue acknowledgement hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2520,6 +2520,8 @@ Set `deduplicateWhileQueued: true` to coalesce an enqueue onto the earliest iden
 
 Use `options: {idempotencyKey}` when producer replay must converge on the original durable job across every state and even after terminal-job pruning. Ownership is scoped to the resolved job class name, resolved queue, and key; reusing that scope with changed canonical arguments or behavior-affecting options fails. This is distinct from queued-only deduplication, and ownership rows are intentionally retained until a future explicit reconciliation/deletion policy. See [durable idempotent enqueue](docs/background-jobs.md#durable-idempotent-enqueue).
 
+The Node producer rejects and destroys its one-shot socket when the main closes before acknowledging or when an enqueue acknowledgement stalls for 5 seconds. Because the main may already have committed the job, this is an ambiguous outcome: replay with the same durable `idempotencyKey` to recover the original job id without creating a duplicate. Direct `BackgroundJobsClient` users can set a different bounded `enqueueTimeoutMs` constructor option. See [durable idempotent enqueue](docs/background-jobs.md#durable-idempotent-enqueue).
+
 Select a non-default runtime explicitly with `options: {executionMode: "inline" | "forked" | "spawned"}`.
 
 Inline jobs share the worker process and run concurrently up to `maxConcurrentInlineJobs`, so a single slow inline job no longer blocks the queue. A single worker can also override the configured cap explicitly:

--- a/changelog.d/20260821184741-background-job-client-timeout.md
+++ b/changelog.d/20260821184741-background-job-client-timeout.md
@@ -1,0 +1,3 @@
+Bound Node background-job enqueue acknowledgements to five seconds, reject prematurely closed sockets promptly, and document idempotent replay after an ambiguous acknowledgement.
+
+Retain the public `AddColumnArgsType` migration alias while routing it to the broader canonical table-column argument type.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -240,6 +240,17 @@ const jobId = await PublishEventJob.performLaterWithOptions({
 
 The durable ownership scope is the tuple of resolved job class name, resolved queue, and caller key. The first enqueue atomically creates the ownership row and job row. Concurrent first enqueues converge through the database's unique ownership key. An exact replay returns the original job id while the job is queued, running, completed, failed, cancelled, or orphaned, and continues returning that id after terminal-job retention prunes the job row.
 
+The Node TCP producer waits at most 5 seconds for the main process's `enqueued`
+acknowledgement. A connection error, a peer that ends or closes before the
+acknowledgement, or a stalled acknowledgement rejects the producer call and
+tears down its one-shot socket. Persistence may already have committed when the
+acknowledgement is lost, so this rejection is deliberately an ambiguous outcome,
+not proof that no job exists. Replay the same request with the same
+`idempotencyKey`: durable ownership returns the already-persisted job id instead
+of creating a second job. Replaying an enqueue without a durable idempotency key
+can create another job. Direct users of the Node `BackgroundJobsClient` may pass
+`enqueueTimeoutMs` to its constructor to use a different bounded deadline.
+
 The owned request includes the serialized arguments and behavior-affecting enqueue options: resolved queue, execution mode, retry cap, resolved concurrency configuration, and immediate-versus-scheduled timing. Reusing the same scope with a different canonical request fails with a safe `background-job-idempotency-conflict` error. Generated job ids and the wall-clock timestamp of an immediate enqueue are not request identity. `deduplicateWhileQueued` is also not identity: it remains the separate, transient queued-row optimization described above.
 
 Idempotency ownership rows are intentionally not pruned in this release, and ordinary terminal-job retention never deletes them. Operators should treat keys as permanent until Velocious gains a separate, explicit reconciliation and deletion policy; deleting ownership without proving that its external operation can no longer be replayed can recreate duplicate work.

--- a/spec/background-jobs/client-transport-spec.js
+++ b/spec/background-jobs/client-transport-spec.js
@@ -1,0 +1,260 @@
+// @ts-check
+
+import net from "net"
+import timeout, {TimeoutError} from "awaitery/build/timeout.js"
+import BackgroundJobsClient from "../../src/background-jobs/client.js"
+import JsonSocket from "../../src/background-jobs/json-socket.js"
+import {clearBackgroundJobs, startBackgroundJobsMain} from "../helpers/background-jobs-helper.js"
+import dummyConfiguration from "../dummy/src/config/configuration.js"
+import waitForEvent from "../../src/testing/wait-for-event.js"
+
+/**
+ * @typedef {object} TcpServerHarness
+ * @property {() => Promise<void>} close - Closes all accepted sockets and the server.
+ * @property {number} port - Bound TCP port.
+ * @property {net.Server} server - TCP server.
+ */
+
+/**
+ * Starts an owned real TCP server.
+ * @param {(socket: net.Socket) => void} onConnection - Connection handler.
+ * @returns {Promise<TcpServerHarness>} - Started server harness.
+ */
+async function startTcpServer(onConnection) {
+  const sockets = new Set()
+  const server = net.createServer((socket) => {
+    sockets.add(socket)
+    socket.once("close", () => sockets.delete(socket))
+    onConnection(socket)
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => resolve(undefined))
+  })
+
+  const address = server.address()
+
+  if (!address || typeof address !== "object") throw new Error("Expected the TCP server address")
+
+  return {
+    close: async () => {
+      for (const socket of sockets) socket.destroy()
+      await new Promise((resolve) => server.close(() => resolve(undefined)))
+    },
+    port: address.port,
+    server
+  }
+}
+
+/**
+ * Captures a promise rejection without losing the error value.
+ * @template T
+ * @param {Promise<T>} promise - Promise expected to reject.
+ * @returns {Promise<Error>} - Rejection error.
+ */
+async function rejectionFrom(promise) {
+  try {
+    await promise
+  } catch (error) {
+    if (error instanceof Error) return error
+    throw error
+  }
+
+  throw new Error("Expected promise to reject")
+}
+
+describe("BackgroundJobsClient transport", {databaseCleaning: {transaction: false, truncate: false}}, () => {
+  afterEach(async () => {
+    await clearBackgroundJobs()
+  })
+
+  it("promptly rejects every request when the peer ends or closes before acknowledging", async () => {
+    const harness = await startTcpServer((socket) => {
+      const jsonSocket = new JsonSocket(socket)
+
+      jsonSocket.on("message", (message) => {
+        if (message?.type !== "enqueue") return
+
+        if (message.args?.[0] === "end") {
+          socket.end()
+        } else {
+          socket.destroy()
+        }
+      })
+    })
+
+    try {
+      dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: harness.port})
+      const client = new BackgroundJobsClient({configuration: dummyConfiguration})
+      const requests = [
+        client.enqueue({args: ["end"], jobName: "TransportTestJob"}),
+        client.enqueue({args: ["close"], jobName: "TransportTestJob"})
+      ]
+      const results = await timeout(
+        {errorMessage: "Prematurely closed enqueue requests did not settle", timeout: 1000},
+        async () => await Promise.allSettled(requests)
+      )
+
+      expect(results).toHaveLength(2)
+      for (const result of results) {
+        expect(result.status).toEqual("rejected")
+        if (result.status === "rejected") {
+          expect(result.reason).toBeInstanceOf(Error)
+          expect(result.reason.message).toMatch(/closed before.*acknowledged/i)
+        }
+      }
+    } finally {
+      await harness.close()
+    }
+  })
+
+  it("times out a stalled acknowledgement and destroys the socket before a later request succeeds", async () => {
+    let requestCount = 0
+    const harness = await startTcpServer((socket) => {
+      const jsonSocket = new JsonSocket(socket)
+
+      jsonSocket.on("message", (message) => {
+        if (message?.type !== "enqueue") return
+        requestCount += 1
+        if (requestCount === 1) return
+
+        jsonSocket.send({jobId: "recovered-job", type: "enqueued"})
+      })
+    })
+
+    try {
+      dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: harness.port})
+      const client = new BackgroundJobsClient({configuration: dummyConfiguration, enqueueTimeoutMs: 40})
+      const serverSocketPromise = waitForEvent(harness.server, "connection", {timeoutMs: 1000})
+      const firstRequest = client.enqueue({args: ["stalled"], jobName: "TransportTestJob"})
+      const serverSocket = /** @type {net.Socket} */ (await serverSocketPromise)
+      const socketClosed = waitForEvent(serverSocket, "close", {timeoutMs: 1000}).then(
+        () => true,
+        (error) => error
+      )
+      const error = await rejectionFrom(timeout(
+        {errorMessage: "Stalled enqueue request did not settle", timeout: 1000},
+        async () => await firstRequest
+      ))
+      const socketCloseResult = await socketClosed
+
+      expect(error).toBeInstanceOf(TimeoutError)
+      expect(error.message).toEqual("Background job enqueue acknowledgement timed out after 40ms")
+      expect(socketCloseResult).toEqual(true)
+      expect(serverSocket.destroyed).toEqual(true)
+      expect(await client.enqueue({args: ["recovered"], jobName: "TransportTestJob"})).toEqual("recovered-job")
+    } finally {
+      await harness.close()
+    }
+  })
+
+  it("replays an ambiguously acknowledged idempotent enqueue to the original durable job", async () => {
+    const {main, store} = await startBackgroundJobsMain()
+    let droppedJobId
+    let proxyConnectionCount = 0
+    const proxy = await startTcpServer((downstream) => {
+      proxyConnectionCount += 1
+      const dropAcknowledgement = proxyConnectionCount === 1
+      const upstream = net.createConnection({host: "127.0.0.1", port: main.getPort()})
+
+      downstream.pipe(upstream)
+      downstream.once("close", () => upstream.destroy())
+      upstream.once("error", () => downstream.destroy())
+
+      if (!dropAcknowledgement) {
+        upstream.pipe(downstream)
+        return
+      }
+
+      let buffer = ""
+      upstream.setEncoding("utf8")
+      upstream.on("data", (chunk) => {
+        buffer += String(chunk)
+
+        while (true) {
+          const newlineIndex = buffer.indexOf("\n")
+          if (newlineIndex === -1) return
+
+          const line = buffer.slice(0, newlineIndex).trim()
+          buffer = buffer.slice(newlineIndex + 1)
+          if (!line) continue
+
+          const message = JSON.parse(line)
+          if (message?.type !== "enqueued") {
+            downstream.write(`${line}\n`)
+            continue
+          }
+
+          droppedJobId = message.jobId
+          downstream.end()
+          upstream.destroy()
+          return
+        }
+      })
+    })
+
+    try {
+      dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: proxy.port})
+      const client = new BackgroundJobsClient({configuration: dummyConfiguration, enqueueTimeoutMs: 500})
+      const request = {
+        args: [{projectId: "project-7"}],
+        jobName: "ProjectedMailJob",
+        options: {idempotencyKey: "projected-mail:command-41"}
+      }
+      const firstError = await rejectionFrom(timeout(
+        {errorMessage: "Dropped acknowledgement did not settle", timeout: 1000},
+        async () => await client.enqueue(request)
+      ))
+      const replayedJobId = await client.enqueue(request)
+
+      expect(firstError.message).toMatch(/closed before.*acknowledged/i)
+      expect(replayedJobId).toEqual(droppedJobId)
+      expect(await store.countJobs({jobName: "ProjectedMailJob"})).toEqual(1)
+    } finally {
+      await proxy.close()
+      await main.stop()
+    }
+  })
+
+  it("keeps concurrent requests isolated when one connection fails", async () => {
+    let connectionCount = 0
+    const harness = await startTcpServer((socket) => {
+      connectionCount += 1
+      const jsonSocket = new JsonSocket(socket)
+
+      jsonSocket.on("message", (message) => {
+        if (message?.type !== "enqueue") return
+        if (message.args?.[0] === "failed") {
+          socket.destroy()
+          return
+        }
+
+        jsonSocket.send({jobId: `job-${message.args?.[0]}`, type: "enqueued"})
+      })
+    })
+
+    try {
+      dummyConfiguration.setBackgroundJobsConfig({host: "127.0.0.1", port: harness.port})
+      const client = new BackgroundJobsClient({configuration: dummyConfiguration})
+      const results = await timeout(
+        {errorMessage: "Concurrent enqueue requests did not settle", timeout: 1000},
+        async () => await Promise.allSettled([
+          client.enqueue({args: ["first"], jobName: "TransportTestJob"}),
+          client.enqueue({args: ["failed"], jobName: "TransportTestJob"}),
+          client.enqueue({args: ["third"], jobName: "TransportTestJob"})
+        ])
+      )
+
+      expect(connectionCount).toEqual(3)
+      expect(results[0]).toEqual({status: "fulfilled", value: "job-first"})
+      expect(results[1]?.status).toEqual("rejected")
+      if (results[1]?.status === "rejected") {
+        expect(results[1].reason.message).toMatch(/closed before.*acknowledged/i)
+      }
+      expect(results[2]).toEqual({status: "fulfilled", value: "job-third"})
+    } finally {
+      await harness.close()
+    }
+  })
+})

--- a/spec/database/migration/change-table.browser-spec.js
+++ b/spec/database/migration/change-table.browser-spec.js
@@ -81,7 +81,7 @@ async function expectAdditionsRemoved(table) {
   }
 }
 
-describe("database - migration - changeTable", {tags: ["dummy"]}, () => {
+describe("database - migration - changeTable browser integration", {tags: ["dummy"]}, () => {
   it("adds and reverses the bulk example while preserving original columns and data", async () => {
     const configuration = Configuration.current()
 

--- a/src/background-jobs/client.js
+++ b/src/background-jobs/client.js
@@ -1,16 +1,21 @@
 // @ts-check
 
+import timeout from "awaitery/build/timeout.js"
 import configurationResolver from "../configuration-resolver.js"
 import BackgroundJobsSocketRequest from "./socket-request.js"
+
+const DEFAULT_ENQUEUE_TIMEOUT_MS = 5000
 
 export default class BackgroundJobsClient {
   /**
    * Runs constructor.
    * @param {object} [args] - Options.
    * @param {import("../configuration.js").default} [args.configuration] - Configuration.
+   * @param {number} [args.enqueueTimeoutMs] - Maximum time to wait for an enqueue acknowledgement in milliseconds (default: 5000).
    */
-  constructor({configuration} = {}) {
+  constructor({configuration, enqueueTimeoutMs = DEFAULT_ENQUEUE_TIMEOUT_MS} = {}) {
     this.configurationPromise = configuration ? Promise.resolve(configuration) : configurationResolver()
+    this.enqueueTimeoutMs = enqueueTimeoutMs
   }
 
   /**
@@ -35,7 +40,11 @@ export default class BackgroundJobsClient {
   async enqueue({jobName, args, options}) {
     const request = await this._request()
 
-    return await request.run({
+    return await timeout({
+      errorMessage: `Background job enqueue acknowledgement timed out after ${this.enqueueTimeoutMs}ms`,
+      timeout: this.enqueueTimeoutMs
+    }, async ({control}) => await request.run({
+      signal: control.signal,
       onConnect: (jsonSocket) => {
         jsonSocket.send({
           type: "enqueue",
@@ -54,7 +63,7 @@ export default class BackgroundJobsClient {
           reject(new Error(message.error || "Failed to enqueue job"))
         }
       }
-    })
+    }))
   }
 
   /**

--- a/src/background-jobs/socket-request.js
+++ b/src/background-jobs/socket-request.js
@@ -89,6 +89,10 @@ export default class BackgroundJobsSocketRequest {
         finish({}, () => reject(error))
       })
 
+      jsonSocket.on("close", () => {
+        finish({destroy: true}, () => reject(new Error("Background jobs socket closed before the request was acknowledged")))
+      })
+
       /**
        * Handles the socket response message.
        * @param {import("./types.js").BackgroundJobSocketMessage} message - Socket message.

--- a/src/database/migration/index.js
+++ b/src/database/migration/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+/** @typedef {import("../table-data/table-column.js").TableColumnArgsType} AddColumnArgsType */
 /**
  * CreateTableIdArgsType type.
  * @typedef {object} CreateTableIdArgsType
@@ -109,7 +110,7 @@ export default class VelociousDatabaseMigration {
    * @param {string} tableName - Table name.
    * @param {string} columnName - Column name.
    * @param {string} columnType - Column type.
-   * @param {import("../table-data/table-column.js").TableColumnArgsType} [args] - Options object.
+   * @param {AddColumnArgsType} [args] - Options object.
    * @returns {Promise<void>} - Resolves when complete.
    */
   async addColumn(tableName, columnName, columnType, args) {


### PR DESCRIPTION
## Summary

- reject background-job enqueue requests when the one-shot TCP socket closes before acknowledgement
- bound Node producer acknowledgement waits to five seconds with cooperative socket teardown
- prove ambiguous idempotent replay returns the already-persisted job instead of creating a duplicate
- preserve concurrent request isolation and restore the public `AddColumnArgsType` compatibility alias
- document timeout/close ambiguity and required stable-idempotency replay

## Why

AwesomeTasks projected mail now durably hands commands to Velocious background jobs. If the main persisted the job but the acknowledgement connection closed or stalled, Velocious 1.0.609 could leave the producer promise pending forever and hold the AwesomeTasks tenant command drain lock indefinitely.

## Validation

- `npm run test -- spec/background-jobs/client-transport-spec.js` — 4 tests
- directly affected background-job, status reporter, durable-idempotency, schedule, and migration specs
- required SQLite-config gate: `npm run lint`, `npm run typecheck`, `npm run fallow`
- downstream AwesomeTasks projected-mail and command-ledger specs — 10 tests
- downstream AwesomeTasks lint and typecheck
- production-style downstream proof: dropped acknowledgement after persistence rejected at the bounded deadline; replay reused one ownership row and one job ID

## Semantics

A timeout or premature close is deliberately an ambiguous enqueue outcome because persistence may already have committed. Callers needing safe replay must use the same durable `idempotencyKey`. This does not claim exactly-once SMTP delivery.

Related AwesomeTasks workboard task: https://tasks.diestoeckels.de/tasks/8ba1b094-dbae-4848-a0d0-803fbd0b1b8f
