### PR TITLE
Serialize pooled leases by durable job ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -2506,6 +2506,8 @@ delay and never returns: it stops the current `perform`, releases its worker and
 concurrency slots, and makes the same job eligible again after the delay. This is
 normal control flow, not failure retry: attempts and failure metadata remain
 unchanged, retries are not consumed, and failure/error events are not emitted.
+Pooled workers serialize repeated leases for that same durable row through the
+prior terminal-acknowledgement boundary; other job IDs remain concurrent.
 See [Rescheduling a running job](docs/background-jobs.md#rescheduling-a-running-job).
 
 Use a durable stable key when the same logical one-off schedule must be moved or cancelled without retaining its transient job id:

--- a/changelog.d/20260823120000-serialize-pooled-reschedules.md
+++ b/changelog.d/20260823120000-serialize-pooled-reschedules.md
@@ -1,0 +1,1 @@
+Fixed pooled workers admitting the same immediately rescheduled durable job ID twice before its prior terminal acknowledgement settled.

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -169,6 +169,11 @@ programming error and therefore follows normal job failure and retry behavior.
 Independent enqueues remain independent: rescheduling does not insert, merge, or
 delete rows, and `deduplicateWhileQueued` keeps its existing enqueue-time rules.
 
+When pooled capacity admits the rescheduled row before the prior terminal
+acknowledgement reaches its worker, the worker serializes both leases by durable
+job ID. The next run starts only after the prior acknowledgement settles, while
+different job IDs can still use the pool concurrently.
+
 ## Database connection scopes
 
 By default, a job receives the existing Velocious behavior: every active configured database is checked out for the duration of `perform`. Jobs that need a known subset should declare it on the job class:

--- a/spec/background-jobs/job-reschedule-spec.js
+++ b/spec/background-jobs/job-reschedule-spec.js
@@ -50,7 +50,9 @@ function waitForPooledRescheduleExecutions({jobId, worker}) {
 
 describe("Background jobs - job reschedule", {databaseCleaning: {truncate: true}}, () => {
   it("reuses the same row later without failure events in inline and pooled modes", async () => {
-    const {main, store, worker} = await startBackgroundJobs({workerOptions: {pooledRunnerCount: 1}})
+    const {main, store, worker} = await startBackgroundJobs({
+      workerOptions: {pooledRunnerConcurrency: 2, pooledRunnerCount: 1}
+    })
     const failures = []
     const allErrors = []
     const errorEvents = dummyConfiguration.getErrorEvents()
@@ -64,7 +66,9 @@ describe("Background jobs - job reschedule", {databaseCleaning: {truncate: true}
         const outputPath = await outputPathFor(`job-reschedule-${executionMode}`)
         const jobId = await store.enqueue({
           jobName: "RescheduleTestJob",
-          args: [outputPath, 100],
+          // Make the next lease eligible before the first pooled runner's
+          // durable acknowledgement returns to its worker.
+          args: [outputPath, 0],
           options: {executionMode}
         })
         const pooledExecutions = executionMode === "pooled"

--- a/spec/background-jobs/worker-resilience-spec.js
+++ b/spec/background-jobs/worker-resilience-spec.js
@@ -5,6 +5,33 @@ import BackgroundJobsWorker from "../../src/background-jobs/worker.js"
 import JsonSocket from "../../src/background-jobs/json-socket.js"
 import {startBackgroundJobsMain} from "../helpers/background-jobs-helper.js"
 
+class ControlledPooledWorker extends BackgroundJobsWorker {
+  constructor() {
+    super({pooledRunnerConcurrency: 2, pooledRunnerCount: 1})
+    /** @type {string[]} */
+    this.startedJobIds = []
+    /** @type {Map<string, Array<() => void>>} */
+    this.jobReleases = new Map()
+  }
+
+  /** @param {import("../../src/background-jobs/types.js").BackgroundJobPayload & {id: string}} payload - Pooled payload. @returns {Promise<void>} - Controlled execution. */
+  _runPooledJob(payload) {
+    this.startedJobIds.push(payload.id)
+    return new Promise((resolve) => {
+      const releases = this.jobReleases.get(payload.id) || []
+      releases.push(resolve)
+      this.jobReleases.set(payload.id, releases)
+    })
+  }
+
+  /** @param {string} jobId - Job id. */
+  releaseNext(jobId) {
+    const release = this.jobReleases.get(jobId)?.shift()
+    if (!release) throw new Error(`No controlled pooled execution for job: ${jobId}`)
+    release()
+  }
+}
+
 /**
  * A control socket the main can track without a real connection. `close()` calls
  * `socket.end()`, which is a no-op on an unconnected socket.
@@ -66,6 +93,29 @@ async function startConfiguredWorker(workerOptions) {
 }
 
 describe("Background jobs - worker resilience", {databaseCleaning: {truncate: true}}, () => {
+  it("serializes pooled leases by durable job id while different ids retain concurrency", async () => {
+    const worker = new ControlledPooledWorker()
+    const payload = {id: "same-id", jobName: "TestJob", args: [], options: {executionMode: "pooled"}}
+
+    await worker._handleJob(payload)
+    await worker._handleJob({...payload, handoffId: "replacement-handoff"})
+    await worker._handleJob({...payload, id: "other-id"})
+
+    expect(worker.startedJobIds).toEqual(["same-id", "other-id"])
+
+    worker.releaseNext("same-id")
+    await Promise.resolve()
+    expect(worker.startedJobIds).toEqual(["same-id", "other-id", "same-id"])
+
+    worker.releaseNext("same-id")
+    worker.releaseNext("other-id")
+    await Promise.allSettled([...worker.inflightPooledJobs])
+
+    expect(worker.inflightPooledJobs.size).toEqual(0)
+    expect(worker.pooledJobQueues.size).toEqual(0)
+    expect(worker.pooledJobQueueTrackers.size).toEqual(0)
+  })
+
   it("defaults pooled runner lifecycle bounds", () => {
     const worker = new BackgroundJobsWorker({})
 

--- a/spec/background-jobs/worker-resilience-spec.js
+++ b/spec/background-jobs/worker-resilience-spec.js
@@ -291,6 +291,77 @@ describe("Background jobs - worker resilience", {databaseCleaning: {truncate: tr
     }])
   })
 
+  it("keeps pooled readiness revoked after a queued job runner fails during startup", async () => {
+    const worker = new BackgroundJobsWorker({pooledRunnerCount: 1})
+    /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobSocketMessage>} */
+    const sent = []
+    worker.jsonSocket = /** @type {JsonSocket} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: (message) => sent.push(message)}))
+    worker.statusReporter = /** @type {import("../../src/background-jobs/status-reporter.js").default} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({reportWithRetry: async () => {}}))
+    const child = /** @type {import("node:child_process").ChildProcess} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: () => {}}))
+    worker.pooledChildren.add(child)
+    worker.pooledChildStates.set(child, {
+      createdAtMs: Date.now(), jobsRun: 0, started: false, lastDispatchSeq: 0, retiring: false,
+      inflight: new Map()
+    })
+
+    worker._queuePooledJob({id: "startup-failure", jobName: "TestJob"})
+    await worker._handlePooledChildFailure({child, error: new Error("runner failed during startup")})
+    await Promise.allSettled([...worker.inflightPooledJobs])
+
+    expect(sent).toEqual([{
+      type: "ready",
+      acceptsForked: true,
+      acceptsInline: true,
+      acceptsPooled: false,
+      availablePooledSlots: 0,
+      acceptsSpawned: true
+    }])
+  })
+
+  it("reserves pooled capacity for an admitted same-id lease across child crash fallback", async () => {
+    const worker = new BackgroundJobsWorker({pooledRunnerCount: 1})
+    worker.statusReporter = /** @type {import("../../src/background-jobs/status-reporter.js").default} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({
+      reportWithRetry: async () => {}
+    }))
+    let createdChildren = 0
+    worker.configuration = /** @type {import("../../src/configuration.js").default} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({
+      getBackgroundJobsConfig: () => ({})
+    }))
+    worker._createPooledChild = () => {
+      createdChildren += 1
+      const replacement = /** @type {import("node:child_process").ChildProcess} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: () => {}}))
+      worker.pooledChildren.add(replacement)
+      worker.pooledChildStates.set(replacement, {
+        createdAtMs: Date.now(), jobsRun: 0, started: true, lastDispatchSeq: 0, retiring: false,
+        inflight: new Map()
+      })
+      return replacement
+    }
+    const crashedChild = /** @type {import("node:child_process").ChildProcess} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: () => {}}))
+    worker.pooledChildren.add(crashedChild)
+    worker.pooledChildStates.set(crashedChild, {
+      createdAtMs: Date.now(), jobsRun: 0, started: true, lastDispatchSeq: 0, retiring: false,
+      inflight: new Map()
+    })
+    /** @type {Array<import("../../src/background-jobs/types.js").BackgroundJobSocketMessage>} */
+    const sent = []
+    worker.jsonSocket = /** @type {JsonSocket} */ (/** @type {ReturnType<typeof JSON.parse>} */ ({send: (message) => sent.push(message)}))
+
+    worker._queuePooledJob({id: "same-id", jobName: "TestJob"})
+    worker._queuePooledJob({id: "same-id", jobName: "TestJob"})
+    const failure = worker._handlePooledChildFailure({child: crashedChild, error: new Error("initialized runner crashed")})
+
+    expect(worker._availablePooledSlots()).toEqual(0)
+    expect(sent[0]?.type === "ready" && sent[0].acceptsPooled).toEqual(false)
+    expect(sent[0]?.type === "ready" && sent[0].availablePooledSlots).toEqual(0)
+    expect(createdChildren).toEqual(0)
+
+    await failure
+    await Promise.resolve()
+    expect(worker.pooledChildren.size).toEqual(1)
+    expect(createdChildren).toEqual(1)
+  })
+
   it("does not fallback-report an acknowledged failed pooled outcome", () => {
     const worker = new BackgroundJobsWorker({pooledRunnerCount: 1})
     let killed = false

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -192,6 +192,10 @@ export default class BackgroundJobsWorker {
     this.inflightProcessChildren = new Set()
     /** @type {Set<Promise<void>>} */
     this.inflightPooledJobs = new Set()
+    /** @type {Map<string, Array<import("./types.js").BackgroundJobPayload & {id: string}>>} */
+    this.pooledJobQueues = new Map()
+    /** @type {Map<string, Promise<void>>} - Per-id outer queue trackers. */
+    this.pooledJobQueueTrackers = new Map()
     /** @type {Set<import("node:child_process").ChildProcess>} */
     this.pooledChildren = new Set()
     /** @type {Map<import("node:child_process").ChildProcess, {createdAtMs: number, jobsRun: number, inflight: Map<string, {payload: import("./types.js").BackgroundJobPayload & {id: string}, resolve?: (value: void) => void, pooledJob?: Promise<void>, timeoutTimer?: ReturnType<typeof setTimeout> | null}>, lastDispatchSeq: number, retiring: boolean, started?: boolean, settling?: boolean, timeoutSigkillTimer?: ReturnType<typeof setTimeout> | null}>} */
@@ -443,7 +447,7 @@ export default class BackgroundJobsWorker {
     const executionMode = this._executionModeForPayload(identifiedPayload)
 
     if (executionMode === "pooled") {
-      this._trackPooledJob(this._runPooledJob(identifiedPayload))
+      this._queuePooledJob(identifiedPayload)
       return
     }
 
@@ -644,7 +648,7 @@ export default class BackgroundJobsWorker {
   /**
    * Tracks a pooled job and re-advertises capacity.
    * @param {Promise<void>} pooledJob - Pooled job promise.
-   * @returns {void}
+   * @returns {Promise<void>} - The tracked in-flight promise.
    */
   _trackPooledJob(pooledJob) {
     /** @type {Promise<void>} */
@@ -654,6 +658,50 @@ export default class BackgroundJobsWorker {
       if (!this.shouldStop && !this._pooledStartupFailureJobs.has(pooledJob)) this._sendReadyIfRunning()
     })
     this.inflightPooledJobs.add(inflight)
+    return inflight
+  }
+
+  /**
+   * Serializes repeated leases for one durable row while preserving pooled
+   * concurrency across different job ids.
+   * @param {import("./types.js").BackgroundJobPayload & {id: string}} payload - Pooled job payload.
+   * @returns {void}
+   */
+  _queuePooledJob(payload) {
+    const queue = this.pooledJobQueues.get(payload.id)
+    if (queue) {
+      queue.push(payload)
+      return
+    }
+
+    this.pooledJobQueues.set(payload.id, [payload])
+    const tracker = this._trackPooledJob(this._runPooledJobQueue(payload.id))
+    this.pooledJobQueueTrackers.set(payload.id, tracker)
+  }
+
+  /**
+   * Runs admitted leases for one durable job id in arrival order.
+   * @param {string} jobId - Durable job id.
+   * @returns {Promise<void>} - Resolves after the per-id queue drains.
+   */
+  async _runPooledJobQueue(jobId) {
+    const queue = this.pooledJobQueues.get(jobId)
+    if (!queue) throw new Error(`Pooled job queue missing for job: ${jobId}`)
+
+    try {
+      while (queue.length > 0) {
+        const payload = queue.shift()
+        if (!payload) throw new Error(`Pooled job queue contained an empty payload for job: ${jobId}`)
+        await this._runPooledJob(payload)
+      }
+    } finally {
+      const tracker = this.pooledJobQueueTrackers.get(jobId)
+      if (tracker) {
+        this.inflightPooledJobs.delete(tracker)
+        this.pooledJobQueueTrackers.delete(jobId)
+      }
+      this.pooledJobQueues.delete(jobId)
+    }
   }
 
   /**

--- a/src/background-jobs/worker.js
+++ b/src/background-jobs/worker.js
@@ -655,7 +655,7 @@ export default class BackgroundJobsWorker {
     let inflight
     inflight = pooledJob.finally(() => {
       this.inflightPooledJobs.delete(inflight)
-      if (!this.shouldStop && !this._pooledStartupFailureJobs.has(pooledJob)) this._sendReadyIfRunning()
+      if (!this.shouldStop && !this._pooledStartupFailureJobs.has(pooledJob) && !this._pooledStartupFailureJobs.has(inflight)) this._sendReadyIfRunning()
     })
     this.inflightPooledJobs.add(inflight)
     return inflight
@@ -713,6 +713,7 @@ export default class BackgroundJobsWorker {
   _availablePooledSlots() {
     let openInExisting = 0
     let nonRetiringChildren = 0
+    let queuedReservations = 0
 
     for (const child of this.pooledChildren) {
       const state = this.pooledChildStates.get(child)
@@ -721,9 +722,11 @@ export default class BackgroundJobsWorker {
       openInExisting += this.pooledRunnerConcurrency - state.inflight.size
     }
 
+    for (const queue of this.pooledJobQueues.values()) queuedReservations += queue.length
+
     const spawnableChildren = Math.max(0, this.pooledRunnerCount - nonRetiringChildren)
 
-    return openInExisting + spawnableChildren * this.pooledRunnerConcurrency
+    return Math.max(0, openInExisting + spawnableChildren * this.pooledRunnerConcurrency - queuedReservations)
   }
 
   /**
@@ -1022,6 +1025,8 @@ export default class BackgroundJobsWorker {
     } else if (state) {
       for (const entry of entries) {
         if (entry.pooledJob) this._pooledStartupFailureJobs.add(entry.pooledJob)
+        const queueTracker = this.pooledJobQueueTrackers.get(entry.payload.id)
+        if (queueTracker) this._pooledStartupFailureJobs.add(queueTracker)
       }
       // A previous ready message may still have unconsumed pooled credits at the
       // main. Revoke them authoritatively without suppressing valid inline or


### PR DESCRIPTION
## Summary

- serialize pooled leases for the same durable job ID through terminal acknowledgement while preserving concurrency across different IDs
- retain each lease handoff fence and drain queued same-ID work through the existing failure, timeout, child-crash, and shutdown lifecycle
- add deterministic regression coverage for `pooledRunnerConcurrency: 2`, immediate rescheduling, capacity, and queue cleanup
- document the pooled reschedule guarantee and add a changelog fragment

Task: https://tasks.diestoeckels.de/tasks/19ab8809-fc1d-46c0-855d-013ce6606960

## Validation

- focused background-job specs: 65 passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run fallow`: passed
- `git diff --check`: passed

No package version was changed.