### PR TITLE
Fix presence validation for non-string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,8 @@ Task.validates("name", {presence: true, uniqueness: true})
 export default Task
 ```
 
+`presence: true` rejects only `null`, `undefined`, and trimmed-empty strings; non-string values are present as-is, so a `Date`, a number (including `0`), or a boolean (including `false`) never fails presence validation. See [docs/validations.md](docs/validations.md) for the full validator contract.
+
 Generated belongs-to setters synchronize the loaded relationship and foreign key before save, so `task.setProject(project)` updates `task.projectId()`, `task.changes()`, callbacks, and scoped features such as `actsAsList`. Custom relationship primary keys are also used after autosaving an assigned new or dirty related record. Generated backend write attributes accept belongs-to relationship names for `create` and `update` payloads. See [docs/relationships.md](docs/relationships.md#assigning-belongs-to-relationships).
 
 Translated models also get a `currentTranslation` `hasOne` relationship scoped to the first available row in the current locale fallback order. See [docs/translations.md](docs/translations.md) for preloading and frontend-model sorting behavior.

--- a/changelog.d/20260825113000-presence-validator-non-string-values.md
+++ b/changelog.d/20260825113000-presence-validator-non-string-values.md
@@ -1,1 +1,1 @@
-- Fix the presence validator crashing with `rawValue?.trim is not a function` on truthy non-string attribute values such as `Date` instances; only string values are trimmed before the blank check now.
+- Fix the presence validator crashing with `rawValue?.trim is not a function` on non-string attribute values such as `Date` instances, and treat falsy non-string values like `0` and `false` as present; only `null`/`undefined` and trimmed-empty strings count as blank.

--- a/changelog.d/20260825113000-presence-validator-non-string-values.md
+++ b/changelog.d/20260825113000-presence-validator-non-string-values.md
@@ -1,0 +1,1 @@
+- Fix the presence validator crashing with `rawValue?.trim is not a function` on truthy non-string attribute values such as `Date` instances; only string values are trimmed before the blank check now.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This folder contains implementation learnings and practical guidance discovered 
 - `docs/sqlite-web-persistence.md`: SQLite web persistence backend auto-selection: OPFS, IndexedDB, and legacy-byte migration.
 - `docs/tenant-databases.md`: Tenant-only database identifiers and tenant lifecycle commands.
 - `docs/tenant-selected-database-generation.md`: Explicit, immutable tenant database selection for base-model and structure generation.
+- `docs/validations.md`: Model `validates(...)` validators and presence semantics for non-string values.
 - `docs/test-profiling.md`: Opt-in test profiling, rich JSON/privacy guarantees, custom activity spans, timing-manifest generation, and strict shard aggregation.
 - `docs/test-transaction-sessions.md`: Backend-owned shared rollback sessions for live external services, workers, and exact tenant physical identities.
 - `docs/frontend-model-resources.md`: Resource recipe requirements for generated frontend models.

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -1,0 +1,31 @@
+# Validations
+
+Declare model validations with `validates(...)` on the record class. Failed
+validations raise a `ValidationError` on `save()` / `create()` with translated
+per-attribute messages from the `velocious.errors.messages.*` layer.
+
+```js
+import Record from "velocious/build/src/database/record/index.js"
+
+class Task extends Record {
+}
+
+Task.validates("name", {presence: true, uniqueness: true})
+
+export default Task
+```
+
+Available validators: `presence`, `uniqueness` (optionally `scope`d), `length`,
+and `format` (with `allowBlank`).
+
+## Presence semantics for non-string values
+
+`{presence: true}` treats only absent values as blank:
+
+- `null` and `undefined` are blank.
+- Strings are trimmed first; an empty or whitespace-only string is blank.
+
+Every non-string value counts as present without any string coercion. This
+includes `Date` instances, numbers (including `0`), and booleans (including
+`false`) — a stored `0` or `false` is a legitimate present value and never
+fails presence validation.

--- a/spec/database/record/validations.browser-spec.js
+++ b/spec/database/record/validations.browser-spec.js
@@ -1,3 +1,4 @@
+import PresenceValidator from "../../../src/database/record/validators/presence.js"
 import Task from "../../dummy/src/models/task.js"
 import User from "../../dummy/src/models/user.js"
 import {ValidationError} from "../../../src/database/record/index.js"
@@ -16,6 +17,65 @@ describe("Record - validations", {tags: ["dummy"]}, () => {
     const task = new Task({name: null, project})
 
     await expect(async () => task.save()).toThrowError(new ValidationError("Name can't be blank"))
+  })
+
+  it("fails presence validation for null and undefined values", async () => {
+    const project = await Project.create()
+
+    for (const [index, value] of [null, undefined].entries()) {
+      const task = await Task.create({name: `Task ${index}`, project})
+      const validator = new PresenceValidator({attributeName: "name", args: {}})
+
+      task.assign({name: value})
+      await validator.validate({model: task, attributeName: "name"})
+
+      expect(task._validationErrors.name?.map((error) => error.type)).toEqual(["presence"])
+    }
+  })
+
+  it("fails presence validation for blank and whitespace-only strings", async () => {
+    const project = await Project.create()
+
+    for (const [index, value] of ["", "   "].entries()) {
+      const task = await Task.create({name: `Task ${index}`, project})
+      const validator = new PresenceValidator({attributeName: "name", args: {}})
+
+      task.assign({name: value})
+      await validator.validate({model: task, attributeName: "name"})
+
+      expect(task._validationErrors.name?.map((error) => error.type)).toEqual(["presence"])
+    }
+  })
+
+  it("passes presence validation for a non-empty string", async () => {
+    const project = await Project.create()
+    const task = new Task({name: "Task", project})
+    const validator = new PresenceValidator({attributeName: "name", args: {}})
+
+    await validator.validate({model: task, attributeName: "name"})
+
+    expect(task._validationErrors.name).toBeUndefined()
+  })
+
+  it("passes presence validation for a Date value", async () => {
+    const project = await Project.create()
+    const task = new Task({createdAt: new Date("2026-08-25T10:00:00Z"), name: "Task", project})
+    const validator = new PresenceValidator({attributeName: "createdAt", args: {}})
+
+    await validator.validate({model: task, attributeName: "createdAt"})
+
+    expect(task._validationErrors.createdAt).toBeUndefined()
+  })
+
+  it("passes presence validation for truthy non-string values", async () => {
+    const project = await Project.create()
+    const task = new Task({name: "Task", project})
+    const validator = new PresenceValidator({attributeName: "isDone", args: {}})
+
+    task.assign({isDone: true})
+    await validator.validate({model: task, attributeName: "isDone"})
+
+    expect(task._validationErrors.isDone).toBeUndefined()
   })
 
   it("raises validations if trying to create an invalid record because of a uniqueness validation", async () => {

--- a/spec/database/record/validations.browser-spec.js
+++ b/spec/database/record/validations.browser-spec.js
@@ -78,6 +78,28 @@ describe("Record - validations", {tags: ["dummy"]}, () => {
     expect(task._validationErrors.isDone).toBeUndefined()
   })
 
+  it("passes presence validation for numeric zero", async () => {
+    const project = await Project.create()
+    const task = await Task.create({name: "Task", project})
+    const validator = new PresenceValidator({attributeName: "projectId", args: {}})
+
+    task.assign({projectId: 0})
+    await validator.validate({model: task, attributeName: "projectId"})
+
+    expect(task._validationErrors.projectId).toBeUndefined()
+  })
+
+  it("passes presence validation for boolean false", async () => {
+    const project = await Project.create()
+    const task = new Task({name: "Task", project})
+    const validator = new PresenceValidator({attributeName: "isDone", args: {}})
+
+    task.assign({isDone: false})
+    await validator.validate({model: task, attributeName: "isDone"})
+
+    expect(task._validationErrors.isDone).toBeUndefined()
+  })
+
   it("raises validations if trying to create an invalid record because of a uniqueness validation", async () => {
     const project = await Project.create()
     await Task.create({name: "Task 1", project})

--- a/src/database/record/validators/presence.js
+++ b/src/database/record/validators/presence.js
@@ -11,8 +11,8 @@ export default class VelociousDatabaseRecordValidatorsPresence extends Base {
    * @param {string} args.attributeName - Attribute name.
    */
   async validate({model, attributeName}) {
-    const rawValue = /** @type {string | undefined} */ (model.readAttribute(attributeName))
-    const attributeValue = rawValue?.trim()
+    const rawValue = /** @type {unknown} */ (model.readAttribute(attributeName))
+    const attributeValue = typeof rawValue === "string" ? rawValue.trim() : rawValue
 
     if (!attributeValue) {
       if (!(attributeName in model._validationErrors)) model._validationErrors[attributeName] = []

--- a/src/database/record/validators/presence.js
+++ b/src/database/record/validators/presence.js
@@ -14,7 +14,9 @@ export default class VelociousDatabaseRecordValidatorsPresence extends Base {
     const rawValue = /** @type {unknown} */ (model.readAttribute(attributeName))
     const attributeValue = typeof rawValue === "string" ? rawValue.trim() : rawValue
 
-    if (!attributeValue) {
+    // Only nullish values and blank (trimmed-empty) strings count as absent;
+    // falsy non-string values like 0 or false are legitimately present.
+    if (attributeValue === null || attributeValue === undefined || attributeValue === "") {
       if (!(attributeName in model._validationErrors)) model._validationErrors[attributeName] = []
 
       const translator = model.getModelClass()._getConfiguration().getTranslator()


### PR DESCRIPTION
## Summary

- accept truthy non-string values in presence validation without calling `.trim()`
- preserve blank handling for null, undefined, empty, and whitespace-only strings
- cover `Date` and boolean values that previously crashed validation

This fixes TensorBuzz artifact persistence where `DockerRegistryArtifact.pushedAt` is a presence-validated `Date`.

## Validation

- direct presence-validator contract: 8/8 passed
- `npm run lint`: passed (ESLint, TypeScript, Fallow)
- repository focused spec was also proven RED before the fix and GREEN by the implementation worker; coordinator rerun was blocked by the lane's unavailable MSSQL test service, so CI remains authoritative for the full configured database matrix

## Delivery boundary

No release or tag has been created. TensorBuzz remains pinned to Velocious 1.0.625 until this is reviewed, merged, and an exact patch release is explicitly approved.
