### PR TITLE
Update SnapReq to 0.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -2028,7 +2028,7 @@ await client.close()
 
 For long-lived Node clients, the constructor also accepts opt-in liveness options (all default off, so browser/Expo usage is unchanged): `webSocketImplementation` (inject Node's `ws`, since the global/undici WebSocket exposes neither protocol ping nor an unref-able socket), `heartbeatIntervalMs` (a ping heartbeat that drops a socket whose peer stops ponging, so a client notices a vanished server), and `unref` (unref the underlying socket so an idle connection can't keep the process alive on its own). See [docs/websocket-channels.md](docs/websocket-channels.md).
 
-`await client.close()` is a final graceful shutdown that releases resumable server-session state; unexpected transport drops remain resumable. See [the WebSocket channel lifecycle guarantees](docs/websocket-channels.md#lifecycle-guarantees-phase-1b).
+`await client.close()` is a final graceful shutdown that releases resumable server-session state; unexpected transport drops first attempt to resume that state. A successful resume retains the existing server-side connection and channel instances. If the server instead rejects the old session with `session-gone`, SnapReq promotes the already-established fresh session, reopens still-live one-to-one connection handles, and re-subscribes still-live channel handles. Those public handles remain usable and channel readiness resolves on the fresh session; explicitly closed handles stay closed. See [the WebSocket channel lifecycle guarantees](docs/websocket-channels.md#lifecycle-guarantees-phase-1b).
 
 ## Subscribe to events
 

--- a/changelog.d/20260824173000-snapreq-session-recovery.md
+++ b/changelog.d/20260824173000-snapreq-session-recovery.md
@@ -1,0 +1,1 @@
+Updated SnapReq to 0.0.13 so browser WebSocket clients recover live connection and channel handles when a previous session can no longer be resumed.

--- a/docs/websocket-channels.md
+++ b/docs/websocket-channels.md
@@ -142,6 +142,7 @@ Client behavior:
 
 - `canSubscribe()` → `subscribed()` is the order on the server. `channel-subscribed` is sent AFTER `subscribed()` resolves.
 - Client's `subscription.ready` resolves after `channel-subscribed` arrives.
-- `subscription.waitForReady()` is the higher-level helper for app code. It resolves after the initial subscribe, then resets on disconnect and resolves again after `session-resumed`.
+- `subscription.waitForReady()` is the higher-level helper for app code. It resolves after the initial subscribe, then resets on disconnect. A successful `session-resumed` retains the existing server-side connection and channel instances and resolves readiness again without creating replacement instances.
+- A rejected resume is fresh-session recovery, not a successful resume. When the server responds with `session-gone`, SnapReq promotes the already-established fresh session, reopens still-live [one-to-one connection handles](websocket-connections.md), and re-subscribes still-live channel handles. The same public handles remain usable, and channel readiness resolves again after the fresh server acknowledges the replacement subscription. Handles explicitly closed before or during reconnect stay closed and are not reopened or re-subscribed.
 - `unsubscribed()` fires exactly once: on client-initiated `channel-unsubscribe` OR on session teardown (socket drop, Phase 2 covers grace-period resumption).
-- No persistent event log, no replay, no cross-reconnect survival in Phase 1B. Publish-and-forget; subscribers who missed events while disconnected don't see them.
+- There is no persistent event log or replay. Live handles can survive or recover across reconnect as described above, but subscribers do not receive messages they missed while disconnected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "pure-uuid": "^2.0.0",
         "require-context": "^1.1.0",
         "set-state-compare": "^1.0.61",
-        "snapreq": "^0.0.12",
+        "snapreq": "^0.0.13",
         "sql-escape-string": "^1.1.0",
         "sql.js": "^1.12.0",
         "strftime": "^0.10.2",
@@ -12736,9 +12736,9 @@
       }
     },
     "node_modules/snapreq": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.12.tgz",
