### PR TITLE
Serialize shared transaction work after cleanup

### DIFF
--- a/changelog.d/20260822102440-shared-transaction-post-cleanup-serialization.md
+++ b/changelog.d/20260822102440-shared-transaction-post-cleanup-serialization.md
@@ -1,0 +1,1 @@
+Fixed shared test-transaction descendants that wake after broker cleanup so they remain serialized with later users of the same physical connection instead of issuing overlapping requests on one MS-SQL transaction.

--- a/changelog.d/20260822102440-shared-transaction-post-cleanup-serialization.md
+++ b/changelog.d/20260822102440-shared-transaction-post-cleanup-serialization.md
@@ -1,1 +1,1 @@
-Fixed shared test-transaction descendants that wake after broker cleanup so they remain serialized with later users of the same physical connection instead of issuing overlapping requests on one MS-SQL transaction.
+Fixed shared test-transaction descendants that wake during or after broker-owned work so detached persistence and later users remain serialized on the same physical connection instead of issuing overlapping requests on one MS-SQL transaction.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -129,7 +129,10 @@ preserving root-savepoint leases. Inherited sibling work is drained before its b
 queue entry is released. A delayed callback whose inherited owner has already ended
 must re-enter that queue, while a nested call inside active owned work remains
 re-entrant; this keeps one-request transaction drivers such as MS-SQL serialized
-without coupling independent physical connections.
+without coupling independent physical connections. The connection-local queue remains
+attached to a physical connection after broker revocation, so an inherited callback
+that wakes during later pool reuse cannot bypass serialization after the transport and
+capability have been cleaned up.
 
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -132,7 +132,9 @@ re-entrant; this keeps one-request transaction drivers such as MS-SQL serialized
 without coupling independent physical connections. The connection-local queue remains
 attached to a physical connection after broker revocation, so an inherited callback
 that wakes during later pool reuse cannot bypass serialization after the transport and
-capability have been cleaned up.
+capability have been cleaned up. Detached delivery boundaries clear inherited
+coordinator ownership along with their connection contexts, so asynchronous replay
+persistence is serialized as independent work rather than mistaken for a nested call.
 
 The broker is not enabled for tests that opt out of transaction cleanup. Keep
 `{transaction: false, truncate: true}` on true concurrency and locking coverage so

--- a/spec/testing/shared-transaction-parent-connection-coordination-spec.js
+++ b/spec/testing/shared-transaction-parent-connection-coordination-spec.js
@@ -207,6 +207,43 @@ describe("Shared transaction parent connection coordination", {databaseCleaning:
     }
   })
 