-      "integrity": "sha512-1W738rAXxBOOMhNQYZTPIjDSC3BawdmTN1zzOmD6FSJi7D4y5H7UbHXsFv7n5mtKoUDC+Ze910OiDfYqp4LNaQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/snapreq/-/snapreq-0.0.13.tgz",
+      "integrity": "sha512-8hijS0XIJmhEbMJtke4OryOpgVU8WUF77zpoTYn0D0az2tE8lYueoWtEq8dorxMGKDDjlBtUhHJ7v57byD045Q==",
       "license": "ISC",
       "dependencies": {
         "awaitery": "1.0.19"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "pure-uuid": "^2.0.0",
     "require-context": "^1.1.0",
     "set-state-compare": "^1.0.61",
-    "snapreq": "^0.0.12",
+    "snapreq": "^0.0.13",
     "sql-escape-string": "^1.1.0",
     "sql.js": "^1.12.0",
     "strftime": "^0.10.2",

--- a/spec/http-server/websocket-session-resume-spec.js
+++ b/spec/http-server/websocket-session-resume-spec.js
@@ -19,10 +19,12 @@ async function waitForConnect(events) {
   await waitFor(() => events.includes("connect"))
 }
 
-async function expectSessionGoneAfterReconnect(client, events) {
-  await waitForConnect(events)
-  client.socket?.close()
-  await waitFor(() => events.some((e) => e === "close:session_gone"), 5000)
+async function waitForFreshSession(client, events, rejectedSessionId) {
+  await waitFor(() => {
+    const connectCount = events.filter((event) => event === "connect").length
+
+    return connectCount === 2 && typeof client._sessionId === "string" && client._sessionId !== rejectedSessionId
+  }, 5000)
 }
 
 async function withReconnectingClient(callback, reconnectDelays = [50]) {
@@ -143,18 +145,72 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
     })
   })
 
-  it("tells the client session-gone + destroys live handles when no paused session exists", async () => {
+  it("promotes a fresh session and re-establishes live handles when the requested session is gone", async () => {
     await withReconnectingClient(async (client) => {
       /** @type {string[]} */
-      const events = []
-      openTrackedEchoConnection(client, events)
+      const connectionEvents = []
+      /** @type {any[]} */
+      const connectionMessages = []
+      const connection = openTrackedEchoConnection(client, connectionEvents, {
+        params: {name: "fresh-session"},
+        onMessage: (body) => connectionMessages.push(body),
+        onResume: () => connectionEvents.push("resume")
+      })
+      /** @type {string[]} */
+      const channelEvents = []
+      /** @type {any[]} */
+      const channelMessages = []
+      const subscription = client.subscribeChannel("Counter", {
+        params: {allow: true, topic: "fresh-session"},
+        onMessage: (body) => channelMessages.push(body),
+        onResume: () => channelEvents.push("resume"),
+        onClose: (reason) => channelEvents.push(`close:${reason}`)
+      })
+
+      /** @type {string[]} */
+      const closedConnectionEvents = []
+      const closedConnection = openTrackedEchoConnection(client, closedConnectionEvents)
+      /** @type {any[]} */
+      const closedChannelMessages = []
+      const closedSubscription = client.subscribeChannel("Counter", {
+        params: {allow: true, topic: "fresh-session"},
+        onMessage: (body) => closedChannelMessages.push(body)
+      })
+
+      await Promise.all([connection.ready, subscription.ready, closedConnection.ready, closedSubscription.ready])
+      await waitFor(() => channelMessages.length === 1 && closedChannelMessages.length === 1)
+
+      closedConnection.close()
+      closedSubscription.close()
 
       // Set a bogus sessionId; on reconnect the server won't find it.
-      client._sessionId = "bogus-sess-id"
+      const rejectedSessionId = "bogus-sess-id"
 
-      await expectSessionGoneAfterReconnect(client, events)
-      expect(events).toContain("close:session_gone")
-      expect(client._sessionId).toBe(null)
+      client._sessionId = rejectedSessionId
+      client.socket?.close()
+
+      await waitForFreshSession(client, connectionEvents, rejectedSessionId)
+      await subscription.waitForReady({timeoutMs: 5000})
+      await waitFor(() => channelMessages.length === 2)
+
+      expect(connectionEvents).toEqual(["connect", "connect"])
+      expect(channelEvents).toEqual([])
+      expect(connection.isConnected()).toBe(true)
+      expect(connection.isClosed()).toBe(false)
+      expect(subscription.isReady()).toBe(true)
+      expect(subscription.isSubscribed()).toBe(true)
+      expect(subscription.isClosed()).toBe(false)
+      expect(closedConnectionEvents).toEqual(["connect", "close:client_close"])
+      expect(closedConnection.isClosed()).toBe(true)
+      expect(closedSubscription.isClosed()).toBe(true)
+
+      connection.sendMessage({after: "fresh-session"})
+      dummyConfiguration.broadcastToChannel("Counter", {topic: "fresh-session"}, {after: "fresh-session"})
+
+      await waitFor(() => connectionMessages.some((message) => message?.echo?.after === "fresh-session"))
+      await waitFor(() => channelMessages.some((message) => message?.after === "fresh-session"))
+
+      expect(closedChannelMessages).toEqual([{welcome: "fresh-session"}])
     })
   })
 
@@ -262,7 +318,7 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
     })
   })
 