+  it("chains replacement broker work behind the retained connection queue", async () => {
+    const connection = new SingleRequestDriver()
+    const firstBroker = await SharedTransactionBroker.start({connections: {default: connection}})
+    /** @type {() => void} */
+    let releaseDelayedQuery = () => {}
+    const delayedQueryGate = new Promise((resolve) => { releaseDelayedQuery = resolve })
+    /** @type {Promise<[]>} */
+    let delayedQuery = Promise.resolve([])
+
+    await coordinateSharedTransactionConnection(connection, async () => {
+      delayedQuery = delayedQueryGate.then(async () => await connection.query("SELECT child", {logQuery: false}))
+    })
+    await firstBroker.close()
+    releaseDelayedQuery()
+    await connection.childStarted
+
+    const replacementBroker = await SharedTransactionBroker.start({connections: {default: connection}})
+    const replacementQuery = connection.query("SELECT parent", {logQuery: false})
+
+    try {
+      void replacementQuery.catch(() => undefined)
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(connection.queries).toEqual(["SELECT child"])
+
+      connection.releaseChild()
+      await Promise.all([delayedQuery, replacementQuery])
+
+      expect(connection.maxActiveRequests).toEqual(1)
+      expect(connection.queries).toEqual(["SELECT child", "SELECT parent"])
+    } finally {
+      connection.releaseChild()
+      await Promise.allSettled([delayedQuery, replacementQuery])
+      await replacementBroker.close()
+    }
+  })
+
   it("allows nested owner coordination to re-enter without deadlocking", async () => {
     const connection = new SingleRequestDriver()
     const broker = await SharedTransactionBroker.start({connections: {default: connection}})

--- a/spec/testing/shared-transaction-parent-connection-coordination-spec.js
+++ b/spec/testing/shared-transaction-parent-connection-coordination-spec.js
@@ -171,6 +171,42 @@ describe("Shared transaction parent connection coordination", {databaseCleaning:
     }
   })
 
+  it("keeps delayed inherited work serialized after broker cleanup", async () => {
+    const connection = new SingleRequestDriver()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    /** @type {() => void} */
+    let releaseDelayedQuery = () => {}
+    const delayedQueryGate = new Promise((resolve) => { releaseDelayedQuery = resolve })
+    /** @type {Promise<[]>} */
+    let delayedQuery = Promise.resolve([])
+
+    await coordinateSharedTransactionConnection(connection, async () => {
+      delayedQuery = delayedQueryGate.then(async () => await connection.query("SELECT parent", {logQuery: false}))
+    })
+    await broker.close()
+
+    const currentQuery = connection.query("SELECT child", {logQuery: false})
+
+    try {
+      await connection.childStarted
+      releaseDelayedQuery()
+      void delayedQuery.catch(() => undefined)
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(connection.queries).toEqual(["SELECT child"])
+
+      connection.releaseChild()
+      await Promise.all([currentQuery, delayedQuery])
+
+      expect(connection.maxActiveRequests).toEqual(1)
+      expect(connection.queries).toEqual(["SELECT child", "SELECT parent"])
+    } finally {
+      releaseDelayedQuery()
+      connection.releaseChild()
+      await Promise.allSettled([currentQuery, delayedQuery])
+    }
+  })
+
   it("allows nested owner coordination to re-enter without deadlocking", async () => {
     const connection = new SingleRequestDriver()
     const broker = await SharedTransactionBroker.start({connections: {default: connection}})

--- a/spec/testing/shared-transaction-parent-connection-coordination-spec.js
+++ b/spec/testing/shared-transaction-parent-connection-coordination-spec.js
@@ -14,6 +14,8 @@ class SingleRequestDriver extends BaseDriver {
   queries = []
   /** @type {() => void} */
   releaseChild = () => {}
+  /** @type {() => void} */
+  onChildStarted = () => {}
   /** @type {Promise<void>} */
   childStarted
   /** @type {() => void} */
@@ -36,6 +38,7 @@ class SingleRequestDriver extends BaseDriver {
     try {
       if (this.activeRequests > 1) throw new Error("Can't acquire connection for the request. There is another request in progress.")
       if (sql == "SELECT child") {
+        this.onChildStarted()
         this.resolveChildStarted()
         await new Promise((resolve) => { this.releaseChild = resolve })
       }
@@ -241,6 +244,50 @@ describe("Shared transaction parent connection coordination", {databaseCleaning:
       connection.releaseChild()
       await Promise.allSettled([delayedQuery, replacementQuery])
       await replacementBroker.close()
+    }
+  })
+
+  it("serializes detached connection-context work inherited by an owned query", async () => {
+    const connection = new SingleRequestDriver()
+    const broker = await SharedTransactionBroker.start({connections: {default: connection}})
+    /** @type {Promise<[]>} */
+    let childQuery = Promise.resolve([])
+    /** @type {Promise<[]>} */
+    let detachedQuery = Promise.resolve([])
+    /** @type {string[]} */
+    let queriesBeforeRelease = []
+    /** @type {() => void} */
+    let resolveQueriesObserved = () => {}
+    const queriesObserved = new Promise((resolve) => { resolveQueriesObserved = resolve })
+
+    connection.onChildStarted = () => {
+      connection.configuration.withoutCurrentConnectionContexts(() => {
+        detachedQuery = Promise.resolve().then(async () => await connection.query("SELECT parent", {logQuery: false}))
+        void detachedQuery.catch(() => undefined)
+      })
+      setImmediate(() => {
+        queriesBeforeRelease = [...connection.queries]
+        connection.releaseChild()
+        resolveQueriesObserved()
+      })
+    }
+
+    const root = coordinateSharedTransactionConnection(connection, async () => {
+      childQuery = connection.query("SELECT child", {logQuery: false})
+      await connection.childStarted
+    })
+
+    try {
+      await queriesObserved
+      await Promise.all([root, childQuery, detachedQuery])
+
+      expect(queriesBeforeRelease).toEqual(["SELECT child"])
+      expect(connection.maxActiveRequests).toEqual(1)
+      expect(connection.queries).toEqual(["SELECT child", "SELECT parent"])
+    } finally {
+      connection.releaseChild()
+      await Promise.allSettled([root, childQuery, detachedQuery])
+      await broker.close()
     }
   })
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -3475,7 +3475,7 @@ export default class VelociousConfiguration {
    * @returns {T} - Callback result.
    */
   withoutCurrentConnectionContexts(callback) {
-    let runCallback = callback
+    let runCallback = () => this.getEnvironmentHandler().runWithoutSharedTransactionCoordinatorOwners(callback)
 
     for (const pool of Object.values(this.databasePools)) {
       if (!pool) continue

--- a/src/environment-handlers/base.js
+++ b/src/environment-handlers/base.js
@@ -55,6 +55,14 @@ export default class VelociousEnvironmentHandlerBase {
   runWithSharedTransactionCoordinatorOwner(_connection, _owner, callback) { return callback() }
 
   /**
+   * Runs work without inherited shared-transaction coordinator ownership.
+   * @template T
+   * @param {() => T} callback - Detached work.
+   * @returns {T} - Callback result.
+   */
+  runWithoutSharedTransactionCoordinatorOwners(callback) { return callback() }
+
+  /**
    * Runs work with test-profile attribution. Runtimes without async-context
    * storage execute the callback without installing ambient attribution.
    * @template T

--- a/src/environment-handlers/node.js
+++ b/src/environment-handlers/node.js
@@ -155,6 +155,18 @@ export default class VelociousEnvironmentHandlerNode extends Base{
   }
 
   /**
+   * Runs work without inherited shared-transaction coordinator ownership.
+   * @template T
+   * @param {() => T} callback - Detached work.
+   * @returns {T} - Callback result.
+   */
+  runWithoutSharedTransactionCoordinatorOwners(callback) {
+    if (!this._sharedTransactionCoordinatorAsyncLocalStorage) return callback()
+
+    return this._sharedTransactionCoordinatorAsyncLocalStorage.run(new Map(), callback)
+  }
+
+  /**
    * Runs work with async-safe test profile attribution.
    * @template T
    * @param {import("../testing/test-profiler.js").TestProfileAsyncContext | undefined} context - Captured profile context, or an explicit absence of attribution.

--- a/src/testing/shared-transaction-connection-coordinator.js
+++ b/src/testing/shared-transaction-connection-coordinator.js
@@ -4,6 +4,17 @@
 
 /** @type {WeakMap<object, CoordinatorRegistration>} */
 const coordinators = new WeakMap()
+/** @type {WeakMap<object, CoordinatorRegistration>} */
+const connectionRegistrations = new WeakMap()
+
+/**
+ * Runs work directly when only the connection-local queue remains registered.
+ * @param {() => Promise<unknown>} callback - Serialized operation.
+ * @returns {Promise<unknown>} - Operation result.
+ */
+async function inactiveCoordinator(callback) {
+  return await callback()
+}
 
 /**
  * Serializes sibling work that inherited one coordinator owner without re-entering the broker queue.
@@ -78,14 +89,17 @@ async function coordinateRootSharedTransactionConnection(connection, registratio
  */
 export function setSharedTransactionCoordinator(connection, coordinator) {
   const owner = Symbol("shared-transaction-coordinator")
+  let registration = connectionRegistrations.get(connection)
 
-  coordinators.set(connection, {
-    coordinator,
-    ownedQueue: Promise.resolve(),
-    owner,
-    reentrantOwners: new Set(),
-    rootOwners: new Set()
-  })
+  if (registration) {
+    registration.coordinator = coordinator
+    registration.owner = owner
+  } else {
+    registration = {coordinator, ownedQueue: Promise.resolve(), owner, reentrantOwners: new Set(), rootOwners: new Set()}
+    connectionRegistrations.set(connection, registration)
+  }
+
+  coordinators.set(connection, registration)
   return owner
 }
 
@@ -96,7 +110,12 @@ export function setSharedTransactionCoordinator(connection, coordinator) {
  * @returns {void}
  */
 export function clearSharedTransactionCoordinator(connection, coordinator) {
-  if (coordinators.get(connection)?.coordinator === coordinator) coordinators.delete(connection)
+  const registration = coordinators.get(connection)
+
+  if (registration?.coordinator === coordinator) {
+    coordinators.delete(connection)
+    registration.coordinator = inactiveCoordinator
+  }
 }
 
 /**
@@ -108,7 +127,8 @@ export function clearSharedTransactionCoordinator(connection, coordinator) {
  * @returns {Promise<T>} - Operation result.
  */
 export async function coordinateSharedTransactionConnection(connection, callback, operationOwner) {
-  const registration = coordinators.get(connection)
+  const activeRegistration = coordinators.get(connection)
+  const registration = activeRegistration || connectionRegistrations.get(connection)
 
   if (!registration) return await callback()
 
@@ -119,6 +139,7 @@ export async function coordinateSharedTransactionConnection(connection, callback
   if (currentOwner && registration.rootOwners.has(currentOwner)) {
     return await coordinateOwnedSharedTransactionConnection(connection, registration, callback)
   }
+  if (!activeRegistration) return await coordinateOwnedSharedTransactionConnection(connection, registration, callback)
   if (operationOwner === registration.owner) {
     return await coordinateRootSharedTransactionConnection(connection, registration, callback)
   }

--- a/src/testing/shared-transaction-connection-coordinator.js
+++ b/src/testing/shared-transaction-connection-coordinator.js
@@ -69,6 +69,7 @@ async function drainOwnedSharedTransactionConnections(registration) {
  * @returns {Promise<T>} - Operation result.
  */
 async function coordinateRootSharedTransactionConnection(connection, registration, callback) {
+  await drainOwnedSharedTransactionConnections(registration)
   const rootOwner = Symbol("shared-transaction-root-operation")
   const environmentHandler = connection.configuration.getEnvironmentHandler()
 


### PR DESCRIPTION
## Summary

- retain the physical connection serialization queue after shared-transaction broker cleanup
- route delayed inherited work and later pool users through that same queue without retaining the closed broker callback
- add a deterministic single-request-driver regression and document the cleanup invariant

## Root cause

AsyncLocalStorage descendants can be created under a broker-owned root and wake after broker cleanup. Cleanup removed the only physical-connection registration, so those delayed descendants bypassed `ownedQueue` and could overlap a later request after the same node-mssql transaction connection returned to use. node-mssql permits only one active request per transaction, and the first overlap poisoned the shared connection for the remaining shard.

## Validation

- deterministic regression: RED before the fix with the same `another request is in progress` error at `coordinateSharedTransactionConnection`; GREEN after the fix
- 73 focused coordinator, broker, transaction-session, request-hook, websocket, background-job, and original earliest-failing sync tests passed serially
- `npm run build`
- exact SQLite Peakflow gate: `npm run lint`, `npm run typecheck`, `npm run fallow`
- `git diff --check`

Authenticated local MS-SQL execution was unavailable because this lane has no MS-SQL password environment value; the service endpoint itself is reachable. Peakflow should provide the real MS-SQL confirmation.