-  it("rejects resume with session-gone when the identity resolver reports a different user", async () => {
+  it("destroys an identity-mismatched paused session and re-establishes live handles on a fresh session", async () => {
     /** @type {{identity: string | null}} */
     const authState = {identity: "alice"}
 
@@ -274,10 +330,13 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
 
         try {
           await client.connect()
+          const rejectedSessionId = client._sessionId
+
+          expect(typeof rejectedSessionId).toBe("string")
 
           /** @type {string[]} */
           const events = []
-          openTrackedEchoConnection(client, events, {
+          const connection = openTrackedEchoConnection(client, events, {
             onResume: () => events.push("resume"),
           })
 
@@ -303,11 +362,32 @@ describe("WebsocketSession resumption (Phase 2)", {databaseCleaning: {transactio
           // reconnect fires.
           authState.identity = "bob"
 
-          // Reconnect will send session-resume with the stored id.
-          // Server should reject and send session-gone, which tears
-          // down live handles with reason `session_gone`.
-          await waitFor(() => events.includes("close:session_gone"), 5000)
+          // Reconnect sends session-resume with the stored id. The
+          // server rejects it, while the client promotes the fresh
+          // session and re-opens the still-live connection handle.
+          await waitForFreshSession(client, events, /** @type {string} */ (rejectedSessionId))
+
+          expect(events).toEqual(["connect", "connect"])
           expect(events).not.toContain("resume")
+          expect(connection.isConnected()).toBe(true)
+          expect(connection.isClosed()).toBe(false)
+          expect(dummyConfiguration._pausedWebsocketSessions.has(/** @type {string} */ (rejectedSessionId))).toBe(false)
+          expect(Array.from(dummyConfiguration._websocketSessions).some((session) => session.sessionId === rejectedSessionId)).toBe(false)
+
+          // Even the original identity cannot reclaim the invalidated
+          // session after the mismatch destroyed it.
+          authState.identity = "alice"
+          const oldIdentityClient = new WebsocketClient()
+
+          try {
+            oldIdentityClient._sessionId = /** @type {string} */ (rejectedSessionId)
+            await oldIdentityClient.connect()
+
+            expect(typeof oldIdentityClient._sessionId).toBe("string")
+            expect(oldIdentityClient._sessionId).not.toEqual(rejectedSessionId)
+          } finally {
+            await oldIdentityClient.close()
+          }
         } finally {
           await client.close()
         }


### PR DESCRIPTION
## Summary

- update SnapReq from `^0.0.12` to `^0.0.13`
- adopt fresh-session WebSocket handle recovery from [snapreq PR #39](https://github.com/kaspernj/snapreq/pull/39)

## Why

TensorBuzz browser clients can receive `session-gone` while reconnecting. SnapReq 0.0.13 promotes the fresh session, reopens live connections, resubscribes channels, and avoids duplicate connection-open sends while resume is pending.

## Validation

- installed SnapReq version verified as `0.0.13`
- CI-equivalent SQLite dummy config copied before checks
- `npm run lint`
- `npm run typecheck`
- `npm run fallow`
- generated lockfile integrity matches the published SnapReq 0.0.13 artifact
- exact TensorBuzz `system-tests/tests/projects/build-groups-spec.js:268` passed against an isolated `dist` export using this SnapReq build
